### PR TITLE
Reimplement kernels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,8 +294,8 @@ target_link_libraries(
 add_library(
         parameter_reader
         src/parameter_parser/run_setup.cpp
-        # src/parameter_parser/solver/solver.cpp
-        # src/parameter_parser/solver/time_marching.cpp
+        src/parameter_parser/solver/solver.cpp
+        src/parameter_parser/solver/time_marching.cpp
         src/parameter_parser/database_configuration.cpp
         src/parameter_parser/header.cpp
         src/parameter_parser/quadrature.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ add_library(
         point
         src/point/coordinates.cpp
         src/point/partial_derivatives.cpp
+        src/point/boundaries.cpp
 )
 
 target_link_libraries(
@@ -290,29 +291,29 @@ target_link_libraries(
 #         receiver_class
 # )
 
-# add_library(
-#         parameter_reader
-#         src/parameter_parser/run_setup.cpp
-#         src/parameter_parser/solver/solver.cpp
-#         src/parameter_parser/solver/time_marching.cpp
-#         src/parameter_parser/database_configuration.cpp
-#         src/parameter_parser/header.cpp
-#         src/parameter_parser/quadrature.cpp
-#         src/parameter_parser/receivers.cpp
-#         src/parameter_parser/seismogram.cpp
-#         src/parameter_parser/writer.cpp
-#         src/parameter_parser/setup.cpp
-# )
+add_library(
+        parameter_reader
+        src/parameter_parser/run_setup.cpp
+        # src/parameter_parser/solver/solver.cpp
+        # src/parameter_parser/solver/time_marching.cpp
+        src/parameter_parser/database_configuration.cpp
+        src/parameter_parser/header.cpp
+        src/parameter_parser/quadrature.cpp
+        src/parameter_parser/receivers.cpp
+        src/parameter_parser/seismogram.cpp
+        # src/parameter_parser/writer.cpp
+        src/parameter_parser/setup.cpp
+)
 
-# target_link_libraries(
-#         parameter_reader
-#         quadrature
-#         timescheme
-#         receiver_class
-#         yaml-cpp
-#         writer
-#         Boost::filesystem
-# )
+target_link_libraries(
+        parameter_reader
+        quadrature
+        # timescheme
+        receiver_class
+        yaml-cpp
+        # writer
+        Boost::filesystem
+)
 
 # add_executable(
 #         specfem2d

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,8 @@ target_link_libraries(
         quadrature
         source_time_function
         yaml-cpp
+        point
+        algorithms
         Boost::boost
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,18 +267,18 @@ target_link_libraries(
         Kokkos::kokkos
 )
 
-# add_library(
-#         timescheme
-#         src/timescheme/timescheme.cpp
-#         src/timescheme/newmark.cpp
-# )
+add_library(
+        timescheme
+        src/timescheme/timescheme.cpp
+        src/timescheme/newmark.cpp
+)
 
-# target_link_libraries(
-#         timescheme
-#         Kokkos::kokkos
-#         yaml-cpp
-#         compute
-# )
+target_link_libraries(
+        timescheme
+        Kokkos::kokkos
+        yaml-cpp
+        compute
+)
 
 # add_library(
 #         writer
@@ -308,7 +308,7 @@ add_library(
 target_link_libraries(
         parameter_reader
         quadrature
-        # timescheme
+        timescheme
         receiver_class
         yaml-cpp
         # writer

--- a/include/algorithms/interpolate.hpp
+++ b/include/algorithms/interpolate.hpp
@@ -53,6 +53,59 @@ T interpolate_function(
   return result;
 }
 
+template <int components, typename Layout, typename MemorySpace,
+          typename MemoryTraits>
+specfem::kokkos::array_type<type_real, components> interpolate_function(
+    const Kokkos::View<type_real **, specfem::kokkos::LayoutWrapper,
+                       MemorySpace, MemoryTraits> &polynomial,
+    const Kokkos::View<type_real **[components], Layout, MemorySpace,
+                       MemoryTraits> &function) {
+
+  using T = specfem::kokkos::array_type<type_real, components>;
+
+  const int N = polynomial.extent(0);
+  T result(0.0);
+
+  Kokkos::parallel_reduce(
+      Kokkos::MDRangePolicy<MemorySpace, Kokkos::Rank<2> >({ 0, 0 }, { N, N }),
+      [&](const int iz, const int ix, T &sum) {
+        for (int icomponent = 0; icomponent < components; ++icomponent) {
+          sum[icomponent] += polynomial(iz, ix) * function(iz, ix, icomponent);
+        }
+      },
+      specfem::kokkos::Sum<T>(result));
+
+  return result;
+}
+
+template <int components, typename Layout, typename MemorySpace,
+          typename MemoryTraits>
+specfem::kokkos::array_type<type_real, components> interpolate_function(
+    const typename Kokkos::TeamPolicy<MemorySpace>::member_type &team_member,
+    const Kokkos::View<type_real **, specfem::kokkos::LayoutWrapper,
+                       MemorySpace, MemoryTraits> &polynomial,
+    const Kokkos::View<type_real **[components], Layout, MemorySpace,
+                       MemoryTraits> &function) {
+
+  using T = specfem::kokkos::array_type<type_real, components>;
+
+  const int N = polynomial.extent(0);
+  T result(0.0);
+
+  Kokkos::parallel_reduce(
+      Kokkos::TeamThreadRange(team_member, N * N),
+      [&](const int &xz, T &sum) {
+        int iz, ix;
+        sub2ind(xz, N, iz, ix);
+        for (int icomponent = 0; icomponent < components; ++icomponent) {
+          sum[icomponent] += polynomial(iz, ix) * function(iz, ix, icomponent);
+        }
+      },
+      specfem::kokkos::Sum<T>(result));
+
+  return result;
+}
+
 } // namespace algorithms
 } // namespace specfem
 

--- a/include/compute/compute_assembly.hpp
+++ b/include/compute/compute_assembly.hpp
@@ -34,7 +34,7 @@ struct assembly {
       const std::vector<std::shared_ptr<specfem::receivers::receiver> >
           &receivers,
       const std::vector<specfem::enums::seismogram::type> &stypes,
-      const int max_sig_step);
+      const int max_timesteps, const int max_sig_step);
 };
 
 } // namespace compute

--- a/include/compute/compute_assembly.hpp
+++ b/include/compute/compute_assembly.hpp
@@ -19,7 +19,6 @@ namespace compute {
 
 struct assembly {
   specfem::compute::mesh mesh;
-  specfem::quadrature::quadrature quadrature;
   specfem::compute::partial_derivatives partial_derivatives;
   specfem::compute::properties properties;
   specfem::compute::sources sources;

--- a/include/compute/compute_mesh.hpp
+++ b/include/compute/compute_mesh.hpp
@@ -48,7 +48,7 @@ struct quadrature {
     specfem::compute::shape_functions shape_functions;  ///< Shape functions
     specfem::kokkos::DeviceView1d<type_real> weights;   ///< Quadrature weights
     specfem::kokkos::HostMirror1d<type_real> h_weights; ///< Quadrature weights
-    specfem::kokkos::DeviceView1d<type_real> hprime;    ///< Derivative of
+    specfem::kokkos::DeviceView2d<type_real> hprime;    ///< Derivative of
                                                      ///< lagrange interpolants
 
     GLL() = default;
@@ -57,6 +57,7 @@ struct quadrature {
         : N(quadratures.gll.get_N()), xi(quadratures.gll.get_xi()),
           weights(quadratures.gll.get_w()), h_xi(quadratures.gll.get_hxi()),
           h_weights(quadratures.gll.get_hw()),
+          hprime(quadratures.gll.get_hprime()),
           shape_functions(xi, xi, N, ngnod) {}
   };
 

--- a/include/compute/compute_mesh.hpp
+++ b/include/compute/compute_mesh.hpp
@@ -43,15 +43,21 @@ struct shape_functions {
 struct quadrature {
   struct GLL {
     int N; ///< Number of quadrature points
-    specfem::kokkos::DeviceView1d<type_real> xi;       ///< Quadrature points
-    specfem::kokkos::HostMirror1d<type_real> h_xi;     ///< Quadrature points
-    specfem::compute::shape_functions shape_functions; ///< Shape functions
+    specfem::kokkos::DeviceView1d<type_real> xi;        ///< Quadrature points
+    specfem::kokkos::HostMirror1d<type_real> h_xi;      ///< Quadrature points
+    specfem::compute::shape_functions shape_functions;  ///< Shape functions
+    specfem::kokkos::DeviceView1d<type_real> weights;   ///< Quadrature weights
+    specfem::kokkos::HostMirror1d<type_real> h_weights; ///< Quadrature weights
+    specfem::kokkos::DeviceView1d<type_real> hprime;    ///< Derivative of
+                                                     ///< lagrange interpolants
 
     GLL() = default;
 
     GLL(const specfem::quadrature::quadratures &quadratures, const int &ngnod)
         : N(quadratures.gll.get_N()), xi(quadratures.gll.get_xi()),
-          h_xi(quadratures.gll.get_hxi()), shape_functions(xi, xi, N, ngnod) {}
+          weights(quadratures.gll.get_w()), h_xi(quadratures.gll.get_hxi()),
+          h_weights(quadratures.gll.get_hw()),
+          shape_functions(xi, xi, N, ngnod) {}
   };
 
   specfem::compute::quadrature::GLL gll; ///< GLL object

--- a/include/compute/compute_partial_derivatives.hpp
+++ b/include/compute/compute_partial_derivatives.hpp
@@ -76,27 +76,35 @@ struct partial_derivatives {
    */
   void sync_views();
 
-  template <bool load_jacobian,
-            typename ExecSpace = specfem::kokkos::DevExecSpace>
+  template <bool load_jacobian>
   KOKKOS_INLINE_FUNCTION specfem::point::partial_derivatives2
-  load_derivatives(const int ispec, const int iz, const int ix) const {
-    if (std::is_same_v<ExecSpace, specfem::kokkos::DevExecSpace>) {
-      if constexpr (load_jacobian) {
-        return { xix(ispec, iz, ix), xiz(ispec, iz, ix), gammax(ispec, iz, ix),
-                 gammaz(ispec, iz, ix), jacobian(ispec, iz, ix) };
-      } else {
-        return { xix(ispec, iz, ix), xiz(ispec, iz, ix), gammax(ispec, iz, ix),
-                 gammaz(ispec, iz, ix) };
-      }
-    } else if (std::is_same_v<ExecSpace, specfem::kokkos::HostExecSpace>) {
-      if constexpr (load_jacobian) {
-        return { h_xix(ispec, iz, ix), h_xiz(ispec, iz, ix),
-                 h_gammax(ispec, iz, ix), h_gammaz(ispec, iz, ix),
-                 h_jacobian(ispec, iz, ix) };
-      } else {
-        return { h_xix(ispec, iz, ix), h_xiz(ispec, iz, ix),
-                 h_gammax(ispec, iz, ix), h_gammaz(ispec, iz, ix) };
-      }
+  load_device_derivatives(const int ispec, const int iz, const int ix) const {
+    if constexpr (load_jacobian) {
+      return { xix(ispec, iz, ix), xiz(ispec, iz, ix), gammax(ispec, iz, ix),
+               gammaz(ispec, iz, ix), jacobian(ispec, iz, ix) };
+    } else {
+      return { xix(ispec, iz, ix), xiz(ispec, iz, ix), gammax(ispec, iz, ix),
+               gammaz(ispec, iz, ix) };
+    }
+    if constexpr (load_jacobian) {
+      return { h_xix(ispec, iz, ix), h_xiz(ispec, iz, ix),
+               h_gammax(ispec, iz, ix), h_gammaz(ispec, iz, ix),
+               h_jacobian(ispec, iz, ix) };
+    } else {
+      return { h_xix(ispec, iz, ix), h_xiz(ispec, iz, ix),
+               h_gammax(ispec, iz, ix), h_gammaz(ispec, iz, ix) };
+    }
+  };
+
+  template <bool load_jacobian>
+  specfem::point::partial_derivatives2
+  load_host_derivatives(const int ispec, const int iz, const int ix) const {
+    if constexpr (load_jacobian) {
+      return { xix(ispec, iz, ix), xiz(ispec, iz, ix), gammax(ispec, iz, ix),
+               gammaz(ispec, iz, ix), jacobian(ispec, iz, ix) };
+    } else {
+      return { xix(ispec, iz, ix), xiz(ispec, iz, ix), gammax(ispec, iz, ix),
+               gammaz(ispec, iz, ix) };
     }
   };
 };

--- a/include/compute/compute_partial_derivatives.hpp
+++ b/include/compute/compute_partial_derivatives.hpp
@@ -80,19 +80,11 @@ struct partial_derivatives {
   KOKKOS_INLINE_FUNCTION specfem::point::partial_derivatives2
   load_device_derivatives(const int ispec, const int iz, const int ix) const {
     if constexpr (load_jacobian) {
-      return { xix(ispec, iz, ix), xiz(ispec, iz, ix), gammax(ispec, iz, ix),
+      return { xix(ispec, iz, ix), gammax(ispec, iz, ix), xiz(ispec, iz, ix),
                gammaz(ispec, iz, ix), jacobian(ispec, iz, ix) };
     } else {
-      return { xix(ispec, iz, ix), xiz(ispec, iz, ix), gammax(ispec, iz, ix),
+      return { xix(ispec, iz, ix), gammax(ispec, iz, ix), xiz(ispec, iz, ix),
                gammaz(ispec, iz, ix) };
-    }
-    if constexpr (load_jacobian) {
-      return { h_xix(ispec, iz, ix), h_xiz(ispec, iz, ix),
-               h_gammax(ispec, iz, ix), h_gammaz(ispec, iz, ix),
-               h_jacobian(ispec, iz, ix) };
-    } else {
-      return { h_xix(ispec, iz, ix), h_xiz(ispec, iz, ix),
-               h_gammax(ispec, iz, ix), h_gammaz(ispec, iz, ix) };
     }
   };
 
@@ -100,11 +92,12 @@ struct partial_derivatives {
   specfem::point::partial_derivatives2
   load_host_derivatives(const int ispec, const int iz, const int ix) const {
     if constexpr (load_jacobian) {
-      return { xix(ispec, iz, ix), xiz(ispec, iz, ix), gammax(ispec, iz, ix),
-               gammaz(ispec, iz, ix), jacobian(ispec, iz, ix) };
+      return { h_xix(ispec, iz, ix), h_gammax(ispec, iz, ix),
+               h_xiz(ispec, iz, ix), h_gammaz(ispec, iz, ix),
+               h_jacobian(ispec, iz, ix) };
     } else {
-      return { xix(ispec, iz, ix), xiz(ispec, iz, ix), gammax(ispec, iz, ix),
-               gammaz(ispec, iz, ix) };
+      return { h_xix(ispec, iz, ix), h_gammax(ispec, iz, ix),
+               h_xiz(ispec, iz, ix), h_gammaz(ispec, iz, ix) };
     }
   };
 };

--- a/include/compute/compute_receivers.hpp
+++ b/include/compute/compute_receivers.hpp
@@ -72,18 +72,22 @@ struct receivers {
   specfem::kokkos::HostMirror1d<specfem::enums::seismogram::type>
       h_seismogram_types; ///< Types of seismograms to be calculated stored on
                           ///< the host
-  specfem::kokkos::DeviceView6d<type_real> receiver_field;   ///< Receiver field
-                                                             ///< inside the
-                                                             ///< element where
-                                                             ///< receiver is
-                                                             ///< located stored
-                                                             ///< on the device
-  specfem::kokkos::HostMirror6d<type_real> h_receiver_field; ///< Receiver field
-                                                             ///< inside the
-                                                             ///< element where
-                                                             ///< receiver is
-                                                             ///< located stored
-                                                             ///< on the host
+  Kokkos::View<type_real *****[2], Kokkos::LayoutLeft,
+               specfem::kokkos::DevMemSpace>
+      receiver_field; ///< Receiver field
+                      ///< inside the
+                      ///< element where
+                      ///< receiver is
+                      ///< located stored
+                      ///< on the device
+  Kokkos::View<type_real *****[2], Kokkos::LayoutLeft,
+               specfem::kokkos::DevMemSpace>::HostMirror
+      h_receiver_field; ///< Receiver field
+                        ///< inside the
+                        ///< element where
+                        ///< receiver is
+                        ///< located stored
+                        ///< on the host
 
   /**
    * @brief Default constructor

--- a/include/compute/coupled_interfaces/coupled_interfaces.hpp
+++ b/include/compute/coupled_interfaces/coupled_interfaces.hpp
@@ -18,6 +18,11 @@ struct coupled_interfaces {
       const specfem::compute::properties &properties,
       const specfem::mesh::coupled_interfaces &coupled_interfaces);
 
+  template <specfem::enums::element::type medium1,
+            specfem::enums::element::type medium2>
+  specfem::compute::interface_container<medium1, medium2>
+  get_interface_container() const;
+
   specfem::compute::interface_container<specfem::enums::element::type::elastic,
                                         specfem::enums::element::type::acoustic>
       elastic_acoustic;

--- a/include/compute/coupled_interfaces/coupled_interfaces.tpp
+++ b/include/compute/coupled_interfaces/coupled_interfaces.tpp
@@ -1,0 +1,37 @@
+#ifndef _COMPUTE_COUPLED_INTERFACES_COUPLED_INTERFACES_TPP
+#define _COMPUTE_COUPLED_INTERFACES_COUPLED_INTERFACES_TPP
+
+#include "coupled_interfaces.hpp"
+#include "enumerations/specfem_enums.hpp"
+#include "interface_container.hpp"
+#include "interface_container.tpp"
+
+template <specfem::enums::element::type medium1,
+          specfem::enums::element::type medium2>
+specfem::compute::interface_container<medium1, medium2>
+specfem::compute::coupled_interfaces::get_interface_container() const {
+  if constexpr (medium1 == specfem::enums::element::type::elastic &&
+                medium2 == specfem::enums::element::type::acoustic) {
+    return elastic_acoustic;
+  } else if constexpr (medium1 == specfem::enums::element::type::acoustic &&
+                       medium2 == specfem::enums::element::type::elastic) {
+    return specfem::compute::interface_container<medium1, medium2>(
+        elastic_acoustic);
+  } else if constexpr (medium1 == specfem::enums::element::type::acoustic &&
+                       medium2 == specfem::enums::element::type::poroelastic) {
+    return acoustic_poroelastic;
+  } else if constexpr (medium1 == specfem::enums::element::type::poroelastic &&
+                       medium2 == specfem::enums::element::type::acoustic) {
+    return specfem::compute::interface_container<medium1, medium2>(
+        acoustic_poroelastic);
+  } else if constexpr (medium1 == specfem::enums::element::type::elastic &&
+                       medium2 == specfem::enums::element::type::poroelastic) {
+    return elastic_poroelastic;
+  } else if constexpr (medium1 == specfem::enums::element::type::poroelastic &&
+                       medium2 == specfem::enums::element::type::elastic) {
+    return specfem::compute::interface_container<medium1, medium2>(
+        elastic_poroelastic);
+  }
+}
+
+#endif

--- a/include/compute/coupled_interfaces/interface_container.hpp
+++ b/include/compute/coupled_interfaces/interface_container.hpp
@@ -23,6 +23,19 @@ struct interface_container {
                       const specfem::mesh::interface_container<medium1, medium2>
                           &coupled_interfaces);
 
+  interface_container(const interface_container<medium2, medium1> &other)
+      : num_interfaces(other.num_interfaces),
+        medium1_index_mapping(other.medium2_index_mapping),
+        h_medium1_index_mapping(other.h_medium2_index_mapping),
+        medium2_index_mapping(other.medium1_index_mapping),
+        h_medium2_index_mapping(other.h_medium1_index_mapping),
+        medium1_edge_type(other.medium2_edge_type),
+        h_medium1_edge_type(other.h_medium2_edge_type),
+        medium2_edge_type(other.medium1_edge_type),
+        h_medium2_edge_type(other.h_medium1_edge_type) {
+    return;
+  }
+
   int num_interfaces = 0;
 
   specfem::kokkos::DeviceView1d<int> medium1_index_mapping; ///< spectral
@@ -61,11 +74,17 @@ struct interface_container {
       h_medium2_edge_type; ///< edge type for the ith edge in medium 2
 
   template <specfem::enums::element::type medium>
-  specfem::kokkos::DeviceView1d<int> get_index_mapping_view() const;
+  KOKKOS_FUNCTION int load_device_index_mapping(const int iedge) const;
 
   template <specfem::enums::element::type medium>
-  specfem::kokkos::DeviceView1d<specfem::edge::interface>
-  get_edge_type_view() const;
+  int load_host_index_mapping(const int iedge) const;
+
+  template <specfem::enums::element::type medium>
+  KOKKOS_FUNCTION specfem::edge::interface load_device_edge_type(
+      const int iedge) const;
+
+  template <specfem::enums::element::type medium>
+  specfem::edge::interface load_host_edge_type(const int iedge) const;
 };
 } // namespace compute
 } // namespace specfem

--- a/include/compute/coupled_interfaces/interface_container.tpp
+++ b/include/compute/coupled_interfaces/interface_container.tpp
@@ -196,8 +196,8 @@ void compute_edges(
     const int ispec2l = ispec2(inum);
 
     int num_connected = 0;
-    for (int edge1l = 0; edge1l < specfem::enums::edge::num_edges; edge1l++) {
-      for (int edge2l = 0; edge2l < specfem::enums::edge::num_edges; edge2l++) {
+    for (int edge1l = 1; edge1l < specfem::enums::edge::num_edges; edge1l++) {
+      for (int edge2l = 1; edge2l < specfem::enums::edge::num_edges; edge2l++) {
         if (check_if_edges_are_connected(
                 h_ibool, static_cast<specfem::enums::edge::type>(edge1l),
                 static_cast<specfem::enums::edge::type>(edge2l), ispec1l,

--- a/include/compute/coupled_interfaces/interface_container.tpp
+++ b/include/compute/coupled_interfaces/interface_container.tpp
@@ -261,13 +261,13 @@ void check_edges(
     for (int ipoint = 0; ipoint < npoints; ipoint++) {
       // Get ipoint along the edge in element1
       int i1, j1;
-      specfem::edge::locate_point_on_self_edge(ipoint, edge1l, i1, j1);
+      specfem::edge::locate_point_on_self_edge(ipoint, edge1l, j1, i1);
       const specfem::point::gcoord2 self_coordinates(
           coordinates(0, ispec1l, j1, i1), coordinates(1, ispec1l, j1, i1));
 
       // Get ipoint along the edge in element2
       int i2, j2;
-      specfem::edge::locate_point_on_coupled_edge(ipoint, edge2l, i2, j2);
+      specfem::edge::locate_point_on_coupled_edge(ipoint, edge2l, j2, i2);
       const specfem::point::gcoord2 coupled_coordinates(
           coordinates(0, ispec2l, j2, i2), coordinates(1, ispec2l, j2, i2));
 

--- a/include/compute/coupled_interfaces/interface_container.tpp
+++ b/include/compute/coupled_interfaces/interface_container.tpp
@@ -187,6 +187,8 @@ void compute_edges(
     specfem::kokkos::HostMirror1d<specfem::edge::interface> edge1,
     specfem::kokkos::HostMirror1d<specfem::edge::interface> edge2) {
 
+  const int ngll = h_ibool.extent(1);
+
   const int num_interfaces = ispec1.extent(0);
 
   for (int inum = 0; inum < num_interfaces; inum++) {
@@ -222,9 +224,9 @@ void compute_edges(
                  "Invalid edge1 and edge2");
 
           edge1(inum) = specfem::edge::interface(
-              static_cast<specfem::enums::edge::type>(edge1l));
+              static_cast<specfem::enums::edge::type>(edge1l), ngll);
           edge2(inum) = specfem::edge::interface(
-              static_cast<specfem::enums::edge::type>(edge2l));
+              static_cast<specfem::enums::edge::type>(edge2l), ngll);
           num_connected++;
         }
       }
@@ -254,20 +256,18 @@ void check_edges(
     const auto edge2l = edge2(interface);
 
     // iterate over the edge
-    int npoints = specfem::edge::num_points_on_interface(edge1l, ngllx, ngllz);
+    int npoints = specfem::edge::num_points_on_interface(edge1l);
 
     for (int ipoint = 0; ipoint < npoints; ipoint++) {
       // Get ipoint along the edge in element1
       int i1, j1;
-      specfem::edge::locate_point_on_self_edge(ipoint, edge1l, ngllx, ngllz, i1,
-                                               j1);
+      specfem::edge::locate_point_on_self_edge(ipoint, edge1l, i1, j1);
       const specfem::point::gcoord2 self_coordinates(
           coordinates(0, ispec1l, j1, i1), coordinates(1, ispec1l, j1, i1));
 
       // Get ipoint along the edge in element2
       int i2, j2;
-      specfem::edge::locate_point_on_coupled_edge(ipoint, edge2l, ngllx, ngllz,
-                                                  i2, j2);
+      specfem::edge::locate_point_on_coupled_edge(ipoint, edge2l, i2, j2);
       const specfem::point::gcoord2 coupled_coordinates(
           coordinates(0, ispec2l, j2, i2), coordinates(1, ispec2l, j2, i2));
 
@@ -350,33 +350,76 @@ specfem::compute::interface_container<medium1, medium2>::interface_container(
   return;
 }
 
+// template <specfem::enums::element::type medium1,
+//           specfem::enums::element::type medium2>
+// specfem::compute::interface_container<medium1, medium2>::interface_container(
+//     const specfem::compute::interface_container<medium2, medium1> &other)
+//     : num_interfaces(other.num_interfaces),
+//       medium1_index_mapping(other.medium2_index_mapping),
+//       h_medium1_index_mapping(other.h_medium2_index_mapping),
+//       medium2_index_mapping(other.medium1_index_mapping),
+//       h_medium2_index_mapping(other.h_medium1_index_mapping),
+//       medium1_edge_type(other.medium2_edge_type),
+//       h_medium1_edge_type(other.h_medium2_edge_type),
+//       medium2_edge_type(other.medium1_edge_type),
+//       h_medium2_edge_type(other.h_medium1_edge_type) {
+//   return;
+// }
+
 template <specfem::enums::element::type medium1,
           specfem::enums::element::type medium2>
 template <specfem::enums::element::type medium>
-specfem::kokkos::DeviceView1d<int>
-specfem::compute::interface_container<medium1,
-                                      medium2>::get_index_mapping_view() const {
+KOKKOS_INLINE_FUNCTION int specfem::compute::interface_container<
+    medium1, medium2>::load_device_index_mapping(const int iedge) const {
   if constexpr (medium == medium1) {
-    return medium1_index_mapping;
+    return medium1_index_mapping(iedge);
   } else if constexpr (medium == medium2) {
-    return medium2_index_mapping;
+    return medium2_index_mapping(iedge);
   } else {
-    throw std::runtime_error("Invalid medium type");
+    static_assert("Invalid medium type");
   }
 }
 
 template <specfem::enums::element::type medium1,
           specfem::enums::element::type medium2>
 template <specfem::enums::element::type medium>
-specfem::kokkos::DeviceView1d<specfem::edge::interface>
-specfem::compute::interface_container<medium1, medium2>::get_edge_type_view()
-    const {
+int specfem::compute::interface_container<
+    medium1, medium2>::load_host_index_mapping(const int iedge) const {
   if constexpr (medium == medium1) {
-    return medium1_edge_type;
+    return h_medium1_index_mapping(iedge);
   } else if constexpr (medium == medium2) {
-    return medium2_edge_type;
+    return h_medium2_index_mapping(iedge);
   } else {
-    throw std::runtime_error("Invalid medium type");
+    static_assert("Invalid medium type");
+  }
+}
+
+template <specfem::enums::element::type medium1,
+          specfem::enums::element::type medium2>
+template <specfem::enums::element::type medium>
+KOKKOS_INLINE_FUNCTION specfem::edge::interface specfem::compute::
+    interface_container<medium1, medium2>::load_device_edge_type(
+        const int iedge) const {
+  if constexpr (medium == medium1) {
+    return medium1_edge_type(iedge);
+  } else if constexpr (medium == medium2) {
+    return medium2_edge_type(iedge);
+  } else {
+    static_assert("Invalid medium type");
+  }
+}
+
+template <specfem::enums::element::type medium1,
+          specfem::enums::element::type medium2>
+template <specfem::enums::element::type medium>
+specfem::edge::interface specfem::compute::interface_container<
+    medium1, medium2>::load_host_edge_type(const int iedge) const {
+  if constexpr (medium == medium1) {
+    return h_medium1_edge_type(iedge);
+  } else if constexpr (medium == medium2) {
+    return h_medium2_edge_type(iedge);
+  } else {
+    static_assert("Invalid medium type");
   }
 }
 

--- a/include/compute/fields/fields.hpp
+++ b/include/compute/fields/fields.hpp
@@ -27,6 +27,10 @@ struct fields {
     }
   }
 
+  template <specfem::sync::kind sync> void sync_fields() {
+    forward.sync_fields<sync>();
+  }
+
   specfem::compute::simulation_field<forward_type> forward;
 };
 } // namespace compute

--- a/include/compute/fields/impl/field_impl.hpp
+++ b/include/compute/fields/impl/field_impl.hpp
@@ -17,14 +17,16 @@ public:
 
   field_impl() = default;
 
-  field_impl(const specfem::compute::mesh &mesh,
-             const specfem::compute::properties &properties,
-             Kokkos::View<int * [specfem::enums::element::ntypes],
-                          Kokkos::LayoutLeft, specfem::kokkos::HostMemSpace>
-                 assembly_index_mapping);
+  field_impl(
+      const specfem::compute::mesh &mesh,
+      const specfem::compute::properties &properties,
+      Kokkos::View<int *, Kokkos::LayoutLeft, specfem::kokkos::HostMemSpace>
+          assembly_index_mapping);
 
   field_impl(const int nglob, const int nspec, const int ngllz,
              const int ngllx);
+
+  template <specfem::sync::kind sync> void sync_fields() const;
 
   int nglob;
   int nspec;

--- a/include/compute/fields/impl/field_impl.tpp
+++ b/include/compute/fields/impl/field_impl.tpp
@@ -68,7 +68,7 @@ specfem::compute::impl::field_impl<medium>::field_impl(
     if (element_type(ispec) == medium::value) {
       for (int iz = 0; iz < ngllz; ++iz) {
         for (int ix = 0; ix < ngllx; ++ix) {
-          const int index = index_mapping(ispec, iz, ix);
+          const int index = index_mapping(ispec, iz, ix); // get global index
           // increase the count only if the global index is not already counted
           /// static_cast<int>(medium::value) is the index of the medium in the
           /// enum class

--- a/include/compute/fields/simulation_field.hpp
+++ b/include/compute/fields/simulation_field.hpp
@@ -24,31 +24,49 @@ template <typename simulation> struct simulation_field {
                    const specfem::compute::properties &properties);
 
   template <typename medium>
-  KOKKOS_INLINE_FUNCTION type_real &field(const int &iglob, const int &icomp);
+  KOKKOS_INLINE_FUNCTION specfem::compute::impl::field_impl<medium>
+  get_field() const {
+    if constexpr (std::is_same_v<medium, elastic_type>) {
+      return elastic;
+    } else if constexpr (std::is_same_v<medium, acoustic_type>) {
+      return acoustic;
+    } else {
+      static_assert("medium type not supported");
+    }
+  }
 
-  template <typename medium>
-  inline type_real &h_field(const int &iglob, const int &icomp);
+  template <specfem::sync::kind sync> void sync_fields() {
+    elastic.sync_fields<sync>();
+    acoustic.sync_fields<sync>();
+  }
 
-  template <typename medium>
-  KOKKOS_INLINE_FUNCTION type_real &field_dot(const int &iglob,
-                                              const int &icomp);
+  // template <typename medium>
+  // KOKKOS_INLINE_FUNCTION type_real &field(const int &iglob, const int
+  // &icomp);
 
-  template <typename medium>
-  inline type_real &h_field_dot(const int &iglob, const int &icomp);
+  // template <typename medium>
+  // inline type_real &h_field(const int &iglob, const int &icomp);
 
-  template <typename medium>
-  KOKKOS_INLINE_FUNCTION type_real &field_dot_dot(const int &iglob,
-                                                  const int &icomp);
+  // template <typename medium>
+  // KOKKOS_INLINE_FUNCTION type_real &field_dot(const int &iglob,
+  //                                             const int &icomp);
 
-  template <typename medium>
-  inline type_real &h_field_dot_dot(const int &iglob, const int &icomp);
+  // template <typename medium>
+  // inline type_real &h_field_dot(const int &iglob, const int &icomp);
 
-  template <typename medium>
-  KOKKOS_INLINE_FUNCTION type_real &mass_inverse(const int &iglob,
-                                                 const int &icomp);
+  // template <typename medium>
+  // KOKKOS_INLINE_FUNCTION type_real &field_dot_dot(const int &iglob,
+  //                                                 const int &icomp);
 
-  template <typename medium>
-  inline type_real &h_mass_inverse(const int &iglob, const int &icomp);
+  // template <typename medium>
+  // inline type_real &h_field_dot_dot(const int &iglob, const int &icomp);
+
+  // template <typename medium>
+  // KOKKOS_INLINE_FUNCTION type_real &mass_inverse(const int &iglob,
+  //                                                const int &icomp);
+
+  // template <typename medium>
+  // inline type_real &h_mass_inverse(const int &iglob, const int &icomp);
 
   int nglob = 0;
   Kokkos::View<int * [specfem::enums::element::ntypes], Kokkos::LayoutLeft,

--- a/include/compute/fields/simulation_field.tpp
+++ b/include/compute/fields/simulation_field.tpp
@@ -1,9 +1,9 @@
 #ifndef _COMPUTE_FIELDS_SIMULATION_FIELD_TPP_
 #define _COMPUTE_FIELDS_SIMULATION_FIELD_TPP_
 
-#include "compute/fields/simulation_field.hpp"
 #include "compute/fields/impl/field_impl.hpp"
 #include "compute/fields/impl/field_impl.tpp"
+#include "compute/fields/simulation_field.hpp"
 #include "enumerations/specfem_enums.hpp"
 #include "kokkos_abstractions.h"
 #include "specfem_setup.hpp"
@@ -21,124 +21,144 @@ specfem::compute::simulation_field<simulation>::simulation_field(
                    specfem::kokkos::DevMemSpace>(
           "specfem::compute::simulation_field::index_mapping", nglob);
 
-  h_assembly_index_mapping = Kokkos::View<
-      int * [specfem::enums::element::ntypes], Kokkos::LayoutLeft,
-      specfem::kokkos::HostMemSpace>(
-      Kokkos::create_mirror_view(assembly_index_mapping));
+  h_assembly_index_mapping =
+      Kokkos::View<int * [specfem::enums::element::ntypes], Kokkos::LayoutLeft,
+                   specfem::kokkos::HostMemSpace>(
+          Kokkos::create_mirror_view(assembly_index_mapping));
 
-  elastic = specfem::compute::impl::field_impl<elastic_type>(
-      mesh, properties, h_assembly_index_mapping);
+  for (int iglob = 0; iglob < nglob; iglob++) {
+    for (int itype = 0; itype < specfem::enums::element::ntypes; itype++) {
+      h_assembly_index_mapping(iglob, itype) = -1;
+    }
+  }
 
-  acoustic = specfem::compute::impl::field_impl<acoustic_type>(
-      mesh, properties, h_assembly_index_mapping);
+  auto acoustic_index = Kokkos::subview(h_assembly_index_mapping, Kokkos::ALL,
+                                        static_cast<int>(acoustic_type::value));
+
+  auto elastic_index = Kokkos::subview(h_assembly_index_mapping, Kokkos::ALL,
+                                       static_cast<int>(elastic_type::value));
+
+  elastic = specfem::compute::impl::field_impl<elastic_type>(mesh, properties,
+                                                             elastic_index);
+
+  acoustic = specfem::compute::impl::field_impl<acoustic_type>(mesh, properties,
+                                                               acoustic_index);
 
   Kokkos::deep_copy(assembly_index_mapping, h_assembly_index_mapping);
 
   return;
 }
 
-template <typename simulation>
-template <typename medium>
-KOKKOS_INLINE_FUNCTION type_real &
-specfem::compute::simulation_field<simulation>::field(const int &iglob,
-                                                      const int &icomp) {
-  if constexpr (std::is_same_v<medium, elastic_type>) {
-    int index = assembly_index_mapping(iglob, static_cast<int>(medium::value));
-    return elastic.field(index, icomp);
-  } else if constexpr (std::is_same_v<medium, acoustic_type>) {
-    int index = assembly_index_mapping(iglob, static_cast<int>(medium::value));
-    return acoustic.field(index, icomp);
-  }
-}
+// template <typename simulation>
+// template <typename medium>
+// KOKKOS_INLINE_FUNCTION type_real &
+// specfem::compute::simulation_field<simulation>::field(const int &iglob,
+//                                                       const int &icomp) {
+//   if constexpr (std::is_same_v<medium, elastic_type>) {
+//     int index = assembly_index_mapping(iglob,
+//     static_cast<int>(medium::value)); return elastic.field(index, icomp);
+//   } else if constexpr (std::is_same_v<medium, acoustic_type>) {
+//     int index = assembly_index_mapping(iglob,
+//     static_cast<int>(medium::value)); return acoustic.field(index, icomp);
+//   }
+// }
 
-template <typename simulation>
-template <typename medium>
-inline type_real &
-specfem::compute::simulation_field<simulation>::h_field(const int &iglob,
-                                                        const int &icomp) {
-  if constexpr (std::is_same_v<medium, elastic_type>) {
-    int index =
-        h_assembly_index_mapping(iglob, static_cast<int>(medium::value));
-    return elastic.h_field(index, icomp);
-  } else if constexpr (std::is_same_v<medium, acoustic_type>) {
-    int index =
-        h_assembly_index_mapping(iglob, static_cast<int>(medium::value));
-    return acoustic.h_field(index, icomp);
-  }
-}
+// template <typename simulation>
+// template <typename medium>
+// inline type_real &
+// specfem::compute::simulation_field<simulation>::h_field(const int &iglob,
+//                                                         const int &icomp) {
+//   if constexpr (std::is_same_v<medium, elastic_type>) {
+//     int index =
+//         h_assembly_index_mapping(iglob, static_cast<int>(medium::value));
+//     return elastic.h_field(index, icomp);
+//   } else if constexpr (std::is_same_v<medium, acoustic_type>) {
+//     int index =
+//         h_assembly_index_mapping(iglob, static_cast<int>(medium::value));
+//     return acoustic.h_field(index, icomp);
+//   }
+// }
 
-template <typename simulation>
-template <typename medium>
-KOKKOS_INLINE_FUNCTION type_real &
-specfem::compute::simulation_field<simulation>::field_dot(const int &iglob,
-                                                          const int &icomp) {
-  if constexpr (std::is_same_v<medium, elastic_type>) {
-    int index = assembly_index_mapping(iglob, static_cast<int>(medium::value));
-    return elastic.field_dot(index, icomp);
-  } else if constexpr (std::is_same_v<medium, acoustic_type>) {
-    int index = assembly_index_mapping(iglob, static_cast<int>(medium::value));
-    return acoustic.field_dot(index, icomp);
-  }
-}
+// template <typename simulation>
+// template <typename medium>
+// KOKKOS_INLINE_FUNCTION type_real &
+// specfem::compute::simulation_field<simulation>::field_dot(const int &iglob,
+//                                                           const int &icomp) {
+//   if constexpr (std::is_same_v<medium, elastic_type>) {
+//     int index = assembly_index_mapping(iglob,
+//     static_cast<int>(medium::value)); return elastic.field_dot(index, icomp);
+//   } else if constexpr (std::is_same_v<medium, acoustic_type>) {
+//     int index = assembly_index_mapping(iglob,
+//     static_cast<int>(medium::value)); return acoustic.field_dot(index,
+//     icomp);
+//   }
+// }
 
-template <typename simulation>
-template <typename medium>
-inline type_real &
-specfem::compute::simulation_field<simulation>::h_field_dot(const int &iglob,
-                                                            const int &icomp) {
-  if constexpr (std::is_same_v<medium, elastic_type>) {
-    int index =
-        h_assembly_index_mapping(iglob, static_cast<int>(medium::value));
-    return elastic.h_field_dot(index, icomp);
-  } else if constexpr (std::is_same_v<medium, acoustic_type>) {
-    int index =
-        h_assembly_index_mapping(iglob, static_cast<int>(medium::value));
-    return acoustic.h_field_dot(index, icomp);
-  }
-}
+// template <typename simulation>
+// template <typename medium>
+// inline type_real &
+// specfem::compute::simulation_field<simulation>::h_field_dot(const int &iglob,
+//                                                             const int &icomp)
+//                                                             {
+//   if constexpr (std::is_same_v<medium, elastic_type>) {
+//     int index =
+//         h_assembly_index_mapping(iglob, static_cast<int>(medium::value));
+//     return elastic.h_field_dot(index, icomp);
+//   } else if constexpr (std::is_same_v<medium, acoustic_type>) {
+//     int index =
+//         h_assembly_index_mapping(iglob, static_cast<int>(medium::value));
+//     return acoustic.h_field_dot(index, icomp);
+//   }
+// }
 
-template <typename simulation>
-template <typename medium>
-KOKKOS_INLINE_FUNCTION type_real &
-specfem::compute::simulation_field<simulation>::field_dot_dot(
-    const int &iglob, const int &icomp) {
-  if constexpr (std::is_same_v<medium, elastic_type>) {
-    int index = assembly_index_mapping(iglob, static_cast<int>(medium::value));
-    return elastic.field_dot_dot(index, icomp);
-  } else if constexpr (std::is_same_v<medium, acoustic_type>) {
-    int index = assembly_index_mapping(iglob, static_cast<int>(medium::value));
-    return acoustic.field_dot_dot(index, icomp);
-  }
-}
+// template <typename simulation>
+// template <typename medium>
+// KOKKOS_INLINE_FUNCTION type_real &
+// specfem::compute::simulation_field<simulation>::field_dot_dot(
+//     const int &iglob, const int &icomp) {
+//   if constexpr (std::is_same_v<medium, elastic_type>) {
+//     int index = assembly_index_mapping(iglob,
+//     static_cast<int>(medium::value)); return elastic.field_dot_dot(index,
+//     icomp);
+//   } else if constexpr (std::is_same_v<medium, acoustic_type>) {
+//     int index = assembly_index_mapping(iglob,
+//     static_cast<int>(medium::value)); return acoustic.field_dot_dot(index,
+//     icomp);
+//   }
+// }
 
-template <typename simulation>
-template <typename medium>
-inline type_real &
-specfem::compute::simulation_field<simulation>::h_field_dot_dot(
-    const int &iglob, const int &icomp) {
-  if constexpr (std::is_same_v<medium, elastic_type>) {
-    int index =
-        h_assembly_index_mapping(iglob, static_cast<int>(medium::value));
-    return elastic.h_field_dot_dot(index, icomp);
-  } else if constexpr (std::is_same_v<medium, acoustic_type>) {
-    int index =
-        h_assembly_index_mapping(iglob, static_cast<int>(medium::value));
-    return acoustic.h_field_dot_dot(index, icomp);
-  }
-}
+// template <typename simulation>
+// template <typename medium>
+// inline type_real &
+// specfem::compute::simulation_field<simulation>::h_field_dot_dot(
+//     const int &iglob, const int &icomp) {
+//   if constexpr (std::is_same_v<medium, elastic_type>) {
+//     int index =
+//         h_assembly_index_mapping(iglob, static_cast<int>(medium::value));
+//     return elastic.h_field_dot_dot(index, icomp);
+//   } else if constexpr (std::is_same_v<medium, acoustic_type>) {
+//     int index =
+//         h_assembly_index_mapping(iglob, static_cast<int>(medium::value));
+//     return acoustic.h_field_dot_dot(index, icomp);
+//   }
+// }
 
-template <typename simulation>
-template <typename medium>
-KOKKOS_INLINE_FUNCTION type_real &
-specfem::compute::simulation_field<simulation>::mass_inverse(const int &iglob,
-                                                             const int &icomp) {
-  if constexpr (std::is_same_v<medium, elastic_type>) {
-    int index = assembly_index_mapping(iglob, static_cast<int>(medium::value));
-    return elastic.mass_inverse(index, icomp);
-  } else if constexpr (std::is_same_v<medium, acoustic_type>) {
-    int index = assembly_index_mapping(iglob, static_cast<int>(medium::value));
-    return acoustic.mass_inverse(index, icomp);
-  }
-}
+// template <typename simulation>
+// template <typename medium>
+// KOKKOS_INLINE_FUNCTION type_real &
+// specfem::compute::simulation_field<simulation>::mass_inverse(const int
+// &iglob,
+//                                                              const int
+//                                                              &icomp) {
+//   if constexpr (std::is_same_v<medium, elastic_type>) {
+//     int index = assembly_index_mapping(iglob,
+//     static_cast<int>(medium::value)); return elastic.mass_inverse(index,
+//     icomp);
+//   } else if constexpr (std::is_same_v<medium, acoustic_type>) {
+//     int index = assembly_index_mapping(iglob,
+//     static_cast<int>(medium::value)); return acoustic.mass_inverse(index,
+//     icomp);
+//   }
+// }
 
 #endif /* _COMPUTE_FIELDS_SIMULATION_FIELD_TPP_ */

--- a/include/compute/interface.hpp
+++ b/include/compute/interface.hpp
@@ -8,6 +8,7 @@
 #include "compute_receivers.hpp"
 #include "compute_sources.hpp"
 // #include "coupled_interfaces.hpp"
+#include "compute_assembly.hpp"
 #include "coupled_interfaces/coupled_interfaces.hpp"
 #include "coupled_interfaces/interface_container.hpp"
 #include "fields/fields.hpp"

--- a/include/compute/properties/impl/properties_container.hpp
+++ b/include/compute/properties/impl/properties_container.hpp
@@ -51,11 +51,11 @@ struct properties_container<specfem::enums::element::type::elastic,
   load_properties(const int &ispec, const int &iz, const int &ix) const {
     if constexpr (std::is_same_v<ExecSpace, specfem::kokkos::DevExecSpace>) {
       return specfem::point::properties<value_type, property_type>(
-          lambdaplus2mu(ispec, iz, ix), rho(ispec, iz, ix), mu(ispec, iz, ix));
+          lambdaplus2mu(ispec, iz, ix), mu(ispec, iz, ix), rho(ispec, iz, ix));
     } else {
       return specfem::point::properties<value_type, property_type>(
-          h_lambdaplus2mu(ispec, iz, ix), h_rho(ispec, iz, ix),
-          h_mu(ispec, iz, ix));
+          h_lambdaplus2mu(ispec, iz, ix), h_mu(ispec, iz, ix),
+          h_rho(ispec, iz, ix));
     }
   }
 

--- a/include/compute/properties/impl/properties_container.hpp
+++ b/include/compute/properties/impl/properties_container.hpp
@@ -46,17 +46,17 @@ struct properties_container<specfem::enums::element::type::elastic,
                       ngllz, ngllx),
         h_lambdaplus2mu(Kokkos::create_mirror_view(lambdaplus2mu)) {}
 
-  template <typename ExecSpace>
   KOKKOS_INLINE_FUNCTION specfem::point::properties<value_type, property_type>
-  load_properties(const int &ispec, const int &iz, const int &ix) const {
-    if constexpr (std::is_same_v<ExecSpace, specfem::kokkos::DevExecSpace>) {
-      return specfem::point::properties<value_type, property_type>(
-          lambdaplus2mu(ispec, iz, ix), mu(ispec, iz, ix), rho(ispec, iz, ix));
-    } else {
-      return specfem::point::properties<value_type, property_type>(
-          h_lambdaplus2mu(ispec, iz, ix), h_mu(ispec, iz, ix),
-          h_rho(ispec, iz, ix));
-    }
+  load_device_properties(const int &ispec, const int &iz, const int &ix) const {
+    return specfem::point::properties<value_type, property_type>(
+        lambdaplus2mu(ispec, iz, ix), mu(ispec, iz, ix), rho(ispec, iz, ix));
+  }
+
+  specfem::point::properties<value_type, property_type>
+  load_host_properties(const int &ispec, const int &iz, const int &ix) const {
+    return specfem::point::properties<value_type, property_type>(
+        h_lambdaplus2mu(ispec, iz, ix), h_mu(ispec, iz, ix),
+        h_rho(ispec, iz, ix));
   }
 
   void copy_to_device() {
@@ -107,18 +107,18 @@ struct properties_container<specfem::enums::element::type::acoustic,
         kappa("specfem::compute::properties::kappa", nspec, ngllz, ngllx),
         h_kappa(Kokkos::create_mirror_view(kappa)) {}
 
-  template <typename ExecSpace>
   KOKKOS_INLINE_FUNCTION specfem::point::properties<value_type, property_type>
-  load_properties(const int &ispec, const int &iz, const int &ix) const {
-    if constexpr (std::is_same_v<ExecSpace, specfem::kokkos::DevExecSpace>) {
-      return specfem::point::properties<value_type, property_type>(
-          lambdaplus2mu_inverse(ispec, iz, ix), rho_inverse(ispec, iz, ix),
-          kappa(ispec, iz, ix));
-    } else {
-      return specfem::point::properties<value_type, property_type>(
-          h_lambdaplus2mu_inverse(ispec, iz, ix), h_rho_inverse(ispec, iz, ix),
-          h_kappa(ispec, iz, ix));
-    }
+  load_device_properties(const int &ispec, const int &iz, const int &ix) const {
+    return specfem::point::properties<value_type, property_type>(
+        lambdaplus2mu_inverse(ispec, iz, ix), rho_inverse(ispec, iz, ix),
+        kappa(ispec, iz, ix));
+  }
+
+  specfem::point::properties<value_type, property_type>
+  load_host_properties(const int &ispec, const int &iz, const int &ix) const {
+    return specfem::point::properties<value_type, property_type>(
+        h_lambdaplus2mu_inverse(ispec, iz, ix), h_rho_inverse(ispec, iz, ix),
+        h_kappa(ispec, iz, ix));
   }
 
   void copy_to_device() {

--- a/include/compute/properties/properties.hpp
+++ b/include/compute/properties/properties.hpp
@@ -41,6 +41,7 @@ struct properties {
       h_element_types; ///< Element types
   specfem::kokkos::HostMirror1d<specfem::enums::element::property_tag>
       h_element_property; ///< Element properties
+
   specfem::compute::impl::properties::material_property<
       specfem::enums::element::type::elastic,
       specfem::enums::element::property_tag::isotropic>
@@ -51,35 +52,41 @@ struct properties {
       acoustic_isotropic;
 
   template <specfem::enums::element::type type,
-            specfem::enums::element::property_tag property, typename ExecSpace>
+            specfem::enums::element::property_tag property>
   KOKKOS_FUNCTION specfem::point::properties<type, property>
-  load_properties(const int ispec, const int iz, const int ix) const {
-    const specfem::compute::impl::properties::properties_container<type,
-                                                                   property>
-        container = [&]() {
-          if constexpr ((type == specfem::enums::element::type::elastic) &&
-                        (property ==
-                         specfem::enums::element::property_tag::isotropic)) {
-            return elastic_isotropic;
-          } else if constexpr ((type ==
-                                specfem::enums::element::type::acoustic) &&
-                               (property == specfem::enums::element::
-                                                property_tag::isotropic)) {
-            return acoustic_isotropic;
-          } else {
-            static_assert("Material type not implemented");
-          }
-        }();
+  load_device_properties(const int ispec, const int iz, const int ix) const {
+    const int index = property_index_mapping(ispec);
 
-    const int index = [&]() {
-      if constexpr (std::is_same_v<ExecSpace, specfem::kokkos::DevExecSpace>) {
-        return property_index_mapping(ispec);
-      } else {
-        return h_property_index_mapping(ispec);
-      }
-    }();
+    if constexpr ((type == specfem::enums::element::type::elastic) &&
+                  (property ==
+                   specfem::enums::element::property_tag::isotropic)) {
+      return elastic_isotropic.load_device_properties(index, iz, ix);
+    } else if constexpr ((type == specfem::enums::element::type::acoustic) &&
+                         (property ==
+                          specfem::enums::element::property_tag::isotropic)) {
+      return acoustic_isotropic.load_device_properties(index, iz, ix);
+    } else {
+      static_assert("Material type not implemented");
+    }
+  }
 
-    return container.template load_properties<ExecSpace>(index, iz, ix);
+  template <specfem::enums::element::type type,
+            specfem::enums::element::property_tag property>
+  specfem::point::properties<type, property>
+  load_host_properties(const int ispec, const int iz, const int ix) const {
+    const int index = h_property_index_mapping(ispec);
+
+    if constexpr ((type == specfem::enums::element::type::elastic) &&
+                  (property ==
+                   specfem::enums::element::property_tag::isotropic)) {
+      return elastic_isotropic.load_host_properties(index, iz, ix);
+    } else if constexpr ((type == specfem::enums::element::type::acoustic) &&
+                         (property ==
+                          specfem::enums::element::property_tag::isotropic)) {
+      return acoustic_isotropic.load_host_properties(index, iz, ix);
+    } else {
+      static_assert("Material type not implemented");
+    }
   }
 
   properties() = default;

--- a/include/compute/properties/properties.hpp
+++ b/include/compute/properties/properties.hpp
@@ -35,8 +35,12 @@ struct properties {
                                                                ///< properties
   specfem::kokkos::DeviceView1d<specfem::enums::element::type>
       element_types; ///< Element types
+  specfem::kokkos::DeviceView1d<specfem::enums::element::property_tag>
+      element_property; ///< Element properties
   specfem::kokkos::HostMirror1d<specfem::enums::element::type>
       h_element_types; ///< Element types
+  specfem::kokkos::HostMirror1d<specfem::enums::element::property_tag>
+      h_element_property; ///< Element properties
   specfem::compute::impl::properties::material_property<
       specfem::enums::element::type::elastic,
       specfem::enums::element::property_tag::isotropic>
@@ -45,6 +49,38 @@ struct properties {
       specfem::enums::element::type::acoustic,
       specfem::enums::element::property_tag::isotropic>
       acoustic_isotropic;
+
+  template <specfem::enums::element::type type,
+            specfem::enums::element::property_tag property, typename ExecSpace>
+  KOKKOS_FUNCTION specfem::point::properties<type, property>
+  load_properties(const int ispec, const int iz, const int ix) const {
+    const specfem::compute::impl::properties::properties_container<type,
+                                                                   property>
+        container = [&]() {
+          if constexpr ((type == specfem::enums::element::type::elastic) &&
+                        (property ==
+                         specfem::enums::element::property_tag::isotropic)) {
+            return elastic_isotropic;
+          } else if constexpr ((type ==
+                                specfem::enums::element::type::acoustic) &&
+                               (property == specfem::enums::element::
+                                                property_tag::isotropic)) {
+            return acoustic_isotropic;
+          } else {
+            static_assert("Material type not implemented");
+          }
+        }();
+
+    const int index = [&]() {
+      if constexpr (std::is_same_v<ExecSpace, specfem::kokkos::DevExecSpace>) {
+        return property_index_mapping(ispec);
+      } else {
+        return h_property_index_mapping(ispec);
+      }
+    }();
+
+    return container.template load_properties<ExecSpace>(index, iz, ix);
+  }
 
   properties() = default;
 

--- a/include/coupled_interface/coupled_interface.hpp
+++ b/include/coupled_interface/coupled_interface.hpp
@@ -15,76 +15,43 @@ namespace coupled_interface {
  * @tparam self_domain_type Primary domain of the interface.
  * @tparam coupled_domain_type Coupled domain of the interface.
  */
-template <class self_domain_type, class coupled_domain_type>
-class coupled_interface {
+template <class self_medium, class coupled_medium> class coupled_interface {
 public:
-  /**
-   * @brief Typedefs
-   *
-   */
-  ///@{
-  /**
-   * @brief Self medium type.
-   *
-   */
-  using self_medium = typename self_domain_type::medium_type;
-  /**
-   * @brief Coupled medium type.
-   *
-   */
-  using coupled_medium = typename coupled_domain_type::medium_type;
-  /**
-   * @brief Quadrature points object to define the quadrature points either at
-   * compile time or run time.
-   *
-   */
-  using quadrature_points_type =
-      typename self_domain_type::quadrature_points_type;
-  ///@}
+  using self_medium_type = self_medium;
+  using coupled_medium_type = coupled_medium;
 
-  /**
-   * @brief Construct a new coupled interface object
-   *
-   * @param self_domain Primary domain of the interface.
-   * @param coupled_domain Coupled domain of the interface.
-   * @param coupled_interfaces struct containing the coupling information.
-   * @param quadrature_points A quadrature points object defining the quadrature
-   * points either at compile time or run time.
-   * @param partial_derivatives struct containing the partial derivatives.
-   * @param ibool Global index of the GLL points.
-   * @param wxgll weights for the GLL quadrature points in the x direction.
-   * @param wzgll weights for the GLL quadrature points in the z direction.
-   */
-  coupled_interface(
-      self_domain_type &self_domain, coupled_domain_type &coupled_domain,
-      const specfem::compute::coupled_interfaces::coupled_interfaces
-          &coupled_interfaces,
-      const quadrature_points_type &quadrature_points,
-      const specfem::compute::partial_derivatives &partial_derivatives,
-      const specfem::kokkos::DeviceView3d<int> ibool,
-      const specfem::kokkos::DeviceView1d<type_real> wxgll,
-      const specfem::kokkos::DeviceView1d<type_real> wzgll);
+  static_assert(std::is_same_v<self_medium_type, coupled_medium_type> == false,
+                "Error: self_medium cannot be equal to coupled_medium");
 
-  /**
-   * @brief Compute the coupling between the primary and coupled domains.
-   *
-   */
+  static_assert(((std::is_same_v<self_medium_type,
+                                 specfem::enums::element::medium::elastic> &&
+                  std::is_same_v<coupled_medium_type,
+                                 specfem::enums::element::medium::acoustic>) ||
+                 (std::is_same_v<self_medium_type,
+                                 specfem::enums::element::medium::acoustic> &&
+                  std::is_same_v<coupled_medium_type,
+                                 specfem::enums::element::medium::elastic>)),
+                "Only acoustic-elastic coupling is supported at the moment.");
+
+  coupled_interface(const specfem::compute::assembly &assembly);
+
   void compute_coupling();
 
 private:
   int nedges; ///< Number of edges in the interface.
-  specfem::kokkos::DeviceView1d<specfem::enums::edge::type>
-      self_edge; ///< Orientation of the edge of the primary domain.
-  specfem::kokkos::DeviceView1d<specfem::enums::edge::type>
-      coupled_edge; ///< Orientation of the edge of the coupled domain.
-  self_domain_type self_domain;       ///< Primary domain of the interface.
-  coupled_domain_type coupled_domain; ///< Coupled domain of the interface.
-  quadrature_points_type quadrature_points; ///< Quadrature points object to
-                                            ///< define the quadrature points
-                                            ///< either at compile time or run
-                                            ///< time.
-  specfem::coupled_interface::impl::edges::edge<self_domain_type,
-                                                coupled_domain_type>
+  specfem::compute::points points;
+  specfem::compute::quadrature quadrature;
+  specfem::compute::partial_derivatives partial_derivatives;
+  Kokkos::View<int * [specfem::enums::element::ntypes], Kokkos::LayoutLeft,
+               specfem::kokkos::DevMemSpace>
+      global_index_mapping;
+  specfem::compute::impl::field_impl<self_medium_type> self_field;
+  specfem::compute::impl::field_impl<coupled_medium_type> coupled_field;
+  specfem::compute::interface_container<self_medium_type::value,
+                                        coupled_medium_type::value>
+      interface_data; ///< Struct containing the coupling information.
+  specfem::coupled_interface::impl::edges::edge<self_medium_type,
+                                                coupled_medium_type>
       edge; ///< Edge class to implement coupling physics
 };
 } // namespace coupled_interface

--- a/include/coupled_interface/impl/edge/edge.hpp
+++ b/include/coupled_interface/impl/edge/edge.hpp
@@ -11,94 +11,37 @@ namespace impl {
 namespace edges {
 
 /**
- * @brief Wrapper for iterator class to iterate through points on the primary
- * domain of a coupled interface.
- *
- */
-struct self_iterator {
-  int ngllx; ///< Number of GLL points in the x direction.
-  int ngllz; ///< Number of GLL points in the z direction.
-
-  self_iterator() = default;
-
-  /**
-   * @brief Construct a new self iterator object
-   *
-   * @param ngllx ///< Number of GLL points in the x direction.
-   * @param ngllz ///< Number of GLL points in the z direction.
-   */
-  self_iterator(const int &ngllx, const int &ngllz)
-      : ngllx(ngllx), ngllz(ngllz){};
-
-  /**
-   * @brief Operator to iterate through points on the primary domain of a
-   * coupled interface.
-   *
-   * @param ipoint Index of the point on the edge of the primary domain.
-   * @param iedge_type Type of the edge of the primary domain.
-   * @param i X index of the quadrature point inside the element of the primary
-   * domain which forms the edge.
-   * @param j Z index of the quadrature point inside the element of the coupled
-   * domain which forms the edge.
-   */
-  KOKKOS_FUNCTION
-  void operator()(const int &ipoint,
-                  const specfem::enums::edge::type &iedge_type, int &i,
-                  int &j) const {
-    specfem::compute::coupled_interfaces::access::self_iterator(
-        ipoint, iedge_type, this->ngllx, this->ngllz, i, j);
-    return;
-  }
-};
-
-/**
- * @brief Wrapper for iterator class to iterate through points on the coupled
- * domain of a coupled interface.
- *
- */
-struct coupled_iterator {
-  int ngllx; ///< Number of GLL points in the x direction.
-  int ngllz; ///< Number of GLL points in the z direction.
-
-  coupled_iterator() = default;
-
-  /**
-   * @brief Construct a new coupled iterator object
-   *
-   * @param ngllx Number of GLL points in the x direction.
-   * @param ngllz Number of GLL points in the z direction.
-   */
-  coupled_iterator(const int &ngllx, const int &ngllz)
-      : ngllx(ngllx), ngllz(ngllz){};
-
-  /**
-   * @brief Operator to iterate through points on the coupled domain of a
-   * coupled interface.
-   *
-   * @param ipoint Index of the point on the edge of the coupled domain.
-   * @param iedge_type Type of the edge of the coupled domain.
-   * @param i X index of the quadrature point inside the element of the coupled
-   * domain which forms the edge.
-   * @param j Z index of the quadrature point inside the element of the coupled
-   * domain which forms the edge.
-   */
-  KOKKOS_FUNCTION
-  void operator()(const int &ipoint,
-                  const specfem::enums::edge::type &iedge_type, int &i,
-                  int &j) const {
-    specfem::compute::coupled_interfaces::access::coupled_iterator(
-        ipoint, iedge_type, this->ngllx, this->ngllz, i, j);
-    return;
-  }
-};
-
-/**
  * @brief Coupling edge class to define coupling physics between 2 domains.
  *
  * @tparam self_domain Primary domain of the interface.
  * @tparam coupled_domain Coupled domain of the interface.
  */
-template <class self_domain, class coupled_domain> class edge {};
+template <class self_medium, class coupled_medium> class edge {
+
+public:
+  using self_medium_type = self_medium;
+  using coupled_medium_type = coupled_medium;
+
+  edge(){};
+
+  edge(const specfem::compute::assembly &assembly){};
+
+  KOKKOS_FUNCTION
+  specfem::kokkos::array_type<type_real, self_medium_type::components>
+  compute_coupling_terms(
+      const specfem::kokkos::array_type<type_real, 2> &normal,
+      const specfem::kokkos::array_type<type_real, 2> &weights,
+      const specfem::edge::interface &coupled_edge_type,
+      const specfem::kokkos::array_type<
+          type_real, coupled_medium_type::components> &field) const;
+
+  KOKKOS_FUNCTION
+  specfem::kokkos::array_type<type_real, coupled_medium_type::components>
+  load_field_elements(
+      const int global_index,
+      const specfem::compute::impl::field_impl<coupled_medium_type> &field)
+      const;
+};
 } // namespace edges
 } // namespace impl
 } // namespace coupled_interface

--- a/include/coupled_interface/impl/edge/elastic_acoustic/acoustic_elastic.tpp
+++ b/include/coupled_interface/impl/edge/elastic_acoustic/acoustic_elastic.tpp
@@ -183,13 +183,16 @@ specfem::coupled_interface::impl::edges::edge<
     switch (coupled_edge.type) {
     case specfem::enums::edge::type::LEFT:
     case specfem::enums::edge::type::RIGHT:
-      return weights[1];
+      return -1.0 * weights[1];
+      break;
     case specfem::enums::edge::type::BOTTOM:
     case specfem::enums::edge::type::TOP:
-      return weights[0];
+      return -1.0 * weights[0];
+      break;
     default:
       ASSERT(false, "Invalid edge type");
       return 0.0;
+      break;
     }
   }();
 

--- a/include/coupled_interface/impl/edge/elastic_acoustic/acoustic_elastic.tpp
+++ b/include/coupled_interface/impl/edge/elastic_acoustic/acoustic_elastic.tpp
@@ -3,145 +3,199 @@
 
 #include "compute/interface.hpp"
 #include "coupled_interface/impl/edge/edge.hpp"
-#include "coupled_interface/impl/edge/elastic_acoustic/acoustic_elastic.hpp"
+// #include "coupled_interface/impl/edge/elastic_acoustic/acoustic_elastic.hpp"
 #include "domain/interface.hpp"
+#include "enumerations/interface.hpp"
 #include "kokkos_abstractions.h"
 #include "macros.hpp"
-#include "enumerations/interface.hpp"
 #include "specfem_setup.hpp"
 #include <Kokkos_Core.hpp>
 
-template <typename qp_type>
+// template <typename qp_type>
+// specfem::coupled_interface::impl::edges::edge<
+//     specfem::domain::domain<specfem::enums::element::medium::acoustic,
+//     qp_type>,
+//     specfem::domain::domain<specfem::enums::element::medium::elastic,
+//                             qp_type> >::
+//     edge(const specfem::domain::domain<
+//              specfem::enums::element::medium::acoustic, qp_type>
+//              &self_domain,
+//          const
+//          specfem::domain::domain<specfem::enums::element::medium::elastic,
+//                                        qp_type> &coupled_domain,
+//          const qp_type &quadrature_points,
+//          const specfem::compute::coupled_interfaces::coupled_interfaces
+//              &coupled_interfaces,
+//          const specfem::compute::partial_derivatives &partial_derivatives,
+//          const specfem::kokkos::DeviceView1d<type_real> wxgll,
+//          const specfem::kokkos::DeviceView1d<type_real> wzgll,
+//          const specfem::kokkos::DeviceView3d<int> ibool)
+//     : acoustic_ispec(coupled_interfaces.elastic_acoustic.acoustic_ispec),
+//       elastic_ispec(coupled_interfaces.elastic_acoustic.elastic_ispec),
+//       acoustic_edge(coupled_interfaces.elastic_acoustic.acoustic_edge),
+//       elastic_edge(coupled_interfaces.elastic_acoustic.elastic_edge),
+//       ibool(ibool), xix(partial_derivatives.xix),
+//       xiz(partial_derivatives.xiz), gammax(partial_derivatives.gammax),
+//       gammaz(partial_derivatives.gammaz),
+//       jacobian(partial_derivatives.jacobian),
+//       self_field_dot_dot(self_domain.get_field_dot_dot()),
+//       coupled_field(coupled_domain.get_field()),
+//       quadrature_points(quadrature_points), wxgll(wxgll), wzgll(wzgll) {
+
+//   int ngllx, ngllz;
+//   quadrature_points.get_ngll(&ngllx, &ngllz);
+
+// #ifndef NDEBUG
+//   assert(ibool.extent(1) == ngllz);
+//   assert(ibool.extent(2) == ngllx);
+//   assert(partial_derivatives.xix.extent(1) == ngllz);
+//   assert(partial_derivatives.xix.extent(2) == ngllx);
+//   assert(partial_derivatives.xiz.extent(1) == ngllz);
+//   assert(partial_derivatives.xiz.extent(2) == ngllx);
+//   assert(partial_derivatives.gammax.extent(1) == ngllz);
+//   assert(partial_derivatives.gammax.extent(2) == ngllx);
+//   assert(partial_derivatives.gammaz.extent(1) == ngllz);
+//   assert(partial_derivatives.gammaz.extent(2) == ngllx);
+//   assert(partial_derivatives.jacobian.extent(1) == ngllz);
+//   assert(partial_derivatives.jacobian.extent(2) == ngllx);
+//   assert(wxgll.extent(0) == ngllx);
+//   assert(wzgll.extent(0) == ngllz);
+// #endif
+
+//   self_iterator =
+//       specfem::coupled_interface::impl::edges::self_iterator(ngllx, ngllz);
+
+//   coupled_iterator =
+//       specfem::coupled_interface::impl::edges::coupled_iterator(ngllx,
+//       ngllz);
+
+// #ifndef NDEBUG
+//   assert(self_field_dot_dot.extent(1) == self_medium::components);
+//   assert(coupled_field.extent(1) == coupled_medium::components);
+// #endif
+
+//   return;
+// }
+
+// template <typename qp_type>
+// KOKKOS_FUNCTION void specfem::coupled_interface::impl::edges::edge<
+//     specfem::domain::domain<specfem::enums::element::medium::acoustic,
+//     qp_type>,
+//     specfem::domain::domain<specfem::enums::element::medium::elastic,
+//                             qp_type> >::compute_coupling(const int &iedge,
+//                                                          const int &ipoint)
+//     const {
+
+//   int ngllx, ngllz;
+//   quadrature_points.get_ngll(&ngllx, &ngllz);
+
+//   const auto acoustic_edge_type = this->acoustic_edge(iedge);
+//   const auto elastic_edge_type = this->elastic_edge(iedge);
+
+//   const int acoustic_ispec_l = this->acoustic_ispec(iedge);
+//   const int elastic_ispec_l = this->elastic_ispec(iedge);
+
+//   int ix, iz;
+//   coupled_iterator(ipoint, elastic_edge_type, ix, iz);
+
+//   int iglob = ibool(elastic_ispec_l, iz, ix);
+//   const type_real displ_x = coupled_field(iglob, 0);
+//   const type_real displ_z = coupled_field(iglob, 1);
+
+//   type_real val;
+
+//   switch (acoustic_edge_type) {
+//   case specfem::enums::edge::type::LEFT:
+//     self_iterator(ipoint, acoustic_edge_type, ix, iz);
+//     iglob = ibool(acoustic_ispec_l, iz, ix);
+//     val = -1.0 * wzgll(iz) *
+//           (xix(acoustic_ispec_l, iz, ix) * jacobian(acoustic_ispec_l, iz, ix)
+//           *
+//                displ_x +
+//            xiz(acoustic_ispec_l, iz, ix) * jacobian(acoustic_ispec_l, iz, ix)
+//            *
+//                displ_z);
+//     Kokkos::atomic_add(&self_field_dot_dot(iglob, 0), val);
+//     break;
+//   case specfem::enums::edge::type::RIGHT:
+//     self_iterator(ipoint, acoustic_edge_type, ix, iz);
+//     iglob = ibool(acoustic_ispec_l, iz, ix);
+//     val = wzgll(iz) * (xix(acoustic_ispec_l, iz, ix) *
+//                           jacobian(acoustic_ispec_l, iz, ix) * displ_x +
+//                       xiz(acoustic_ispec_l, iz, ix) *
+//                           jacobian(acoustic_ispec_l, iz, ix) * displ_z);
+//     Kokkos::atomic_add(&self_field_dot_dot(iglob, 0), val);
+//     break;
+//   case specfem::enums::edge::type::BOTTOM:
+//     self_iterator(ipoint, acoustic_edge_type, ix, iz);
+//     iglob = ibool(acoustic_ispec_l, iz, ix);
+//     val = -1.0 * wxgll(ix) *
+//           (gammax(acoustic_ispec_l, iz, ix) *
+//                jacobian(acoustic_ispec_l, iz, ix) * displ_x +
+//            gammaz(acoustic_ispec_l, iz, ix) *
+//                jacobian(acoustic_ispec_l, iz, ix) * displ_z);
+//     Kokkos::atomic_add(&self_field_dot_dot(iglob, 0), val);
+//     break;
+//   case specfem::enums::edge::type::TOP:
+//     self_iterator(ipoint, acoustic_edge_type, ix, iz);
+//     iglob = ibool(acoustic_ispec_l, iz, ix);
+//     val = wxgll(ix) * (gammax(acoustic_ispec_l, iz, ix) *
+//                           jacobian(acoustic_ispec_l, iz, ix) * displ_x +
+//                       gammaz(acoustic_ispec_l, iz, ix) *
+//                           jacobian(acoustic_ispec_l, iz, ix) * displ_z);
+//     Kokkos::atomic_add(&self_field_dot_dot(iglob, 0), val);
+//     break;
+//   default:
+//     break;
+//   }
+
+//   return;
+// }
+
+template <>
+KOKKOS_FUNCTION specfem::kokkos::array_type<type_real, 2>
 specfem::coupled_interface::impl::edges::edge<
-    specfem::domain::domain<specfem::enums::element::medium::acoustic, qp_type>,
-    specfem::domain::domain<specfem::enums::element::medium::elastic,
-                            qp_type> >::
-    edge(const specfem::domain::domain<
-             specfem::enums::element::medium::acoustic, qp_type> &self_domain,
-         const specfem::domain::domain<specfem::enums::element::medium::elastic,
-                                       qp_type> &coupled_domain,
-         const qp_type &quadrature_points,
-         const specfem::compute::coupled_interfaces::coupled_interfaces
-             &coupled_interfaces,
-         const specfem::compute::partial_derivatives &partial_derivatives,
-         const specfem::kokkos::DeviceView1d<type_real> wxgll,
-         const specfem::kokkos::DeviceView1d<type_real> wzgll,
-         const specfem::kokkos::DeviceView3d<int> ibool)
-    : acoustic_ispec(coupled_interfaces.elastic_acoustic.acoustic_ispec),
-      elastic_ispec(coupled_interfaces.elastic_acoustic.elastic_ispec),
-      acoustic_edge(coupled_interfaces.elastic_acoustic.acoustic_edge),
-      elastic_edge(coupled_interfaces.elastic_acoustic.elastic_edge),
-      ibool(ibool), xix(partial_derivatives.xix), xiz(partial_derivatives.xiz),
-      gammax(partial_derivatives.gammax), gammaz(partial_derivatives.gammaz),
-      jacobian(partial_derivatives.jacobian),
-      self_field_dot_dot(self_domain.get_field_dot_dot()),
-      coupled_field(coupled_domain.get_field()),
-      quadrature_points(quadrature_points), wxgll(wxgll), wzgll(wzgll) {
+    specfem::enums::element::medium::acoustic,
+    specfem::enums::element::medium::elastic>::
+    load_field_elements(
+        const int coupled_global_index,
+        const specfem::compute::impl::field_impl<coupled_medium_type>
+            &coupled_field) const {
 
-  int ngllx, ngllz;
-  quadrature_points.get_ngll(&ngllx, &ngllz);
-
-#ifndef NDEBUG
-  assert(ibool.extent(1) == ngllz);
-  assert(ibool.extent(2) == ngllx);
-  assert(partial_derivatives.xix.extent(1) == ngllz);
-  assert(partial_derivatives.xix.extent(2) == ngllx);
-  assert(partial_derivatives.xiz.extent(1) == ngllz);
-  assert(partial_derivatives.xiz.extent(2) == ngllx);
-  assert(partial_derivatives.gammax.extent(1) == ngllz);
-  assert(partial_derivatives.gammax.extent(2) == ngllx);
-  assert(partial_derivatives.gammaz.extent(1) == ngllz);
-  assert(partial_derivatives.gammaz.extent(2) == ngllx);
-  assert(partial_derivatives.jacobian.extent(1) == ngllz);
-  assert(partial_derivatives.jacobian.extent(2) == ngllx);
-  assert(wxgll.extent(0) == ngllx);
-  assert(wzgll.extent(0) == ngllz);
-#endif
-
-  self_iterator =
-      specfem::coupled_interface::impl::edges::self_iterator(ngllx, ngllz);
-
-  coupled_iterator =
-      specfem::coupled_interface::impl::edges::coupled_iterator(ngllx, ngllz);
-
-#ifndef NDEBUG
-  assert(self_field_dot_dot.extent(1) == self_medium::components);
-  assert(coupled_field.extent(1) == coupled_medium::components);
-#endif
-
-  return;
+  return specfem::kokkos::array_type<type_real, 2>(
+      coupled_field.field(coupled_global_index, 0),
+      coupled_field.field(coupled_global_index, 1));
 }
 
-template <typename qp_type>
-KOKKOS_FUNCTION void specfem::coupled_interface::impl::edges::edge<
-    specfem::domain::domain<specfem::enums::element::medium::acoustic, qp_type>,
-    specfem::domain::domain<specfem::enums::element::medium::elastic,
-                            qp_type> >::compute_coupling(const int &iedge,
-                                                         const int &ipoint)
-    const {
+template <>
+KOKKOS_FUNCTION specfem::kokkos::array_type<type_real, 1>
+specfem::coupled_interface::impl::edges::edge<
+    specfem::enums::element::medium::acoustic,
+    specfem::enums::element::medium::elastic>::
+    compute_coupling_terms(
+        const specfem::kokkos::array_type<type_real, 2> &normal,
+        const specfem::kokkos::array_type<type_real, 2> &weights,
+        const specfem::edge::interface &coupled_edge,
+        const specfem::kokkos::array_type<type_real, 2> &coupled_field_elements)
+        const {
 
-  int ngllx, ngllz;
-  quadrature_points.get_ngll(&ngllx, &ngllz);
+  const type_real factor = [&]() -> type_real {
+    switch (coupled_edge.type) {
+    case specfem::enums::edge::type::LEFT:
+    case specfem::enums::edge::type::RIGHT:
+      return weights[1];
+    case specfem::enums::edge::type::BOTTOM:
+    case specfem::enums::edge::type::TOP:
+      return weights[0];
+    default:
+      ASSERT(false, "Invalid edge type");
+      return 0.0;
+    }
+  }();
 
-  const auto acoustic_edge_type = this->acoustic_edge(iedge);
-  const auto elastic_edge_type = this->elastic_edge(iedge);
-
-  const int acoustic_ispec_l = this->acoustic_ispec(iedge);
-  const int elastic_ispec_l = this->elastic_ispec(iedge);
-
-  int ix, iz;
-  coupled_iterator(ipoint, elastic_edge_type, ix, iz);
-
-  int iglob = ibool(elastic_ispec_l, iz, ix);
-  const type_real displ_x = coupled_field(iglob, 0);
-  const type_real displ_z = coupled_field(iglob, 1);
-
-  type_real val;
-
-  switch (acoustic_edge_type) {
-  case specfem::enums::edge::type::LEFT:
-    self_iterator(ipoint, acoustic_edge_type, ix, iz);
-    iglob = ibool(acoustic_ispec_l, iz, ix);
-    val = -1.0 * wzgll(iz) *
-          (xix(acoustic_ispec_l, iz, ix) * jacobian(acoustic_ispec_l, iz, ix) *
-               displ_x +
-           xiz(acoustic_ispec_l, iz, ix) * jacobian(acoustic_ispec_l, iz, ix) *
-               displ_z);
-    Kokkos::atomic_add(&self_field_dot_dot(iglob, 0), val);
-    break;
-  case specfem::enums::edge::type::RIGHT:
-    self_iterator(ipoint, acoustic_edge_type, ix, iz);
-    iglob = ibool(acoustic_ispec_l, iz, ix);
-    val = wzgll(iz) * (xix(acoustic_ispec_l, iz, ix) *
-                          jacobian(acoustic_ispec_l, iz, ix) * displ_x +
-                      xiz(acoustic_ispec_l, iz, ix) *
-                          jacobian(acoustic_ispec_l, iz, ix) * displ_z);
-    Kokkos::atomic_add(&self_field_dot_dot(iglob, 0), val);
-    break;
-  case specfem::enums::edge::type::BOTTOM:
-    self_iterator(ipoint, acoustic_edge_type, ix, iz);
-    iglob = ibool(acoustic_ispec_l, iz, ix);
-    val = -1.0 * wxgll(ix) *
-          (gammax(acoustic_ispec_l, iz, ix) *
-               jacobian(acoustic_ispec_l, iz, ix) * displ_x +
-           gammaz(acoustic_ispec_l, iz, ix) *
-               jacobian(acoustic_ispec_l, iz, ix) * displ_z);
-    Kokkos::atomic_add(&self_field_dot_dot(iglob, 0), val);
-    break;
-  case specfem::enums::edge::type::TOP:
-    self_iterator(ipoint, acoustic_edge_type, ix, iz);
-    iglob = ibool(acoustic_ispec_l, iz, ix);
-    val = wxgll(ix) * (gammax(acoustic_ispec_l, iz, ix) *
-                          jacobian(acoustic_ispec_l, iz, ix) * displ_x +
-                      gammaz(acoustic_ispec_l, iz, ix) *
-                          jacobian(acoustic_ispec_l, iz, ix) * displ_z);
-    Kokkos::atomic_add(&self_field_dot_dot(iglob, 0), val);
-    break;
-  default:
-    break;
-  }
-
-  return;
+  return specfem::kokkos::array_type<type_real, 1>(
+      factor * (normal[0] * coupled_field_elements[0] +
+                normal[1] * coupled_field_elements[1]));
 }
 
 #endif // _COUPLED_INTERFACE_IMPL_ACOUSTIC_ELASTIC_TPP

--- a/include/coupled_interface/impl/edge/elastic_acoustic/elastic_acoustic.hpp
+++ b/include/coupled_interface/impl/edge/elastic_acoustic/elastic_acoustic.hpp
@@ -18,36 +18,13 @@ namespace edges {
  *
  * @tparam qp_type Quadrature points type.
  */
-template <typename qp_type>
-class edge<
-    specfem::domain::domain<specfem::enums::element::medium::elastic, qp_type>,
-    specfem::domain::domain<specfem::enums::element::medium::acoustic,
-                            qp_type> > {
+template <>
+class edge<specfem::enums::element::medium::elastic,
+           specfem::enums::element::medium::acoustic> {
 
 public:
-  /**
-   * @name Typedefs
-   *
-   */
-  ///@{
-  /**
-   * @brief Self medium type.
-   */
-  using self_medium =
-      typename specfem::domain::domain<specfem::enums::element::medium::elastic,
-                                       qp_type>::medium_type;
-  /**
-   * @brief Coupled medium type.
-   *
-   */
-  using coupled_medium = typename specfem::domain::domain<
-      specfem::enums::element::medium::acoustic, qp_type>::medium_type;
-  /**
-   * @brief Quadrature points type.
-   *
-   */
-  using quadrature_points_type = qp_type;
-  ///@}
+  using self_medium_type = specfem::enums::element::medium::elastic;
+  using coupled_medium_type = specfem::enums::element::medium::acoustic;
 
   edge(){};
 
@@ -64,17 +41,7 @@ public:
    * @param wzgll weights for the GLL quadrature points in the z direction.
    * @param ibool Global indexing for all GLL points
    */
-  edge(const specfem::domain::domain<specfem::enums::element::medium::elastic,
-                                     qp_type> &self_domain,
-       const specfem::domain::domain<specfem::enums::element::medium::acoustic,
-                                     qp_type> &coupled_domain,
-       const qp_type &quadrature_points,
-       const specfem::compute::coupled_interfaces::coupled_interfaces
-           &coupled_interfaces,
-       const specfem::compute::partial_derivatives &partial_derivatives,
-       const specfem::kokkos::DeviceView1d<type_real> wxgll,
-       const specfem::kokkos::DeviceView1d<type_real> wzgll,
-       const specfem::kokkos::DeviceView3d<int> ibool);
+  edge(const specfem::compute::assembly &assembly){};
 
   /**
    * @brief Compute coupling interaction between domains
@@ -82,59 +49,69 @@ public:
    * @param iedge Index of the edge.
    * @param ipoint Index of the quadrature point on the edge.
    */
-  KOKKOS_FUNCTION
-  void compute_coupling(const int &iedge, const int &ipoint) const;
+  KOKKOS_FUNCTION specfem::kokkos::array_type<type_real, 2>
+  specfem::coupled_interface::impl::edges::edge<
+      specfem::enums::element::medium::elastic,
+      specfem::enums::element::medium::acoustic>::
+      compute_coupling_terms(
+          const specfem::kokkos::array_type<type_real, 2> &normal,
+          const specfem::kokkos::array_type<type_real, 2> &weights,
+          const specfem::enums::edge::type &coupled_edge_type,
+          const specfem::kokkos::array_type<type_real, 1> &pressure)
+          const const;
 
-  /**
-   * @brief Get the orientation of coupling edges
-   *
-   * @param iedge Index of the edge.
-   * @param self_edge_type Orientation of edge in primary domain.
-   * @param coupled_edge_type Orientation of edge in coupled domain.
-   */
-  KOKKOS_FUNCTION void
-  get_edges(const int &iedge, specfem::enums::edge::type &self_edge_type,
-            specfem::enums::edge::type &coupled_edge_type) const {
-    self_edge_type = this->elastic_edge(iedge);
-    coupled_edge_type = this->acoustic_edge(iedge);
-    return;
-  }
+  KOKKOS_FUNCTION specfem::kokkos::array_type<type_real, 1>
+  specfem::coupled_interface::impl::edges::edge<
+      specfem::enums::element::medium::elastic,
+      specfem::enums::element::medium::acoustic>::
+      load_field_elements(
+          const int coupled_global_index,
+          const specfem::compute::impl::field_impl<coupled_medium_type>
+              &coupled_field) const;
 
 private:
-  specfem::kokkos::DeviceView1d<int> acoustic_ispec; ///< Index of acoustic
-                                                     ///< elements on the edge
-  specfem::kokkos::DeviceView1d<int> elastic_ispec;  ///< Index of elastic
-                                                     ///< elements on the edge
-  specfem::kokkos::DeviceView3d<int> ibool;     ///< Global indexing for all GLL
-                                                ///< points
-  specfem::kokkos::DeviceView3d<type_real> xix; ///< xix
-  specfem::kokkos::DeviceView3d<type_real> xiz; ///< xiz
-  specfem::kokkos::DeviceView3d<type_real> gammax;   ///< gammax
-  specfem::kokkos::DeviceView3d<type_real> gammaz;   ///< gammaz
-  specfem::kokkos::DeviceView3d<type_real> jacobian; ///< Jacobian
-  specfem::kokkos::DeviceView1d<specfem::enums::edge::type>
-      acoustic_edge; ///< Orientation of edge in acoustic domain
-  specfem::kokkos::DeviceView1d<specfem::enums::edge::type>
-      elastic_edge; ///< Orientation of edge in elastic domain
-  specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
-      self_field_dot_dot; ///< Acceleration in elastic domain
-  specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
-      coupled_field_dot_dot; ///< Second derivative of potential in acoustic
-                             ///< domain
-  qp_type quadrature_points; ///< Quadrature points object to define quadrature
-                             ///< points at compile time or run time
-  specfem::kokkos::DeviceView1d<type_real> wxgll; ///< Weights for the GLL
-                                                  ///< quadrature points in the
-                                                  ///< x direction
-  specfem::kokkos::DeviceView1d<type_real> wzgll; ///< Weights for the GLL
-                                                  ///< quadrature points in the
-                                                  ///< z direction
+  //   specfem::kokkos::DeviceView1d<int> acoustic_ispec; ///< Index of acoustic
+  //                                                      ///< elements on the
+  //                                                      edge
+  //   specfem::kokkos::DeviceView1d<int> elastic_ispec;  ///< Index of elastic
+  //                                                      ///< elements on the
+  //                                                      edge
+  //   specfem::kokkos::DeviceView3d<int> ibool;     ///< Global indexing for
+  //   all GLL
+  //                                                 ///< points
+  //   specfem::kokkos::DeviceView3d<type_real> xix; ///< xix
+  //   specfem::kokkos::DeviceView3d<type_real> xiz; ///< xiz
+  //   specfem::kokkos::DeviceView3d<type_real> gammax;   ///< gammax
+  //   specfem::kokkos::DeviceView3d<type_real> gammaz;   ///< gammaz
+  //   specfem::kokkos::DeviceView3d<type_real> jacobian; ///< Jacobian
+  //   specfem::kokkos::DeviceView1d<specfem::enums::edge::type>
+  //       acoustic_edge; ///< Orientation of edge in acoustic domain
+  //   specfem::kokkos::DeviceView1d<specfem::enums::edge::type>
+  //       elastic_edge; ///< Orientation of edge in elastic domain
+  //   specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
+  //       self_field_dot_dot; ///< Acceleration in elastic domain
+  //   specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
+  //       coupled_field_dot_dot; ///< Second derivative of potential in
+  //       acoustic
+  //                              ///< domain
+  //   qp_type quadrature_points; ///< Quadrature points object to define
+  //   quadrature
+  //                              ///< points at compile time or run time
+  //   specfem::kokkos::DeviceView1d<type_real> wxgll; ///< Weights for the GLL
+  //                                                   ///< quadrature points in
+  //                                                   the
+  //                                                   ///< x direction
+  //   specfem::kokkos::DeviceView1d<type_real> wzgll; ///< Weights for the GLL
+  //                                                   ///< quadrature points in
+  //                                                   the
+  //                                                   ///< z direction
 
-  specfem::coupled_interface::impl::edges::self_iterator
-      self_iterator; ///< Iterator for points on the edge in the primary domain
-  specfem::coupled_interface::impl::edges::coupled_iterator
-      coupled_iterator; ///< Iterator for points on the edge in the coupled
-                        ///< domain
+  //   specfem::coupled_interface::impl::edges::self_iterator
+  //       self_iterator; ///< Iterator for points on the edge in the primary
+  //       domain
+  //   specfem::coupled_interface::impl::edges::coupled_iterator
+  //       coupled_iterator; ///< Iterator for points on the edge in the coupled
+  //                         ///< domain
 };
 } // namespace edges
 } // namespace impl

--- a/include/coupled_interface/impl/edge/elastic_acoustic/elastic_acoustic.tpp
+++ b/include/coupled_interface/impl/edge/elastic_acoustic/elastic_acoustic.tpp
@@ -183,13 +183,16 @@ specfem::coupled_interface::impl::edges::edge<
     switch (coupled_edge.type) {
     case specfem::enums::edge::type::LEFT:
     case specfem::enums::edge::type::RIGHT:
-      return weights[1];
+      return -1.0 * weights[1];
+      break;
     case specfem::enums::edge::type::BOTTOM:
     case specfem::enums::edge::type::TOP:
-      return weights[0];
+      return -1.0 * weights[0];
+      break;
     default:
       ASSERT(false, "Invalid edge type");
       return 0.0;
+      break;
     }
   }();
 

--- a/include/coupled_interface/impl/edge/elastic_acoustic/elastic_acoustic.tpp
+++ b/include/coupled_interface/impl/edge/elastic_acoustic/elastic_acoustic.tpp
@@ -3,148 +3,198 @@
 
 #include "compute/interface.hpp"
 #include "coupled_interface/impl/edge/edge.hpp"
-#include "coupled_interface/impl/edge/elastic_acoustic/elastic_acoustic.hpp"
+// #include "coupled_interface/impl/edge/elastic_acoustic/elastic_acoustic.hpp"
 #include "domain/interface.hpp"
+#include "enumerations/interface.hpp"
 #include "kokkos_abstractions.h"
 #include "macros.hpp"
-#include "enumerations/interface.hpp"
 #include "specfem_setup.hpp"
 #include <Kokkos_Core.hpp>
 
-template <typename qp_type>
+// template <typename qp_type>
+// specfem::coupled_interface::impl::edges::edge<
+//     specfem::domain::domain<specfem::enums::element::medium::elastic,
+//     qp_type>,
+//     specfem::domain::domain<specfem::enums::element::medium::acoustic,
+//                             qp_type> >::
+//     edge(const
+//     specfem::domain::domain<specfem::enums::element::medium::elastic,
+//                                       qp_type> &self_domain,
+//         const
+//         specfem::domain::domain<specfem::enums::element::medium::acoustic,
+//                                       qp_type> &coupled_domain,
+//         const qp_type &quadrature_points,
+//         const specfem::compute::coupled_interfaces::coupled_interfaces
+//             &coupled_interfaces,
+//         const specfem::compute::partial_derivatives &partial_derivatives,
+//         const specfem::kokkos::DeviceView1d<type_real> wxgll,
+//         const specfem::kokkos::DeviceView1d<type_real> wzgll,
+//         const specfem::kokkos::DeviceView3d<int> ibool)
+//     : acoustic_ispec(coupled_interfaces.elastic_acoustic.acoustic_ispec),
+//       elastic_ispec(coupled_interfaces.elastic_acoustic.elastic_ispec),
+//       acoustic_edge(coupled_interfaces.elastic_acoustic.acoustic_edge),
+//       elastic_edge(coupled_interfaces.elastic_acoustic.elastic_edge),
+//       ibool(ibool), xix(partial_derivatives.xix),
+//       xiz(partial_derivatives.xiz), gammax(partial_derivatives.gammax),
+//       gammaz(partial_derivatives.gammaz),
+//       jacobian(partial_derivatives.jacobian),
+//       self_field_dot_dot(self_domain.get_field_dot_dot()),
+//       coupled_field_dot_dot(coupled_domain.get_field_dot_dot()),
+//       quadrature_points(quadrature_points), wxgll(wxgll), wzgll(wzgll) {
+
+//   int ngllx, ngllz;
+//   quadrature_points.get_ngll(&ngllx, &ngllz);
+
+// #ifndef NDEBUG
+//   assert(ibool.extent(1) == ngllz);
+//   assert(ibool.extent(2) == ngllx);
+//   assert(partial_derivatives.xix.extent(1) == ngllz);
+//   assert(partial_derivatives.xix.extent(2) == ngllx);
+//   assert(partial_derivatives.xiz.extent(1) == ngllz);
+//   assert(partial_derivatives.xiz.extent(2) == ngllx);
+//   assert(partial_derivatives.gammax.extent(1) == ngllz);
+//   assert(partial_derivatives.gammax.extent(2) == ngllx);
+//   assert(partial_derivatives.gammaz.extent(1) == ngllz);
+//   assert(partial_derivatives.gammaz.extent(2) == ngllx);
+//   assert(partial_derivatives.jacobian.extent(1) == ngllz);
+//   assert(partial_derivatives.jacobian.extent(2) == ngllx);
+//   assert(wxgll.extent(0) == ngllx);
+//   assert(wzgll.extent(0) == ngllz);
+// #endif
+
+//   self_iterator =
+//       specfem::coupled_interface::impl::edges::self_iterator(ngllx, ngllz);
+//   coupled_iterator =
+//       specfem::coupled_interface::impl::edges::coupled_iterator(ngllx,
+//       ngllz);
+
+// #ifndef NDEBUG
+//   assert(self_field_dot_dot.extent(1) == self_medium::components);
+//   assert(coupled_field_dot_dot.extent(1) == coupled_medium::components);
+// #endif
+
+//   return;
+// }
+
+// template <typename qp_type>
+// KOKKOS_FUNCTION void specfem::coupled_interface::impl::edges::edge<
+//     specfem::domain::domain<specfem::enums::element::medium::elastic,
+//     qp_type>,
+//     specfem::domain::domain<specfem::enums::element::medium::acoustic,
+//                             qp_type> >::compute_coupling(const int &iedge,
+//                                                          const int &ipoint)
+//     const {
+//   int ngllx, ngllz;
+
+//   quadrature_points.get_ngll(&ngllx, &ngllz);
+
+//   const auto acoustic_edge_type = this->acoustic_edge(iedge);
+//   const auto elastic_edge_type = this->elastic_edge(iedge);
+
+//   const int acoustic_ispec_l = this->acoustic_ispec(iedge);
+//   const int elastic_ispec_l = this->elastic_ispec(iedge);
+
+//   int ix, iz;
+//   coupled_iterator(ipoint, acoustic_edge_type, ix, iz);
+
+//   int iglob = ibool(acoustic_ispec_l, iz, ix);
+//   type_real pressure = -1.0 * coupled_field_dot_dot(iglob, 0);
+
+//   type_real valx, valz;
+
+//   switch (acoustic_edge_type) {
+//   case specfem::enums::edge::type::LEFT:
+//     valx = -1.0 * wzgll(iz) *
+//            (xix(acoustic_ispec_l, iz, ix) * jacobian(acoustic_ispec_l, iz,
+//            ix) *
+//             pressure);
+//     valz = -1.0 * wzgll(iz) *
+//            (xiz(acoustic_ispec_l, iz, ix) * jacobian(acoustic_ispec_l, iz,
+//            ix) *
+//             pressure);
+//     self_iterator(ipoint, elastic_edge_type, ix, iz);
+//     iglob = ibool(elastic_ispec_l, iz, ix);
+//     Kokkos::atomic_add(&self_field_dot_dot(iglob, 0), valx);
+//     Kokkos::atomic_add(&self_field_dot_dot(iglob, 1), valz);
+//     break;
+//   case specfem::enums::edge::type::RIGHT:
+//     valx = wzgll(iz) * (xix(acoustic_ispec_l, iz, ix) *
+//                         jacobian(acoustic_ispec_l, iz, ix) * pressure);
+//     valz = wzgll(iz) * (xiz(acoustic_ispec_l, iz, ix) *
+//                         jacobian(acoustic_ispec_l, iz, ix) * pressure);
+//     self_iterator(ipoint, elastic_edge_type, ix, iz);
+//     iglob = ibool(elastic_ispec_l, iz, ix);
+//     Kokkos::atomic_add(&self_field_dot_dot(iglob, 0), valx);
+//     Kokkos::atomic_add(&self_field_dot_dot(iglob, 1), valz);
+//     break;
+//   case specfem::enums::edge::type::BOTTOM:
+//     valx = -1.0 * wxgll(ix) *
+//            (gammax(acoustic_ispec_l, iz, ix) *
+//             jacobian(acoustic_ispec_l, iz, ix) * pressure);
+//     valz = -1.0 * wxgll(ix) *
+//            (gammaz(acoustic_ispec_l, iz, ix) *
+//             jacobian(acoustic_ispec_l, iz, ix) * pressure);
+//     self_iterator(ipoint, elastic_edge_type, ix, iz);
+//     iglob = ibool(elastic_ispec_l, iz, ix);
+//     Kokkos::atomic_add(&self_field_dot_dot(iglob, 0), valx);
+//     Kokkos::atomic_add(&self_field_dot_dot(iglob, 1), valz);
+//     break;
+//   case specfem::enums::edge::type::TOP:
+//     valx = wxgll(ix) * (gammax(acoustic_ispec_l, iz, ix) *
+//                         jacobian(acoustic_ispec_l, iz, ix) * pressure);
+//     valz = wxgll(ix) * (gammaz(acoustic_ispec_l, iz, ix) *
+//                         jacobian(acoustic_ispec_l, iz, ix) * pressure);
+//     self_iterator(ipoint, elastic_edge_type, ix, iz);
+//     iglob = ibool(elastic_ispec_l, iz, ix);
+//     Kokkos::atomic_add(&self_field_dot_dot(iglob, 0), valx);
+//     Kokkos::atomic_add(&self_field_dot_dot(iglob, 1), valz);
+//     break;
+//   default:
+//     assert(false);
+//     break;
+//   }
+// }
+
+template<>
+KOKKOS_FUNCTION specfem::kokkos::array_type<type_real, 1>
 specfem::coupled_interface::impl::edges::edge<
-    specfem::domain::domain<specfem::enums::element::medium::elastic, qp_type>,
-    specfem::domain::domain<specfem::enums::element::medium::acoustic,
-                            qp_type> >::
-    edge(const specfem::domain::domain<specfem::enums::element::medium::elastic,
-                                      qp_type> &self_domain,
-        const specfem::domain::domain<specfem::enums::element::medium::acoustic,
-                                      qp_type> &coupled_domain,
-        const qp_type &quadrature_points,
-        const specfem::compute::coupled_interfaces::coupled_interfaces
-            &coupled_interfaces,
-        const specfem::compute::partial_derivatives &partial_derivatives,
-        const specfem::kokkos::DeviceView1d<type_real> wxgll,
-        const specfem::kokkos::DeviceView1d<type_real> wzgll,
-        const specfem::kokkos::DeviceView3d<int> ibool)
-    : acoustic_ispec(coupled_interfaces.elastic_acoustic.acoustic_ispec),
-      elastic_ispec(coupled_interfaces.elastic_acoustic.elastic_ispec),
-      acoustic_edge(coupled_interfaces.elastic_acoustic.acoustic_edge),
-      elastic_edge(coupled_interfaces.elastic_acoustic.elastic_edge),
-      ibool(ibool), xix(partial_derivatives.xix), xiz(partial_derivatives.xiz),
-      gammax(partial_derivatives.gammax), gammaz(partial_derivatives.gammaz),
-      jacobian(partial_derivatives.jacobian),
-      self_field_dot_dot(self_domain.get_field_dot_dot()),
-      coupled_field_dot_dot(coupled_domain.get_field_dot_dot()),
-      quadrature_points(quadrature_points), wxgll(wxgll), wzgll(wzgll) {
-
-  int ngllx, ngllz;
-  quadrature_points.get_ngll(&ngllx, &ngllz);
-
-#ifndef NDEBUG
-  assert(ibool.extent(1) == ngllz);
-  assert(ibool.extent(2) == ngllx);
-  assert(partial_derivatives.xix.extent(1) == ngllz);
-  assert(partial_derivatives.xix.extent(2) == ngllx);
-  assert(partial_derivatives.xiz.extent(1) == ngllz);
-  assert(partial_derivatives.xiz.extent(2) == ngllx);
-  assert(partial_derivatives.gammax.extent(1) == ngllz);
-  assert(partial_derivatives.gammax.extent(2) == ngllx);
-  assert(partial_derivatives.gammaz.extent(1) == ngllz);
-  assert(partial_derivatives.gammaz.extent(2) == ngllx);
-  assert(partial_derivatives.jacobian.extent(1) == ngllz);
-  assert(partial_derivatives.jacobian.extent(2) == ngllx);
-  assert(wxgll.extent(0) == ngllx);
-  assert(wzgll.extent(0) == ngllz);
-#endif
-
-  self_iterator =
-      specfem::coupled_interface::impl::edges::self_iterator(ngllx, ngllz);
-  coupled_iterator =
-      specfem::coupled_interface::impl::edges::coupled_iterator(ngllx, ngllz);
-
-#ifndef NDEBUG
-  assert(self_field_dot_dot.extent(1) == self_medium::components);
-  assert(coupled_field_dot_dot.extent(1) == coupled_medium::components);
-#endif
-
-  return;
+    specfem::enums::element::medium::elastic,
+    specfem::enums::element::medium::acoustic>::
+    load_field_elements(
+        const int coupled_global_index,
+        const specfem::compute::impl::field_impl<coupled_medium_type>
+            &coupled_field) const {
+  return specfem::kokkos::array_type<type_real, 1>(
+      coupled_field.field_dot_dot(coupled_global_index, 0));
 }
 
-template <typename qp_type>
-KOKKOS_FUNCTION void specfem::coupled_interface::impl::edges::edge<
-    specfem::domain::domain<specfem::enums::element::medium::elastic, qp_type>,
-    specfem::domain::domain<specfem::enums::element::medium::acoustic,
-                            qp_type> >::compute_coupling(const int &iedge,
-                                                         const int &ipoint)
-    const {
-  int ngllx, ngllz;
+template <>
+KOKKOS_FUNCTION specfem::kokkos::array_type<type_real, 2>
+specfem::coupled_interface::impl::edges::edge<
+    specfem::enums::element::medium::elastic,
+    specfem::enums::element::medium::acoustic>::
+    compute_coupling_terms(
+        const specfem::kokkos::array_type<type_real, 2> &normal,
+        const specfem::kokkos::array_type<type_real, 2> &weights,
+        const specfem::edge::interface &coupled_edge,
+        const specfem::kokkos::array_type<type_real, 1> &pressure) const {
 
-  quadrature_points.get_ngll(&ngllx, &ngllz);
+  const type_real factor = [&]() -> type_real {
+    switch (coupled_edge.type) {
+    case specfem::enums::edge::type::LEFT:
+    case specfem::enums::edge::type::RIGHT:
+      return weights[1];
+    case specfem::enums::edge::type::BOTTOM:
+    case specfem::enums::edge::type::TOP:
+      return weights[0];
+    default:
+      ASSERT(false, "Invalid edge type");
+      return 0.0;
+    }
+  }();
 
-  const auto acoustic_edge_type = this->acoustic_edge(iedge);
-  const auto elastic_edge_type = this->elastic_edge(iedge);
-
-  const int acoustic_ispec_l = this->acoustic_ispec(iedge);
-  const int elastic_ispec_l = this->elastic_ispec(iedge);
-
-  int ix, iz;
-  coupled_iterator(ipoint, acoustic_edge_type, ix, iz);
-
-  int iglob = ibool(acoustic_ispec_l, iz, ix);
-  type_real pressure = -1.0 * coupled_field_dot_dot(iglob, 0);
-
-  type_real valx, valz;
-
-  switch (acoustic_edge_type) {
-  case specfem::enums::edge::type::LEFT:
-    valx = -1.0 * wzgll(iz) *
-           (xix(acoustic_ispec_l, iz, ix) * jacobian(acoustic_ispec_l, iz, ix) *
-            pressure);
-    valz = -1.0 * wzgll(iz) *
-           (xiz(acoustic_ispec_l, iz, ix) * jacobian(acoustic_ispec_l, iz, ix) *
-            pressure);
-    self_iterator(ipoint, elastic_edge_type, ix, iz);
-    iglob = ibool(elastic_ispec_l, iz, ix);
-    Kokkos::atomic_add(&self_field_dot_dot(iglob, 0), valx);
-    Kokkos::atomic_add(&self_field_dot_dot(iglob, 1), valz);
-    break;
-  case specfem::enums::edge::type::RIGHT:
-    valx = wzgll(iz) * (xix(acoustic_ispec_l, iz, ix) *
-                        jacobian(acoustic_ispec_l, iz, ix) * pressure);
-    valz = wzgll(iz) * (xiz(acoustic_ispec_l, iz, ix) *
-                        jacobian(acoustic_ispec_l, iz, ix) * pressure);
-    self_iterator(ipoint, elastic_edge_type, ix, iz);
-    iglob = ibool(elastic_ispec_l, iz, ix);
-    Kokkos::atomic_add(&self_field_dot_dot(iglob, 0), valx);
-    Kokkos::atomic_add(&self_field_dot_dot(iglob, 1), valz);
-    break;
-  case specfem::enums::edge::type::BOTTOM:
-    valx = -1.0 * wxgll(ix) *
-           (gammax(acoustic_ispec_l, iz, ix) *
-            jacobian(acoustic_ispec_l, iz, ix) * pressure);
-    valz = -1.0 * wxgll(ix) *
-           (gammaz(acoustic_ispec_l, iz, ix) *
-            jacobian(acoustic_ispec_l, iz, ix) * pressure);
-    self_iterator(ipoint, elastic_edge_type, ix, iz);
-    iglob = ibool(elastic_ispec_l, iz, ix);
-    Kokkos::atomic_add(&self_field_dot_dot(iglob, 0), valx);
-    Kokkos::atomic_add(&self_field_dot_dot(iglob, 1), valz);
-    break;
-  case specfem::enums::edge::type::TOP:
-    valx = wxgll(ix) * (gammax(acoustic_ispec_l, iz, ix) *
-                        jacobian(acoustic_ispec_l, iz, ix) * pressure);
-    valz = wxgll(ix) * (gammaz(acoustic_ispec_l, iz, ix) *
-                        jacobian(acoustic_ispec_l, iz, ix) * pressure);
-    self_iterator(ipoint, elastic_edge_type, ix, iz);
-    iglob = ibool(elastic_ispec_l, iz, ix);
-    Kokkos::atomic_add(&self_field_dot_dot(iglob, 0), valx);
-    Kokkos::atomic_add(&self_field_dot_dot(iglob, 1), valz);
-    break;
-  default:
-    assert(false);
-    break;
-  }
+  return specfem::kokkos::array_type<type_real, 2>(
+      factor * normal[0] * pressure[0], factor * normal[1] * pressure[0]);
 }
 
 #endif // _COUPLED_INTERFACE_IMPL_ELASTIC_ACOUSTIC_EDGE_TPP

--- a/include/coupled_interface/impl/edge/interface.hpp
+++ b/include/coupled_interface/impl/edge/interface.hpp
@@ -2,9 +2,9 @@
 #define _COUPLED_INTERFACE_IMPL_EDGE_INTERFACE_HPP
 
 #include "edge.hpp"
-#include "elastic_acoustic/acoustic_elastic.hpp"
+// #include "elastic_acoustic/acoustic_elastic.hpp"
 #include "elastic_acoustic/acoustic_elastic.tpp"
-#include "elastic_acoustic/elastic_acoustic.hpp"
+// #include "elastic_acoustic/elastic_acoustic.hpp"
 #include "elastic_acoustic/elastic_acoustic.tpp"
 
 #endif // _COUPLED_INTERFACE_IMPL_EDGE_INTERFACE_HPP

--- a/include/domain/domain.hpp
+++ b/include/domain/domain.hpp
@@ -134,16 +134,16 @@ public:
   //  */
   // void sync_rmass_inverse(specfem::sync::kind kind);
 
-  // /**
-  //  * @brief Compute seismograms at for all receivers at isig_step
-  //  *
-  //  * @param seismogram_types DeviceView of types of seismograms to be
-  //  * calculated
-  //  * @param isig_step timestep for seismogram calculation
-  //  */
-  // void compute_seismogram(const int isig_step) {
-  //   kernels.compute_seismograms(isig_step);
-  // };
+  /**
+   * @brief Compute seismograms at for all receivers at isig_step
+   *
+   * @param seismogram_types DeviceView of types of seismograms to be
+   * calculated
+   * @param isig_step timestep for seismogram calculation
+   */
+  void compute_seismogram(const int isig_step) {
+    kernels.compute_seismograms(isig_step);
+  };
 
   // /**
   //  * @brief Get a view of field stored on the device

--- a/include/domain/domain.hpp
+++ b/include/domain/domain.hpp
@@ -77,13 +77,13 @@ public:
     kernels.template mass_time_contribution<time_scheme>(dt);
   };
 
-  // /**
-  //  * @brief Compute interaction of stiffness matrix on acceleration
-  //  *
-  //  */
-  // void compute_stiffness_interaction() {
-  //   kernels.compute_stiffness_interaction();
-  // };
+  /**
+   * @brief Compute interaction of stiffness matrix on acceleration
+   *
+   */
+  void compute_stiffness_interaction() {
+    kernels.compute_stiffness_interaction();
+  };
 
   /**
    * @brief Invert the mass matrix
@@ -97,14 +97,14 @@ public:
    */
   void divide_mass_matrix();
 
-  // /**
-  //  * @brief Compute interaction of sources on acceleration
-  //  *
-  //  * @param timeval
-  //  */
-  // void compute_source_interaction(const type_real timeval) {
-  //   kernels.compute_source_interaction(timeval);
-  // };
+  /**
+   * @brief Compute interaction of sources on acceleration
+   *
+   * @param timeval
+   */
+  void compute_source_interaction(const type_real timeval) {
+    kernels.compute_source_interaction(timeval);
+  };
 
   // /**
   //  * @brief Sync displacements views between host and device

--- a/include/domain/domain.hpp
+++ b/include/domain/domain.hpp
@@ -57,31 +57,10 @@ public:
   /**
    * @brief Construct a new domain object
    *
-   * @param nglob Total number of distinct quadrature points
-   * @param quadrature_points Type of quadrature points - either static (number
-   * of quadrature points defined at compile time) or dynamic (number of
-   * quadrature points defined at runtime)
-   * @param compute Pointer to compute struct used to store spectral element
-   * numbering mapping (ibool)
-   * @param material_properties properties struct used to store material
-   * properties at each quadrature point
-   * @param partial_derivatives partial derivatives struct used to store partial
-   * derivatives of basis functions at each quadrature point
-   * @param compute_sources sources struct used to store source information
-   * @param compute_receivers receivers struct used to store receiver
-   * information
-   * @param quadx Quadrature object in x-dimension
-   * @param quadz Quadrature object in z-dimension
+   * @param assembly object containing the assembly information
    */
-  domain(const int nglob, const qp_type &quadrature_points,
-         specfem::compute::compute *compute,
-         specfem::compute::properties material_properties,
-         specfem::compute::partial_derivatives partial_derivatives,
-         specfem::compute::boundaries boundary_conditions,
-         specfem::compute::sources compute_sources,
-         specfem::compute::receivers compute_receivers,
-         specfem::quadrature::quadrature *quadx,
-         specfem::quadrature::quadrature *quadz);
+  domain(const specfem::compute::assembly &assembly,
+         const quadrature_points_type &quadrature_points);
 
   /**
    * @brief Default destructor
@@ -89,22 +68,22 @@ public:
    */
   ~domain() = default;
 
-  /**
-   * @brief Initialize the domain
-   *
-   */
-  template <specfem::enums::time_scheme::type time_scheme>
-  void mass_time_contribution(const type_real dt) {
-    kernels.template mass_time_contribution<time_scheme>(dt);
-  };
+  // /**
+  //  * @brief Initialize the domain
+  //  *
+  //  */
+  // template <specfem::enums::time_scheme::type time_scheme>
+  // void mass_time_contribution(const type_real dt) {
+  //   kernels.template mass_time_contribution<time_scheme>(dt);
+  // };
 
-  /**
-   * @brief Compute interaction of stiffness matrix on acceleration
-   *
-   */
-  void compute_stiffness_interaction() {
-    kernels.compute_stiffness_interaction();
-  };
+  // /**
+  //  * @brief Compute interaction of stiffness matrix on acceleration
+  //  *
+  //  */
+  // void compute_stiffness_interaction() {
+  //   kernels.compute_stiffness_interaction();
+  // };
 
   /**
    * @brief Invert the mass matrix
@@ -118,163 +97,136 @@ public:
    */
   void divide_mass_matrix();
 
-  /**
-   * @brief Compute interaction of sources on acceleration
-   *
-   * @param timeval
-   */
-  void compute_source_interaction(const type_real timeval) {
-    kernels.compute_source_interaction(timeval);
-  };
+  // /**
+  //  * @brief Compute interaction of sources on acceleration
+  //  *
+  //  * @param timeval
+  //  */
+  // void compute_source_interaction(const type_real timeval) {
+  //   kernels.compute_source_interaction(timeval);
+  // };
 
-  /**
-   * @brief Sync displacements views between host and device
-   *
-   * @param kind defines sync direction i.e. DeviceToHost or HostToDevice
-   */
-  void sync_field(specfem::sync::kind kind);
+  // /**
+  //  * @brief Sync displacements views between host and device
+  //  *
+  //  * @param kind defines sync direction i.e. DeviceToHost or HostToDevice
+  //  */
+  // void sync_field(specfem::sync::kind kind);
 
-  /**
-   * @brief Sync velocity views between host and device
-   *
-   * @param kind defines sync direction i.e. DeviceToHost or HostToDevice
-   */
-  void sync_field_dot(specfem::sync::kind kind);
+  // /**
+  //  * @brief Sync velocity views between host and device
+  //  *
+  //  * @param kind defines sync direction i.e. DeviceToHost or HostToDevice
+  //  */
+  // void sync_field_dot(specfem::sync::kind kind);
 
-  /**
-   * @brief Sync acceleration views between host and device
-   *
-   * @param kind defines sync direction i.e. DeviceToHost or HostToDevice
-   */
-  void sync_field_dot_dot(specfem::sync::kind kind);
+  // /**
+  //  * @brief Sync acceleration views between host and device
+  //  *
+  //  * @param kind defines sync direction i.e. DeviceToHost or HostToDevice
+  //  */
+  // void sync_field_dot_dot(specfem::sync::kind kind);
 
-  /**
-   * @brief Sync inverse of mass matrix views between host and device
-   *
-   * @param kind defines sync direction i.e. DeviceToHost or HostToDevice
-   */
-  void sync_rmass_inverse(specfem::sync::kind kind);
+  // /**
+  //  * @brief Sync inverse of mass matrix views between host and device
+  //  *
+  //  * @param kind defines sync direction i.e. DeviceToHost or HostToDevice
+  //  */
+  // void sync_rmass_inverse(specfem::sync::kind kind);
 
-  /**
-   * @brief Compute seismograms at for all receivers at isig_step
-   *
-   * @param seismogram_types DeviceView of types of seismograms to be
-   * calculated
-   * @param isig_step timestep for seismogram calculation
-   */
-  void compute_seismogram(const int isig_step) {
-    kernels.compute_seismograms(isig_step);
-  };
+  // /**
+  //  * @brief Compute seismograms at for all receivers at isig_step
+  //  *
+  //  * @param seismogram_types DeviceView of types of seismograms to be
+  //  * calculated
+  //  * @param isig_step timestep for seismogram calculation
+  //  */
+  // void compute_seismogram(const int isig_step) {
+  //   kernels.compute_seismograms(isig_step);
+  // };
 
-  /**
-   * @brief Get a view of field stored on the device
-   *
-   * @return specfem::kokkos::DeviceView2d<type_real>
-   */
-  specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
-  get_field() const {
-    return this->field;
-  }
+  // /**
+  //  * @brief Get a view of field stored on the device
+  //  *
+  //  * @return specfem::kokkos::DeviceView2d<type_real>
+  //  */
+  // specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
+  // get_field() const {
+  //   return this->field;
+  // }
 
-  /**
-   * @brief Get a view of field stored on the host
-   *
-   * @return specfem::kokkos::DeviceView2d<type_real>
-   */
-  specfem::kokkos::HostMirror2d<type_real, Kokkos::LayoutLeft>
-  get_host_field() const {
-    return this->h_field;
-  }
+  // /**
+  //  * @brief Get a view of field stored on the host
+  //  *
+  //  * @return specfem::kokkos::DeviceView2d<type_real>
+  //  */
+  // specfem::kokkos::HostMirror2d<type_real, Kokkos::LayoutLeft>
+  // get_host_field() const {
+  //   return this->h_field;
+  // }
 
-  /**
-   * @brief Get a view of derivate of field stored on device
-   *
-   * @return specfem::kokkos::DeviceView2d<type_real>
-   */
-  specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
-  get_field_dot() const {
-    return this->field_dot;
-  }
+  // /**
+  //  * @brief Get a view of derivate of field stored on device
+  //  *
+  //  * @return specfem::kokkos::DeviceView2d<type_real>
+  //  */
+  // specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
+  // get_field_dot() const {
+  //   return this->field_dot;
+  // }
 
-  /**
-   * @brief Get a view of derivative of field stored on host
-   *
-   * @return specfem::kokkos::DeviceView2d<type_real>
-   */
-  specfem::kokkos::HostMirror2d<type_real, Kokkos::LayoutLeft>
-  get_host_field_dot() const {
-    return this->h_field_dot;
-  }
+  // /**
+  //  * @brief Get a view of derivative of field stored on host
+  //  *
+  //  * @return specfem::kokkos::DeviceView2d<type_real>
+  //  */
+  // specfem::kokkos::HostMirror2d<type_real, Kokkos::LayoutLeft>
+  // get_host_field_dot() const {
+  //   return this->h_field_dot;
+  // }
 
-  /**
-   * @brief Get a view of double derivative of field stored on device
-   *
-   * @return specfem::kokkos::DeviceView2d<type_real>
-   */
-  specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
-  get_field_dot_dot() const {
-    return this->field_dot_dot;
-  }
+  // /**
+  //  * @brief Get a view of double derivative of field stored on device
+  //  *
+  //  * @return specfem::kokkos::DeviceView2d<type_real>
+  //  */
+  // specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
+  // get_field_dot_dot() const {
+  //   return this->field_dot_dot;
+  // }
 
-  /**
-   * @brief Get a view of double derivative of field stored on host
-   *
-   * @return specfem::kokkos::DeviceView2d<type_real>
-   */
-  specfem::kokkos::HostMirror2d<type_real, Kokkos::LayoutLeft>
-  get_host_field_dot_dot() const {
-    return this->h_field_dot_dot;
-  }
+  // /**
+  //  * @brief Get a view of double derivative of field stored on host
+  //  *
+  //  * @return specfem::kokkos::DeviceView2d<type_real>
+  //  */
+  // specfem::kokkos::HostMirror2d<type_real, Kokkos::LayoutLeft>
+  // get_host_field_dot_dot() const {
+  //   return this->h_field_dot_dot;
+  // }
 
-  /**
-   * @brief Get a view of inverse of mass matrix stored on device
-   *
-   * @return specfem::kokkos::DeviceView2d<type_real>
-   */
-  specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
-  get_rmass_inverse() const {
-    return this->rmass_inverse;
-  }
+  // /**
+  //  * @brief Get a view of inverse of mass matrix stored on device
+  //  *
+  //  * @return specfem::kokkos::DeviceView2d<type_real>
+  //  */
+  // specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
+  // get_rmass_inverse() const {
+  //   return this->rmass_inverse;
+  // }
 
-  /**
-   * @brief Get a view of inverse of mass matrix stored on host
-   *
-   * @return specfem::kokkos::DeviceView2d<type_real>
-   */
-  specfem::kokkos::HostMirror2d<type_real, Kokkos::LayoutLeft>
-  get_host_rmass_inverse() const {
-    return this->h_rmass_inverse;
-  }
+  // /**
+  //  * @brief Get a view of inverse of mass matrix stored on host
+  //  *
+  //  * @return specfem::kokkos::DeviceView2d<type_real>
+  //  */
+  // specfem::kokkos::HostMirror2d<type_real, Kokkos::LayoutLeft>
+  // get_host_rmass_inverse() const {
+  //   return this->h_rmass_inverse;
+  // }
 
 private:
-  specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
-      field; ///< View of field on Device
-  specfem::kokkos::HostMirror2d<type_real, Kokkos::LayoutLeft>
-      h_field; ///< View of field on host
-  specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
-      field_dot; ///< View of derivative of
-                 ///< field on Device
-  specfem::kokkos::HostMirror2d<type_real, Kokkos::LayoutLeft>
-      h_field_dot; ///< View of derivative
-                   ///< of field on host
-  specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
-      field_dot_dot; ///< View of second
-                     ///< derivative of
-                     ///< field on Device
-  specfem::kokkos::HostMirror2d<type_real, Kokkos::LayoutLeft>
-      h_field_dot_dot; ///< View of second
-                       ///< derivative of
-                       ///< field on host
-  specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
-      rmass_inverse; ///< View of inverse
-                     ///< of mass matrix on
-                     ///< device
-  specfem::kokkos::HostMirror2d<type_real, Kokkos::LayoutLeft>
-      h_rmass_inverse; ///< View of inverse
-                       ///< of mass matrix
-                       ///< on host
-  int nelem_domain;    ///< Total number of elements in this domain
-
+  specfem::compute::impl::field_impl<medium_type> field; ///< Field object
   specfem::domain::impl::kernels::kernels<medium_type, quadrature_points_type>
       kernels; ///< Kernels object used to compute elemental kernels
 };

--- a/include/domain/domain.hpp
+++ b/include/domain/domain.hpp
@@ -68,14 +68,14 @@ public:
    */
   ~domain() = default;
 
-  // /**
-  //  * @brief Initialize the domain
-  //  *
-  //  */
-  // template <specfem::enums::time_scheme::type time_scheme>
-  // void mass_time_contribution(const type_real dt) {
-  //   kernels.template mass_time_contribution<time_scheme>(dt);
-  // };
+  /**
+   * @brief Initialize the domain
+   *
+   */
+  template <specfem::enums::time_scheme::type time_scheme>
+  void mass_time_contribution(const type_real dt) {
+    kernels.template mass_time_contribution<time_scheme>(dt);
+  };
 
   // /**
   //  * @brief Compute interaction of stiffness matrix on acceleration

--- a/include/domain/domain.tpp
+++ b/include/domain/domain.tpp
@@ -166,6 +166,8 @@ void specfem::domain::domain<medium, qp_type>::divide_mass_matrix() {
       specfem::kokkos::DeviceMDrange<2, Kokkos::Iterate::Left>(
           { 0, 0 }, { nglob, components }),
       KOKKOS_CLASS_LAMBDA(const int iglob, const int idim) {
+        type_real mass = field.mass_inverse(iglob, idim);
+        type_real acceleration = field.field_dot_dot(iglob, idim);
         field.field_dot_dot(iglob, idim) =
             field.field_dot_dot(iglob, idim) * field.mass_inverse(iglob, idim);
       });

--- a/include/domain/domain.tpp
+++ b/include/domain/domain.tpp
@@ -39,13 +39,8 @@ void initialize_views(
 
 template <class medium, class qp_type>
 void initialize_rmass_inverse(
-    const specfem::domain::impl::kernels::kernels<medium, qp_type> &kernels,
-    specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
-        &rmass_inverse) {
+    const specfem::domain::impl::kernels::kernels<medium, qp_type> &kernels) {
   // Compute the mass matrix
-
-  const int nglob = rmass_inverse.extent(0);
-  const int components = rmass_inverse.extent(1);
 
   kernels.compute_mass_matrix();
 
@@ -72,119 +67,99 @@ void initialize_rmass_inverse(
 
 template <class medium, class qp_type>
 specfem::domain::domain<medium, qp_type>::domain(
-    const int nglob, const qp_type &quadrature_points,
-    specfem::compute::compute *compute,
-    specfem::compute::properties material_properties,
-    specfem::compute::partial_derivatives partial_derivatives,
-    specfem::compute::boundaries boundary_conditions,
-    specfem::compute::sources compute_sources,
-    specfem::compute::receivers compute_receivers,
-    specfem::quadrature::quadrature *quadx,
-    specfem::quadrature::quadrature *quadz)
-    : field(specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>(
-          "specfem::domain::domain::field", nglob, medium::components)),
-      field_dot(specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>(
-          "specfem::domain::domain::field_dot", nglob, medium::components)),
-      field_dot_dot(
-          specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>(
-              "specfem::domain::domain::field_dot_dot", nglob,
-              medium::components)),
-      rmass_inverse(
-          specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>(
-              "specfem::domain::domain::rmass_inverse", nglob,
-              medium::components)) {
+    const specfem::compute::assembly &assembly,
+    const qp_type &quadrature_points)
+    : field(assembly.fields.forward.get_field<medium>()) {
 
-  this->h_field = Kokkos::create_mirror_view(this->field);
-  this->h_field_dot = Kokkos::create_mirror_view(this->field_dot);
-  this->h_field_dot_dot = Kokkos::create_mirror_view(this->field_dot_dot);
-  this->h_rmass_inverse = Kokkos::create_mirror_view(this->rmass_inverse);
+  // this->h_field = Kokkos::create_mirror_view(this->field);
+  // this->h_field_dot = Kokkos::create_mirror_view(this->field_dot);
+  // this->h_field_dot_dot = Kokkos::create_mirror_view(this->field_dot_dot);
+  // this->h_rmass_inverse = Kokkos::create_mirror_view(this->rmass_inverse);
 
-  //----------------------------------------------------------------------------
-  // Initialize views
+  // //----------------------------------------------------------------------------
+  // // Initialize views
 
-  // In CUDA you can't call class lambdas inside the constructors
-  // Hence I need to use this function to initialize views
-  initialize_views<medium>(nglob, this->field, this->field_dot,
-                           this->field_dot_dot, this->rmass_inverse);
+  // // In CUDA you can't call class lambdas inside the constructors
+  // // Hence I need to use this function to initialize views
+  // initialize_views<medium>(nglob, this->field, this->field_dot,
+  //                          this->field_dot_dot, this->rmass_inverse);
 
   this->kernels = specfem::domain::impl::kernels::kernels<medium, qp_type>(
-      compute->ibool, partial_derivatives, material_properties,
-      boundary_conditions, compute_sources, compute_receivers, quadx, quadz,
-      quadrature_points, this->field, this->field_dot, this->field_dot_dot, this->rmass_inverse);
+      assembly, quadrature_points);
 
   //----------------------------------------------------------------------------
   // Inverse of mass matrix
 
-  initialize_rmass_inverse(this->kernels, this->rmass_inverse);
+  initialize_rmass_inverse(this->kernels);
 
   return;
 };
 
-template <class medium, class qp_type>
-void specfem::domain::domain<medium, qp_type>::sync_field(
-    specfem::sync::kind kind) {
+// template <class medium, class qp_type>
+// void specfem::domain::domain<medium, qp_type>::sync_field(
+//     specfem::sync::kind kind) {
 
-  if (kind == specfem::sync::DeviceToHost) {
-    Kokkos::deep_copy(h_field, field);
-  } else if (kind == specfem::sync::HostToDevice) {
-    Kokkos::deep_copy(field, h_field);
-  } else {
-    throw std::runtime_error("Could not recognize the kind argument");
-  }
+//   if (kind == specfem::sync::DeviceToHost) {
+//     Kokkos::deep_copy(h_field, field);
+//   } else if (kind == specfem::sync::HostToDevice) {
+//     Kokkos::deep_copy(field, h_field);
+//   } else {
+//     throw std::runtime_error("Could not recognize the kind argument");
+//   }
 
-  return;
-}
+//   return;
+// }
 
-template <class medium, class qp_type>
-void specfem::domain::domain<medium, qp_type>::sync_field_dot(
-    specfem::sync::kind kind) {
+// template <class medium, class qp_type>
+// void specfem::domain::domain<medium, qp_type>::sync_field_dot(
+//     specfem::sync::kind kind) {
 
-  if (kind == specfem::sync::DeviceToHost) {
-    Kokkos::deep_copy(h_field_dot, field_dot);
-  } else if (kind == specfem::sync::HostToDevice) {
-    Kokkos::deep_copy(field_dot, h_field_dot);
-  } else {
-    throw std::runtime_error("Could not recognize the kind argument");
-  }
+//   if (kind == specfem::sync::DeviceToHost) {
+//     Kokkos::deep_copy(h_field_dot, field_dot);
+//   } else if (kind == specfem::sync::HostToDevice) {
+//     Kokkos::deep_copy(field_dot, h_field_dot);
+//   } else {
+//     throw std::runtime_error("Could not recognize the kind argument");
+//   }
 
-  return;
-}
+//   return;
+// }
 
-template <class medium, class qp_type>
-void specfem::domain::domain<medium, qp_type>::sync_field_dot_dot(
-    specfem::sync::kind kind) {
+// template <class medium, class qp_type>
+// void specfem::domain::domain<medium, qp_type>::sync_field_dot_dot(
+//     specfem::sync::kind kind) {
 
-  if (kind == specfem::sync::DeviceToHost) {
-    Kokkos::deep_copy(h_field_dot_dot, field_dot_dot);
-  } else if (kind == specfem::sync::HostToDevice) {
-    Kokkos::deep_copy(field_dot_dot, h_field_dot_dot);
-  } else {
-    throw std::runtime_error("Could not recognize the kind argument");
-  }
+//   if (kind == specfem::sync::DeviceToHost) {
+//     Kokkos::deep_copy(h_field_dot_dot, field_dot_dot);
+//   } else if (kind == specfem::sync::HostToDevice) {
+//     Kokkos::deep_copy(field_dot_dot, h_field_dot_dot);
+//   } else {
+//     throw std::runtime_error("Could not recognize the kind argument");
+//   }
 
-  return;
-}
+//   return;
+// }
 
-template <class medium, class qp_type>
-void specfem::domain::domain<medium, qp_type>::sync_rmass_inverse(
-    specfem::sync::kind kind) {
+// template <class medium, class qp_type>
+// void specfem::domain::domain<medium, qp_type>::sync_rmass_inverse(
+//     specfem::sync::kind kind) {
 
-  if (kind == specfem::sync::DeviceToHost) {
-    Kokkos::deep_copy(h_rmass_inverse, rmass_inverse);
-  } else if (kind == specfem::sync::HostToDevice) {
-    Kokkos::deep_copy(rmass_inverse, h_rmass_inverse);
-  } else {
-    throw std::runtime_error("Could not recognize the kind argument");
-  }
+//   if (kind == specfem::sync::DeviceToHost) {
+//     Kokkos::deep_copy(h_rmass_inverse, rmass_inverse);
+//   } else if (kind == specfem::sync::HostToDevice) {
+//     Kokkos::deep_copy(rmass_inverse, h_rmass_inverse);
+//   } else {
+//     throw std::runtime_error("Could not recognize the kind argument");
+//   }
 
-  return;
-}
+//   return;
+// }
 
 template <class medium, class qp_type>
 void specfem::domain::domain<medium, qp_type>::divide_mass_matrix() {
 
   constexpr int components = medium::components;
-  const int nglob = this->rmass_inverse.extent(0);
+  const int nglob = field.nglob;
 
   Kokkos::parallel_for(
       "specfem::domain::domain::divide_mass_matrix",
@@ -192,10 +167,8 @@ void specfem::domain::domain<medium, qp_type>::divide_mass_matrix() {
       KOKKOS_CLASS_LAMBDA(const int in) {
         const int iglob = in % nglob;
         const int idim = in / nglob;
-        const type_real acceleration = this->field_dot_dot(iglob, idim);
-        const type_real rmass_inverse = this->rmass_inverse(iglob, idim);
-        this->field_dot_dot(iglob, idim) =
-            this->field_dot_dot(iglob, idim) * this->rmass_inverse(iglob, idim);
+        field.field_dot_dot(iglob, idim) =
+            field.field_dot_dot(iglob, idim) * field.rmass_inverse(iglob, idim);
       });
 
   Kokkos::fence();
@@ -207,7 +180,7 @@ template <class medium, class qp_type>
 void specfem::domain::domain<medium, qp_type>::invert_mass_matrix() {
 
   constexpr int components = medium::components;
-  const int nglob = this->rmass_inverse.extent(0);
+  const int nglob = field.nglob;
 
   Kokkos::parallel_for(
       "specfem::domain::domain::invert_mass_matrix",
@@ -215,11 +188,11 @@ void specfem::domain::domain<medium, qp_type>::invert_mass_matrix() {
       KOKKOS_CLASS_LAMBDA(const int in) {
         const int iglob = in % nglob;
         const int idim = in / nglob;
-        if (this->rmass_inverse(iglob, idim) == 0) {
-          this->rmass_inverse(iglob, idim) = 1.0;
+        if (field.mass_inverse(iglob, idim) == 0) {
+          field.mass_inverse(iglob, idim) = 1.0;
         } else {
-          this->rmass_inverse(iglob, idim) =
-              1.0 / this->rmass_inverse(iglob, idim);
+          field.mass_inverse(iglob, idim) =
+              1.0 / field.mass_inverse(iglob, idim);
         }
       });
 

--- a/include/domain/impl/elements/acoustic/acoustic2d_isotropic.hpp
+++ b/include/domain/impl/elements/acoustic/acoustic2d_isotropic.hpp
@@ -179,44 +179,47 @@ public:
       specfem::kokkos::array_type<type_real, medium_type::components>
           &stress_integrand_gamma) const;
 
-  //   /**
-  //    * @brief Update the acceleration at a particular Gauss-Lobatto-Legendre
-  //    * quadrature point
-  //    *
-  //    * @param xz Index of Gauss-Lobatto-Legendre quadrature point
-  //    * @param wxglll Weight of the Gauss-Lobatto-Legendre quadrature point in
-  //    x
-  //    * direction
-  //    * @param wzglll Weight of the Gauss-Lobatto-Legendre quadrature point in
-  //    z
-  //    * direction
-  //    * @param stress_integrand_xi Stress integrand  wrt. \f$ \xi \f$
-  //    * \f$ J^{\alpha\gamma} * {\rho^{\alpha\gamma}}^{-1}
-  //    * \partial_x \chi \partial_x \xi + \partial_z \chi * \partial_z \xi \f$
-  //    as
-  //    * computed by compute_stress
-  //    * @param stress_integrand_gamma Stress integrand  wrt. \f$\gamma\f$
-  //    * \f$ J^{\alpha\gamma} * {\rho^{\alpha\gamma}}^{-1}
-  //    * \partial_x \chi \partial_x \gamma + \partial_z \chi * \partial_z
-  //    \gamma \f$
-  //    * as computed by compute_stress
-  //    * @param s_hprimewgll_xx Scratch view hprime_xx * wxgll
-  //    * @param s_hprimewgll_zz Scratch view hprime_zz * wzgll
-  //    * @param field_dot_dot Acceleration of the field subviewed at global
-  //    index xz
-  //    */
-  //   KOKKOS_INLINE_FUNCTION void compute_acceleration(
-  //       const int &ispec, const int &ielement, const int &xz,
-  //       const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
-  //       const ScratchViewType<type_real, medium_type::components>
-  //           stress_integrand_xi,
-  //       const ScratchViewType<type_real, medium_type::components>
-  //           stress_integrand_gamma,
-  //       const ScratchViewType<type_real, 1> s_hprimewgll_xx,
-  //       const ScratchViewType<type_real, 1> s_hprimewgll_zz,
-  //       const specfem::kokkos::array_type<type_real, medium_type::components>
-  //           &velocity,
-  //       specfem::kokkos::array_type<type_real, 1> &acceleration) const;
+  /**
+   * @brief Update the acceleration at a particular Gauss-Lobatto-Legendre
+   * quadrature point
+   *
+   * @param xz Index of Gauss-Lobatto-Legendre quadrature point
+   * @param wxglll Weight of the Gauss-Lobatto-Legendre quadrature point in
+   x
+   * direction
+   * @param wzglll Weight of the Gauss-Lobatto-Legendre quadrature point in
+   z
+   * direction
+   * @param stress_integrand_xi Stress integrand  wrt. \f$ \xi \f$
+   * \f$ J^{\alpha\gamma} * {\rho^{\alpha\gamma}}^{-1}
+   * \partial_x \chi \partial_x \xi + \partial_z \chi * \partial_z \xi \f$
+   as
+   * computed by compute_stress
+   * @param stress_integrand_gamma Stress integrand  wrt. \f$\gamma\f$
+   * \f$ J^{\alpha\gamma} * {\rho^{\alpha\gamma}}^{-1}
+   * \partial_x \chi \partial_x \gamma + \partial_z \chi * \partial_z
+   \gamma \f$
+   * as computed by compute_stress
+   * @param s_hprimewgll_xx Scratch view hprime_xx * wxgll
+   * @param s_hprimewgll_zz Scratch view hprime_zz * wzgll
+   * @param field_dot_dot Acceleration of the field subviewed at global
+   index xz
+   */
+  KOKKOS_INLINE_FUNCTION void compute_acceleration(
+      const int &xz,
+      const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
+      const ScratchViewType<type_real, medium_type::components>
+          stress_integrand_xi,
+      const ScratchViewType<type_real, medium_type::components>
+          stress_integrand_gamma,
+      const ScratchViewType<type_real, 1> s_hprimewgll,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
+      const specfem::point::properties<medium_type::value, property_type::value>
+          &properties,
+      const specfem::point::boundary &boundary_type,
+      const specfem::kokkos::array_type<type_real, medium_type::components>
+          &velocity,
+      specfem::kokkos::array_type<type_real, 1> &acceleration) const;
 
 private:
   //   specfem::kokkos::DeviceView3d<type_real> xix;         ///< xix

--- a/include/domain/impl/elements/acoustic/acoustic2d_isotropic.hpp
+++ b/include/domain/impl/elements/acoustic/acoustic2d_isotropic.hpp
@@ -120,56 +120,64 @@ public:
       specfem::kokkos::array_type<type_real, medium_type::components>
           &rmass_inverse) const;
 
-  //   /**
-  //    * @brief Compute the gradient of the field at the quadrature point xz
-  //    * (Komatisch & Tromp, 2002-I., eq. 22(theory, OC),44,45)
-  //    *
-  //    * @param xz Index of the quadrature point
-  //    * @param s_hprime_xx lagrange polynomial derivative in x direction
-  //    * @param s_hprime_zz lagraange polynomial derivative in z direction
-  //    * @param field_chi potential field
-  //    * @param dchidxl Computed partial derivative of field \f$ \frac{\partial
-  //    * \chi}{\partial x} \f$
-  //    * @param dchidzl Computed partial derivative of field \f$ \frac{\partial
-  //    * \chi}{\partial z} \f$
-  //    */
-  //   KOKKOS_INLINE_FUNCTION void compute_gradient(
-  //       const int &ispec, const int &ielement, const int &xz,
-  //       const ScratchViewType<type_real, 1> s_hprime_xx,
-  //       const ScratchViewType<type_real, 1> s_hprime_zz,
-  //       const ScratchViewType<type_real, medium_type::components> field_chi,
-  //       specfem::kokkos::array_type<type_real, 1> &dchidxl,
-  //       specfem::kokkos::array_type<type_real, 1> &dchidzl) const;
+  /**
+   * @brief Compute the gradient of the field at the quadrature point xz
+   * (Komatisch & Tromp, 2002-I., eq. 22(theory, OC),44,45)
+   *
+   * @param xz Index of the quadrature point
+   * @param s_hprime_xx lagrange polynomial derivative in x direction
+   * @param s_hprime_zz lagraange polynomial derivative in z direction
+   * @param field_chi potential field
+   * @param dchidxl Computed partial derivative of field \f$ \frac{\partial
+   * \chi}{\partial x} \f$
+   * @param dchidzl Computed partial derivative of field \f$ \frac{\partial
+   * \chi}{\partial z} \f$
+   */
+  KOKKOS_INLINE_FUNCTION void compute_gradient(
+      const int xz, const ScratchViewType<type_real, 1> s_hprime,
+      const ScratchViewType<type_real, medium_type::components> field_chi,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
+      const specfem::point::boundary &boundary_type,
+      specfem::kokkos::array_type<type_real, medium_type::components> &dudxl,
+      specfem::kokkos::array_type<type_real, medium_type::components> &dudzl)
+      const;
 
-  //   /**
-  //    * @brief Compute the stress integrand at a particular
-  //    Gauss-Lobatto-Legendre
-  //    * quadrature point. Note the collapse of jacobian elements into the
-  //    * integrands for the gradient of \f$ w \f$
-  //    * (Komatisch & Tromp, 2002-I., eq. 44,45)
-  //    *
-  //    * @param xz Index of Gauss-Lobatto-Legendre quadrature point
-  //    * @param dchidxl Partial derivative of field \f$ \frac{\partial
-  //    * \chi}{\partial x} \f$
-  //    * @param dchipdzl Partial derivative of field \f$ \frac{\partial
-  //    * \chi}{\partial z} \f$
-  //    * @param stress_integrand_xi Stress integrand  wrt. \f$ \xi \f$
-  //    * \f$ J^{\alpha\gamma} * {\rho^{\alpha\gamma}}^{-1}
-  //    * \partial_x \chi \partial_x \xi
-  //    * + \partial_z \chi * \partial_z \xi \f$
-  //    * @param stress_integrand_gamma Stress integrand  wrt. \f$\gamma\f$
-  //    * \f$ J^{\alpha\gamma} * {\rho^{\alpha\gamma}}^{-1}
-  //    * \partial_x \chi \partial_x \gamma
-  //    * + \partial_z \chi * \partial_z \gamma \f$
-  //    * @return KOKKOS_FUNCTION
-  //    */
-  //   KOKKOS_INLINE_FUNCTION void compute_stress(
-  //       const int &ispec, const int &ielement, const int &xz,
-  //       const specfem::kokkos::array_type<type_real, 1> &dchidxl,
-  //       const specfem::kokkos::array_type<type_real, 1> &dchidzl,
-  //       specfem::kokkos::array_type<type_real, 1> &stress_integrand_xi,
-  //       specfem::kokkos::array_type<type_real, 1> &stress_integrand_gamma)
-  //       const;
+  /**
+   * @brief Compute the stress integrand at a particular
+   Gauss-Lobatto-Legendre
+   * quadrature point. Note the collapse of jacobian elements into the
+   * integrands for the gradient of \f$ w \f$
+   * (Komatisch & Tromp, 2002-I., eq. 44,45)
+   *
+   * @param xz Index of Gauss-Lobatto-Legendre quadrature point
+   * @param dchidxl Partial derivative of field \f$ \frac{\partial
+   * \chi}{\partial x} \f$
+   * @param dchipdzl Partial derivative of field \f$ \frac{\partial
+   * \chi}{\partial z} \f$
+   * @param stress_integrand_xi Stress integrand  wrt. \f$ \xi \f$
+   * \f$ J^{\alpha\gamma} * {\rho^{\alpha\gamma}}^{-1}
+   * \partial_x \chi \partial_x \xi
+   * + \partial_z \chi * \partial_z \xi \f$
+   * @param stress_integrand_gamma Stress integrand  wrt. \f$\gamma\f$
+   * \f$ J^{\alpha\gamma} * {\rho^{\alpha\gamma}}^{-1}
+   * \partial_x \chi \partial_x \gamma
+   * + \partial_z \chi * \partial_z \gamma \f$
+   * @return KOKKOS_FUNCTION
+   */
+  KOKKOS_INLINE_FUNCTION void compute_stress(
+      const int xz,
+      const specfem::kokkos::array_type<type_real, medium_type::components>
+          &dudxl,
+      const specfem::kokkos::array_type<type_real, medium_type::components>
+          &dudzl,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
+      const specfem::point::properties<medium_type::value, property_type::value>
+          &properties,
+      const specfem::point::boundary &boundary_type,
+      specfem::kokkos::array_type<type_real, medium_type::components>
+          &stress_integrand_xi,
+      specfem::kokkos::array_type<type_real, medium_type::components>
+          &stress_integrand_gamma) const;
 
   //   /**
   //    * @brief Update the acceleration at a particular Gauss-Lobatto-Legendre

--- a/include/domain/impl/elements/acoustic/acoustic2d_isotropic.hpp
+++ b/include/domain/impl/elements/acoustic/acoustic2d_isotropic.hpp
@@ -89,7 +89,8 @@ public:
    */
   KOKKOS_FUNCTION
   element(const specfem::compute::assembly &assembly,
-          const quadrature_points_type &quadrature_points){};
+          const quadrature_points_type &quadrature_points)
+      : boundary_conditions(assembly.boundaries, quadrature_points){};
 
   /**
    * @brief Compute the mass matrix component ($ m_{\alpha, \beta} $) for a
@@ -108,13 +109,16 @@ public:
       const specfem::point::partial_derivatives2 &partial_derivatives,
       specfem::kokkos::array_type<type_real, 1> &mass_matrix) const;
 
-  //   template <specfem::enums::time_scheme::type time_scheme>
-  //   KOKKOS_INLINE_FUNCTION void mass_time_contribution(
-  //       const int &ispec, const int &ielement, const int &xz, const type_real
-  //       &dt, const specfem::kokkos::array_type<type_real, dimension::dim>
-  //       &weight, specfem::kokkos::array_type<type_real,
-  //       medium_type::components>
-  //           &rmass_inverse) const;
+  template <specfem::enums::time_scheme::type time_scheme>
+  KOKKOS_INLINE_FUNCTION void mass_time_contribution(
+      const int &xz, const type_real &dt,
+      const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
+      const specfem::point::properties<medium_type::value, property_type::value>
+          &properties,
+      const specfem::point::boundary &boundary_type,
+      specfem::kokkos::array_type<type_real, medium_type::components>
+          &rmass_inverse) const;
 
   //   /**
   //    * @brief Compute the gradient of the field at the quadrature point xz
@@ -219,8 +223,8 @@ private:
   //                                                                   ///<
   //                                                                   inverse
   //   specfem::kokkos::DeviceView3d<type_real> kappa;                 ///<
-  //   kappa boundary_conditions_type boundary_conditions; ///< boundary
-  //   conditions
+  //   kappa
+  boundary_conditions_type boundary_conditions; ///< boundary conditions
 };
 } // namespace elements
 } // namespace impl

--- a/include/domain/impl/elements/acoustic/acoustic2d_isotropic.hpp
+++ b/include/domain/impl/elements/acoustic/acoustic2d_isotropic.hpp
@@ -88,10 +88,8 @@ public:
    * @param properties Properties of the element
    */
   KOKKOS_FUNCTION
-  element(const specfem::compute::partial_derivatives &partial_derivatives,
-          const specfem::compute::properties &properties,
-          const specfem::compute::boundaries &boundary_conditions,
-          const quadrature_points_type &quadrature_points);
+  element(const specfem::compute::assembly &assembly,
+          const quadrature_points_type &quadrature_points){};
 
   /**
    * @brief Compute the mass matrix component ($ m_{\alpha, \beta} $) for a
@@ -105,111 +103,124 @@ public:
    */
   KOKKOS_INLINE_FUNCTION
   void compute_mass_matrix_component(
-      const int &ispec, const int &xz,
+      const specfem::point::properties<medium_type::value, property_type::value>
+          &properties,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
       specfem::kokkos::array_type<type_real, 1> &mass_matrix) const;
 
-  template <specfem::enums::time_scheme::type time_scheme>
-  KOKKOS_INLINE_FUNCTION void mass_time_contribution(
-      const int &ispec, const int &ielement, const int &xz, const type_real &dt,
-      const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
-      specfem::kokkos::array_type<type_real, medium_type::components>
-          &rmass_inverse) const;
+  //   template <specfem::enums::time_scheme::type time_scheme>
+  //   KOKKOS_INLINE_FUNCTION void mass_time_contribution(
+  //       const int &ispec, const int &ielement, const int &xz, const type_real
+  //       &dt, const specfem::kokkos::array_type<type_real, dimension::dim>
+  //       &weight, specfem::kokkos::array_type<type_real,
+  //       medium_type::components>
+  //           &rmass_inverse) const;
 
-  /**
-   * @brief Compute the gradient of the field at the quadrature point xz
-   * (Komatisch & Tromp, 2002-I., eq. 22(theory, OC),44,45)
-   *
-   * @param xz Index of the quadrature point
-   * @param s_hprime_xx lagrange polynomial derivative in x direction
-   * @param s_hprime_zz lagraange polynomial derivative in z direction
-   * @param field_chi potential field
-   * @param dchidxl Computed partial derivative of field \f$ \frac{\partial
-   * \chi}{\partial x} \f$
-   * @param dchidzl Computed partial derivative of field \f$ \frac{\partial
-   * \chi}{\partial z} \f$
-   */
-  KOKKOS_INLINE_FUNCTION void compute_gradient(
-      const int &ispec, const int &ielement, const int &xz,
-      const ScratchViewType<type_real, 1> s_hprime_xx,
-      const ScratchViewType<type_real, 1> s_hprime_zz,
-      const ScratchViewType<type_real, medium_type::components> field_chi,
-      specfem::kokkos::array_type<type_real, 1> &dchidxl,
-      specfem::kokkos::array_type<type_real, 1> &dchidzl) const;
+  //   /**
+  //    * @brief Compute the gradient of the field at the quadrature point xz
+  //    * (Komatisch & Tromp, 2002-I., eq. 22(theory, OC),44,45)
+  //    *
+  //    * @param xz Index of the quadrature point
+  //    * @param s_hprime_xx lagrange polynomial derivative in x direction
+  //    * @param s_hprime_zz lagraange polynomial derivative in z direction
+  //    * @param field_chi potential field
+  //    * @param dchidxl Computed partial derivative of field \f$ \frac{\partial
+  //    * \chi}{\partial x} \f$
+  //    * @param dchidzl Computed partial derivative of field \f$ \frac{\partial
+  //    * \chi}{\partial z} \f$
+  //    */
+  //   KOKKOS_INLINE_FUNCTION void compute_gradient(
+  //       const int &ispec, const int &ielement, const int &xz,
+  //       const ScratchViewType<type_real, 1> s_hprime_xx,
+  //       const ScratchViewType<type_real, 1> s_hprime_zz,
+  //       const ScratchViewType<type_real, medium_type::components> field_chi,
+  //       specfem::kokkos::array_type<type_real, 1> &dchidxl,
+  //       specfem::kokkos::array_type<type_real, 1> &dchidzl) const;
 
-  /**
-   * @brief Compute the stress integrand at a particular Gauss-Lobatto-Legendre
-   * quadrature point. Note the collapse of jacobian elements into the
-   * integrands for the gradient of \f$ w \f$
-   * (Komatisch & Tromp, 2002-I., eq. 44,45)
-   *
-   * @param xz Index of Gauss-Lobatto-Legendre quadrature point
-   * @param dchidxl Partial derivative of field \f$ \frac{\partial
-   * \chi}{\partial x} \f$
-   * @param dchipdzl Partial derivative of field \f$ \frac{\partial
-   * \chi}{\partial z} \f$
-   * @param stress_integrand_xi Stress integrand  wrt. \f$ \xi \f$
-   * \f$ J^{\alpha\gamma} * {\rho^{\alpha\gamma}}^{-1}
-   * \partial_x \chi \partial_x \xi
-   * + \partial_z \chi * \partial_z \xi \f$
-   * @param stress_integrand_gamma Stress integrand  wrt. \f$\gamma\f$
-   * \f$ J^{\alpha\gamma} * {\rho^{\alpha\gamma}}^{-1}
-   * \partial_x \chi \partial_x \gamma
-   * + \partial_z \chi * \partial_z \gamma \f$
-   * @return KOKKOS_FUNCTION
-   */
-  KOKKOS_INLINE_FUNCTION void compute_stress(
-      const int &ispec, const int &ielement, const int &xz,
-      const specfem::kokkos::array_type<type_real, 1> &dchidxl,
-      const specfem::kokkos::array_type<type_real, 1> &dchidzl,
-      specfem::kokkos::array_type<type_real, 1> &stress_integrand_xi,
-      specfem::kokkos::array_type<type_real, 1> &stress_integrand_gamma) const;
+  //   /**
+  //    * @brief Compute the stress integrand at a particular
+  //    Gauss-Lobatto-Legendre
+  //    * quadrature point. Note the collapse of jacobian elements into the
+  //    * integrands for the gradient of \f$ w \f$
+  //    * (Komatisch & Tromp, 2002-I., eq. 44,45)
+  //    *
+  //    * @param xz Index of Gauss-Lobatto-Legendre quadrature point
+  //    * @param dchidxl Partial derivative of field \f$ \frac{\partial
+  //    * \chi}{\partial x} \f$
+  //    * @param dchipdzl Partial derivative of field \f$ \frac{\partial
+  //    * \chi}{\partial z} \f$
+  //    * @param stress_integrand_xi Stress integrand  wrt. \f$ \xi \f$
+  //    * \f$ J^{\alpha\gamma} * {\rho^{\alpha\gamma}}^{-1}
+  //    * \partial_x \chi \partial_x \xi
+  //    * + \partial_z \chi * \partial_z \xi \f$
+  //    * @param stress_integrand_gamma Stress integrand  wrt. \f$\gamma\f$
+  //    * \f$ J^{\alpha\gamma} * {\rho^{\alpha\gamma}}^{-1}
+  //    * \partial_x \chi \partial_x \gamma
+  //    * + \partial_z \chi * \partial_z \gamma \f$
+  //    * @return KOKKOS_FUNCTION
+  //    */
+  //   KOKKOS_INLINE_FUNCTION void compute_stress(
+  //       const int &ispec, const int &ielement, const int &xz,
+  //       const specfem::kokkos::array_type<type_real, 1> &dchidxl,
+  //       const specfem::kokkos::array_type<type_real, 1> &dchidzl,
+  //       specfem::kokkos::array_type<type_real, 1> &stress_integrand_xi,
+  //       specfem::kokkos::array_type<type_real, 1> &stress_integrand_gamma)
+  //       const;
 
-  /**
-   * @brief Update the acceleration at a particular Gauss-Lobatto-Legendre
-   * quadrature point
-   *
-   * @param xz Index of Gauss-Lobatto-Legendre quadrature point
-   * @param wxglll Weight of the Gauss-Lobatto-Legendre quadrature point in x
-   * direction
-   * @param wzglll Weight of the Gauss-Lobatto-Legendre quadrature point in z
-   * direction
-   * @param stress_integrand_xi Stress integrand  wrt. \f$ \xi \f$
-   * \f$ J^{\alpha\gamma} * {\rho^{\alpha\gamma}}^{-1}
-   * \partial_x \chi \partial_x \xi + \partial_z \chi * \partial_z \xi \f$ as
-   * computed by compute_stress
-   * @param stress_integrand_gamma Stress integrand  wrt. \f$\gamma\f$
-   * \f$ J^{\alpha\gamma} * {\rho^{\alpha\gamma}}^{-1}
-   * \partial_x \chi \partial_x \gamma + \partial_z \chi * \partial_z \gamma \f$
-   * as computed by compute_stress
-   * @param s_hprimewgll_xx Scratch view hprime_xx * wxgll
-   * @param s_hprimewgll_zz Scratch view hprime_zz * wzgll
-   * @param field_dot_dot Acceleration of the field subviewed at global index xz
-   */
-  KOKKOS_INLINE_FUNCTION void compute_acceleration(
-      const int &ispec, const int &ielement, const int &xz,
-      const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
-      const ScratchViewType<type_real, medium_type::components>
-          stress_integrand_xi,
-      const ScratchViewType<type_real, medium_type::components>
-          stress_integrand_gamma,
-      const ScratchViewType<type_real, 1> s_hprimewgll_xx,
-      const ScratchViewType<type_real, 1> s_hprimewgll_zz,
-      const specfem::kokkos::array_type<type_real, medium_type::components>
-          &velocity,
-      specfem::kokkos::array_type<type_real, 1> &acceleration) const;
+  //   /**
+  //    * @brief Update the acceleration at a particular Gauss-Lobatto-Legendre
+  //    * quadrature point
+  //    *
+  //    * @param xz Index of Gauss-Lobatto-Legendre quadrature point
+  //    * @param wxglll Weight of the Gauss-Lobatto-Legendre quadrature point in
+  //    x
+  //    * direction
+  //    * @param wzglll Weight of the Gauss-Lobatto-Legendre quadrature point in
+  //    z
+  //    * direction
+  //    * @param stress_integrand_xi Stress integrand  wrt. \f$ \xi \f$
+  //    * \f$ J^{\alpha\gamma} * {\rho^{\alpha\gamma}}^{-1}
+  //    * \partial_x \chi \partial_x \xi + \partial_z \chi * \partial_z \xi \f$
+  //    as
+  //    * computed by compute_stress
+  //    * @param stress_integrand_gamma Stress integrand  wrt. \f$\gamma\f$
+  //    * \f$ J^{\alpha\gamma} * {\rho^{\alpha\gamma}}^{-1}
+  //    * \partial_x \chi \partial_x \gamma + \partial_z \chi * \partial_z
+  //    \gamma \f$
+  //    * as computed by compute_stress
+  //    * @param s_hprimewgll_xx Scratch view hprime_xx * wxgll
+  //    * @param s_hprimewgll_zz Scratch view hprime_zz * wzgll
+  //    * @param field_dot_dot Acceleration of the field subviewed at global
+  //    index xz
+  //    */
+  //   KOKKOS_INLINE_FUNCTION void compute_acceleration(
+  //       const int &ispec, const int &ielement, const int &xz,
+  //       const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
+  //       const ScratchViewType<type_real, medium_type::components>
+  //           stress_integrand_xi,
+  //       const ScratchViewType<type_real, medium_type::components>
+  //           stress_integrand_gamma,
+  //       const ScratchViewType<type_real, 1> s_hprimewgll_xx,
+  //       const ScratchViewType<type_real, 1> s_hprimewgll_zz,
+  //       const specfem::kokkos::array_type<type_real, medium_type::components>
+  //           &velocity,
+  //       specfem::kokkos::array_type<type_real, 1> &acceleration) const;
 
 private:
-  specfem::kokkos::DeviceView3d<type_real> xix;         ///< xix
-  specfem::kokkos::DeviceView3d<type_real> xiz;         ///< xiz
-  specfem::kokkos::DeviceView3d<type_real> gammax;      ///< gammax
-  specfem::kokkos::DeviceView3d<type_real> gammaz;      ///< gammaz
-  specfem::kokkos::DeviceView3d<type_real> jacobian;    ///< jacobian
-  specfem::kokkos::DeviceView3d<type_real> rho_inverse; ///< rho inverse
-  specfem::kokkos::DeviceView3d<type_real> lambdaplus2mu_inverse; ///< lambda +
-                                                                  ///< 2 mu
-                                                                  ///< inverse
-  specfem::kokkos::DeviceView3d<type_real> kappa;                 ///< kappa
-  boundary_conditions_type boundary_conditions; ///< boundary conditions
+  //   specfem::kokkos::DeviceView3d<type_real> xix;         ///< xix
+  //   specfem::kokkos::DeviceView3d<type_real> xiz;         ///< xiz
+  //   specfem::kokkos::DeviceView3d<type_real> gammax;      ///< gammax
+  //   specfem::kokkos::DeviceView3d<type_real> gammaz;      ///< gammaz
+  //   specfem::kokkos::DeviceView3d<type_real> jacobian;    ///< jacobian
+  //   specfem::kokkos::DeviceView3d<type_real> rho_inverse; ///< rho inverse
+  //   specfem::kokkos::DeviceView3d<type_real> lambdaplus2mu_inverse; ///<
+  //   lambda +
+  //                                                                   ///< 2 mu
+  //                                                                   ///<
+  //                                                                   inverse
+  //   specfem::kokkos::DeviceView3d<type_real> kappa;                 ///<
+  //   kappa boundary_conditions_type boundary_conditions; ///< boundary
+  //   conditions
 };
 } // namespace elements
 } // namespace impl

--- a/include/domain/impl/elements/acoustic/acoustic2d_isotropic.tpp
+++ b/include/domain/impl/elements/acoustic/acoustic2d_isotropic.tpp
@@ -22,276 +22,280 @@ using StaticScratchViewType =
 // -----------------------------------------------------------------------------
 //                     SPECIALIZED ELEMENT
 // -----------------------------------------------------------------------------
-template <int NGLL, typename BC>
-KOKKOS_FUNCTION specfem::domain::impl::elements::element<
-    specfem::enums::element::dimension::dim2,
-    specfem::enums::element::medium::acoustic,
-    specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
-    specfem::enums::element::property::isotropic,
-    BC>::element(const specfem::compute::partial_derivatives
-                     &partial_derivatives,
-                 const specfem::compute::properties &properties,
-                 const specfem::compute::boundaries &boundary_conditions,
-                 const quadrature_points_type &quadrature_points) {
+// template <int NGLL, typename BC>
+// KOKKOS_FUNCTION specfem::domain::impl::elements::element<
+//     specfem::enums::element::dimension::dim2,
+//     specfem::enums::element::medium::acoustic,
+//     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
+//     specfem::enums::element::property::isotropic,
+//     BC>::element(const specfem::compute::partial_derivatives
+//                      &partial_derivatives,
+//                  const specfem::compute::properties &properties,
+//                  const specfem::compute::boundaries &boundary_conditions,
+//                  const quadrature_points_type &quadrature_points) {
 
-#ifndef NDEBUG
-  assert(partial_derivatives.xix.extent(1) == NGLL);
-  assert(partial_derivatives.xix.extent(2) == NGLL);
-  assert(partial_derivatives.gammax.extent(1) == NGLL);
-  assert(partial_derivatives.gammax.extent(2) == NGLL);
-  assert(partial_derivatives.xiz.extent(1) == NGLL);
-  assert(partial_derivatives.xiz.extent(2) == NGLL);
-  assert(partial_derivatives.gammaz.extent(1) == NGLL);
-  assert(partial_derivatives.gammaz.extent(2) == NGLL);
-  assert(partial_derivatives.jacobian.extent(1) == NGLL);
-  assert(partial_derivatives.jacobian.extent(2) == NGLL);
+// #ifndef NDEBUG
+//   assert(partial_derivatives.xix.extent(1) == NGLL);
+//   assert(partial_derivatives.xix.extent(2) == NGLL);
+//   assert(partial_derivatives.gammax.extent(1) == NGLL);
+//   assert(partial_derivatives.gammax.extent(2) == NGLL);
+//   assert(partial_derivatives.xiz.extent(1) == NGLL);
+//   assert(partial_derivatives.xiz.extent(2) == NGLL);
+//   assert(partial_derivatives.gammaz.extent(1) == NGLL);
+//   assert(partial_derivatives.gammaz.extent(2) == NGLL);
+//   assert(partial_derivatives.jacobian.extent(1) == NGLL);
+//   assert(partial_derivatives.jacobian.extent(2) == NGLL);
 
-  // Properties
-  assert(properties.rho_inverse.extent(1) == NGLL);
-  assert(properties.rho_inverse.extent(2) == NGLL);
-  assert(properties.lambdaplus2mu_inverse.extent(1) == NGLL);
-  assert(properties.lambdaplus2mu_inverse.extent(2) == NGLL);
-  assert(properties.kappa.extent(1) == NGLL);
-  assert(properties.kappa.extent(2) == NGLL);
-#endif
+//   // Properties
+//   assert(properties.rho_inverse.extent(1) == NGLL);
+//   assert(properties.rho_inverse.extent(2) == NGLL);
+//   assert(properties.lambdaplus2mu_inverse.extent(1) == NGLL);
+//   assert(properties.lambdaplus2mu_inverse.extent(2) == NGLL);
+//   assert(properties.kappa.extent(1) == NGLL);
+//   assert(properties.kappa.extent(2) == NGLL);
+// #endif
 
-  this->xix = partial_derivatives.xix;
-  this->gammax = partial_derivatives.gammax;
-  this->xiz = partial_derivatives.xiz;
-  this->gammaz = partial_derivatives.gammaz;
-  this->jacobian = partial_derivatives.jacobian;
-  this->rho_inverse = properties.rho_inverse;
-  this->lambdaplus2mu_inverse = properties.lambdaplus2mu_inverse;
-  this->kappa = properties.kappa;
+//   this->xix = partial_derivatives.xix;
+//   this->gammax = partial_derivatives.gammax;
+//   this->xiz = partial_derivatives.xiz;
+//   this->gammaz = partial_derivatives.gammaz;
+//   this->jacobian = partial_derivatives.jacobian;
+//   this->rho_inverse = properties.rho_inverse;
+//   this->lambdaplus2mu_inverse = properties.lambdaplus2mu_inverse;
+//   this->kappa = properties.kappa;
 
-  this->boundary_conditions =
-      boundary_conditions_type(boundary_conditions, quadrature_points);
+//   this->boundary_conditions =
+//       boundary_conditions_type(boundary_conditions, quadrature_points);
 
-  return;
-}
+//   return;
+// }
 
 template <int NGLL, typename BC>
 KOKKOS_INLINE_FUNCTION void specfem::domain::impl::elements::element<
     specfem::enums::element::dimension::dim2,
     specfem::enums::element::medium::acoustic,
     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
-    specfem::enums::element::property::isotropic,
-    BC>::compute_mass_matrix_component(const int &ispec, const int &xz,
-                                       specfem::kokkos::array_type<type_real, 1>
-                                           &mass_matrix) const {
-  int ix, iz;
-  sub2ind(xz, NGLL, iz, ix);
+    specfem::enums::element::property::isotropic, BC>::
+    compute_mass_matrix_component(
+        const specfem::point::properties<medium_type::value,
+                                         property_type::value> &properties,
+        const specfem::point::partial_derivatives2 &partial_derivatives,
+        specfem::kokkos::array_type<type_real, 1> &mass_matrix) const {
 
   constexpr int components = medium_type::components;
 
   static_assert(components == 1, "Acoustic medium has only one component");
 
-  mass_matrix[0] = this->jacobian(ispec, iz, ix) / this->kappa(ispec, iz, ix);
+  mass_matrix[0] = partial_derivatives.jacobian / properties.kappa;
 
   return;
 }
 
-template <int NGLL, typename BC>
-template <specfem::enums::time_scheme::type time_scheme>
-KOKKOS_INLINE_FUNCTION void specfem::domain::impl::elements::element<
-    specfem::enums::element::dimension::dim2,
-    specfem::enums::element::medium::acoustic,
-    specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
-    specfem::enums::element::property::isotropic, BC>::
-    mass_time_contribution(
-        const int &ispec, const int &ielement, const int &xz,
-        const type_real &dt,
-        const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
-        specfem::kokkos::array_type<type_real, medium_type::components>
-            &rmass_inverse) const {
+// template <int NGLL, typename BC>
+// template <specfem::enums::time_scheme::type time_scheme>
+// KOKKOS_INLINE_FUNCTION void specfem::domain::impl::elements::element<
+//     specfem::enums::element::dimension::dim2,
+//     specfem::enums::element::medium::acoustic,
+//     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
+//     specfem::enums::element::property::isotropic, BC>::
+//     mass_time_contribution(
+//         const int &ispec, const int &ielement, const int &xz,
+//         const type_real &dt,
+//         const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
+//         specfem::kokkos::array_type<type_real, medium_type::components>
+//             &rmass_inverse) const {
 
-  int ix, iz;
-  sub2ind(xz, NGLL, iz, ix);
+//   int ix, iz;
+//   sub2ind(xz, NGLL, iz, ix);
 
-  const specfem::compute::element_partial_derivatives partial_derivatives(
-      this->xix(ispec, iz, ix), this->gammax(ispec, iz, ix),
-      this->xiz(ispec, iz, ix), this->gammaz(ispec, iz, ix),
-      this->jacobian(ispec, iz, ix));
+//   const specfem::compute::element_partial_derivatives partial_derivatives(
+//       this->xix(ispec, iz, ix), this->gammax(ispec, iz, ix),
+//       this->xiz(ispec, iz, ix), this->gammaz(ispec, iz, ix),
+//       this->jacobian(ispec, iz, ix));
 
-  const specfem::compute::element_properties<medium_type::value,
-                                             property_type::value>
-      properties(this->lambdaplus2mu_inverse(ispec, iz, ix),
-                 this->rho_inverse(ispec, iz, ix));
+//   const specfem::compute::element_properties<medium_type::value,
+//                                              property_type::value>
+//       properties(this->lambdaplus2mu_inverse(ispec, iz, ix),
+//                  this->rho_inverse(ispec, iz, ix));
 
-  rmass_inverse[0] = 0.0;
+//   rmass_inverse[0] = 0.0;
 
-  // comppute mass matrix component
-  boundary_conditions.template mass_time_contribution<time_scheme>(
-      ielement, xz, dt, weight, partial_derivatives, properties, rmass_inverse);
+//   // comppute mass matrix component
+//   boundary_conditions.template mass_time_contribution<time_scheme>(
+//       ielement, xz, dt, weight, partial_derivatives, properties,
+//       rmass_inverse);
 
-  return;
-}
+//   return;
+// }
 
-template <int NGLL, typename BC>
-KOKKOS_INLINE_FUNCTION void specfem::domain::impl::elements::element<
-    specfem::enums::element::dimension::dim2,
-    specfem::enums::element::medium::acoustic,
-    specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
-    specfem::enums::element::property::isotropic, BC>::
-    compute_gradient(
-        const int &ispec, const int &ielement, const int &xz,
-        const ScratchViewType<type_real, 1> s_hprime_xx,
-        const ScratchViewType<type_real, 1> s_hprime_zz,
-        const ScratchViewType<type_real, medium_type::components> field_chi,
-        specfem::kokkos::array_type<type_real, 1> &dchidxl,
-        specfem::kokkos::array_type<type_real, 1> &dchidzl) const {
+// template <int NGLL, typename BC>
+// KOKKOS_INLINE_FUNCTION void specfem::domain::impl::elements::element<
+//     specfem::enums::element::dimension::dim2,
+//     specfem::enums::element::medium::acoustic,
+//     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
+//     specfem::enums::element::property::isotropic, BC>::
+//     compute_gradient(
+//         const int &ispec, const int &ielement, const int &xz,
+//         const ScratchViewType<type_real, 1> s_hprime_xx,
+//         const ScratchViewType<type_real, 1> s_hprime_zz,
+//         const ScratchViewType<type_real, medium_type::components> field_chi,
+//         specfem::kokkos::array_type<type_real, 1> &dchidxl,
+//         specfem::kokkos::array_type<type_real, 1> &dchidzl) const {
 
-  int ix, iz;
-  sub2ind(xz, NGLL, iz, ix);
+//   int ix, iz;
+//   sub2ind(xz, NGLL, iz, ix);
 
-  const specfem::compute::element_partial_derivatives partial_derivatives =
-      specfem::compute::element_partial_derivatives(
-          this->xix(ispec, iz, ix), this->gammax(ispec, iz, ix),
-          this->xiz(ispec, iz, ix), this->gammaz(ispec, iz, ix));
+//   const specfem::compute::element_partial_derivatives partial_derivatives =
+//       specfem::compute::element_partial_derivatives(
+//           this->xix(ispec, iz, ix), this->gammax(ispec, iz, ix),
+//           this->xiz(ispec, iz, ix), this->gammaz(ispec, iz, ix));
 
-  type_real dchi_dxi = 0.0;
-  type_real dchi_dgamma = 0.0;
+//   type_real dchi_dxi = 0.0;
+//   type_real dchi_dgamma = 0.0;
 
-#ifdef KOKKOS_ENABLE_CUDA
-#pragma unroll
-#endif
-  for (int l = 0; l < NGLL; l++) {
-    dchi_dxi += s_hprime_xx(ix, l, 0) * field_chi(iz, l, 0);
-    dchi_dgamma += s_hprime_zz(iz, l, 0) * field_chi(l, ix, 0);
-  }
+// #ifdef KOKKOS_ENABLE_CUDA
+// #pragma unroll
+// #endif
+//   for (int l = 0; l < NGLL; l++) {
+//     dchi_dxi += s_hprime_xx(ix, l, 0) * field_chi(iz, l, 0);
+//     dchi_dgamma += s_hprime_zz(iz, l, 0) * field_chi(l, ix, 0);
+//   }
 
-  // dchidx
-  dchidxl[0] = dchi_dxi * partial_derivatives.xix +
-               dchi_dgamma * partial_derivatives.gammax;
+//   // dchidx
+//   dchidxl[0] = dchi_dxi * partial_derivatives.xix +
+//                dchi_dgamma * partial_derivatives.gammax;
 
-  // dchidz
-  dchidzl[0] = dchi_dxi * partial_derivatives.xiz +
-               dchi_dgamma * partial_derivatives.gammaz;
+//   // dchidz
+//   dchidzl[0] = dchi_dxi * partial_derivatives.xiz +
+//                dchi_dgamma * partial_derivatives.gammaz;
 
-  boundary_conditions.enforce_gradient(ielement, xz, partial_derivatives,
-                                       dchidxl, dchidzl);
+//   boundary_conditions.enforce_gradient(ielement, xz, partial_derivatives,
+//                                        dchidxl, dchidzl);
 
-  return;
-}
+//   return;
+// }
 
-template <int NGLL, typename BC>
-KOKKOS_INLINE_FUNCTION void specfem::domain::impl::elements::element<
-    specfem::enums::element::dimension::dim2,
-    specfem::enums::element::medium::acoustic,
-    specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
-    specfem::enums::element::property::isotropic, BC>::
-    compute_stress(
-        const int &ispec, const int &ielement, const int &xz,
-        const specfem::kokkos::array_type<type_real, 1> &dchidxl,
-        const specfem::kokkos::array_type<type_real, 1> &dchidzl,
-        specfem::kokkos::array_type<type_real, 1> &stress_integrand_xi,
-        specfem::kokkos::array_type<type_real, 1> &stress_integrand_gamma)
-        const {
+// template <int NGLL, typename BC>
+// KOKKOS_INLINE_FUNCTION void specfem::domain::impl::elements::element<
+//     specfem::enums::element::dimension::dim2,
+//     specfem::enums::element::medium::acoustic,
+//     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
+//     specfem::enums::element::property::isotropic, BC>::
+//     compute_stress(
+//         const int &ispec, const int &ielement, const int &xz,
+//         const specfem::kokkos::array_type<type_real, 1> &dchidxl,
+//         const specfem::kokkos::array_type<type_real, 1> &dchidzl,
+//         specfem::kokkos::array_type<type_real, 1> &stress_integrand_xi,
+//         specfem::kokkos::array_type<type_real, 1> &stress_integrand_gamma)
+//         const {
 
-  int ix, iz;
-  sub2ind(xz, NGLL, iz, ix);
+//   int ix, iz;
+//   sub2ind(xz, NGLL, iz, ix);
 
-  const specfem::compute::element_partial_derivatives partial_derivatives(
-      this->xix(ispec, iz, ix), this->gammax(ispec, iz, ix),
-      this->xiz(ispec, iz, ix), this->gammaz(ispec, iz, ix),
-      this->jacobian(ispec, iz, ix));
+//   const specfem::compute::element_partial_derivatives partial_derivatives(
+//       this->xix(ispec, iz, ix), this->gammax(ispec, iz, ix),
+//       this->xiz(ispec, iz, ix), this->gammaz(ispec, iz, ix),
+//       this->jacobian(ispec, iz, ix));
 
-  const specfem::compute::element_properties<medium_type::value,
-                                             property_type::value>
-      properties(this->lambdaplus2mu_inverse(ispec, iz, ix),
-                 this->rho_inverse(ispec, iz, ix));
+//   const specfem::compute::element_properties<medium_type::value,
+//                                              property_type::value>
+//       properties(this->lambdaplus2mu_inverse(ispec, iz, ix),
+//                  this->rho_inverse(ispec, iz, ix));
 
-  // Precompute the factor
-  type_real fac = partial_derivatives.jacobian * properties.rho_inverse;
+//   // Precompute the factor
+//   type_real fac = partial_derivatives.jacobian * properties.rho_inverse;
 
-  // Compute stress integrands 1 and 2
-  // Here it is extremely important that this seems at odds with
-  // equations (44) & (45) from Komatitsch and Tromp 2002 I. - Validation
-  // The equations are however missing dxi/dx, dxi/dz, dzeta/dx, dzeta/dz
-  // for the gradient of w^{\alpha\gamma}. In this->update_acceleration
-  // the weights for the integration and the interpolated values for the
-  // first derivatives of the lagrange polynomials are then collapsed
-  stress_integrand_xi[0] = fac * (partial_derivatives.xix * dchidxl[0] +
-                                  partial_derivatives.xiz * dchidzl[0]);
-  stress_integrand_gamma[0] = fac * (partial_derivatives.gammax * dchidxl[0] +
-                                     partial_derivatives.gammaz * dchidzl[0]);
+//   // Compute stress integrands 1 and 2
+//   // Here it is extremely important that this seems at odds with
+//   // equations (44) & (45) from Komatitsch and Tromp 2002 I. - Validation
+//   // The equations are however missing dxi/dx, dxi/dz, dzeta/dx, dzeta/dz
+//   // for the gradient of w^{\alpha\gamma}. In this->update_acceleration
+//   // the weights for the integration and the interpolated values for the
+//   // first derivatives of the lagrange polynomials are then collapsed
+//   stress_integrand_xi[0] = fac * (partial_derivatives.xix * dchidxl[0] +
+//                                   partial_derivatives.xiz * dchidzl[0]);
+//   stress_integrand_gamma[0] = fac * (partial_derivatives.gammax * dchidxl[0]
+//   +
+//                                      partial_derivatives.gammaz *
+//                                      dchidzl[0]);
 
-  boundary_conditions.enforce_stress(ielement, xz, partial_derivatives,
-                                     properties, stress_integrand_xi,
-                                     stress_integrand_gamma);
+//   boundary_conditions.enforce_stress(ielement, xz, partial_derivatives,
+//                                      properties, stress_integrand_xi,
+//                                      stress_integrand_gamma);
 
-  return;
-}
+//   return;
+// }
 
-template <int NGLL, typename BC>
-KOKKOS_INLINE_FUNCTION void specfem::domain::impl::elements::element<
-    specfem::enums::element::dimension::dim2,
-    specfem::enums::element::medium::acoustic,
-    specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
-    specfem::enums::element::property::isotropic, BC>::
-    compute_acceleration(
-        const int &ispec, const int &ielement, const int &xz,
-        const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
-        const ScratchViewType<type_real, medium_type::components>
-            stress_integrand_xi,
-        const ScratchViewType<type_real, medium_type::components>
-            stress_integrand_gamma,
-        const ScratchViewType<type_real, medium_type::components>
-            s_hprimewgll_xx,
-        const ScratchViewType<type_real, medium_type::components>
-            s_hprimewgll_zz,
-        const specfem::kokkos::array_type<type_real, medium_type::components>
-            &velocity,
-        specfem::kokkos::array_type<type_real, medium_type::components>
-            &acceleration) const {
+// template <int NGLL, typename BC>
+// KOKKOS_INLINE_FUNCTION void specfem::domain::impl::elements::element<
+//     specfem::enums::element::dimension::dim2,
+//     specfem::enums::element::medium::acoustic,
+//     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
+//     specfem::enums::element::property::isotropic, BC>::
+//     compute_acceleration(
+//         const int &ispec, const int &ielement, const int &xz,
+//         const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
+//         const ScratchViewType<type_real, medium_type::components>
+//             stress_integrand_xi,
+//         const ScratchViewType<type_real, medium_type::components>
+//             stress_integrand_gamma,
+//         const ScratchViewType<type_real, medium_type::components>
+//             s_hprimewgll_xx,
+//         const ScratchViewType<type_real, medium_type::components>
+//             s_hprimewgll_zz,
+//         const specfem::kokkos::array_type<type_real, medium_type::components>
+//             &velocity,
+//         specfem::kokkos::array_type<type_real, medium_type::components>
+//             &acceleration) const {
 
-  int ix, iz;
-  sub2ind(xz, NGLL, iz, ix);
-  type_real temp1l = 0.0;
-  type_real temp2l = 0.0;
+//   int ix, iz;
+//   sub2ind(xz, NGLL, iz, ix);
+//   type_real temp1l = 0.0;
+//   type_real temp2l = 0.0;
 
-  constexpr int components = medium_type::components;
+//   constexpr int components = medium_type::components;
 
-  static_assert(components == 1, "Acoustic medium has only one component");
+//   static_assert(components == 1, "Acoustic medium has only one component");
 
-  specfem::compute::element_partial_derivatives partial_derivatives;
+//   specfem::compute::element_partial_derivatives partial_derivatives;
 
-  specfem::compute::element_properties<medium_type::value, property_type::value>
-      properties;
+//   specfem::compute::element_properties<medium_type::value,
+//   property_type::value>
+//       properties;
 
-  // populate partial derivatives only if the boundary is stacey
-  // or if the boundary is composite_stacey_dirichlet
-  if constexpr ((boundary_conditions_type::value ==
-                 specfem::enums::element::boundary_tag::stacey) ||
-                (boundary_conditions_type::value ==
-                 specfem::enums::element::boundary_tag::
-                     composite_stacey_dirichlet)) {
-    partial_derivatives = specfem::compute::element_partial_derivatives(
-        this->xix(ispec, iz, ix), this->gammax(ispec, iz, ix),
-        this->xiz(ispec, iz, ix), this->gammaz(ispec, iz, ix),
-        this->jacobian(ispec, iz, ix));
+//   // populate partial derivatives only if the boundary is stacey
+//   // or if the boundary is composite_stacey_dirichlet
+//   if constexpr ((boundary_conditions_type::value ==
+//                  specfem::enums::element::boundary_tag::stacey) ||
+//                 (boundary_conditions_type::value ==
+//                  specfem::enums::element::boundary_tag::
+//                      composite_stacey_dirichlet)) {
+//     partial_derivatives = specfem::compute::element_partial_derivatives(
+//         this->xix(ispec, iz, ix), this->gammax(ispec, iz, ix),
+//         this->xiz(ispec, iz, ix), this->gammaz(ispec, iz, ix),
+//         this->jacobian(ispec, iz, ix));
 
-    properties = specfem::compute::element_properties<medium_type::value,
-                                                      property_type::value>(
-        this->lambdaplus2mu_inverse(ispec, iz, ix),
-        this->rho_inverse(ispec, iz, ix));
-  }
+//     properties = specfem::compute::element_properties<medium_type::value,
+//                                                       property_type::value>(
+//         this->lambdaplus2mu_inverse(ispec, iz, ix),
+//         this->rho_inverse(ispec, iz, ix));
+//   }
 
-#ifdef KOKKOS_ENABLE_CUDA
-#pragma unroll
-#endif
-  for (int l = 0; l < NGLL; l++) {
-    temp1l += s_hprimewgll_xx(ix, l, 0) * stress_integrand_xi(iz, l, 0);
-    temp2l += s_hprimewgll_zz(iz, l, 0) * stress_integrand_gamma(l, ix, 0);
-  }
+// #ifdef KOKKOS_ENABLE_CUDA
+// #pragma unroll
+// #endif
+//   for (int l = 0; l < NGLL; l++) {
+//     temp1l += s_hprimewgll_xx(ix, l, 0) * stress_integrand_xi(iz, l, 0);
+//     temp2l += s_hprimewgll_zz(iz, l, 0) * stress_integrand_gamma(l, ix, 0);
+//   }
 
-  acceleration[0] = -1.0 * ((weight[1] * temp1l) + (weight[0] * temp2l));
+//   acceleration[0] = -1.0 * ((weight[1] * temp1l) + (weight[0] * temp2l));
 
-  boundary_conditions.enforce_traction(ielement, xz, weight,
-                                       partial_derivatives, properties,
-                                       velocity, acceleration);
+//   boundary_conditions.enforce_traction(ielement, xz, weight,
+//                                        partial_derivatives, properties,
+//                                        velocity, acceleration);
 
-  return;
-}
+//   return;
+// }
 
 #endif

--- a/include/domain/impl/elements/acoustic/acoustic2d_isotropic.tpp
+++ b/include/domain/impl/elements/acoustic/acoustic2d_isotropic.tpp
@@ -91,42 +91,32 @@ KOKKOS_INLINE_FUNCTION void specfem::domain::impl::elements::element<
   return;
 }
 
-// template <int NGLL, typename BC>
-// template <specfem::enums::time_scheme::type time_scheme>
-// KOKKOS_INLINE_FUNCTION void specfem::domain::impl::elements::element<
-//     specfem::enums::element::dimension::dim2,
-//     specfem::enums::element::medium::acoustic,
-//     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
-//     specfem::enums::element::property::isotropic, BC>::
-//     mass_time_contribution(
-//         const int &ispec, const int &ielement, const int &xz,
-//         const type_real &dt,
-//         const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
-//         specfem::kokkos::array_type<type_real, medium_type::components>
-//             &rmass_inverse) const {
+template <int NGLL, typename BC>
+template <specfem::enums::time_scheme::type time_scheme>
+KOKKOS_INLINE_FUNCTION void specfem::domain::impl::elements::element<
+    specfem::enums::element::dimension::dim2,
+    specfem::enums::element::medium::acoustic,
+    specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
+    specfem::enums::element::property::isotropic, BC>::
+    mass_time_contribution(
+        const int &xz, const type_real &dt,
+        const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
+        const specfem::point::partial_derivatives2 &partial_derivatives,
+        const specfem::point::properties<medium_type::value,
+                                         property_type::value> &properties,
+        const specfem::point::boundary &boundary_type,
+        specfem::kokkos::array_type<type_real, medium_type::components>
+            &rmass_inverse) const {
 
-//   int ix, iz;
-//   sub2ind(xz, NGLL, iz, ix);
+  rmass_inverse[0] = 0.0;
 
-//   const specfem::compute::element_partial_derivatives partial_derivatives(
-//       this->xix(ispec, iz, ix), this->gammax(ispec, iz, ix),
-//       this->xiz(ispec, iz, ix), this->gammaz(ispec, iz, ix),
-//       this->jacobian(ispec, iz, ix));
+  // comppute mass matrix component
+  boundary_conditions.template mass_time_contribution<time_scheme>(
+      xz, dt, weight, partial_derivatives, properties, boundary_type,
+      rmass_inverse);
 
-//   const specfem::compute::element_properties<medium_type::value,
-//                                              property_type::value>
-//       properties(this->lambdaplus2mu_inverse(ispec, iz, ix),
-//                  this->rho_inverse(ispec, iz, ix));
-
-//   rmass_inverse[0] = 0.0;
-
-//   // comppute mass matrix component
-//   boundary_conditions.template mass_time_contribution<time_scheme>(
-//       ielement, xz, dt, weight, partial_derivatives, properties,
-//       rmass_inverse);
-
-//   return;
-// }
+  return;
+}
 
 // template <int NGLL, typename BC>
 // KOKKOS_INLINE_FUNCTION void specfem::domain::impl::elements::element<

--- a/include/domain/impl/elements/elastic/elastic2d_isotropic.hpp
+++ b/include/domain/impl/elements/elastic/elastic2d_isotropic.hpp
@@ -127,60 +127,67 @@ public:
       specfem::kokkos::array_type<type_real, medium_type::components>
           &rmass_inverse) const;
 
-  //   /**
-  //    * @brief Compute the gradient of the field at a particular
-  //    * Gauss-Lobatto-Legendre quadrature point
-  //    *
-  //    * @param ispec Index of the spectral element
-  //    * @param xz Index of Gauss-Lobatto-Legendre quadrature point
-  //    * @param s_hprime_xx Scratch view of derivative of Lagrange polynomial
-  //    in x
-  //    * direction
-  //    * @param s_hprime_zz Scratch view of derivative of Lagrange polynomial
-  //    in z
-  //    * direction
-  //    * @param u Scrath view of field. For elastic domains the field has 2
-  //    * components
-  //    * @param dudxl Computed partial derivative of field \f$ \frac{\partial
-  //    * \tilde{u}}{\partial x} \f$
-  //    * @param dudzl Computed partial derivative of field \f$ \frac{\partial
-  //    * \tilde{u}}{\partial z} \f$
-  //    */
-  //   KOKKOS_INLINE_FUNCTION void
-  //   compute_gradient(const int &ispec, const int &ielement, const int &xz,
-  //                    const ScratchViewType<type_real, 1> s_hprime_xx,
-  //                    const ScratchViewType<type_real, 1> s_hprime_zz,
-  //                    const ScratchViewType<type_real,
-  //                    medium_type::components> u,
-  //                    specfem::kokkos::array_type<type_real, 2> &dudxl,
-  //                    specfem::kokkos::array_type<type_real, 2> &dudzl) const;
+  /**
+   * @brief Compute the gradient of the field at a particular
+   * Gauss-Lobatto-Legendre quadrature point
+   *
+   * @param ispec Index of the spectral element
+   * @param xz Index of Gauss-Lobatto-Legendre quadrature point
+   * @param s_hprime_xx Scratch view of derivative of Lagrange polynomial
+   in x
+   * direction
+   * @param s_hprime_zz Scratch view of derivative of Lagrange polynomial
+   in z
+   * direction
+   * @param u Scrath view of field. For elastic domains the field has 2
+   * components
+   * @param dudxl Computed partial derivative of field \f$ \frac{\partial
+   * \tilde{u}}{\partial x} \f$
+   * @param dudzl Computed partial derivative of field \f$ \frac{\partial
+   * \tilde{u}}{\partial z} \f$
+   */
+  KOKKOS_INLINE_FUNCTION void compute_gradient(
+      const int xz, const ScratchViewType<type_real, 1> s_hprime,
+      const ScratchViewType<type_real, medium_type::components> u,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
+      const specfem::point::boundary &boundary_type,
+      specfem::kokkos::array_type<type_real, medium_type::components> &dudxl,
+      specfem::kokkos::array_type<type_real, medium_type::components> &dudzl)
+      const;
 
-  //   /**
-  //    * @brief Compute the stress integrand at a particular
-  //    Gauss-Lobatto-Legendre
-  //    * quadrature point.
-  //    *
-  //    * @param ispec Index of the spectral element
-  //    * @param xz Index of Gauss-Lobatto-Legendre quadrature point
-  //    * @param dudxl Partial derivative of field \f$ \frac{\partial
-  //    * \tilde{u}}{\partial x} \f$
-  //    * @param dudzl Partial derivative of field \f$ \frac{\partial
-  //    * \tilde{u}}{\partial z} \f$
-  //    * @param stress_integrand_xi Stress integrand  wrt. \f$ \xi \f$ \f$
-  //    * J^{\alpha, \gamma} \partial_x u \partial_x \xi + \partial_z u *
-  //    \partial_z
-  //    * \xi \f$
-  //    * @param stress_integrand_gamma Stress integrand  wrt. \f$\gamma\f$ \f$
-  //    * J^{\alpha, \gamma} \partial_x u \partial_x \gamma + \partial_z u *
-  //    * \partial_z \gamma \f$
-  //    */
-  //   KOKKOS_INLINE_FUNCTION void compute_stress(
-  //       const int &ispec, const int &ielement, const int &xz,
-  //       const specfem::kokkos::array_type<type_real, 2> &dudxl,
-  //       const specfem::kokkos::array_type<type_real, 2> &dudzl,
-  //       specfem::kokkos::array_type<type_real, 2> &stress_integrand_xi,
-  //       specfem::kokkos::array_type<type_real, 2> &stress_integrand_gamma)
-  //       const;
+  /**
+   * @brief Compute the stress integrand at a particular
+   Gauss-Lobatto-Legendre
+   * quadrature point.
+   *
+   * @param ispec Index of the spectral element
+   * @param xz Index of Gauss-Lobatto-Legendre quadrature point
+   * @param dudxl Partial derivative of field \f$ \frac{\partial
+   * \tilde{u}}{\partial x} \f$
+   * @param dudzl Partial derivative of field \f$ \frac{\partial
+   * \tilde{u}}{\partial z} \f$
+   * @param stress_integrand_xi Stress integrand  wrt. \f$ \xi \f$ \f$
+   * J^{\alpha, \gamma} \partial_x u \partial_x \xi + \partial_z u *
+   \partial_z
+   * \xi \f$
+   * @param stress_integrand_gamma Stress integrand  wrt. \f$\gamma\f$ \f$
+   * J^{\alpha, \gamma} \partial_x u \partial_x \gamma + \partial_z u *
+   * \partial_z \gamma \f$
+   */
+  KOKKOS_INLINE_FUNCTION void compute_stress(
+      const int xz,
+      const specfem::kokkos::array_type<type_real, medium_type::components>
+          &dudxl,
+      const specfem::kokkos::array_type<type_real, medium_type::components>
+          &dudzl,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
+      const specfem::point::properties<medium_type::value, property_type::value>
+          &properties,
+      const specfem::point::boundary &boundary_type,
+      specfem::kokkos::array_type<type_real, medium_type::components>
+          &stress_integrand_xi,
+      specfem::kokkos::array_type<type_real, medium_type::components>
+          &stress_integrand_gamma) const;
 
   //   /**
   //    * @brief Update the acceleration at the quadrature point xz

--- a/include/domain/impl/elements/elastic/elastic2d_isotropic.hpp
+++ b/include/domain/impl/elements/elastic/elastic2d_isotropic.hpp
@@ -95,7 +95,8 @@ public:
    */
   KOKKOS_FUNCTION
   element(const specfem::compute::assembly &assembly,
-          const quadrature_points_type &quadrature_points){};
+          const quadrature_points_type &quadrature_points)
+      : boundary_conditions(assembly.boundaries, quadrature_points){};
 
   /**
    * @brief Compute the mass matrix component ($ m_{\alpha, \beta} $) for a
@@ -115,13 +116,16 @@ public:
       const specfem::point::partial_derivatives2 &partial_derivatives,
       specfem::kokkos::array_type<type_real, 2> &mass_matrix) const;
 
-  //   template <specfem::enums::time_scheme::type time_scheme>
-  //   KOKKOS_INLINE_FUNCTION void mass_time_contribution(
-  //       const int &ispec, const int &ielement, const int &xz, const type_real
-  //       &dt, const specfem::kokkos::array_type<type_real, dimension::dim>
-  //       &weight, specfem::kokkos::array_type<type_real,
-  //       medium_type::components>
-  //           &rmass_inverse) const;
+  template <specfem::enums::time_scheme::type time_scheme>
+  KOKKOS_INLINE_FUNCTION void mass_time_contribution(
+      const int &xz, const type_real &dt,
+      const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
+      const specfem::point::properties<medium_type::value, property_type::value>
+          &properties,
+      const specfem::point::boundary &boundary_type,
+      specfem::kokkos::array_type<type_real, medium_type::components>
+          &rmass_inverse) const;
 
   //   /**
   //    * @brief Compute the gradient of the field at a particular
@@ -224,7 +228,7 @@ private:
   //                                                           ///< 2 * mu
   //   specfem::kokkos::DeviceView3d<type_real> mu;            ///< mu
   //   specfem::kokkos::DeviceView3d<type_real> rho;           ///< rho
-  //   boundary_conditions_type boundary_conditions; ///< Boundary conditions
+  boundary_conditions_type boundary_conditions; ///< Boundary conditions
 };
 } // namespace elements
 } // namespace impl

--- a/include/domain/impl/elements/elastic/elastic2d_isotropic.hpp
+++ b/include/domain/impl/elements/elastic/elastic2d_isotropic.hpp
@@ -189,41 +189,44 @@ public:
       specfem::kokkos::array_type<type_real, medium_type::components>
           &stress_integrand_gamma) const;
 
-  //   /**
-  //    * @brief Update the acceleration at the quadrature point xz
-  //    *
-  //    * @param xz Index of the quadrature point
-  //    * @param wxglll Weight of the Gauss-Lobatto-Legendre quadrature point in
-  //    x
-  //    * direction
-  //    * @param wzglll Weight of the Gauss-Lobatto-Legendre quadrature point in
-  //    z
-  //    * direction
-  //    * @param stress_integrand_xi Stress integrand wrt. \f$ \xi \f$ \f$
-  //    J^{\alpha,
-  //    * \gamma} \partial_x u \partial_x \xi + \partial_z u * \partial_z \xi
-  //    \f$ as
-  //    * computed by compute_stress
-  //    * @param stress_integrand_gamma Stress integrand wrt. \f$\gamma\f$ \f$
-  //    * J^{\alpha, \gamma} \partial_x u \partial_x \gamma + \partial_z u *
-  //    * \partial_z \gamma \f$ as computed by compute_stress
-  //    * @param s_hprimewgll_xx Scratch view hprime_xx * wxgll
-  //    * @param s_hprimewgll_zz Scratch view hprime_zz * wzgll
-  //    * @param field_dot_dot Acceleration of the field subviewed at global
-  //    index xz
-  //    */
-  //   KOKKOS_INLINE_FUNCTION void compute_acceleration(
-  //       const int &ispec, const int &ielement, const int &xz,
-  //       const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
-  //       const ScratchViewType<type_real, medium_type::components>
-  //           stress_integrand_xi,
-  //       const ScratchViewType<type_real, medium_type::components>
-  //           stress_integrand_gamma,
-  //       const ScratchViewType<type_real, 1> s_hprimewgll_xx,
-  //       const ScratchViewType<type_real, 1> s_hprimewgll_zz,
-  //       const specfem::kokkos::array_type<type_real, medium_type::components>
-  //           &velocity,
-  //       specfem::kokkos::array_type<type_real, 2> &acceleration) const;
+  /**
+   * @brief Update the acceleration at the quadrature point xz
+   *
+   * @param xz Index of the quadrature point
+   * @param wxglll Weight of the Gauss-Lobatto-Legendre quadrature point in
+   x
+   * direction
+   * @param wzglll Weight of the Gauss-Lobatto-Legendre quadrature point in
+   z
+   * direction
+   * @param stress_integrand_xi Stress integrand wrt. \f$ \xi \f$ \f$
+   J^{\alpha,
+   * \gamma} \partial_x u \partial_x \xi + \partial_z u * \partial_z \xi
+   \f$ as
+   * computed by compute_stress
+   * @param stress_integrand_gamma Stress integrand wrt. \f$\gamma\f$ \f$
+   * J^{\alpha, \gamma} \partial_x u \partial_x \gamma + \partial_z u *
+   * \partial_z \gamma \f$ as computed by compute_stress
+   * @param s_hprimewgll_xx Scratch view hprime_xx * wxgll
+   * @param s_hprimewgll_zz Scratch view hprime_zz * wzgll
+   * @param field_dot_dot Acceleration of the field subviewed at global
+   index xz
+   */
+  KOKKOS_INLINE_FUNCTION void compute_acceleration(
+      const int &xz,
+      const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
+      const ScratchViewType<type_real, medium_type::components>
+          stress_integrand_xi,
+      const ScratchViewType<type_real, medium_type::components>
+          stress_integrand_gamma,
+      const ScratchViewType<type_real, 1> s_hprimewgll,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
+      const specfem::point::properties<medium_type::value, property_type::value>
+          &properties,
+      const specfem::point::boundary &boundary_type,
+      const specfem::kokkos::array_type<type_real, medium_type::components>
+          &velocity,
+      specfem::kokkos::array_type<type_real, 2> &acceleration) const;
 
 private:
   //   specfem::kokkos::DeviceView3d<type_real> xix;           ///< xix

--- a/include/domain/impl/elements/elastic/elastic2d_isotropic.hpp
+++ b/include/domain/impl/elements/elastic/elastic2d_isotropic.hpp
@@ -94,10 +94,8 @@ public:
    * point
    */
   KOKKOS_FUNCTION
-  element(const specfem::compute::partial_derivatives &partial_derivatives,
-          const specfem::compute::properties &properties,
-          const specfem::compute::boundaries &boundary_conditions,
-          const quadrature_points_type &quadrature_points);
+  element(const specfem::compute::assembly &assembly,
+          const quadrature_points_type &quadrature_points){};
 
   /**
    * @brief Compute the mass matrix component ($ m_{\alpha, \beta} $) for a
@@ -112,107 +110,121 @@ public:
    */
   KOKKOS_INLINE_FUNCTION
   void compute_mass_matrix_component(
-      const int &ispec, const int &xz,
+      const specfem::point::properties<medium_type::value, property_type::value>
+          &properties,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
       specfem::kokkos::array_type<type_real, 2> &mass_matrix) const;
 
-  template <specfem::enums::time_scheme::type time_scheme>
-  KOKKOS_INLINE_FUNCTION void mass_time_contribution(
-      const int &ispec, const int &ielement, const int &xz, const type_real &dt,
-      const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
-      specfem::kokkos::array_type<type_real, medium_type::components>
-          &rmass_inverse) const;
+  //   template <specfem::enums::time_scheme::type time_scheme>
+  //   KOKKOS_INLINE_FUNCTION void mass_time_contribution(
+  //       const int &ispec, const int &ielement, const int &xz, const type_real
+  //       &dt, const specfem::kokkos::array_type<type_real, dimension::dim>
+  //       &weight, specfem::kokkos::array_type<type_real,
+  //       medium_type::components>
+  //           &rmass_inverse) const;
 
-  /**
-   * @brief Compute the gradient of the field at a particular
-   * Gauss-Lobatto-Legendre quadrature point
-   *
-   * @param ispec Index of the spectral element
-   * @param xz Index of Gauss-Lobatto-Legendre quadrature point
-   * @param s_hprime_xx Scratch view of derivative of Lagrange polynomial in x
-   * direction
-   * @param s_hprime_zz Scratch view of derivative of Lagrange polynomial in z
-   * direction
-   * @param u Scrath view of field. For elastic domains the field has 2
-   * components
-   * @param dudxl Computed partial derivative of field \f$ \frac{\partial
-   * \tilde{u}}{\partial x} \f$
-   * @param dudzl Computed partial derivative of field \f$ \frac{\partial
-   * \tilde{u}}{\partial z} \f$
-   */
-  KOKKOS_INLINE_FUNCTION void
-  compute_gradient(const int &ispec, const int &ielement, const int &xz,
-                   const ScratchViewType<type_real, 1> s_hprime_xx,
-                   const ScratchViewType<type_real, 1> s_hprime_zz,
-                   const ScratchViewType<type_real, medium_type::components> u,
-                   specfem::kokkos::array_type<type_real, 2> &dudxl,
-                   specfem::kokkos::array_type<type_real, 2> &dudzl) const;
+  //   /**
+  //    * @brief Compute the gradient of the field at a particular
+  //    * Gauss-Lobatto-Legendre quadrature point
+  //    *
+  //    * @param ispec Index of the spectral element
+  //    * @param xz Index of Gauss-Lobatto-Legendre quadrature point
+  //    * @param s_hprime_xx Scratch view of derivative of Lagrange polynomial
+  //    in x
+  //    * direction
+  //    * @param s_hprime_zz Scratch view of derivative of Lagrange polynomial
+  //    in z
+  //    * direction
+  //    * @param u Scrath view of field. For elastic domains the field has 2
+  //    * components
+  //    * @param dudxl Computed partial derivative of field \f$ \frac{\partial
+  //    * \tilde{u}}{\partial x} \f$
+  //    * @param dudzl Computed partial derivative of field \f$ \frac{\partial
+  //    * \tilde{u}}{\partial z} \f$
+  //    */
+  //   KOKKOS_INLINE_FUNCTION void
+  //   compute_gradient(const int &ispec, const int &ielement, const int &xz,
+  //                    const ScratchViewType<type_real, 1> s_hprime_xx,
+  //                    const ScratchViewType<type_real, 1> s_hprime_zz,
+  //                    const ScratchViewType<type_real,
+  //                    medium_type::components> u,
+  //                    specfem::kokkos::array_type<type_real, 2> &dudxl,
+  //                    specfem::kokkos::array_type<type_real, 2> &dudzl) const;
 
-  /**
-   * @brief Compute the stress integrand at a particular Gauss-Lobatto-Legendre
-   * quadrature point.
-   *
-   * @param ispec Index of the spectral element
-   * @param xz Index of Gauss-Lobatto-Legendre quadrature point
-   * @param dudxl Partial derivative of field \f$ \frac{\partial
-   * \tilde{u}}{\partial x} \f$
-   * @param dudzl Partial derivative of field \f$ \frac{\partial
-   * \tilde{u}}{\partial z} \f$
-   * @param stress_integrand_xi Stress integrand  wrt. \f$ \xi \f$ \f$
-   * J^{\alpha, \gamma} \partial_x u \partial_x \xi + \partial_z u * \partial_z
-   * \xi \f$
-   * @param stress_integrand_gamma Stress integrand  wrt. \f$\gamma\f$ \f$
-   * J^{\alpha, \gamma} \partial_x u \partial_x \gamma + \partial_z u *
-   * \partial_z \gamma \f$
-   */
-  KOKKOS_INLINE_FUNCTION void compute_stress(
-      const int &ispec, const int &ielement, const int &xz,
-      const specfem::kokkos::array_type<type_real, 2> &dudxl,
-      const specfem::kokkos::array_type<type_real, 2> &dudzl,
-      specfem::kokkos::array_type<type_real, 2> &stress_integrand_xi,
-      specfem::kokkos::array_type<type_real, 2> &stress_integrand_gamma) const;
+  //   /**
+  //    * @brief Compute the stress integrand at a particular
+  //    Gauss-Lobatto-Legendre
+  //    * quadrature point.
+  //    *
+  //    * @param ispec Index of the spectral element
+  //    * @param xz Index of Gauss-Lobatto-Legendre quadrature point
+  //    * @param dudxl Partial derivative of field \f$ \frac{\partial
+  //    * \tilde{u}}{\partial x} \f$
+  //    * @param dudzl Partial derivative of field \f$ \frac{\partial
+  //    * \tilde{u}}{\partial z} \f$
+  //    * @param stress_integrand_xi Stress integrand  wrt. \f$ \xi \f$ \f$
+  //    * J^{\alpha, \gamma} \partial_x u \partial_x \xi + \partial_z u *
+  //    \partial_z
+  //    * \xi \f$
+  //    * @param stress_integrand_gamma Stress integrand  wrt. \f$\gamma\f$ \f$
+  //    * J^{\alpha, \gamma} \partial_x u \partial_x \gamma + \partial_z u *
+  //    * \partial_z \gamma \f$
+  //    */
+  //   KOKKOS_INLINE_FUNCTION void compute_stress(
+  //       const int &ispec, const int &ielement, const int &xz,
+  //       const specfem::kokkos::array_type<type_real, 2> &dudxl,
+  //       const specfem::kokkos::array_type<type_real, 2> &dudzl,
+  //       specfem::kokkos::array_type<type_real, 2> &stress_integrand_xi,
+  //       specfem::kokkos::array_type<type_real, 2> &stress_integrand_gamma)
+  //       const;
 
-  /**
-   * @brief Update the acceleration at the quadrature point xz
-   *
-   * @param xz Index of the quadrature point
-   * @param wxglll Weight of the Gauss-Lobatto-Legendre quadrature point in x
-   * direction
-   * @param wzglll Weight of the Gauss-Lobatto-Legendre quadrature point in z
-   * direction
-   * @param stress_integrand_xi Stress integrand wrt. \f$ \xi \f$ \f$ J^{\alpha,
-   * \gamma} \partial_x u \partial_x \xi + \partial_z u * \partial_z \xi \f$ as
-   * computed by compute_stress
-   * @param stress_integrand_gamma Stress integrand wrt. \f$\gamma\f$ \f$
-   * J^{\alpha, \gamma} \partial_x u \partial_x \gamma + \partial_z u *
-   * \partial_z \gamma \f$ as computed by compute_stress
-   * @param s_hprimewgll_xx Scratch view hprime_xx * wxgll
-   * @param s_hprimewgll_zz Scratch view hprime_zz * wzgll
-   * @param field_dot_dot Acceleration of the field subviewed at global index xz
-   */
-  KOKKOS_INLINE_FUNCTION void compute_acceleration(
-      const int &ispec, const int &ielement, const int &xz,
-      const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
-      const ScratchViewType<type_real, medium_type::components>
-          stress_integrand_xi,
-      const ScratchViewType<type_real, medium_type::components>
-          stress_integrand_gamma,
-      const ScratchViewType<type_real, 1> s_hprimewgll_xx,
-      const ScratchViewType<type_real, 1> s_hprimewgll_zz,
-      const specfem::kokkos::array_type<type_real, medium_type::components>
-          &velocity,
-      specfem::kokkos::array_type<type_real, 2> &acceleration) const;
+  //   /**
+  //    * @brief Update the acceleration at the quadrature point xz
+  //    *
+  //    * @param xz Index of the quadrature point
+  //    * @param wxglll Weight of the Gauss-Lobatto-Legendre quadrature point in
+  //    x
+  //    * direction
+  //    * @param wzglll Weight of the Gauss-Lobatto-Legendre quadrature point in
+  //    z
+  //    * direction
+  //    * @param stress_integrand_xi Stress integrand wrt. \f$ \xi \f$ \f$
+  //    J^{\alpha,
+  //    * \gamma} \partial_x u \partial_x \xi + \partial_z u * \partial_z \xi
+  //    \f$ as
+  //    * computed by compute_stress
+  //    * @param stress_integrand_gamma Stress integrand wrt. \f$\gamma\f$ \f$
+  //    * J^{\alpha, \gamma} \partial_x u \partial_x \gamma + \partial_z u *
+  //    * \partial_z \gamma \f$ as computed by compute_stress
+  //    * @param s_hprimewgll_xx Scratch view hprime_xx * wxgll
+  //    * @param s_hprimewgll_zz Scratch view hprime_zz * wzgll
+  //    * @param field_dot_dot Acceleration of the field subviewed at global
+  //    index xz
+  //    */
+  //   KOKKOS_INLINE_FUNCTION void compute_acceleration(
+  //       const int &ispec, const int &ielement, const int &xz,
+  //       const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
+  //       const ScratchViewType<type_real, medium_type::components>
+  //           stress_integrand_xi,
+  //       const ScratchViewType<type_real, medium_type::components>
+  //           stress_integrand_gamma,
+  //       const ScratchViewType<type_real, 1> s_hprimewgll_xx,
+  //       const ScratchViewType<type_real, 1> s_hprimewgll_zz,
+  //       const specfem::kokkos::array_type<type_real, medium_type::components>
+  //           &velocity,
+  //       specfem::kokkos::array_type<type_real, 2> &acceleration) const;
 
 private:
-  specfem::kokkos::DeviceView3d<type_real> xix;           ///< xix
-  specfem::kokkos::DeviceView3d<type_real> xiz;           ///< xiz
-  specfem::kokkos::DeviceView3d<type_real> gammax;        ///< gammax
-  specfem::kokkos::DeviceView3d<type_real> gammaz;        ///< gammaz
-  specfem::kokkos::DeviceView3d<type_real> jacobian;      ///< jacobian
-  specfem::kokkos::DeviceView3d<type_real> lambdaplus2mu; ///< lambda +
-                                                          ///< 2 * mu
-  specfem::kokkos::DeviceView3d<type_real> mu;            ///< mu
-  specfem::kokkos::DeviceView3d<type_real> rho;           ///< rho
-  boundary_conditions_type boundary_conditions; ///< Boundary conditions
+  //   specfem::kokkos::DeviceView3d<type_real> xix;           ///< xix
+  //   specfem::kokkos::DeviceView3d<type_real> xiz;           ///< xiz
+  //   specfem::kokkos::DeviceView3d<type_real> gammax;        ///< gammax
+  //   specfem::kokkos::DeviceView3d<type_real> gammaz;        ///< gammaz
+  //   specfem::kokkos::DeviceView3d<type_real> jacobian;      ///< jacobian
+  //   specfem::kokkos::DeviceView3d<type_real> lambdaplus2mu; ///< lambda +
+  //                                                           ///< 2 * mu
+  //   specfem::kokkos::DeviceView3d<type_real> mu;            ///< mu
+  //   specfem::kokkos::DeviceView3d<type_real> rho;           ///< rho
+  //   boundary_conditions_type boundary_conditions; ///< Boundary conditions
 };
 } // namespace elements
 } // namespace impl

--- a/include/domain/impl/elements/elastic/elastic2d_isotropic.tpp
+++ b/include/domain/impl/elements/elastic/elastic2d_isotropic.tpp
@@ -8,6 +8,8 @@
 #include "globals.h"
 #include "kokkos_abstractions.h"
 #include "specfem_setup.hpp"
+#include "point/properties.hpp"
+#include "point/partial_derivatives.hpp"
 #include <Kokkos_Core.hpp>
 
 template <int N, typename T>
@@ -22,65 +24,64 @@ using StaticScratchViewType =
 // -----------------------------------------------------------------------------
 //                     SPECIALIZED ELEMENT
 // -----------------------------------------------------------------------------
-template <int NGLL, typename BC>
-KOKKOS_FUNCTION specfem::domain::impl::elements::element<
-    specfem::enums::element::dimension::dim2,
-    specfem::enums::element::medium::elastic,
-    specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
-    specfem::enums::element::property::isotropic,
-    BC>::element(const specfem::compute::partial_derivatives
-                     &partial_derivatives,
-                 const specfem::compute::properties &properties,
-                 const specfem::compute::boundaries &boundary_conditions,
-                 const quadrature_points_type &quadrature_points) {
+// template <int NGLL, typename BC>
+// KOKKOS_FUNCTION specfem::domain::impl::elements::element<
+//     specfem::enums::element::dimension::dim2,
+//     specfem::enums::element::medium::elastic,
+//     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
+//     specfem::enums::element::property::isotropic,
+//     BC>::element(const specfem::compute::partial_derivatives
+//                      &partial_derivatives,
+//                  const specfem::compute::properties &properties,
+//                  const specfem::compute::boundaries &boundary_conditions,
+//                  const quadrature_points_type &quadrature_points) {
 
-#ifndef NDEBUG
-  assert(partial_derivatives.xix.extent(1) == NGLL);
-  assert(partial_derivatives.xix.extent(2) == NGLL);
-  assert(partial_derivatives.gammax.extent(1) == NGLL);
-  assert(partial_derivatives.gammax.extent(2) == NGLL);
-  assert(partial_derivatives.xiz.extent(1) == NGLL);
-  assert(partial_derivatives.xiz.extent(2) == NGLL);
-  assert(partial_derivatives.gammaz.extent(1) == NGLL);
-  assert(partial_derivatives.gammaz.extent(2) == NGLL);
-  assert(partial_derivatives.jacobian.extent(1) == NGLL);
-  assert(partial_derivatives.jacobian.extent(2) == NGLL);
+// #ifndef NDEBUG
+//   assert(partial_derivatives.xix.extent(1) == NGLL);
+//   assert(partial_derivatives.xix.extent(2) == NGLL);
+//   assert(partial_derivatives.gammax.extent(1) == NGLL);
+//   assert(partial_derivatives.gammax.extent(2) == NGLL);
+//   assert(partial_derivatives.xiz.extent(1) == NGLL);
+//   assert(partial_derivatives.xiz.extent(2) == NGLL);
+//   assert(partial_derivatives.gammaz.extent(1) == NGLL);
+//   assert(partial_derivatives.gammaz.extent(2) == NGLL);
+//   assert(partial_derivatives.jacobian.extent(1) == NGLL);
+//   assert(partial_derivatives.jacobian.extent(2) == NGLL);
 
-  // Properties
-  assert(properties.rho.extent(1) == NGLL);
-  assert(properties.rho.extent(2) == NGLL);
-  assert(properties.lambdaplus2mu.extent(1) == NGLL);
-  assert(properties.lambdaplus2mu.extent(2) == NGLL);
-  assert(properties.mu.extent(1) == NGLL);
-  assert(properties.mu.extent(2) == NGLL);
-#endif
+//   // Properties
+//   assert(properties.rho.extent(1) == NGLL);
+//   assert(properties.rho.extent(2) == NGLL);
+//   assert(properties.lambdaplus2mu.extent(1) == NGLL);
+//   assert(properties.lambdaplus2mu.extent(2) == NGLL);
+//   assert(properties.mu.extent(1) == NGLL);
+//   assert(properties.mu.extent(2) == NGLL);
+// #endif
 
-  this->xix = partial_derivatives.xix;
-  this->gammax = partial_derivatives.gammax;
-  this->xiz = partial_derivatives.xiz;
-  this->gammaz = partial_derivatives.gammaz;
-  this->jacobian = partial_derivatives.jacobian;
-  this->rho = properties.rho;
-  this->lambdaplus2mu = properties.lambdaplus2mu;
-  this->mu = properties.mu;
+//   this->xix = partial_derivatives.xix;
+//   this->gammax = partial_derivatives.gammax;
+//   this->xiz = partial_derivatives.xiz;
+//   this->gammaz = partial_derivatives.gammaz;
+//   this->jacobian = partial_derivatives.jacobian;
+//   this->rho = properties.rho;
+//   this->lambdaplus2mu = properties.lambdaplus2mu;
+//   this->mu = properties.mu;
 
-  this->boundary_conditions =
-      boundary_conditions_type(boundary_conditions, quadrature_points);
+//   this->boundary_conditions =
+//       boundary_conditions_type(boundary_conditions, quadrature_points);
 
-  return;
-}
+//   return;
+// }
 
 template <int NGLL, typename BC>
 KOKKOS_INLINE_FUNCTION void specfem::domain::impl::elements::element<
     specfem::enums::element::dimension::dim2,
     specfem::enums::element::medium::elastic,
     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
-    specfem::enums::element::property::isotropic,
-    BC>::compute_mass_matrix_component(const int &ispec, const int &xz,
-                                       specfem::kokkos::array_type<type_real, 2>
-                                           &mass_matrix) const {
-  int ix, iz;
-  sub2ind(xz, NGLL, iz, ix);
+    specfem::enums::element::property::isotropic, BC>::
+    compute_mass_matrix_component(
+        const specfem::point::properties<medium_type::value, property_type::value> &properties,
+        const specfem::point::partial_derivatives2 &partial_derivatives,
+        specfem::kokkos::array_type<type_real, 2> &mass_matrix) const {
 
   constexpr int components = medium_type::components;
 
@@ -88,248 +89,248 @@ KOKKOS_INLINE_FUNCTION void specfem::domain::impl::elements::element<
                 "Number of components must be 2 for 2D isotropic elastic "
                 "medium");
 
-  mass_matrix[0] = this->rho(ispec, iz, ix) * this->jacobian(ispec, iz, ix);
-  mass_matrix[1] = this->rho(ispec, iz, ix) * this->jacobian(ispec, iz, ix);
+  mass_matrix[0] = properties.rho * partial_derivatives.jacobian;
+  mass_matrix[1] = properties.rho * partial_derivatives.jacobian;
 
   return;
 }
 
-template <int NGLL, typename BC>
-template <specfem::enums::time_scheme::type time_scheme>
-KOKKOS_INLINE_FUNCTION void specfem::domain::impl::elements::element<
-    specfem::enums::element::dimension::dim2,
-    specfem::enums::element::medium::elastic,
-    specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
-    specfem::enums::element::property::isotropic, BC>::
-    mass_time_contribution(
-        const int &ispec, const int &ielement, const int &xz,
-        const type_real &dt,
-        const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
-        specfem::kokkos::array_type<type_real, 2> &rmass_inverse) const {
+// template <int NGLL, typename BC>
+// template <specfem::enums::time_scheme::type time_scheme>
+// KOKKOS_INLINE_FUNCTION void specfem::domain::impl::elements::element<
+//     specfem::enums::element::dimension::dim2,
+//     specfem::enums::element::medium::elastic,
+//     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
+//     specfem::enums::element::property::isotropic, BC>::
+//     mass_time_contribution(
+//         const int &ispec, const int &ielement, const int &xz,
+//         const type_real &dt,
+//         const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
+//         specfem::kokkos::array_type<type_real, 2> &rmass_inverse) const {
 
-  int ix, iz;
-  sub2ind(xz, NGLL, iz, ix);
+//   int ix, iz;
+//   sub2ind(xz, NGLL, iz, ix);
 
-  constexpr int components = medium_type::components;
+//   constexpr int components = medium_type::components;
 
-  const specfem::compute::element_partial_derivatives partial_derivatives =
-      specfem::compute::element_partial_derivatives(
-          this->xix(ispec, iz, ix), this->gammax(ispec, iz, ix),
-          this->xiz(ispec, iz, ix), this->gammaz(ispec, iz, ix),
-          this->jacobian(ispec, iz, ix));
+//   const specfem::compute::element_partial_derivatives partial_derivatives =
+//       specfem::compute::element_partial_derivatives(
+//           this->xix(ispec, iz, ix), this->gammax(ispec, iz, ix),
+//           this->xiz(ispec, iz, ix), this->gammaz(ispec, iz, ix),
+//           this->jacobian(ispec, iz, ix));
 
-  const specfem::compute::element_properties<medium_type::value,
-                                             property_type::value>
-      properties(this->lambdaplus2mu(ispec, iz, ix), this->mu(ispec, iz, ix),
-                 this->rho(ispec, iz, ix));
+//   const specfem::compute::element_properties<medium_type::value,
+//                                              property_type::value>
+//       properties(this->lambdaplus2mu(ispec, iz, ix), this->mu(ispec, iz, ix),
+//                  this->rho(ispec, iz, ix));
 
-  rmass_inverse[0] = 0.0;
-  rmass_inverse[1] = 0.0;
+//   rmass_inverse[0] = 0.0;
+//   rmass_inverse[1] = 0.0;
 
-  boundary_conditions.template mass_time_contribution<time_scheme>(
-      ielement, xz, dt, weight, partial_derivatives, properties, rmass_inverse);
+//   boundary_conditions.template mass_time_contribution<time_scheme>(
+//       ielement, xz, dt, weight, partial_derivatives, properties, rmass_inverse);
 
-  return;
-}
+//   return;
+// }
 
-template <int NGLL, typename BC>
-KOKKOS_INLINE_FUNCTION void specfem::domain::impl::elements::element<
-    specfem::enums::element::dimension::dim2,
-    specfem::enums::element::medium::elastic,
-    specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
-    specfem::enums::element::property::isotropic, BC>::
-    compute_gradient(
-        const int &ispec, const int &ielement, const int &xz,
-        const ScratchViewType<type_real, 1> s_hprime_xx,
-        const ScratchViewType<type_real, 1> s_hprime_zz,
-        const ScratchViewType<type_real, medium_type::components> u,
-        specfem::kokkos::array_type<type_real, 2> &dudxl,
-        specfem::kokkos::array_type<type_real, 2> &dudzl) const {
+// template <int NGLL, typename BC>
+// KOKKOS_INLINE_FUNCTION void specfem::domain::impl::elements::element<
+//     specfem::enums::element::dimension::dim2,
+//     specfem::enums::element::medium::elastic,
+//     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
+//     specfem::enums::element::property::isotropic, BC>::
+//     compute_gradient(
+//         const int &ispec, const int &ielement, const int &xz,
+//         const ScratchViewType<type_real, 1> s_hprime_xx,
+//         const ScratchViewType<type_real, 1> s_hprime_zz,
+//         const ScratchViewType<type_real, medium_type::components> u,
+//         specfem::kokkos::array_type<type_real, 2> &dudxl,
+//         specfem::kokkos::array_type<type_real, 2> &dudzl) const {
 
-  int ix, iz;
-  sub2ind(xz, NGLL, iz, ix);
+//   int ix, iz;
+//   sub2ind(xz, NGLL, iz, ix);
 
-  const specfem::compute::element_partial_derivatives partial_derivatives =
-      specfem::compute::element_partial_derivatives(
-          this->xix(ispec, iz, ix), this->gammax(ispec, iz, ix),
-          this->xiz(ispec, iz, ix), this->gammaz(ispec, iz, ix));
+//   const specfem::compute::element_partial_derivatives partial_derivatives =
+//       specfem::compute::element_partial_derivatives(
+//           this->xix(ispec, iz, ix), this->gammax(ispec, iz, ix),
+//           this->xiz(ispec, iz, ix), this->gammaz(ispec, iz, ix));
 
-  type_real du_dxi[medium_type::components] = { 0.0, 0.0 };
-  type_real du_dgamma[medium_type::components] = { 0.0, 0.0 };
+//   type_real du_dxi[medium_type::components] = { 0.0, 0.0 };
+//   type_real du_dgamma[medium_type::components] = { 0.0, 0.0 };
 
-#ifdef KOKKOS_ENABLE_CUDA
-#pragma unroll
-#endif
-  for (int l = 0; l < NGLL; l++) {
-    du_dxi[0] += s_hprime_xx(ix, l, 0) * u(iz, l, 0);
-    du_dxi[1] += s_hprime_xx(ix, l, 0) * u(iz, l, 1);
-    du_dgamma[0] += s_hprime_zz(iz, l, 0) * u(l, ix, 0);
-    du_dgamma[1] += s_hprime_zz(iz, l, 0) * u(l, ix, 1);
-  }
-  // duxdx
-  dudxl[0] = partial_derivatives.xix * du_dxi[0] +
-             partial_derivatives.gammax * du_dgamma[0];
+// #ifdef KOKKOS_ENABLE_CUDA
+// #pragma unroll
+// #endif
+//   for (int l = 0; l < NGLL; l++) {
+//     du_dxi[0] += s_hprime_xx(ix, l, 0) * u(iz, l, 0);
+//     du_dxi[1] += s_hprime_xx(ix, l, 0) * u(iz, l, 1);
+//     du_dgamma[0] += s_hprime_zz(iz, l, 0) * u(l, ix, 0);
+//     du_dgamma[1] += s_hprime_zz(iz, l, 0) * u(l, ix, 1);
+//   }
+//   // duxdx
+//   dudxl[0] = partial_derivatives.xix * du_dxi[0] +
+//              partial_derivatives.gammax * du_dgamma[0];
 
-  // duxdz
-  dudzl[0] = partial_derivatives.xiz * du_dxi[0] +
-             partial_derivatives.gammaz * du_dgamma[0];
+//   // duxdz
+//   dudzl[0] = partial_derivatives.xiz * du_dxi[0] +
+//              partial_derivatives.gammaz * du_dgamma[0];
 
-  // duzdx
-  dudxl[1] = partial_derivatives.xix * du_dxi[1] +
-             partial_derivatives.gammax * du_dgamma[1];
+//   // duzdx
+//   dudxl[1] = partial_derivatives.xix * du_dxi[1] +
+//              partial_derivatives.gammax * du_dgamma[1];
 
-  // duzdz
-  dudzl[1] = partial_derivatives.gammax * du_dxi[1] +
-             partial_derivatives.gammaz * du_dgamma[1];
+//   // duzdz
+//   dudzl[1] = partial_derivatives.gammax * du_dxi[1] +
+//              partial_derivatives.gammaz * du_dgamma[1];
 
-  boundary_conditions.enforce_gradient(ielement, xz, partial_derivatives, dudxl,
-                                       dudzl);
+//   boundary_conditions.enforce_gradient(ielement, xz, partial_derivatives, dudxl,
+//                                        dudzl);
 
-  return;
-}
+//   return;
+// }
 
-template <int NGLL, typename BC>
-KOKKOS_INLINE_FUNCTION void specfem::domain::impl::elements::element<
-    specfem::enums::element::dimension::dim2,
-    specfem::enums::element::medium::elastic,
-    specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
-    specfem::enums::element::property::isotropic,
-    BC>::compute_stress(const int &ispec, const int &ielement, const int &xz,
-                        const specfem::kokkos::array_type<type_real, 2> &dudxl,
-                        const specfem::kokkos::array_type<type_real, 2> &dudzl,
-                        specfem::kokkos::array_type<type_real, 2>
-                            &stress_integrand_xi,
-                        specfem::kokkos::array_type<type_real, 2>
-                            &stress_integrand_gamma) const {
+// template <int NGLL, typename BC>
+// KOKKOS_INLINE_FUNCTION void specfem::domain::impl::elements::element<
+//     specfem::enums::element::dimension::dim2,
+//     specfem::enums::element::medium::elastic,
+//     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
+//     specfem::enums::element::property::isotropic,
+//     BC>::compute_stress(const int &ispec, const int &ielement, const int &xz,
+//                         const specfem::kokkos::array_type<type_real, 2> &dudxl,
+//                         const specfem::kokkos::array_type<type_real, 2> &dudzl,
+//                         specfem::kokkos::array_type<type_real, 2>
+//                             &stress_integrand_xi,
+//                         specfem::kokkos::array_type<type_real, 2>
+//                             &stress_integrand_gamma) const {
 
-  int ix, iz;
-  sub2ind(xz, NGLL, iz, ix);
+//   int ix, iz;
+//   sub2ind(xz, NGLL, iz, ix);
 
-  const specfem::compute::element_partial_derivatives partial_derivatives =
-      specfem::compute::element_partial_derivatives(
-          this->xix(ispec, iz, ix), this->gammax(ispec, iz, ix),
-          this->xiz(ispec, iz, ix), this->gammaz(ispec, iz, ix),
-          this->jacobian(ispec, iz, ix));
+//   const specfem::compute::element_partial_derivatives partial_derivatives =
+//       specfem::compute::element_partial_derivatives(
+//           this->xix(ispec, iz, ix), this->gammax(ispec, iz, ix),
+//           this->xiz(ispec, iz, ix), this->gammaz(ispec, iz, ix),
+//           this->jacobian(ispec, iz, ix));
 
-  const specfem::compute::element_properties<medium_type::value,
-                                             property_type::value>
-      properties(this->lambdaplus2mu(ispec, iz, ix), this->mu(ispec, iz, ix),
-                 this->rho(ispec, iz, ix));
+//   const specfem::compute::element_properties<medium_type::value,
+//                                              property_type::value>
+//       properties(this->lambdaplus2mu(ispec, iz, ix), this->mu(ispec, iz, ix),
+//                  this->rho(ispec, iz, ix));
 
-  type_real sigma_xx, sigma_zz, sigma_xz;
+//   type_real sigma_xx, sigma_zz, sigma_xz;
 
-  if (specfem::globals::simulation_wave == specfem::wave::p_sv) {
-    // P_SV case
-    // sigma_xx
-    sigma_xx =
-        properties.lambdaplus2mu * dudxl[0] + properties.lambda * dudzl[1];
+//   if (specfem::globals::simulation_wave == specfem::wave::p_sv) {
+//     // P_SV case
+//     // sigma_xx
+//     sigma_xx =
+//         properties.lambdaplus2mu * dudxl[0] + properties.lambda * dudzl[1];
 
-    // sigma_zz
-    sigma_zz =
-        properties.lambdaplus2mu * dudzl[1] + properties.lambda * dudxl[0];
+//     // sigma_zz
+//     sigma_zz =
+//         properties.lambdaplus2mu * dudzl[1] + properties.lambda * dudxl[0];
 
-    // sigma_xz
-    sigma_xz = properties.mu * (dudxl[1] + dudzl[0]);
-  } else if (specfem::globals::simulation_wave == specfem::wave::sh) {
-    // SH-case
-    // sigma_xx
-    sigma_xx = properties.mu * dudxl[0]; // would be sigma_xy in
-                                         // CPU-version
+//     // sigma_xz
+//     sigma_xz = properties.mu * (dudxl[1] + dudzl[0]);
+//   } else if (specfem::globals::simulation_wave == specfem::wave::sh) {
+//     // SH-case
+//     // sigma_xx
+//     sigma_xx = properties.mu * dudxl[0]; // would be sigma_xy in
+//                                          // CPU-version
 
-    // sigma_xz
-    sigma_xz = properties.mu * dudzl[0]; // sigma_zy
-  }
+//     // sigma_xz
+//     sigma_xz = properties.mu * dudzl[0]; // sigma_zy
+//   }
 
-  stress_integrand_xi[0] =
-      partial_derivatives.jacobian *
-      (sigma_xx * partial_derivatives.xix + sigma_xz * partial_derivatives.xiz);
-  stress_integrand_xi[1] =
-      partial_derivatives.jacobian *
-      (sigma_xz * partial_derivatives.xix + sigma_zz * partial_derivatives.xiz);
-  stress_integrand_gamma[0] =
-      partial_derivatives.jacobian * (sigma_xx * partial_derivatives.gammax +
-                                      sigma_xz * partial_derivatives.gammaz);
-  stress_integrand_gamma[1] =
-      partial_derivatives.jacobian * (sigma_xz * partial_derivatives.gammax +
-                                      sigma_zz * partial_derivatives.gammaz);
+//   stress_integrand_xi[0] =
+//       partial_derivatives.jacobian *
+//       (sigma_xx * partial_derivatives.xix + sigma_xz * partial_derivatives.xiz);
+//   stress_integrand_xi[1] =
+//       partial_derivatives.jacobian *
+//       (sigma_xz * partial_derivatives.xix + sigma_zz * partial_derivatives.xiz);
+//   stress_integrand_gamma[0] =
+//       partial_derivatives.jacobian * (sigma_xx * partial_derivatives.gammax +
+//                                       sigma_xz * partial_derivatives.gammaz);
+//   stress_integrand_gamma[1] =
+//       partial_derivatives.jacobian * (sigma_xz * partial_derivatives.gammax +
+//                                       sigma_zz * partial_derivatives.gammaz);
 
-  boundary_conditions.enforce_stress(ielement, xz, partial_derivatives,
-                                     properties, stress_integrand_xi,
-                                     stress_integrand_gamma);
+//   boundary_conditions.enforce_stress(ielement, xz, partial_derivatives,
+//                                      properties, stress_integrand_xi,
+//                                      stress_integrand_gamma);
 
-  return;
-}
+//   return;
+// }
 
-template <int NGLL, typename BC>
-KOKKOS_INLINE_FUNCTION void specfem::domain::impl::elements::element<
-    specfem::enums::element::dimension::dim2,
-    specfem::enums::element::medium::elastic,
-    specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
-    specfem::enums::element::property::isotropic, BC>::
-    compute_acceleration(
-        const int &ispec, const int &ielement, const int &xz,
-        const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
-        const ScratchViewType<type_real, medium_type::components>
-            stress_integrand_xi,
-        const ScratchViewType<type_real, medium_type::components>
-            stress_integrand_gamma,
-        const ScratchViewType<type_real, 1> s_hprimewgll_xx,
-        const ScratchViewType<type_real, 1> s_hprimewgll_zz,
-        const specfem::kokkos::array_type<type_real, medium_type::components>
-            &velocity,
-        specfem::kokkos::array_type<type_real, 2> &acceleration) const {
+// template <int NGLL, typename BC>
+// KOKKOS_INLINE_FUNCTION void specfem::domain::impl::elements::element<
+//     specfem::enums::element::dimension::dim2,
+//     specfem::enums::element::medium::elastic,
+//     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
+//     specfem::enums::element::property::isotropic, BC>::
+//     compute_acceleration(
+//         const int &ispec, const int &ielement, const int &xz,
+//         const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
+//         const ScratchViewType<type_real, medium_type::components>
+//             stress_integrand_xi,
+//         const ScratchViewType<type_real, medium_type::components>
+//             stress_integrand_gamma,
+//         const ScratchViewType<type_real, 1> s_hprimewgll_xx,
+//         const ScratchViewType<type_real, 1> s_hprimewgll_zz,
+//         const specfem::kokkos::array_type<type_real, medium_type::components>
+//             &velocity,
+//         specfem::kokkos::array_type<type_real, 2> &acceleration) const {
 
-  int ix, iz;
-  sub2ind(xz, NGLL, iz, ix);
-  type_real tempx1 = 0.0;
-  type_real tempz1 = 0.0;
-  type_real tempx3 = 0.0;
-  type_real tempz3 = 0.0;
+//   int ix, iz;
+//   sub2ind(xz, NGLL, iz, ix);
+//   type_real tempx1 = 0.0;
+//   type_real tempz1 = 0.0;
+//   type_real tempx3 = 0.0;
+//   type_real tempz3 = 0.0;
 
-  constexpr int components = medium_type::components;
+//   constexpr int components = medium_type::components;
 
-  static_assert(components == 2,
-                "Number of components must be 2 for 2D isotropic elastic "
-                "medium");
+//   static_assert(components == 2,
+//                 "Number of components must be 2 for 2D isotropic elastic "
+//                 "medium");
 
-  specfem::compute::element_partial_derivatives partial_derivatives;
+//   specfem::compute::element_partial_derivatives partial_derivatives;
 
-  specfem::compute::element_properties<medium_type::value, property_type::value>
-      properties;
+//   specfem::compute::element_properties<medium_type::value, property_type::value>
+//       properties;
 
-  //   populate partial derivatives only if the boundary is stacey
-  if constexpr ((boundary_conditions_type::value ==
-                 specfem::enums::element::boundary_tag::stacey) ||
-                (boundary_conditions_type::value ==
-                 specfem::enums::element::boundary_tag::
-                     composite_stacey_dirichlet)) {
-    partial_derivatives = specfem::compute::element_partial_derivatives(
-        this->xix(ispec, iz, ix), this->gammax(ispec, iz, ix),
-        this->xiz(ispec, iz, ix), this->gammaz(ispec, iz, ix),
-        this->jacobian(ispec, iz, ix));
+//   //   populate partial derivatives only if the boundary is stacey
+//   if constexpr ((boundary_conditions_type::value ==
+//                  specfem::enums::element::boundary_tag::stacey) ||
+//                 (boundary_conditions_type::value ==
+//                  specfem::enums::element::boundary_tag::
+//                      composite_stacey_dirichlet)) {
+//     partial_derivatives = specfem::compute::element_partial_derivatives(
+//         this->xix(ispec, iz, ix), this->gammax(ispec, iz, ix),
+//         this->xiz(ispec, iz, ix), this->gammaz(ispec, iz, ix),
+//         this->jacobian(ispec, iz, ix));
 
-    properties = specfem::compute::element_properties<medium_type::value,
-                                                      property_type::value>(
-        this->lambdaplus2mu(ispec, iz, ix), this->mu(ispec, iz, ix),
-        this->rho(ispec, iz, ix));
-  }
+//     properties = specfem::compute::element_properties<medium_type::value,
+//                                                       property_type::value>(
+//         this->lambdaplus2mu(ispec, iz, ix), this->mu(ispec, iz, ix),
+//         this->rho(ispec, iz, ix));
+//   }
 
-#ifdef KOKKOS_ENABLE_CUDA
-#pragma unroll
-#endif
-  for (int l = 0; l < NGLL; l++) {
-    tempx1 += s_hprimewgll_xx(ix, l, 0) * stress_integrand_xi(iz, l, 0);
-    tempz1 += s_hprimewgll_xx(ix, l, 0) * stress_integrand_xi(iz, l, 1);
-    tempx3 += s_hprimewgll_zz(iz, l, 0) * stress_integrand_gamma(l, ix, 0);
-    tempz3 += s_hprimewgll_zz(iz, l, 0) * stress_integrand_gamma(l, ix, 1);
-  }
+// #ifdef KOKKOS_ENABLE_CUDA
+// #pragma unroll
+// #endif
+//   for (int l = 0; l < NGLL; l++) {
+//     tempx1 += s_hprimewgll_xx(ix, l, 0) * stress_integrand_xi(iz, l, 0);
+//     tempz1 += s_hprimewgll_xx(ix, l, 0) * stress_integrand_xi(iz, l, 1);
+//     tempx3 += s_hprimewgll_zz(iz, l, 0) * stress_integrand_gamma(l, ix, 0);
+//     tempz3 += s_hprimewgll_zz(iz, l, 0) * stress_integrand_gamma(l, ix, 1);
+//   }
 
-  acceleration[0] = -1.0 * (weight[1] * tempx1) - (weight[0] * tempx3);
-  acceleration[1] = -1.0 * (weight[1] * tempz1) - (weight[0] * tempz3);
+//   acceleration[0] = -1.0 * (weight[1] * tempx1) - (weight[0] * tempx3);
+//   acceleration[1] = -1.0 * (weight[1] * tempz1) - (weight[0] * tempz3);
 
-  boundary_conditions.enforce_traction(ielement, xz, weight,
-                                       partial_derivatives, properties,
-                                       velocity, acceleration);
-}
+//   boundary_conditions.enforce_traction(ielement, xz, weight,
+//                                        partial_derivatives, properties,
+//                                        velocity, acceleration);
+// }
 
 #endif

--- a/include/domain/impl/elements/kernel.hpp
+++ b/include/domain/impl/elements/kernel.hpp
@@ -40,7 +40,7 @@ public:
   element_kernel() = default;
   element_kernel(
       const specfem::compute::assembly &assembly,
-      const specfem::kokkos::DeviceView1d<int> element_kernel_index_mapping,
+      const specfem::kokkos::HostView1d<int> h_element_kernel_index_mapping,
       const quadrature_point_type &quadrature_points);
 
   void compute_mass_matrix() const;

--- a/include/domain/impl/elements/kernel.hpp
+++ b/include/domain/impl/elements/kernel.hpp
@@ -45,7 +45,7 @@ public:
 
   void compute_mass_matrix() const;
 
-  // void compute_stiffness_interaction() const;
+  void compute_stiffness_interaction() const;
 
   template <specfem::enums::time_scheme::type time_scheme>
   void mass_time_contribution(const type_real dt) const;

--- a/include/domain/impl/elements/kernel.hpp
+++ b/include/domain/impl/elements/kernel.hpp
@@ -47,8 +47,8 @@ public:
 
   // void compute_stiffness_interaction() const;
 
-  // template <specfem::enums::time_scheme::type time_scheme>
-  // void mass_time_contribution(const type_real dt) const;
+  template <specfem::enums::time_scheme::type time_scheme>
+  void mass_time_contribution(const type_real dt) const;
 
   inline int total_elements() const { return nelements; }
 
@@ -63,6 +63,7 @@ private:
       global_index_mapping;
   specfem::compute::properties properties;
   specfem::compute::partial_derivatives partial_derivatives;
+  specfem::kokkos::DeviceView1d<specfem::point::boundary> boundary_conditions;
   specfem::compute::impl::field_impl<medium_type> field;
   quadrature_point_type quadrature_points;
   specfem::domain::impl::elements::element<

--- a/include/domain/impl/elements/kernel.hpp
+++ b/include/domain/impl/elements/kernel.hpp
@@ -57,6 +57,7 @@ private:
   specfem::compute::points points;
   specfem::compute::quadrature quadrature;
   specfem::kokkos::DeviceView1d<int> element_kernel_index_mapping;
+  specfem::kokkos::HostMirror1d<int> h_element_kernel_index_mapping;
   Kokkos::View<int * [specfem::enums::element::ntypes], Kokkos::LayoutLeft,
                specfem::kokkos::DevMemSpace>
       global_index_mapping;

--- a/include/domain/impl/elements/kernel.tpp
+++ b/include/domain/impl/elements/kernel.tpp
@@ -50,13 +50,16 @@ specfem::domain::impl::kernels::element_kernel<medium, qp_type, property, BC>::
       h_element_kernel_index_mapping(h_element_kernel_index_mapping),
       points(assembly.mesh.points), quadrature(assembly.mesh.quadratures),
       partial_derivatives(assembly.partial_derivatives),
-      properties(assembly.properties), quadrature_points(quadrature_points),
+      properties(assembly.properties),
+      boundary_conditions(assembly.boundaries.boundary_types),
+      quadrature_points(quadrature_points),
       global_index_mapping(assembly.fields.forward.assembly_index_mapping),
       field(assembly.fields.forward.get_field<medium>()) {
 
   Kokkos::parallel_for(
       "specfem::domain::impl::kernels::element_kernel::check_properties",
-      specfem::kokkos::HostRange(0, nelements), KOKKOS_LAMBDA(const int ielement) {
+      specfem::kokkos::HostRange(0, nelements),
+      KOKKOS_LAMBDA(const int ielement) {
         const int ispec = h_element_kernel_index_mapping(ielement);
         if ((assembly.properties.h_element_types(ispec) !=
              medium_type::value) &&
@@ -121,14 +124,16 @@ void specfem::domain::impl::kernels::element_kernel<
                                                                       iz, ix);
 
               const auto point_partial_derivatives =
-                  partial_derivatives.load_derivatives<
-                      true, specfem::kokkos::DevExecSpace>(ispec_l, iz, ix);
+                  partial_derivatives
+                      .load_derivatives<true, specfem::kokkos::DevExecSpace>(
+                          ispec_l, iz, ix);
 
               specfem::kokkos::array_type<type_real, medium_type::components>
                   mass_matrix_element;
 
-              element.compute_mass_matrix_component(
-                  point_property, point_partial_derivatives, mass_matrix_element);
+              element.compute_mass_matrix_component(point_property,
+                                                    point_partial_derivatives,
+                                                    mass_matrix_element);
 
 #ifdef KOKKOS_ENABLE_CUDA
 #pragma unroll
@@ -148,73 +153,80 @@ void specfem::domain::impl::kernels::element_kernel<
   return;
 }
 
-// template <class medium, class qp_type, class property, class BC>
-// template <specfem::enums::time_scheme::type time_scheme>
-// void specfem::domain::impl::kernels::element_kernel<
-//     medium, qp_type, property, BC>::mass_time_contribution(const type_real
-//     dt) const {
+template <class medium, class qp_type, class property, class BC>
+template <specfem::enums::time_scheme::type time_scheme>
+void specfem::domain::impl::kernels::element_kernel<
+    medium, qp_type, property, BC>::mass_time_contribution(const type_real dt)
+    const {
 
-//   constexpr int components = medium::components;
-//   const int nelements = ispec.extent(0);
+  constexpr int components = medium::components;
 
-//   if (nelements == 0)
-//     return;
+  if (nelements == 0)
+    return;
 
-//   const auto wxgll = this->quadx->get_w();
-//   const auto wzgll = this->quadz->get_w();
+  const auto wgll = quadrature.gll.weights;
+  const auto index_mapping = points.index_mapping;
 
-//   Kokkos::parallel_for(
-//       "specfem::domain::kernes::elements::add_mass_matrix_contribution",
-//       specfem::kokkos::DeviceTeam(ispec.extent(0), Kokkos::AUTO, 1),
-//       KOKKOS_CLASS_LAMBDA(
-//           const specfem::kokkos::DeviceTeam::member_type &team_member) {
-//         int ngllx, ngllz;
-//         quadrature_points.get_ngll(&ngllx, &ngllz);
-//         const auto ielement = team_member.league_rank();
-//         const auto ispec_l = ispec(ielement);
+  Kokkos::parallel_for(
+      "specfem::domain::kernes::elements::add_mass_matrix_contribution",
+      specfem::kokkos::DeviceTeam(nelements, Kokkos::AUTO, 1),
+      KOKKOS_CLASS_LAMBDA(
+          const specfem::kokkos::DeviceTeam::member_type &team_member) {
+        int ngllx, ngllz;
+        quadrature_points.get_ngll(&ngllx, &ngllz);
+        const auto ispec_l =
+            element_kernel_index_mapping(team_member.league_rank());
 
-//         Kokkos::parallel_for(
-//             quadrature_points.template
-//             TeamThreadRange<specfem::enums::axes::x,
-//                                                        specfem::enums::axes::z>(
-//                 team_member),
-//             [&](const int xz) {
-//               int ix, iz;
-//               sub2ind(xz, ngllx, iz, ix);
-//               int iglob = ibool(ispec_l, iz, ix);
+        const auto point_boundary_type = boundary_conditions(ispec_l);
 
-//               specfem::kokkos::array_type<type_real,
-//               medium_type::components>
-//                   mass_matrix_element;
+        Kokkos::parallel_for(
+            quadrature_points.template TeamThreadRange<specfem::enums::axes::x,
+                                                       specfem::enums::axes::z>(
+                team_member),
+            [&](const int xz) {
+              int ix, iz;
+              sub2ind(xz, ngllx, iz, ix);
+              int iglob = index_mapping(ispec_l, iz, ix);
 
-//               specfem::kokkos::array_type<type_real, dimension::dim>
-//               weight;
+              int iglob_l =
+                  global_index_mapping(iglob, static_cast<int>(medium::value));
 
-//               weight[0] = wxgll(ix);
-//               weight[1] = wzgll(iz);
+              const auto point_property =
+                  properties
+                      .load_properties<medium_type::value, property_type::value,
+                                       specfem::kokkos::DevExecSpace>(ispec_l,
+                                                                      iz, ix);
 
-//               element.template mass_time_contribution<time_scheme>(
-//                   ispec_l, ielement, xz, dt, weight, mass_matrix_element);
+              const auto point_partial_derivatives =
+                  partial_derivatives
+                      .load_derivatives<true, specfem::kokkos::DevExecSpace>(
+                          ispec_l, iz, ix);
 
-// #ifdef KOKKOS_ENABLE_CUDA
-// #pragma unroll
-// #endif
-//               for (int icomponent = 0; icomponent < components;
-//               ++icomponent)
-//               {
-//                 const type_real __mass_matrix = mass_matrix(iglob,
-//                 icomponent); Kokkos::single(Kokkos::PerThread(team_member),
-//                 [&]() {
-//                   Kokkos::atomic_add(&mass_matrix(iglob, icomponent),
-//                                      mass_matrix_element[icomponent]);
-//                 });
-//               }
-//             });
-//       });
+              specfem::kokkos::array_type<type_real, medium_type::components>
+                  mass_matrix_element;
 
-//   Kokkos::fence();
-//   return;
-// }
+              specfem::kokkos::array_type<type_real, dimension::dim> weight(
+                  wgll(ix), wgll(iz));
+
+              element.template mass_time_contribution<time_scheme>(
+                  xz, dt, weight, point_partial_derivatives, point_property,
+                  point_boundary_type, mass_matrix_element);
+
+#ifdef KOKKOS_ENABLE_CUDA
+#pragma unroll
+#endif
+              for (int icomponent = 0; icomponent < components; ++icomponent) {
+                Kokkos::single(Kokkos::PerThread(team_member), [&]() {
+                  Kokkos::atomic_add(&field.mass_inverse(iglob_l, icomponent),
+                                     mass_matrix_element[icomponent]);
+                });
+              }
+            });
+      });
+
+  Kokkos::fence();
+  return;
+}
 
 // template <class medium, class qp_type, class property, class BC>
 // void specfem::domain::impl::kernels::element_kernel<

--- a/include/domain/impl/elements/kernel.tpp
+++ b/include/domain/impl/elements/kernel.tpp
@@ -300,7 +300,7 @@ void specfem::domain::impl::kernels::element_kernel<
             [&](const int xz) {
               int ix, iz;
               sub2ind(xz, ngllx, iz, ix);
-              s_hprime(ix, iz, 0) = hprime(iz, ix);
+              s_hprime(iz, ix, 0) = hprime(iz, ix);
               s_hprimewgll(ix, iz, 0) = wgll(iz) * hprime(iz, ix);
               const int iglob =
                   global_index_mapping(index_mapping(ispec_l, iz, ix),
@@ -326,6 +326,8 @@ void specfem::domain::impl::kernels::element_kernel<
             [&](const int xz) {
               int ix, iz;
               sub2ind(xz, ngllx, iz, ix);
+
+              specfem::kokkos::array_type<type_real, 50> field_test(s_field.data());
 
               specfem::kokkos::array_type<type_real, medium_type::components>
                   dudxl;
@@ -373,6 +375,9 @@ void specfem::domain::impl::kernels::element_kernel<
               int iz, ix;
               sub2ind(xz, ngllx, iz, ix);
               constexpr auto tag = BC::value;
+
+              specfem::kokkos::array_type<type_real, 50> stress_integrand_xi_test(s_stress_integrand_xi.data());
+              specfem::kokkos::array_type<type_real, 50> stress_integrand_gamma_test(s_stress_integrand_gamma.data());
 
               const int iglob =
                   global_index_mapping(index_mapping(ispec_l, iz, ix),

--- a/include/domain/impl/elements/kernel.tpp
+++ b/include/domain/impl/elements/kernel.tpp
@@ -47,6 +47,7 @@ specfem::domain::impl::kernels::element_kernel<medium, qp_type, property, BC>::
         const specfem::kokkos::HostView1d<int> h_element_kernel_index_mapping,
         const quadrature_point_type &quadrature_points)
     : nelements(h_element_kernel_index_mapping.extent(0)),
+      h_element_kernel_index_mapping(h_element_kernel_index_mapping),
       points(assembly.mesh.points), quadrature(assembly.mesh.quadratures),
       partial_derivatives(assembly.partial_derivatives),
       properties(assembly.properties), quadrature_points(quadrature_points),

--- a/include/domain/impl/elements/kernel.tpp
+++ b/include/domain/impl/elements/kernel.tpp
@@ -43,69 +43,64 @@ get_velocity(
 template <class medium, class qp_type, class property, class BC>
 specfem::domain::impl::kernels::element_kernel<medium, qp_type, property, BC>::
     element_kernel(
-        const specfem::kokkos::DeviceView3d<int> ibool,
-        const specfem::kokkos::DeviceView1d<int> ispec,
-        const specfem::compute::partial_derivatives &partial_derivatives,
-        const specfem::compute::properties &properties,
-        const specfem::compute::boundaries &boundary_conditions,
-        specfem::quadrature::quadrature *quadx,
-        specfem::quadrature::quadrature *quadz, qp_type quadrature_points,
-        specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field,
-        specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field_dot,
-        specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
-            field_dot_dot,
-        specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
-            mass_matrix)
-    : ibool(ibool), ispec(ispec), quadx(quadx), quadz(quadz),
-      quadrature_points(quadrature_points), field(field), field_dot(field_dot),
-      field_dot_dot(field_dot_dot), mass_matrix(mass_matrix) {
+        const specfem::compute::assembly &assembly,
+        const specfem::kokkos::HostView1d<int> h_element_kernel_index_mapping,
+        const quadrature_point_type &quadrature_points)
+    : nelements(h_element_kernel_index_mapping.extent(0)),
+      points(assembly.mesh.points), quadrature(assembly.mesh.quadratures),
+      partial_derivatives(assembly.partial_derivatives),
+      properties(assembly.properties), quadrature_points(quadrature_points),
+      global_index_mapping(assembly.fields.forward.assembly_index_mapping),
+      field(assembly.fields.forward.get_field<medium>()) {
 
-#ifndef NDEBUG
-  assert(field.extent(1) == medium::components);
-  assert(field_dot_dot.extent(1) == medium::components);
-  assert(mass_matrix.extent(1) == medium::components);
-#endif
+  Kokkos::parallel_for(
+      "specfem::domain::impl::kernels::element_kernel::check_properties",
+      specfem::kokkos::HostRange(0, nelements), KOKKOS_LAMBDA(const int ielement) {
+        const int ispec = h_element_kernel_index_mapping(ielement);
+        if ((assembly.properties.h_element_types(ispec) !=
+             medium_type::value) &&
+            (assembly.properties.h_element_property(ispec) !=
+             property::value)) {
+          throw std::runtime_error("Invalid element detected in kernel");
+        }
+      });
 
-  static_assert(std::is_same_v<medium, typename BC::medium_type>,
-                "Boundary conditions should have the same medium type as the "
-                "element kernel");
-  static_assert(std::is_same_v<dimension, typename BC::dimension>,
-                "Boundary conditions should have the same dimension as the "
-                "element kernel");
-  static_assert(std::is_same_v<qp_type, typename BC::quadrature_points_type>,
-                "Boundary conditions should have the same quadrature point "
-                "type as the element kernel");
-  static_assert(std::is_same_v<property, typename BC::property_type>,
-                "Boundary conditions should have the same property as the "
-                "element kernel");
+  Kokkos::fence();
+
+  element_kernel_index_mapping = specfem::kokkos::DeviceView1d<int>(
+      "specfem::domain::impl::kernels::element_kernel::element_kernel_index_"
+      "mapping",
+      nelements);
+
+  Kokkos::deep_copy(element_kernel_index_mapping,
+                    h_element_kernel_index_mapping);
 
   element = specfem::domain::impl::elements::element<
       dimension, medium_type, quadrature_point_type, property, BC>(
-      partial_derivatives, properties, boundary_conditions, quadrature_points);
+      assembly, quadrature_points);
   return;
 }
 
 template <class medium, class qp_type, class property, class BC>
 void specfem::domain::impl::kernels::element_kernel<
     medium, qp_type, property, BC>::compute_mass_matrix() const {
-
   constexpr int components = medium::components;
-  const int nelements = ispec.extent(0);
 
   if (nelements == 0)
     return;
 
-  const auto wxgll = this->quadx->get_w();
-  const auto wzgll = this->quadz->get_w();
+  const auto wgll = quadrature.gll.weights;
+  const auto index_mapping = points.index_mapping;
 
   Kokkos::parallel_for(
       "specfem::domain::kernes::elements::compute_mass_matrix",
-      specfem::kokkos::DeviceTeam(ispec.extent(0), Kokkos::AUTO, 1),
+      specfem::kokkos::DeviceTeam(nelements, Kokkos::AUTO, 1),
       KOKKOS_CLASS_LAMBDA(
           const specfem::kokkos::DeviceTeam::member_type &team_member) {
         int ngllx, ngllz;
         quadrature_points.get_ngll(&ngllx, &ngllz);
-        const auto ispec_l = ispec(team_member.league_rank());
+        const auto ispec_l =
+            element_kernel_index_mapping(team_member.league_rank());
 
         Kokkos::parallel_for(
             quadrature_points.template TeamThreadRange<specfem::enums::axes::x,
@@ -114,21 +109,33 @@ void specfem::domain::impl::kernels::element_kernel<
             [&](const int xz) {
               int ix, iz;
               sub2ind(xz, ngllx, iz, ix);
-              int iglob = ibool(ispec_l, iz, ix);
+              int iglob = index_mapping(ispec_l, iz, ix);
+              int iglob_l =
+                  global_index_mapping(iglob, static_cast<int>(medium::value));
+
+              const auto point_property =
+                  properties
+                      .load_properties<medium_type::value, property_type::value,
+                                       specfem::kokkos::DevExecSpace>(ispec_l,
+                                                                      iz, ix);
+
+              const auto point_partial_derivatives =
+                  partial_derivatives.load_derivatives<
+                      true, specfem::kokkos::DevExecSpace>(ispec_l, iz, ix);
 
               specfem::kokkos::array_type<type_real, medium_type::components>
                   mass_matrix_element;
 
-              element.compute_mass_matrix_component(ispec_l, xz,
-                                                    mass_matrix_element);
+              element.compute_mass_matrix_component(
+                  point_property, point_partial_derivatives, mass_matrix_element);
 
 #ifdef KOKKOS_ENABLE_CUDA
 #pragma unroll
 #endif
               for (int icomponent = 0; icomponent < components; icomponent++) {
                 Kokkos::single(Kokkos::PerThread(team_member), [&]() {
-                  Kokkos::atomic_add(&mass_matrix(iglob, icomponent),
-                                     wxgll(ix) * wzgll(iz) *
+                  Kokkos::atomic_add(&field.mass_inverse(iglob_l, icomponent),
+                                     wgll(ix) * wgll(iz) *
                                          mass_matrix_element[icomponent]);
                 });
               }
@@ -140,274 +147,302 @@ void specfem::domain::impl::kernels::element_kernel<
   return;
 }
 
-template <class medium, class qp_type, class property, class BC>
-template <specfem::enums::time_scheme::type time_scheme>
-void specfem::domain::impl::kernels::element_kernel<
-    medium, qp_type, property, BC>::mass_time_contribution(const type_real dt)
-    const {
+// template <class medium, class qp_type, class property, class BC>
+// template <specfem::enums::time_scheme::type time_scheme>
+// void specfem::domain::impl::kernels::element_kernel<
+//     medium, qp_type, property, BC>::mass_time_contribution(const type_real
+//     dt) const {
 
-  constexpr int components = medium::components;
-  const int nelements = ispec.extent(0);
+//   constexpr int components = medium::components;
+//   const int nelements = ispec.extent(0);
 
-  if (nelements == 0)
-    return;
+//   if (nelements == 0)
+//     return;
 
-  const auto wxgll = this->quadx->get_w();
-  const auto wzgll = this->quadz->get_w();
+//   const auto wxgll = this->quadx->get_w();
+//   const auto wzgll = this->quadz->get_w();
 
-  Kokkos::parallel_for(
-      "specfem::domain::kernes::elements::add_mass_matrix_contribution",
-      specfem::kokkos::DeviceTeam(ispec.extent(0), Kokkos::AUTO, 1),
-      KOKKOS_CLASS_LAMBDA(
-          const specfem::kokkos::DeviceTeam::member_type &team_member) {
-        int ngllx, ngllz;
-        quadrature_points.get_ngll(&ngllx, &ngllz);
-        const auto ielement = team_member.league_rank();
-        const auto ispec_l = ispec(ielement);
+//   Kokkos::parallel_for(
+//       "specfem::domain::kernes::elements::add_mass_matrix_contribution",
+//       specfem::kokkos::DeviceTeam(ispec.extent(0), Kokkos::AUTO, 1),
+//       KOKKOS_CLASS_LAMBDA(
+//           const specfem::kokkos::DeviceTeam::member_type &team_member) {
+//         int ngllx, ngllz;
+//         quadrature_points.get_ngll(&ngllx, &ngllz);
+//         const auto ielement = team_member.league_rank();
+//         const auto ispec_l = ispec(ielement);
 
-        Kokkos::parallel_for(
-            quadrature_points.template TeamThreadRange<specfem::enums::axes::x,
-                                                       specfem::enums::axes::z>(
-                team_member),
-            [&](const int xz) {
-              int ix, iz;
-              sub2ind(xz, ngllx, iz, ix);
-              int iglob = ibool(ispec_l, iz, ix);
+//         Kokkos::parallel_for(
+//             quadrature_points.template
+//             TeamThreadRange<specfem::enums::axes::x,
+//                                                        specfem::enums::axes::z>(
+//                 team_member),
+//             [&](const int xz) {
+//               int ix, iz;
+//               sub2ind(xz, ngllx, iz, ix);
+//               int iglob = ibool(ispec_l, iz, ix);
 
-              specfem::kokkos::array_type<type_real, medium_type::components>
-                  mass_matrix_element;
+//               specfem::kokkos::array_type<type_real,
+//               medium_type::components>
+//                   mass_matrix_element;
 
-              specfem::kokkos::array_type<type_real, dimension::dim> weight;
+//               specfem::kokkos::array_type<type_real, dimension::dim>
+//               weight;
 
-              weight[0] = wxgll(ix);
-              weight[1] = wzgll(iz);
+//               weight[0] = wxgll(ix);
+//               weight[1] = wzgll(iz);
 
-              element.template mass_time_contribution<time_scheme>(
-                  ispec_l, ielement, xz, dt, weight, mass_matrix_element);
+//               element.template mass_time_contribution<time_scheme>(
+//                   ispec_l, ielement, xz, dt, weight, mass_matrix_element);
 
-#ifdef KOKKOS_ENABLE_CUDA
-#pragma unroll
-#endif
-              for (int icomponent = 0; icomponent < components; ++icomponent) {
-                const type_real __mass_matrix = mass_matrix(iglob, icomponent);
-                Kokkos::single(Kokkos::PerThread(team_member), [&]() {
-                  Kokkos::atomic_add(&mass_matrix(iglob, icomponent),
-                                     mass_matrix_element[icomponent]);
-                });
-              }
-            });
-      });
+// #ifdef KOKKOS_ENABLE_CUDA
+// #pragma unroll
+// #endif
+//               for (int icomponent = 0; icomponent < components;
+//               ++icomponent)
+//               {
+//                 const type_real __mass_matrix = mass_matrix(iglob,
+//                 icomponent); Kokkos::single(Kokkos::PerThread(team_member),
+//                 [&]() {
+//                   Kokkos::atomic_add(&mass_matrix(iglob, icomponent),
+//                                      mass_matrix_element[icomponent]);
+//                 });
+//               }
+//             });
+//       });
 
-  Kokkos::fence();
-  return;
-}
+//   Kokkos::fence();
+//   return;
+// }
 
-template <class medium, class qp_type, class property, class BC>
-void specfem::domain::impl::kernels::element_kernel<
-    medium, qp_type, property, BC>::compute_stiffness_interaction() const {
+// template <class medium, class qp_type, class property, class BC>
+// void specfem::domain::impl::kernels::element_kernel<
+//     medium, qp_type, property, BC>::compute_stiffness_interaction() const {
 
-  constexpr int components = medium::components;
-  const int nelements = ispec.extent(0);
+//   constexpr int components = medium::components;
+//   const int nelements = ispec.extent(0);
 
-  if (nelements == 0)
-    return;
+//   if (nelements == 0)
+//     return;
 
-  const auto hprime_xx = this->quadx->get_hprime();
-  const auto hprime_zz = this->quadz->get_hprime();
-  const auto wxgll = this->quadx->get_w();
-  const auto wzgll = this->quadz->get_w();
+//   const auto hprime_xx = this->quadx->get_hprime();
+//   const auto hprime_zz = this->quadz->get_hprime();
+//   const auto wxgll = this->quadx->get_w();
+//   const auto wzgll = this->quadz->get_w();
 
-  // s_hprime_xx, s_hprimewgll_xx
-  int scratch_size =
-      2 * quadrature_points.template shmem_size<
-              type_real, 1, specfem::enums::axes::x, specfem::enums::axes::x>();
+//   // s_hprime_xx, s_hprimewgll_xx
+//   int scratch_size =
+//       2 * quadrature_points.template shmem_size<
+//               type_real, 1, specfem::enums::axes::x,
+//               specfem::enums::axes::x>();
 
-  // s_hprime_zz, s_hprimewgll_zz
-  scratch_size +=
-      2 * quadrature_points.template shmem_size<
-              type_real, 1, specfem::enums::axes::z, specfem::enums::axes::z>();
+//   // s_hprime_zz, s_hprimewgll_zz
+//   scratch_size +=
+//       2 * quadrature_points.template shmem_size<
+//               type_real, 1, specfem::enums::axes::z,
+//               specfem::enums::axes::z>();
 
-  // s_field, s_stress_integrand_xi, s_stress_integrand_gamma
-  scratch_size +=
-      3 *
-      quadrature_points
-          .template shmem_size<type_real, components, specfem::enums::axes::x,
-                               specfem::enums::axes::z>();
+//   // s_field, s_stress_integrand_xi, s_stress_integrand_gamma
+//   scratch_size +=
+//       3 *
+//       quadrature_points
+//           .template shmem_size<type_real, components,
+//           specfem::enums::axes::x,
+//                                specfem::enums::axes::z>();
 
-  // s_iglob
-  scratch_size +=
-      quadrature_points.template shmem_size<int, 1, specfem::enums::axes::x,
-                                            specfem::enums::axes::z>();
+//   // s_iglob
+//   scratch_size +=
+//       quadrature_points.template shmem_size<int, 1,
+//       specfem::enums::axes::x,
+//                                             specfem::enums::axes::z>();
 
-  Kokkos::parallel_for(
-      "specfem::domain::impl::kernels::elements::compute_stiffness_interaction",
-      specfem::kokkos::DeviceTeam(nelements, NTHREADS, NLANES)
-          .set_scratch_size(0, Kokkos::PerTeam(scratch_size)),
-      KOKKOS_CLASS_LAMBDA(
-          const specfem::kokkos::DeviceTeam::member_type &team_member) {
-        int ngllx, ngllz;
-        quadrature_points.get_ngll(&ngllx, &ngllz);
-        const auto ielement = team_member.league_rank();
-        const auto ispec_l = ispec(ielement);
+//   Kokkos::parallel_for(
+//       "specfem::domain::impl::kernels::elements::compute_stiffness_interaction",
+//       specfem::kokkos::DeviceTeam(nelements, NTHREADS, NLANES)
+//           .set_scratch_size(0, Kokkos::PerTeam(scratch_size)),
+//       KOKKOS_CLASS_LAMBDA(
+//           const specfem::kokkos::DeviceTeam::member_type &team_member) {
+//         int ngllx, ngllz;
+//         quadrature_points.get_ngll(&ngllx, &ngllz);
+//         const auto ielement = team_member.league_rank();
+//         const auto ispec_l = ispec(ielement);
 
-        // Instantiate shared views
-        // ---------------------------------------------------------------
-        auto s_hprime_xx = quadrature_points.template ScratchView<
-            type_real, 1, specfem::enums::axes::x, specfem::enums::axes::x>(
-            team_member.team_scratch(0));
-        auto s_hprime_zz = quadrature_points.template ScratchView<
-            type_real, 1, specfem::enums::axes::z, specfem::enums::axes::z>(
-            team_member.team_scratch(0));
-        auto s_hprimewgll_xx = quadrature_points.template ScratchView<
-            type_real, 1, specfem::enums::axes::x, specfem::enums::axes::x>(
-            team_member.team_scratch(0));
-        auto s_hprimewgll_zz = quadrature_points.template ScratchView<
-            type_real, 1, specfem::enums::axes::z, specfem::enums::axes::z>(
-            team_member.team_scratch(0));
+//         // Instantiate shared views
+//         // ---------------------------------------------------------------
+//         auto s_hprime_xx = quadrature_points.template ScratchView<
+//             type_real, 1, specfem::enums::axes::x,
+//             specfem::enums::axes::x>( team_member.team_scratch(0));
+//         auto s_hprime_zz = quadrature_points.template ScratchView<
+//             type_real, 1, specfem::enums::axes::z,
+//             specfem::enums::axes::z>( team_member.team_scratch(0));
+//         auto s_hprimewgll_xx = quadrature_points.template ScratchView<
+//             type_real, 1, specfem::enums::axes::x,
+//             specfem::enums::axes::x>( team_member.team_scratch(0));
+//         auto s_hprimewgll_zz = quadrature_points.template ScratchView<
+//             type_real, 1, specfem::enums::axes::z,
+//             specfem::enums::axes::z>( team_member.team_scratch(0));
 
-        auto s_field =
-            quadrature_points.template ScratchView<type_real, components,
-                                                   specfem::enums::axes::z,
-                                                   specfem::enums::axes::x>(
-                team_member.team_scratch(0));
-        auto s_stress_integrand_xi =
-            quadrature_points.template ScratchView<type_real, components,
-                                                   specfem::enums::axes::z,
-                                                   specfem::enums::axes::x>(
-                team_member.team_scratch(0));
-        auto s_stress_integrand_gamma =
-            quadrature_points.template ScratchView<type_real, components,
-                                                   specfem::enums::axes::z,
-                                                   specfem::enums::axes::x>(
-                team_member.team_scratch(0));
-        auto s_iglob = quadrature_points.template ScratchView<
-            int, 1, specfem::enums::axes::z, specfem::enums::axes::x>(
-            team_member.team_scratch(0));
+//         auto s_field =
+//             quadrature_points.template ScratchView<type_real, components,
+//                                                    specfem::enums::axes::z,
+//                                                    specfem::enums::axes::x>(
+//                 team_member.team_scratch(0));
+//         auto s_stress_integrand_xi =
+//             quadrature_points.template ScratchView<type_real, components,
+//                                                    specfem::enums::axes::z,
+//                                                    specfem::enums::axes::x>(
+//                 team_member.team_scratch(0));
+//         auto s_stress_integrand_gamma =
+//             quadrature_points.template ScratchView<type_real, components,
+//                                                    specfem::enums::axes::z,
+//                                                    specfem::enums::axes::x>(
+//                 team_member.team_scratch(0));
+//         auto s_iglob = quadrature_points.template ScratchView<
+//             int, 1, specfem::enums::axes::z, specfem::enums::axes::x>(
+//             team_member.team_scratch(0));
 
-        // ---------- Allocate shared views -------------------------------
-        Kokkos::parallel_for(
-            quadrature_points.template TeamThreadRange<specfem::enums::axes::x,
-                                                       specfem::enums::axes::x>(
-                team_member),
-            [&](const int xz) {
-              int iz, ix;
-              sub2ind(xz, ngllx, iz, ix);
-              s_hprime_xx(iz, ix, 0) = hprime_xx(iz, ix);
-              s_hprimewgll_xx(ix, iz, 0) = wxgll(iz) * hprime_xx(iz, ix);
-            });
+//         // ---------- Allocate shared views -------------------------------
+//         Kokkos::parallel_for(
+//             quadrature_points.template
+//             TeamThreadRange<specfem::enums::axes::x,
+//                                                        specfem::enums::axes::x>(
+//                 team_member),
+//             [&](const int xz) {
+//               int iz, ix;
+//               sub2ind(xz, ngllx, iz, ix);
+//               s_hprime_xx(iz, ix, 0) = hprime_xx(iz, ix);
+//               s_hprimewgll_xx(ix, iz, 0) = wxgll(iz) * hprime_xx(iz, ix);
+//             });
 
-        Kokkos::parallel_for(
-            quadrature_points.template TeamThreadRange<specfem::enums::axes::z,
-                                                       specfem::enums::axes::z>(
-                team_member),
-            [&](const int xz) {
-              int iz, ix;
-              sub2ind(xz, ngllz, iz, ix);
-              s_hprime_zz(iz, ix, 0) = hprime_zz(iz, ix);
-              s_hprimewgll_zz(ix, iz, 0) = wzgll(iz) * hprime_zz(iz, ix);
-            });
+//         Kokkos::parallel_for(
+//             quadrature_points.template
+//             TeamThreadRange<specfem::enums::axes::z,
+//                                                        specfem::enums::axes::z>(
+//                 team_member),
+//             [&](const int xz) {
+//               int iz, ix;
+//               sub2ind(xz, ngllz, iz, ix);
+//               s_hprime_zz(iz, ix, 0) = hprime_zz(iz, ix);
+//               s_hprimewgll_zz(ix, iz, 0) = wzgll(iz) * hprime_zz(iz, ix);
+//             });
 
-        Kokkos::parallel_for(
-            quadrature_points.template TeamThreadRange<specfem::enums::axes::z,
-                                                       specfem::enums::axes::x>(
-                team_member),
-            [&](const int xz) {
-              int iz, ix;
-              sub2ind(xz, ngllx, iz, ix);
-              const int iglob = ibool(ispec_l, iz, ix);
-              s_iglob(iz, ix, 0) = iglob;
-#ifdef KOKKOS_ENABLE_CUDA
-#pragma unroll
-#endif
-              for (int icomponent = 0; icomponent < components; ++icomponent) {
-                s_field(iz, ix, icomponent) = field(iglob, icomponent);
-                s_stress_integrand_xi(iz, ix, icomponent) = 0.0;
-                s_stress_integrand_gamma(iz, ix, icomponent) = 0.0;
-              }
-            });
+//         Kokkos::parallel_for(
+//             quadrature_points.template
+//             TeamThreadRange<specfem::enums::axes::z,
+//                                                        specfem::enums::axes::x>(
+//                 team_member),
+//             [&](const int xz) {
+//               int iz, ix;
+//               sub2ind(xz, ngllx, iz, ix);
+//               const int iglob = ibool(ispec_l, iz, ix);
+//               s_iglob(iz, ix, 0) = iglob;
+// #ifdef KOKKOS_ENABLE_CUDA
+// #pragma unroll
+// #endif
+//               for (int icomponent = 0; icomponent < components;
+//               ++icomponent)
+//               {
+//                 s_field(iz, ix, icomponent) = field(iglob, icomponent);
+//                 s_stress_integrand_xi(iz, ix, icomponent) = 0.0;
+//                 s_stress_integrand_gamma(iz, ix, icomponent) = 0.0;
+//               }
+//             });
 
-        // ------------------------------------------------------------------
+//         //
+//         ------------------------------------------------------------------
 
-        team_member.team_barrier();
+//         team_member.team_barrier();
 
-        Kokkos::parallel_for(
-            quadrature_points.template TeamThreadRange<specfem::enums::axes::z,
-                                                       specfem::enums::axes::x>(
-                team_member),
-            [&](const int xz) {
-              int ix, iz;
-              sub2ind(xz, ngllx, iz, ix);
+//         Kokkos::parallel_for(
+//             quadrature_points.template
+//             TeamThreadRange<specfem::enums::axes::z,
+//                                                        specfem::enums::axes::x>(
+//                 team_member),
+//             [&](const int xz) {
+//               int ix, iz;
+//               sub2ind(xz, ngllx, iz, ix);
 
-              specfem::kokkos::array_type<type_real, medium_type::components>
-                  dudxl;
-              specfem::kokkos::array_type<type_real, medium_type::components>
-                  dudzl;
+//               specfem::kokkos::array_type<type_real,
+//               medium_type::components>
+//                   dudxl;
+//               specfem::kokkos::array_type<type_real,
+//               medium_type::components>
+//                   dudzl;
 
-              element.compute_gradient(ispec_l, ielement, xz, s_hprime_xx,
-                                       s_hprime_zz, s_field, dudxl, dudzl);
+//               element.compute_gradient(ispec_l, ielement, xz, s_hprime_xx,
+//                                        s_hprime_zz, s_field, dudxl, dudzl);
 
-              specfem::kokkos::array_type<type_real, medium_type::components>
-                  stress_integrand_xi;
-              specfem::kokkos::array_type<type_real, medium_type::components>
-                  stress_integrand_gamma;
+//               specfem::kokkos::array_type<type_real,
+//               medium_type::components>
+//                   stress_integrand_xi;
+//               specfem::kokkos::array_type<type_real,
+//               medium_type::components>
+//                   stress_integrand_gamma;
 
-              element.compute_stress(ispec_l, ielement, xz, dudxl, dudzl,
-                                     stress_integrand_xi,
-                                     stress_integrand_gamma);
-#ifdef KOKKOS_ENABLE_CUDA
-#pragma unroll
-#endif
-              for (int icomponent = 0; icomponent < components; ++icomponent) {
-                s_stress_integrand_xi(iz, ix, icomponent) =
-                    stress_integrand_xi[icomponent];
-                s_stress_integrand_gamma(iz, ix, icomponent) =
-                    stress_integrand_gamma[icomponent];
-              }
-            });
+//               element.compute_stress(ispec_l, ielement, xz, dudxl, dudzl,
+//                                      stress_integrand_xi,
+//                                      stress_integrand_gamma);
+// #ifdef KOKKOS_ENABLE_CUDA
+// #pragma unroll
+// #endif
+//               for (int icomponent = 0; icomponent < components;
+//               ++icomponent)
+//               {
+//                 s_stress_integrand_xi(iz, ix, icomponent) =
+//                     stress_integrand_xi[icomponent];
+//                 s_stress_integrand_gamma(iz, ix, icomponent) =
+//                     stress_integrand_gamma[icomponent];
+//               }
+//             });
 
-        team_member.team_barrier();
+//         team_member.team_barrier();
 
-        Kokkos::parallel_for(
-            quadrature_points.template TeamThreadRange<specfem::enums::axes::z,
-                                                       specfem::enums::axes::x>(
-                team_member),
-            [&](const int xz) {
-              int iz, ix;
-              sub2ind(xz, ngllx, iz, ix);
+//         Kokkos::parallel_for(
+//             quadrature_points.template
+//             TeamThreadRange<specfem::enums::axes::z,
+//                                                        specfem::enums::axes::x>(
+//                 team_member),
+//             [&](const int xz) {
+//               int iz, ix;
+//               sub2ind(xz, ngllx, iz, ix);
 
-              const int iglob = s_iglob(iz, ix, 0);
-              specfem::kokkos::array_type<type_real, dimension::dim> weight;
+//               const int iglob = s_iglob(iz, ix, 0);
+//               specfem::kokkos::array_type<type_real, dimension::dim>
+//               weight;
 
-              weight[0] = wxgll(ix);
-              weight[1] = wzgll(iz);
+//               weight[0] = wxgll(ix);
+//               weight[1] = wzgll(iz);
 
-              specfem::kokkos::array_type<type_real, medium_type::components>
-                  acceleration;
+//               specfem::kokkos::array_type<type_real,
+//               medium_type::components>
+//                   acceleration;
 
-              // only get velocity from global memory for stacey boundary
-              auto velocity =
-                  get_velocity<components, BC::value>(iglob, field_dot);
+//               // only get velocity from global memory for stacey boundary
+//               auto velocity =
+//                   get_velocity<components, BC::value>(iglob, field_dot);
 
-              element.compute_acceleration(
-                  ispec_l, ielement, xz, weight, s_stress_integrand_xi,
-                  s_stress_integrand_gamma, s_hprimewgll_xx, s_hprimewgll_zz,
-                  velocity, acceleration);
+//               element.compute_acceleration(
+//                   ispec_l, ielement, xz, weight, s_stress_integrand_xi,
+//                   s_stress_integrand_gamma, s_hprimewgll_xx,
+//                   s_hprimewgll_zz, velocity, acceleration);
 
-#ifdef KOKKOS_ENABLE_CUDA
-#pragma unroll
-#endif
-              for (int icomponent = 0; icomponent < components; ++icomponent) {
-                Kokkos::single(Kokkos::PerThread(team_member), [&]() {
-                  Kokkos::atomic_add(&field_dot_dot(iglob, icomponent),
-                                     acceleration[icomponent]);
-                });
-              }
-            });
-      });
+// #ifdef KOKKOS_ENABLE_CUDA
+// #pragma unroll
+// #endif
+//               for (int icomponent = 0; icomponent < components;
+//               ++icomponent)
+//               {
+//                 Kokkos::single(Kokkos::PerThread(team_member), [&]() {
+//                   Kokkos::atomic_add(&field_dot_dot(iglob, icomponent),
+//                                      acceleration[icomponent]);
+//                 });
+//               }
+//             });
+//       });
 
-  Kokkos::fence();
+//   Kokkos::fence();
 
-  return;
-}
+//   return;
+// }
 
 #endif // _DOMAIN_IMPL_ELEMENTS_KERNEL_TPP

--- a/include/domain/impl/kernels.hpp
+++ b/include/domain/impl/kernels.hpp
@@ -78,19 +78,19 @@ public:
     return;
   }
 
-  // /**
-  //  * @brief execute Kokkos kernel to compute contribution of stiffness matrix
-  //  to
-  //  * the global acceleration
-  //  *
-  //  */
-  // inline void compute_stiffness_interaction() const {
-  //   isotropic_elements.compute_stiffness_interaction();
-  //   isotropic_elements_dirichlet.compute_stiffness_interaction();
-  //   isotropic_elements_stacey.compute_stiffness_interaction();
-  //   isotropic_elements_stacey_dirichlet.compute_stiffness_interaction();
-  //   return;
-  // }
+  //   /**
+  //    * @brief execute Kokkos kernel to compute contribution of stiffness
+  //    matrix to
+  //    * the global acceleration
+  //    *
+  //    */
+  //   inline void compute_stiffness_interaction() const {
+  //     isotropic_elements.compute_stiffness_interaction();
+  //     isotropic_elements_dirichlet.compute_stiffness_interaction();
+  //     isotropic_elements_stacey.compute_stiffness_interaction();
+  //     isotropic_elements_stacey_dirichlet.compute_stiffness_interaction();
+  //     return;
+  //   }
 
   /**
    * @brief execute Kokkos kernel to compute the mass matrix for every GLL point
@@ -104,16 +104,16 @@ public:
     return;
   }
 
-  // /**
-  //  * @brief execute Kokkos kernel compute the contribution of sources to the
-  //  * global acceleration
-  //  *
-  //  * @param timeval time value at the current time step
-  //  */
-  // inline void compute_source_interaction(const type_real timeval) const {
-  //   isotropic_sources.compute_source_interaction(timeval);
-  //   return;
-  // }
+  /**
+   * @brief execute Kokkos kernel compute the contribution of sources to the
+   * global acceleration
+   *
+   * @param timeval time value at the current time step
+   */
+  inline void compute_source_interaction(const type_real timeval) const {
+    isotropic_sources.compute_source_interaction(timeval);
+    return;
+  }
 
   // /**
   //  * @brief execute Kokkos kernel to compute seismogram values at every
@@ -198,14 +198,14 @@ private:
           dirichlet<specfem::enums::element::property::isotropic> > >
       isotropic_elements_stacey_dirichlet;
 
-  // /**
-  //  * @brief Elemental source kernels for isotropic elements
-  //  *
-  //  */
-  // specfem::domain::impl::kernels::source_kernel<
-  //     medium_type, quadrature_point_type,
-  //     specfem::enums::element::property::isotropic>
-  //     isotropic_sources;
+  /**
+   * @brief Elemental source kernels for isotropic elements
+   *
+   */
+  specfem::domain::impl::kernels::source_kernel<
+      medium_type, quadrature_point_type,
+      specfem::enums::element::property::isotropic>
+      isotropic_sources;
 
   // /**
   //  * @brief Elemental receiver kernels for isotropic elements

--- a/include/domain/impl/kernels.hpp
+++ b/include/domain/impl/kernels.hpp
@@ -5,6 +5,7 @@
 #include "domain/impl/elements/interface.hpp"
 #include "domain/impl/receivers/interface.hpp"
 #include "domain/impl/sources/interface.hpp"
+#include "enumerations/boundary_conditions/none.hpp"
 #include "enumerations/interface.hpp"
 
 namespace specfem {
@@ -60,48 +61,39 @@ public:
    * @param field_dot_dot double derivative of wavefield inside the domain
    * @param mass_matrix mass matrix for every GLL point inside the domain
    */
-  kernels(
-      const specfem::kokkos::DeviceView3d<int> ibool,
-      const specfem::compute::partial_derivatives &partial_derivatives,
-      const specfem::compute::properties &properties,
-      const specfem::compute::boundaries &boundaries,
-      const specfem::compute::sources &sources,
-      const specfem::compute::receivers &receives,
-      specfem::quadrature::quadrature *quadx,
-      specfem::quadrature::quadrature *quadz, qp_type quadrature_points,
-      specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field,
-      specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field_dot,
-      specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
-          field_dot_dot,
-      specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> mass_matrix);
+  kernels(const specfem::compute::assembly &assembly,
+          const quadrature_point_type &quadrature_points);
 
-  /**
-   * @brief
-   *
-   */
-  template <specfem::enums::time_scheme::type time_scheme>
-  inline void mass_time_contribution(const type_real &dt) const {
-    isotropic_elements.template mass_time_contribution<time_scheme>(dt);
-    isotropic_elements_dirichlet.template mass_time_contribution<time_scheme>(
-        dt);
-    isotropic_elements_stacey.template mass_time_contribution<time_scheme>(dt);
-    isotropic_elements_stacey_dirichlet
-        .template mass_time_contribution<time_scheme>(dt);
-    return;
-  }
+  // /**
+  //  * @brief
+  //  *
+  //  */
+  // template <specfem::enums::time_scheme::type time_scheme>
+  // inline void mass_time_contribution(const type_real &dt) const {
+  //   isotropic_elements.template mass_time_contribution<time_scheme>(dt);
+  //   isotropic_elements_dirichlet.template
+  //   mass_time_contribution<time_scheme>(
+  //       dt);
+  //   isotropic_elements_stacey.template
+  //   mass_time_contribution<time_scheme>(dt);
+  //   isotropic_elements_stacey_dirichlet
+  //       .template mass_time_contribution<time_scheme>(dt);
+  //   return;
+  // }
 
-  /**
-   * @brief execute Kokkos kernel to compute contribution of stiffness matrix to
-   * the global acceleration
-   *
-   */
-  inline void compute_stiffness_interaction() const {
-    isotropic_elements.compute_stiffness_interaction();
-    isotropic_elements_dirichlet.compute_stiffness_interaction();
-    isotropic_elements_stacey.compute_stiffness_interaction();
-    isotropic_elements_stacey_dirichlet.compute_stiffness_interaction();
-    return;
-  }
+  // /**
+  //  * @brief execute Kokkos kernel to compute contribution of stiffness matrix
+  //  to
+  //  * the global acceleration
+  //  *
+  //  */
+  // inline void compute_stiffness_interaction() const {
+  //   isotropic_elements.compute_stiffness_interaction();
+  //   isotropic_elements_dirichlet.compute_stiffness_interaction();
+  //   isotropic_elements_stacey.compute_stiffness_interaction();
+  //   isotropic_elements_stacey_dirichlet.compute_stiffness_interaction();
+  //   return;
+  // }
 
   /**
    * @brief execute Kokkos kernel to compute the mass matrix for every GLL point
@@ -109,59 +101,60 @@ public:
    */
   inline void compute_mass_matrix() const {
     isotropic_elements.compute_mass_matrix();
-    isotropic_elements_dirichlet.compute_mass_matrix();
-    isotropic_elements_stacey.compute_mass_matrix();
-    isotropic_elements_stacey_dirichlet.compute_mass_matrix();
+    // isotropic_elements_dirichlet.compute_mass_matrix();
+    // isotropic_elements_stacey.compute_mass_matrix();
+    // isotropic_elements_stacey_dirichlet.compute_mass_matrix();
     return;
   }
 
-  /**
-   * @brief execute Kokkos kernel compute the contribution of sources to the
-   * global acceleration
-   *
-   * @param timeval time value at the current time step
-   */
-  inline void compute_source_interaction(const type_real timeval) const {
-    isotropic_sources.compute_source_interaction(timeval);
-    return;
-  }
+  // /**
+  //  * @brief execute Kokkos kernel compute the contribution of sources to the
+  //  * global acceleration
+  //  *
+  //  * @param timeval time value at the current time step
+  //  */
+  // inline void compute_source_interaction(const type_real timeval) const {
+  //   isotropic_sources.compute_source_interaction(timeval);
+  //   return;
+  // }
 
-  /**
-   * @brief execute Kokkos kernel to compute seismogram values at every receiver
-   * for the current seismogram step
-   *
-   * A seismogram step is defined as the current time step divided by the
-   * seismogram sampling rate
-   *
-   * @param isig_step current seismogram step.
-   */
-  inline void compute_seismograms(const int &isig_step) const {
-    isotropic_receivers.compute_seismograms(isig_step);
-    return;
-  }
+  // /**
+  //  * @brief execute Kokkos kernel to compute seismogram values at every
+  //  receiver
+  //  * for the current seismogram step
+  //  *
+  //  * A seismogram step is defined as the current time step divided by the
+  //  * seismogram sampling rate
+  //  *
+  //  * @param isig_step current seismogram step.
+  //  */
+  // inline void compute_seismograms(const int &isig_step) const {
+  //   isotropic_receivers.compute_seismograms(isig_step);
+  //   return;
+  // }
 
 private:
-  template <class property>
-  using dirichlet = specfem::enums::boundary_conditions::template dirichlet<
-      dimension, medium_type, property, quadrature_point_type>; // Dirichlet
-                                                                // boundary
-                                                                // conditions
+  // template <class property>
+  // using dirichlet = specfem::enums::boundary_conditions::template dirichlet<
+  //     dimension, medium_type, property, quadrature_point_type>; // Dirichlet
+  //                                                               // boundary
+  //                                                               // conditions
 
-  template <class property>
-  using stacey = specfem::enums::boundary_conditions::template stacey<
-      dimension, medium_type, property, quadrature_point_type>; // Stacey
-                                                                // boundary
-                                                                // conditions
+  // template <class property>
+  // using stacey = specfem::enums::boundary_conditions::template stacey<
+  //     dimension, medium_type, property, quadrature_point_type>; // Stacey
+  //                                                               // boundary
+  //                                                               // conditions
 
   template <class property>
   using none = specfem::enums::boundary_conditions::template none<
       dimension, medium_type, property, quadrature_point_type>; // No boundary
                                                                 // conditions
 
-  template <class BC1, class BC2>
-  using composite_boundary =
-      specfem::enums::boundary_conditions::composite_boundary<
-          BC1, BC2>; // Composite boundary conditions
+  // template <class BC1, class BC2>
+  // using composite_boundary =
+  //     specfem::enums::boundary_conditions::composite_boundary<
+  //         BC1, BC2>; // Composite boundary conditions
 
   /**
    * @brief Elemental kernels for isotropic elements
@@ -173,58 +166,59 @@ private:
       none<specfem::enums::element::property::isotropic> >
       isotropic_elements;
 
-  /**
-   * @brief Elemental kernels for isotropic elements with dirichlet boundary
-   * conditions
-   *
-   */
-  specfem::domain::impl::kernels::element_kernel<
-      medium_type, quadrature_point_type,
-      specfem::enums::element::property::isotropic,
-      dirichlet<specfem::enums::element::property::isotropic> >
-      isotropic_elements_dirichlet;
+  // /**
+  //  * @brief Elemental kernels for isotropic elements with dirichlet boundary
+  //  * conditions
+  //  *
+  //  */
+  // specfem::domain::impl::kernels::element_kernel<
+  //     medium_type, quadrature_point_type,
+  //     specfem::enums::element::property::isotropic,
+  //     dirichlet<specfem::enums::element::property::isotropic> >
+  //     isotropic_elements_dirichlet;
 
-  /**
-   * @brief Elemental kernels for isotropic elements with stacey boundary
-   *
-   */
-  specfem::domain::impl::kernels::element_kernel<
-      medium_type, quadrature_point_type,
-      specfem::enums::element::property::isotropic,
-      stacey<specfem::enums::element::property::isotropic> >
-      isotropic_elements_stacey;
+  // /**
+  //  * @brief Elemental kernels for isotropic elements with stacey boundary
+  //  *
+  //  */
+  // specfem::domain::impl::kernels::element_kernel<
+  //     medium_type, quadrature_point_type,
+  //     specfem::enums::element::property::isotropic,
+  //     stacey<specfem::enums::element::property::isotropic> >
+  //     isotropic_elements_stacey;
 
-  /**
-   * @brief Elemental kernels for isotropic elements with composite stacey and
-   * dirichlet boundary
-   *
-   */
-  specfem::domain::impl::kernels::element_kernel<
-      medium_type, quadrature_point_type,
-      specfem::enums::element::property::isotropic,
-      composite_boundary<
-          stacey<specfem::enums::element::property::isotropic>,
-          dirichlet<specfem::enums::element::property::isotropic> > >
-      isotropic_elements_stacey_dirichlet;
+  // /**
+  //  * @brief Elemental kernels for isotropic elements with composite stacey
+  //  and
+  //  * dirichlet boundary
+  //  *
+  //  */
+  // specfem::domain::impl::kernels::element_kernel<
+  //     medium_type, quadrature_point_type,
+  //     specfem::enums::element::property::isotropic,
+  //     composite_boundary<
+  //         stacey<specfem::enums::element::property::isotropic>,
+  //         dirichlet<specfem::enums::element::property::isotropic> > >
+  //     isotropic_elements_stacey_dirichlet;
 
-  /**
-   * @brief Elemental source kernels for isotropic elements
-   *
-   */
-  specfem::domain::impl::kernels::source_kernel<
-      medium_type, quadrature_point_type,
-      specfem::enums::element::property::isotropic>
-      isotropic_sources;
+  // /**
+  //  * @brief Elemental source kernels for isotropic elements
+  //  *
+  //  */
+  // specfem::domain::impl::kernels::source_kernel<
+  //     medium_type, quadrature_point_type,
+  //     specfem::enums::element::property::isotropic>
+  //     isotropic_sources;
 
-  /**
-   * @brief Elemental receiver kernels for isotropic elements
-   *
-   */
-  specfem::domain::impl::kernels::receiver_kernel<
-      medium_type, quadrature_point_type,
-      specfem::enums::element::property::isotropic>
-      isotropic_receivers; ///< Elemental receiver kernels for isotropic
-                           ///< elements
+  // /**
+  //  * @brief Elemental receiver kernels for isotropic elements
+  //  *
+  //  */
+  // specfem::domain::impl::kernels::receiver_kernel<
+  //     medium_type, quadrature_point_type,
+  //     specfem::enums::element::property::isotropic>
+  //     isotropic_receivers; ///< Elemental receiver kernels for isotropic
+  //                          ///< elements
 };
 } // namespace kernels
 } // namespace impl

--- a/include/domain/impl/kernels.hpp
+++ b/include/domain/impl/kernels.hpp
@@ -78,19 +78,19 @@ public:
     return;
   }
 
-  //   /**
-  //    * @brief execute Kokkos kernel to compute contribution of stiffness
-  //    matrix to
-  //    * the global acceleration
-  //    *
-  //    */
-  //   inline void compute_stiffness_interaction() const {
-  //     isotropic_elements.compute_stiffness_interaction();
-  //     isotropic_elements_dirichlet.compute_stiffness_interaction();
-  //     isotropic_elements_stacey.compute_stiffness_interaction();
-  //     isotropic_elements_stacey_dirichlet.compute_stiffness_interaction();
-  //     return;
-  //   }
+  /**
+   * @brief execute Kokkos kernel to compute contribution of stiffness
+   matrix to
+   * the global acceleration
+   *
+   */
+  inline void compute_stiffness_interaction() const {
+    isotropic_elements.compute_stiffness_interaction();
+    isotropic_elements_dirichlet.compute_stiffness_interaction();
+    isotropic_elements_stacey.compute_stiffness_interaction();
+    isotropic_elements_stacey_dirichlet.compute_stiffness_interaction();
+    return;
+  }
 
   /**
    * @brief execute Kokkos kernel to compute the mass matrix for every GLL point

--- a/include/domain/impl/kernels.hpp
+++ b/include/domain/impl/kernels.hpp
@@ -5,8 +5,6 @@
 #include "domain/impl/elements/interface.hpp"
 #include "domain/impl/receivers/interface.hpp"
 #include "domain/impl/sources/interface.hpp"
-#include "enumerations/boundary_conditions/dirichlet.hpp"
-#include "enumerations/boundary_conditions/none.hpp"
 #include "enumerations/interface.hpp"
 
 namespace specfem {
@@ -65,22 +63,20 @@ public:
   kernels(const specfem::compute::assembly &assembly,
           const quadrature_point_type &quadrature_points);
 
-  // /**
-  //  * @brief
-  //  *
-  //  */
-  // template <specfem::enums::time_scheme::type time_scheme>
-  // inline void mass_time_contribution(const type_real &dt) const {
-  //   isotropic_elements.template mass_time_contribution<time_scheme>(dt);
-  //   isotropic_elements_dirichlet.template
-  //   mass_time_contribution<time_scheme>(
-  //       dt);
-  //   isotropic_elements_stacey.template
-  //   mass_time_contribution<time_scheme>(dt);
-  //   isotropic_elements_stacey_dirichlet
-  //       .template mass_time_contribution<time_scheme>(dt);
-  //   return;
-  // }
+  /**
+   * @brief
+   *
+   */
+  template <specfem::enums::time_scheme::type time_scheme>
+  inline void mass_time_contribution(const type_real &dt) const {
+    isotropic_elements.template mass_time_contribution<time_scheme>(dt);
+    isotropic_elements_dirichlet.template mass_time_contribution<time_scheme>(
+        dt);
+    isotropic_elements_stacey.template mass_time_contribution<time_scheme>(dt);
+    isotropic_elements_stacey_dirichlet
+        .template mass_time_contribution<time_scheme>(dt);
+    return;
+  }
 
   // /**
   //  * @brief execute Kokkos kernel to compute contribution of stiffness matrix
@@ -103,8 +99,8 @@ public:
   inline void compute_mass_matrix() const {
     isotropic_elements.compute_mass_matrix();
     isotropic_elements_dirichlet.compute_mass_matrix();
-    // isotropic_elements_stacey.compute_mass_matrix();
-    // isotropic_elements_stacey_dirichlet.compute_mass_matrix();
+    isotropic_elements_stacey.compute_mass_matrix();
+    isotropic_elements_stacey_dirichlet.compute_mass_matrix();
     return;
   }
 
@@ -141,21 +137,21 @@ private:
                                                                 // boundary
                                                                 // conditions
 
-  // template <class property>
-  // using stacey = specfem::enums::boundary_conditions::template stacey<
-  //     dimension, medium_type, property, quadrature_point_type>; // Stacey
-  //                                                               // boundary
-  //                                                               // conditions
+  template <class property>
+  using stacey = specfem::enums::boundary_conditions::template stacey<
+      dimension, medium_type, property, quadrature_point_type>; // Stacey
+                                                                // boundary
+                                                                // conditions
 
   template <class property>
   using none = specfem::enums::boundary_conditions::template none<
       dimension, medium_type, property, quadrature_point_type>; // No boundary
                                                                 // conditions
 
-  // template <class BC1, class BC2>
-  // using composite_boundary =
-  //     specfem::enums::boundary_conditions::composite_boundary<
-  //         BC1, BC2>; // Composite boundary conditions
+  template <class BC1, class BC2>
+  using composite_boundary =
+      specfem::enums::boundary_conditions::composite_boundary<
+          BC1, BC2>; // Composite boundary conditions
 
   /**
    * @brief Elemental kernels for isotropic elements
@@ -178,29 +174,29 @@ private:
       dirichlet<specfem::enums::element::property::isotropic> >
       isotropic_elements_dirichlet;
 
-  // /**
-  //  * @brief Elemental kernels for isotropic elements with stacey boundary
-  //  *
-  //  */
-  // specfem::domain::impl::kernels::element_kernel<
-  //     medium_type, quadrature_point_type,
-  //     specfem::enums::element::property::isotropic,
-  //     stacey<specfem::enums::element::property::isotropic> >
-  //     isotropic_elements_stacey;
+  /**
+   * @brief Elemental kernels for isotropic elements with stacey boundary
+   *
+   */
+  specfem::domain::impl::kernels::element_kernel<
+      medium_type, quadrature_point_type,
+      specfem::enums::element::property::isotropic,
+      stacey<specfem::enums::element::property::isotropic> >
+      isotropic_elements_stacey;
 
-  // /**
-  //  * @brief Elemental kernels for isotropic elements with composite stacey
-  //  and
-  //  * dirichlet boundary
-  //  *
-  //  */
-  // specfem::domain::impl::kernels::element_kernel<
-  //     medium_type, quadrature_point_type,
-  //     specfem::enums::element::property::isotropic,
-  //     composite_boundary<
-  //         stacey<specfem::enums::element::property::isotropic>,
-  //         dirichlet<specfem::enums::element::property::isotropic> > >
-  //     isotropic_elements_stacey_dirichlet;
+  /**
+   * @brief Elemental kernels for isotropic elements with composite stacey
+   and
+   * dirichlet boundary
+   *
+   */
+  specfem::domain::impl::kernels::element_kernel<
+      medium_type, quadrature_point_type,
+      specfem::enums::element::property::isotropic,
+      composite_boundary<
+          stacey<specfem::enums::element::property::isotropic>,
+          dirichlet<specfem::enums::element::property::isotropic> > >
+      isotropic_elements_stacey_dirichlet;
 
   // /**
   //  * @brief Elemental source kernels for isotropic elements

--- a/include/domain/impl/kernels.hpp
+++ b/include/domain/impl/kernels.hpp
@@ -5,6 +5,7 @@
 #include "domain/impl/elements/interface.hpp"
 #include "domain/impl/receivers/interface.hpp"
 #include "domain/impl/sources/interface.hpp"
+#include "enumerations/boundary_conditions/dirichlet.hpp"
 #include "enumerations/boundary_conditions/none.hpp"
 #include "enumerations/interface.hpp"
 
@@ -101,7 +102,7 @@ public:
    */
   inline void compute_mass_matrix() const {
     isotropic_elements.compute_mass_matrix();
-    // isotropic_elements_dirichlet.compute_mass_matrix();
+    isotropic_elements_dirichlet.compute_mass_matrix();
     // isotropic_elements_stacey.compute_mass_matrix();
     // isotropic_elements_stacey_dirichlet.compute_mass_matrix();
     return;
@@ -134,11 +135,11 @@ public:
   // }
 
 private:
-  // template <class property>
-  // using dirichlet = specfem::enums::boundary_conditions::template dirichlet<
-  //     dimension, medium_type, property, quadrature_point_type>; // Dirichlet
-  //                                                               // boundary
-  //                                                               // conditions
+  template <class property>
+  using dirichlet = specfem::enums::boundary_conditions::template dirichlet<
+      dimension, medium_type, property, quadrature_point_type>; // Dirichlet
+                                                                // boundary
+                                                                // conditions
 
   // template <class property>
   // using stacey = specfem::enums::boundary_conditions::template stacey<
@@ -166,16 +167,16 @@ private:
       none<specfem::enums::element::property::isotropic> >
       isotropic_elements;
 
-  // /**
-  //  * @brief Elemental kernels for isotropic elements with dirichlet boundary
-  //  * conditions
-  //  *
-  //  */
-  // specfem::domain::impl::kernels::element_kernel<
-  //     medium_type, quadrature_point_type,
-  //     specfem::enums::element::property::isotropic,
-  //     dirichlet<specfem::enums::element::property::isotropic> >
-  //     isotropic_elements_dirichlet;
+  /**
+   * @brief Elemental kernels for isotropic elements with dirichlet boundary
+   * conditions
+   *
+   */
+  specfem::domain::impl::kernels::element_kernel<
+      medium_type, quadrature_point_type,
+      specfem::enums::element::property::isotropic,
+      dirichlet<specfem::enums::element::property::isotropic> >
+      isotropic_elements_dirichlet;
 
   // /**
   //  * @brief Elemental kernels for isotropic elements with stacey boundary

--- a/include/domain/impl/kernels.hpp
+++ b/include/domain/impl/kernels.hpp
@@ -115,20 +115,20 @@ public:
     return;
   }
 
-  // /**
-  //  * @brief execute Kokkos kernel to compute seismogram values at every
-  //  receiver
-  //  * for the current seismogram step
-  //  *
-  //  * A seismogram step is defined as the current time step divided by the
-  //  * seismogram sampling rate
-  //  *
-  //  * @param isig_step current seismogram step.
-  //  */
-  // inline void compute_seismograms(const int &isig_step) const {
-  //   isotropic_receivers.compute_seismograms(isig_step);
-  //   return;
-  // }
+  /**
+   * @brief execute Kokkos kernel to compute seismogram values at every
+   receiver
+   * for the current seismogram step
+   *
+   * A seismogram step is defined as the current time step divided by the
+   * seismogram sampling rate
+   *
+   * @param isig_step current seismogram step.
+   */
+  inline void compute_seismograms(const int &isig_step) const {
+    isotropic_receivers.compute_seismograms(isig_step);
+    return;
+  }
 
 private:
   template <class property>
@@ -207,15 +207,15 @@ private:
       specfem::enums::element::property::isotropic>
       isotropic_sources;
 
-  // /**
-  //  * @brief Elemental receiver kernels for isotropic elements
-  //  *
-  //  */
-  // specfem::domain::impl::kernels::receiver_kernel<
-  //     medium_type, quadrature_point_type,
-  //     specfem::enums::element::property::isotropic>
-  //     isotropic_receivers; ///< Elemental receiver kernels for isotropic
-  //                          ///< elements
+  /**
+   * @brief Elemental receiver kernels for isotropic elements
+   *
+   */
+  specfem::domain::impl::kernels::receiver_kernel<
+      medium_type, quadrature_point_type,
+      specfem::enums::element::property::isotropic>
+      isotropic_receivers; ///< Elemental receiver kernels for isotropic
+                           ///< elements
 };
 } // namespace kernels
 } // namespace impl

--- a/include/domain/impl/kernels.tpp
+++ b/include/domain/impl/kernels.tpp
@@ -376,16 +376,15 @@ specfem::domain::impl::kernels::kernels<medium, qp_type>::kernels(
   allocate_elements(assembly, quadrature_points, element_tags,
                     isotropic_elements_dirichlet);
 
-  // // Allocate isotropic elements with stacey boundary conditions
-  // allocate_elements(assembly, quadrature_points, element_tags,
-  //                   isotropic_elements_stacey);
+  // Allocate isotropic elements with stacey boundary conditions
+  allocate_elements(assembly, quadrature_points, element_tags,
+                    isotropic_elements_stacey);
 
-  // // Allocate isotropic elements with stacey dirichlet boundary conditions
-  // allocate_elements(assembly, quadrature_points, element_tags,
-  //                   isotropic_elements_stacey_dirichlet);
+  // Allocate isotropic elements with stacey dirichlet boundary conditions
+  allocate_elements(assembly, quadrature_points, element_tags,
+                    isotropic_elements_stacey_dirichlet);
 
-  // // Allocate isotropic elements
-
+  // Allocate isotropic elements
   allocate_elements(assembly, quadrature_points, element_tags,
                     isotropic_elements);
 

--- a/include/domain/impl/kernels.tpp
+++ b/include/domain/impl/kernels.tpp
@@ -373,8 +373,8 @@ specfem::domain::impl::kernels::kernels<medium, qp_type>::kernels(
   // -----------------------------------------------------------
 
   // Allocate isotropic elements with dirichlet boundary conditions
-  // allocate_elements(assembly, quadrature_points, element_tags,
-  //                   isotropic_elements_dirichlet);
+  allocate_elements(assembly, quadrature_points, element_tags,
+                    isotropic_elements_dirichlet);
 
   // // Allocate isotropic elements with stacey boundary conditions
   // allocate_elements(assembly, quadrature_points, element_tags,

--- a/include/domain/impl/kernels.tpp
+++ b/include/domain/impl/kernels.tpp
@@ -152,59 +152,52 @@ void allocate_elements(
       assembly, h_ispec_domain, quadrature_points);
 }
 
-// template <class medium, class qp_type>
-// void allocate_isotropic_sources(
-//     const specfem::kokkos::DeviceView3d<int> ibool,
-//     const specfem::compute::properties &properties,
-//     const specfem::compute::sources &sources, qp_type quadrature_points,
-//     specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field_dot_dot,
-//     specfem::domain::impl::kernels::source_kernel<
-//         medium, qp_type, specfem::enums::element::property::isotropic>
-//         &isotropic_sources) {
+template <class medium, class qp_type>
+void allocate_isotropic_sources(
+    const specfem::compute::assembly &assembly, qp_type quadrature_points,
+    specfem::domain::impl::kernels::source_kernel<
+        medium, qp_type, specfem::enums::element::property::isotropic>
+        &isotropic_sources) {
 
-//   const auto value = medium::value;
+  const auto value = medium::value;
 
-//   // Create isotropic sources
+  // Create isotropic sources
+  const auto ispec_array = assembly.sources.h_ispec_array;
 
-//   const auto ispec_array = sources.h_ispec_array;
-//   int nsources = 0;
-//   for (int isource = 0; isource < ispec_array.extent(0); isource++) {
-//     if (properties.h_ispec_type(ispec_array(isource)) == value) {
-//       nsources++;
-//     }
-//   }
+  // Count the number of sources within this medium
+  int nsources = 0;
+  for (int isource = 0; isource < ispec_array.extent(0); isource++) {
+    const int ispec = ispec_array(isource);
+    if (assembly.properties.h_element_types(ispec) == value) {
+      nsources++;
+    }
+  }
 
-//   specfem::kokkos::DeviceView1d<int> ispec_sources(
-//       "specfem::domain::domain::ispec_sources", nsources);
+  // Save the index for sources in this domain
+  specfem::kokkos::HostView1d<int> h_source_kernel_index_mapping(
+      "specfem::domain::domain::source_kernel_index_mapping", nsources);
 
-//   specfem::kokkos::HostMirror1d<int> h_ispec_sources =
-//       Kokkos::create_mirror_view(ispec_sources);
+  specfem::kokkos::HostMirror1d<int> h_source_mapping(
+      "specfem::domain::domain::source_mapping", nsources);
 
-//   specfem::kokkos::DeviceView1d<int> isource_array(
-//       "specfem::domain::domain::isource_array", nsources);
+  int index = 0;
+  for (int isource = 0; isource < ispec_array.extent(0); isource++) {
+    const int ispec = ispec_array(isource);
+    if (assembly.properties.h_element_types(ispec) == value) {
+      h_source_kernel_index_mapping(index) = ispec_array(isource);
+      h_source_mapping(index) = isource;
+      index++;
+    }
+  }
 
-//   specfem::kokkos::HostMirror1d<int> h_isource_array =
-//       Kokkos::create_mirror_view(isource_array);
+  // Allocate isotropic sources
+  isotropic_sources = specfem::domain::impl::kernels::source_kernel<
+      medium, qp_type, specfem::enums::element::property::isotropic>(
+      assembly, h_source_kernel_index_mapping, h_source_mapping,
+      quadrature_points);
 
-//   int index = 0;
-//   for (int isource = 0; isource < ispec_array.extent(0); isource++) {
-//     if (properties.h_ispec_type(ispec_array(isource)) == value) {
-//       h_ispec_sources(index) = ispec_array(isource);
-//       h_isource_array(index) = isource;
-//       index++;
-//     }
-//   }
-
-//   Kokkos::deep_copy(ispec_sources, h_ispec_sources);
-//   Kokkos::deep_copy(isource_array, h_isource_array);
-
-//   isotropic_sources = specfem::domain::impl::kernels::source_kernel<
-//       medium, qp_type, specfem::enums::element::property::isotropic>(
-//       ibool, ispec_sources, isource_array, properties, sources,
-//       quadrature_points, field_dot_dot);
-
-//   return;
-// }
+  return;
+}
 
 // template <class medium, class qp_type>
 // void allocate_isotropic_receivers(
@@ -214,8 +207,8 @@ void allocate_elements(
 //     const specfem::compute::receivers &receivers,
 //     specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field,
 //     specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field_dot,
-//     specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field_dot_dot,
-//     specfem::quadrature::quadrature *quadx,
+//     specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
+//     field_dot_dot, specfem::quadrature::quadrature *quadx,
 //     specfem::quadrature::quadrature *quadz, qp_type quadrature_points,
 //     specfem::domain::impl::kernels::receiver_kernel<
 //         medium, qp_type, specfem::enums::element::property::isotropic>
@@ -259,8 +252,8 @@ void allocate_elements(
 
 //   isotropic_receivers = specfem::domain::impl::kernels::receiver_kernel<
 //       medium, qp_type, specfem::enums::element::property::isotropic>(
-//       ibool, ispec_receivers, ireceiver_array, partial_derivatives, properties,
-//       receivers, field, field_dot, field_dot_dot, quadx, quadz,
+//       ibool, ispec_receivers, ireceiver_array, partial_derivatives,
+//       properties, receivers, field, field_dot, field_dot_dot, quadx, quadz,
 //       quadrature_points);
 
 //   return;
@@ -390,7 +383,7 @@ specfem::domain::impl::kernels::kernels<medium, qp_type>::kernels(
 
   // // Allocate isotropic sources
 
-  // allocate_isotropic_sources(assembly, quadrature_points, isotropic_sources);
+  allocate_isotropic_sources(assembly, quadrature_points, isotropic_sources);
 
   // // Allocate isotropic receivers
 

--- a/include/domain/impl/kernels.tpp
+++ b/include/domain/impl/kernels.tpp
@@ -31,17 +31,8 @@ struct element_tag {
 
 template <class medium, class qp_type, class property, class BC>
 void allocate_elements(
-    const specfem::kokkos::DeviceView3d<int> ibool,
+    const specfem::compute::assembly &assembly, qp_type quadrature_points,
     const specfem::kokkos::HostView1d<element_tag> element_tags,
-    const specfem::compute::partial_derivatives &partial_derivatives,
-    const specfem::compute::properties &properties,
-    const specfem::compute::boundaries &boundary_conditions,
-    specfem::quadrature::quadrature *quadx,
-    specfem::quadrature::quadrature *quadz, qp_type quadrature_points,
-    specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field,
-    specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field_dot,
-    specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field_dot_dot,
-    specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> mass_matrix,
     specfem::domain::impl::kernels::element_kernel<medium, qp_type, property,
                                                    BC> &elements) {
 
@@ -49,7 +40,7 @@ void allocate_elements(
   constexpr auto medium_tag = medium::value;
   constexpr auto property_tag = property::value;
 
-  const int nspec = partial_derivatives.xix.extent(0);
+  const int nspec = assembly.mesh.nspec;
 
   // count number of elements in this domain
   int nelements = 0;
@@ -87,60 +78,63 @@ void allocate_elements(
     }
   }
 
-  // assert that boundary_conditions ispec matches with calculated ispec
-  if constexpr (((boundary_tag == specfem::enums::element::boundary_tag::
-                                      acoustic_free_surface) &&
-                 (medium_tag == specfem::enums::element::type::acoustic))) {
-    ASSERT(
-        nelements == boundary_conditions.acoustic_free_surface.nelements,
-        "nelements = " << nelements << " nelem_acoustic_surface = "
-                       << boundary_conditions.acoustic_free_surface.nelements);
-    for (int i = 0; i < nelements; i++) {
-      ASSERT(h_ispec_domain(i) ==
-                 boundary_conditions.acoustic_free_surface.h_ispec(i),
-             "Error: computing ispec for acoustic free surface elements");
-    }
-  }
+  // // assert that boundary_conditions ispec matches with calculated ispec
+  // if constexpr (((boundary_tag == specfem::enums::element::boundary_tag::
+  //                                     acoustic_free_surface) &&
+  //                (medium_tag == specfem::enums::element::type::acoustic))) {
+  //   ASSERT(
+  //       nelements == boundary_conditions.acoustic_free_surface.nelements,
+  //       "nelements = " << nelements << " nelem_acoustic_surface = "
+  //                      <<
+  //                      boundary_conditions.acoustic_free_surface.nelements);
+  //   for (int i = 0; i < nelements; i++) {
+  //     ASSERT(h_ispec_domain(i) ==
+  //                boundary_conditions.acoustic_free_surface.h_ispec(i),
+  //            "Error: computing ispec for acoustic free surface elements");
+  //   }
+  // }
 
-  // assert that boundary_conditions ispec matches with calculated ispec
-  if constexpr ((boundary_tag ==
-                 specfem::enums::element::boundary_tag::stacey) &&
-                (medium_tag == specfem::enums::element::type::acoustic)) {
-    ASSERT(nelements == boundary_conditions.stacey.acoustic.nelements,
-           "nelements = " << nelements << " nelements = "
-                          << boundary_conditions.stacey.acoustic.nelements);
-    for (int i = 0; i < nelements; i++) {
-      ASSERT(h_ispec_domain(i) ==
-                 boundary_conditions.stacey.acoustic.h_ispec(i),
-             "Error: computing ispec for stacey elements");
-    }
-  } else if constexpr ((boundary_tag ==
-                        specfem::enums::element::boundary_tag::stacey) &&
-                       (medium_tag == specfem::enums::element::type::elastic)) {
-    ASSERT(nelements == boundary_conditions.stacey.elastic.nelements,
-           "nelements = " << nelements << " nelements = "
-                          << boundary_conditions.stacey.elastic.nelements);
-    for (int i = 0; i < nelements; i++) {
-      ASSERT(h_ispec_domain(i) == boundary_conditions.stacey.elastic.h_ispec(i),
-             "Error: computing ispec for stacey elements");
-    }
-  }
+  // // assert that boundary_conditions ispec matches with calculated ispec
+  // if constexpr ((boundary_tag ==
+  //                specfem::enums::element::boundary_tag::stacey) &&
+  //               (medium_tag == specfem::enums::element::type::acoustic)) {
+  //   ASSERT(nelements == boundary_conditions.stacey.acoustic.nelements,
+  //          "nelements = " << nelements << " nelements = "
+  //                         << boundary_conditions.stacey.acoustic.nelements);
+  //   for (int i = 0; i < nelements; i++) {
+  //     ASSERT(h_ispec_domain(i) ==
+  //                boundary_conditions.stacey.acoustic.h_ispec(i),
+  //            "Error: computing ispec for stacey elements");
+  //   }
+  // } else if constexpr ((boundary_tag ==
+  //                       specfem::enums::element::boundary_tag::stacey) &&
+  //                      (medium_tag ==
+  //                      specfem::enums::element::type::elastic)) {
+  //   ASSERT(nelements == boundary_conditions.stacey.elastic.nelements,
+  //          "nelements = " << nelements << " nelements = "
+  //                         << boundary_conditions.stacey.elastic.nelements);
+  //   for (int i = 0; i < nelements; i++) {
+  //     ASSERT(h_ispec_domain(i) ==
+  //     boundary_conditions.stacey.elastic.h_ispec(i),
+  //            "Error: computing ispec for stacey elements");
+  //   }
+  // }
 
-  // assert that boundary_conditions ispec matches with calculated ispec
-  if constexpr ((boundary_tag == specfem::enums::element::boundary_tag::
-                                     composite_stacey_dirichlet) &&
-                (medium_tag == specfem::enums::element::type::acoustic)) {
-    ASSERT(nelements ==
-               boundary_conditions.composite_stacey_dirichlet.nelements,
-           "nelements = "
-               << nelements << " nelements = "
-               << boundary_conditions.composite_stacey_dirichlet.nelements);
-    for (int i = 0; i < nelements; i++) {
-      ASSERT(h_ispec_domain(i) ==
-                 boundary_conditions.composite_stacey_dirichlet.h_ispec(i),
-             "Error: computing ispec for stacey dirichlet elements");
-    }
-  }
+  // // assert that boundary_conditions ispec matches with calculated ispec
+  // if constexpr ((boundary_tag == specfem::enums::element::boundary_tag::
+  //                                    composite_stacey_dirichlet) &&
+  //               (medium_tag == specfem::enums::element::type::acoustic)) {
+  //   ASSERT(nelements ==
+  //              boundary_conditions.composite_stacey_dirichlet.nelements,
+  //          "nelements = "
+  //              << nelements << " nelements = "
+  //              << boundary_conditions.composite_stacey_dirichlet.nelements);
+  //   for (int i = 0; i < nelements; i++) {
+  //     ASSERT(h_ispec_domain(i) ==
+  //                boundary_conditions.composite_stacey_dirichlet.h_ispec(i),
+  //            "Error: computing ispec for stacey dirichlet elements");
+  //   }
+  // }
 
   // Copy ispec_domain to device
   Kokkos::deep_copy(ispec_domain, h_ispec_domain);
@@ -155,224 +149,220 @@ void allocate_elements(
   // Create isotropic acoustic surface elements
   elements = specfem::domain::impl::kernels::element_kernel<medium, qp_type,
                                                             property, BC>(
-      ibool, ispec_domain, partial_derivatives, properties, boundary_conditions,
-      quadx, quadz, quadrature_points, field, field_dot, field_dot_dot,
-      mass_matrix);
+      assembly, h_ispec_domain, quadrature_points);
 }
 
-template <class medium, class qp_type>
-void allocate_isotropic_sources(
-    const specfem::kokkos::DeviceView3d<int> ibool,
-    const specfem::compute::properties &properties,
-    const specfem::compute::sources &sources, qp_type quadrature_points,
-    specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field_dot_dot,
-    specfem::domain::impl::kernels::source_kernel<
-        medium, qp_type, specfem::enums::element::property::isotropic>
-        &isotropic_sources) {
+// template <class medium, class qp_type>
+// void allocate_isotropic_sources(
+//     const specfem::kokkos::DeviceView3d<int> ibool,
+//     const specfem::compute::properties &properties,
+//     const specfem::compute::sources &sources, qp_type quadrature_points,
+//     specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field_dot_dot,
+//     specfem::domain::impl::kernels::source_kernel<
+//         medium, qp_type, specfem::enums::element::property::isotropic>
+//         &isotropic_sources) {
 
-  const auto value = medium::value;
+//   const auto value = medium::value;
 
-  // Create isotropic sources
+//   // Create isotropic sources
 
-  const auto ispec_array = sources.h_ispec_array;
-  int nsources = 0;
-  for (int isource = 0; isource < ispec_array.extent(0); isource++) {
-    if (properties.h_ispec_type(ispec_array(isource)) == value) {
-      nsources++;
-    }
-  }
+//   const auto ispec_array = sources.h_ispec_array;
+//   int nsources = 0;
+//   for (int isource = 0; isource < ispec_array.extent(0); isource++) {
+//     if (properties.h_ispec_type(ispec_array(isource)) == value) {
+//       nsources++;
+//     }
+//   }
 
-  specfem::kokkos::DeviceView1d<int> ispec_sources(
-      "specfem::domain::domain::ispec_sources", nsources);
+//   specfem::kokkos::DeviceView1d<int> ispec_sources(
+//       "specfem::domain::domain::ispec_sources", nsources);
 
-  specfem::kokkos::HostMirror1d<int> h_ispec_sources =
-      Kokkos::create_mirror_view(ispec_sources);
+//   specfem::kokkos::HostMirror1d<int> h_ispec_sources =
+//       Kokkos::create_mirror_view(ispec_sources);
 
-  specfem::kokkos::DeviceView1d<int> isource_array(
-      "specfem::domain::domain::isource_array", nsources);
+//   specfem::kokkos::DeviceView1d<int> isource_array(
+//       "specfem::domain::domain::isource_array", nsources);
 
-  specfem::kokkos::HostMirror1d<int> h_isource_array =
-      Kokkos::create_mirror_view(isource_array);
+//   specfem::kokkos::HostMirror1d<int> h_isource_array =
+//       Kokkos::create_mirror_view(isource_array);
 
-  int index = 0;
-  for (int isource = 0; isource < ispec_array.extent(0); isource++) {
-    if (properties.h_ispec_type(ispec_array(isource)) == value) {
-      h_ispec_sources(index) = ispec_array(isource);
-      h_isource_array(index) = isource;
-      index++;
-    }
-  }
+//   int index = 0;
+//   for (int isource = 0; isource < ispec_array.extent(0); isource++) {
+//     if (properties.h_ispec_type(ispec_array(isource)) == value) {
+//       h_ispec_sources(index) = ispec_array(isource);
+//       h_isource_array(index) = isource;
+//       index++;
+//     }
+//   }
 
-  Kokkos::deep_copy(ispec_sources, h_ispec_sources);
-  Kokkos::deep_copy(isource_array, h_isource_array);
+//   Kokkos::deep_copy(ispec_sources, h_ispec_sources);
+//   Kokkos::deep_copy(isource_array, h_isource_array);
 
-  isotropic_sources = specfem::domain::impl::kernels::source_kernel<
-      medium, qp_type, specfem::enums::element::property::isotropic>(
-      ibool, ispec_sources, isource_array, properties, sources,
-      quadrature_points, field_dot_dot);
+//   isotropic_sources = specfem::domain::impl::kernels::source_kernel<
+//       medium, qp_type, specfem::enums::element::property::isotropic>(
+//       ibool, ispec_sources, isource_array, properties, sources,
+//       quadrature_points, field_dot_dot);
 
-  return;
-}
+//   return;
+// }
 
-template <class medium, class qp_type>
-void allocate_isotropic_receivers(
-    const specfem::kokkos::DeviceView3d<int> ibool,
-    const specfem::compute::partial_derivatives &partial_derivatives,
-    const specfem::compute::properties &properties,
-    const specfem::compute::receivers &receivers,
-    specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field,
-    specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field_dot,
-    specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field_dot_dot,
-    specfem::quadrature::quadrature *quadx,
-    specfem::quadrature::quadrature *quadz, qp_type quadrature_points,
-    specfem::domain::impl::kernels::receiver_kernel<
-        medium, qp_type, specfem::enums::element::property::isotropic>
-        &isotropic_receivers) {
+// template <class medium, class qp_type>
+// void allocate_isotropic_receivers(
+//     const specfem::kokkos::DeviceView3d<int> ibool,
+//     const specfem::compute::partial_derivatives &partial_derivatives,
+//     const specfem::compute::properties &properties,
+//     const specfem::compute::receivers &receivers,
+//     specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field,
+//     specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field_dot,
+//     specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field_dot_dot,
+//     specfem::quadrature::quadrature *quadx,
+//     specfem::quadrature::quadrature *quadz, qp_type quadrature_points,
+//     specfem::domain::impl::kernels::receiver_kernel<
+//         medium, qp_type, specfem::enums::element::property::isotropic>
+//         &isotropic_receivers) {
 
-  const auto value = medium::value;
+//   const auto value = medium::value;
 
-  // Create isotropic receivers
+//   // Create isotropic receivers
 
-  const auto ispec_array = receivers.h_ispec_array;
-  int nreceivers = 0;
-  for (int ireceiver = 0; ireceiver < ispec_array.extent(0); ireceiver++) {
-    if (properties.h_ispec_type(ispec_array(ireceiver)) == value) {
-      nreceivers++;
-    }
-  }
+//   const auto ispec_array = receivers.h_ispec_array;
+//   int nreceivers = 0;
+//   for (int ireceiver = 0; ireceiver < ispec_array.extent(0); ireceiver++) {
+//     if (properties.h_ispec_type(ispec_array(ireceiver)) == value) {
+//       nreceivers++;
+//     }
+//   }
 
-  specfem::kokkos::DeviceView1d<int> ispec_receivers(
-      "specfem::domain::domain::ispec_receivers", nreceivers);
+//   specfem::kokkos::DeviceView1d<int> ispec_receivers(
+//       "specfem::domain::domain::ispec_receivers", nreceivers);
 
-  specfem::kokkos::HostMirror1d<int> h_ispec_receivers =
-      Kokkos::create_mirror_view(ispec_receivers);
+//   specfem::kokkos::HostMirror1d<int> h_ispec_receivers =
+//       Kokkos::create_mirror_view(ispec_receivers);
 
-  specfem::kokkos::DeviceView1d<int> ireceiver_array(
-      "specfem::domain::domain::ireceiver_array", nreceivers);
+//   specfem::kokkos::DeviceView1d<int> ireceiver_array(
+//       "specfem::domain::domain::ireceiver_array", nreceivers);
 
-  specfem::kokkos::HostMirror1d<int> h_ireceiver_array =
-      Kokkos::create_mirror_view(ireceiver_array);
+//   specfem::kokkos::HostMirror1d<int> h_ireceiver_array =
+//       Kokkos::create_mirror_view(ireceiver_array);
 
-  int index = 0;
-  for (int ireceiver = 0; ireceiver < ispec_array.extent(0); ireceiver++) {
-    if (properties.h_ispec_type(ispec_array(ireceiver)) == value) {
-      h_ispec_receivers(index) = ispec_array(ireceiver);
-      h_ireceiver_array(index) = ireceiver;
-      index++;
-    }
-  }
+//   int index = 0;
+//   for (int ireceiver = 0; ireceiver < ispec_array.extent(0); ireceiver++) {
+//     if (properties.h_ispec_type(ispec_array(ireceiver)) == value) {
+//       h_ispec_receivers(index) = ispec_array(ireceiver);
+//       h_ireceiver_array(index) = ireceiver;
+//       index++;
+//     }
+//   }
 
-  Kokkos::deep_copy(ispec_receivers, h_ispec_receivers);
-  Kokkos::deep_copy(ireceiver_array, h_ireceiver_array);
+//   Kokkos::deep_copy(ispec_receivers, h_ispec_receivers);
+//   Kokkos::deep_copy(ireceiver_array, h_ireceiver_array);
 
-  isotropic_receivers = specfem::domain::impl::kernels::receiver_kernel<
-      medium, qp_type, specfem::enums::element::property::isotropic>(
-      ibool, ispec_receivers, ireceiver_array, partial_derivatives, properties,
-      receivers, field, field_dot, field_dot_dot, quadx, quadz,
-      quadrature_points);
+//   isotropic_receivers = specfem::domain::impl::kernels::receiver_kernel<
+//       medium, qp_type, specfem::enums::element::property::isotropic>(
+//       ibool, ispec_receivers, ireceiver_array, partial_derivatives, properties,
+//       receivers, field, field_dot, field_dot_dot, quadx, quadz,
+//       quadrature_points);
 
-  return;
-}
+//   return;
+// }
 } // namespace
 
 template <class medium, class qp_type>
 specfem::domain::impl::kernels::kernels<medium, qp_type>::kernels(
-    const specfem::kokkos::DeviceView3d<int> ibool,
-    const specfem::compute::partial_derivatives &partial_derivatives,
-    const specfem::compute::properties &properties,
-    const specfem::compute::boundaries &boundary_conditions,
-    const specfem::compute::sources &sources,
-    const specfem::compute::receivers &receivers,
-    specfem::quadrature::quadrature *quadx,
-    specfem::quadrature::quadrature *quadz, qp_type quadrature_points,
-    specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field,
-    specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field_dot,
-    specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field_dot_dot,
-    specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> mass_matrix) {
+    const specfem::compute::assembly &assembly,
+    const qp_type &quadrature_points) {
 
-  const int nspec = ibool.extent(0);
+  const int nspec = assembly.mesh.nspec;
   specfem::kokkos::HostView1d<element_tag> element_tags(
       "specfem::domain::domain::element_tag", nspec);
   // -----------------------------------------------------------
   // Start by tagging different elements
   // -----------------------------------------------------------
   // creating a context here for memory management
-  {
-    // find medium type for every element
-    specfem::kokkos::HostView1d<specfem::enums::element::type> ielement_type(
-        "specfem::domain::impl::kernels::kernels::ielement_type", nspec);
+  // {
+  //   // find medium type for every element
+  //   specfem::kokkos::HostView1d<specfem::enums::element::type> ielement_type(
+  //       "specfem::domain::impl::kernels::kernels::ielement_type", nspec);
 
-    for (int ispec = 0; ispec < nspec; ispec++) {
-      ielement_type(ispec) = properties.h_ispec_type(ispec);
-    }
+  //   for (int ispec = 0; ispec < nspec; ispec++) {
+  //     ielement_type(ispec) = properties.h_ispec_type(ispec);
+  //   }
 
-    // at start we consider every element is isotropic
-    specfem::kokkos::HostView1d<specfem::enums::element::property_tag>
-        ielement_property(
-            "specfem::domain::impl::kernels::kernels::ielement_property",
-            nspec);
+  //   // at start we consider every element is isotropic
+  //   specfem::kokkos::HostView1d<specfem::enums::element::property_tag>
+  //       ielement_property(
+  //           "specfem::domain::impl::kernels::kernels::ielement_property",
+  //           nspec);
 
-    for (int ispec = 0; ispec < nspec; ispec++) {
-      ielement_property(ispec) =
-          specfem::enums::element::property_tag::isotropic;
-    }
+  //   for (int ispec = 0; ispec < nspec; ispec++) {
+  //     ielement_property(ispec) =
+  //         specfem::enums::element::property_tag::isotropic;
+  //   }
 
-    // at start we consider every element is not on the boundary
-    specfem::kokkos::HostView1d<specfem::enums::element::boundary_tag_container>
-        ielement_boundary(
-            "specfem::domain::impl::kernels::kernels::ielement_boundary",
-            nspec);
+  //   // at start we consider every element is not on the boundary
+  //   specfem::kokkos::HostView1d<specfem::enums::element::boundary_tag_container>
+  //       ielement_boundary(
+  //           "specfem::domain::impl::kernels::kernels::ielement_boundary",
+  //           nspec);
 
-    const auto &stacey = boundary_conditions.stacey;
-    // mark stacey elements
-    if (stacey.nelements > 0) {
-      if (stacey.acoustic.nelements > 0) {
-        for (int i = 0; i < stacey.acoustic.nelements; i++) {
-          const int ispec = stacey.acoustic.h_ispec(i);
-          ielement_boundary(ispec) +=
-              specfem::enums::element::boundary_tag::stacey;
-        }
-      }
+  //   const auto &stacey = boundary_conditions.stacey;
+  //   // mark stacey elements
+  //   if (stacey.nelements > 0) {
+  //     if (stacey.acoustic.nelements > 0) {
+  //       for (int i = 0; i < stacey.acoustic.nelements; i++) {
+  //         const int ispec = stacey.acoustic.h_ispec(i);
+  //         ielement_boundary(ispec) +=
+  //             specfem::enums::element::boundary_tag::stacey;
+  //       }
+  //     }
 
-      if (stacey.elastic.nelements > 0) {
-        for (int i = 0; i < stacey.elastic.nelements; i++) {
-          const int ispec = stacey.elastic.h_ispec(i);
-          ielement_boundary(ispec) +=
-              specfem::enums::element::boundary_tag::stacey;
-        }
-      }
-    }
+  //     if (stacey.elastic.nelements > 0) {
+  //       for (int i = 0; i < stacey.elastic.nelements; i++) {
+  //         const int ispec = stacey.elastic.h_ispec(i);
+  //         ielement_boundary(ispec) +=
+  //             specfem::enums::element::boundary_tag::stacey;
+  //       }
+  //     }
+  //   }
 
-    const auto &acoustic_free_surface =
-        boundary_conditions.acoustic_free_surface;
+  //   const auto &acoustic_free_surface =
+  //       boundary_conditions.acoustic_free_surface;
 
-    // mark acoustic free surface elements
-    if (acoustic_free_surface.nelements > 0) {
-      for (int i = 0; i < acoustic_free_surface.nelements; i++) {
-        const int ispec = acoustic_free_surface.h_ispec(i);
-        ielement_boundary(ispec) +=
-            specfem::enums::element::boundary_tag::acoustic_free_surface;
-      }
-    }
+  //   // mark acoustic free surface elements
+  //   if (acoustic_free_surface.nelements > 0) {
+  //     for (int i = 0; i < acoustic_free_surface.nelements; i++) {
+  //       const int ispec = acoustic_free_surface.h_ispec(i);
+  //       ielement_boundary(ispec) +=
+  //           specfem::enums::element::boundary_tag::acoustic_free_surface;
+  //     }
+  //   }
 
-    const auto &composite_stacey_dirichlet =
-        boundary_conditions.composite_stacey_dirichlet;
+  //   const auto &composite_stacey_dirichlet =
+  //       boundary_conditions.composite_stacey_dirichlet;
 
-    // mark composite stacey dirichlet elements
-    if (composite_stacey_dirichlet.nelements > 0) {
-      for (int i = 0; i < composite_stacey_dirichlet.nelements; i++) {
-        const int ispec = composite_stacey_dirichlet.h_ispec(i);
-        ielement_boundary(ispec) +=
-            specfem::enums::element::boundary_tag::composite_stacey_dirichlet;
-      }
-    }
+  //   // mark composite stacey dirichlet elements
+  //   if (composite_stacey_dirichlet.nelements > 0) {
+  //     for (int i = 0; i < composite_stacey_dirichlet.nelements; i++) {
+  //       const int ispec = composite_stacey_dirichlet.h_ispec(i);
+  //       ielement_boundary(ispec) +=
+  //           specfem::enums::element::boundary_tag::composite_stacey_dirichlet;
+  //     }
+  //   }
 
-    // mark every element type
-    for (int ispec = 0; ispec < nspec; ispec++) {
-      element_tags(ispec) =
-          element_tag(ielement_type(ispec), ielement_property(ispec),
-                      ielement_boundary(ispec));
-    }
+  //   // mark every element type
+  //   for (int ispec = 0; ispec < nspec; ispec++) {
+  //     element_tags(ispec) =
+  //         element_tag(ielement_type(ispec), ielement_property(ispec),
+  //                     ielement_boundary(ispec));
+  //   }
+  // }
+
+  // -----------------------------------------------------------
+  for (int ispec = 0; ispec < nspec; ispec++) {
+    element_tags(ispec) =
+        element_tag(assembly.properties.h_element_types(ispec),
+                    assembly.properties.h_element_property(ispec),
+                    assembly.boundaries.h_boundary_tags(ispec));
   }
 
   std::cout << " Element Statistics \n"
@@ -383,39 +373,30 @@ specfem::domain::impl::kernels::kernels<medium, qp_type>::kernels(
   // -----------------------------------------------------------
 
   // Allocate isotropic elements with dirichlet boundary conditions
-  allocate_elements(ibool, element_tags, partial_derivatives, properties,
-                    boundary_conditions, quadx, quadz, quadrature_points, field,
-                    field_dot, field_dot_dot, mass_matrix,
-                    isotropic_elements_dirichlet);
+  // allocate_elements(assembly, quadrature_points, element_tags,
+  //                   isotropic_elements_dirichlet);
 
-  // Allocate isotropic elements with stacey boundary conditions
-  allocate_elements(ibool, element_tags, partial_derivatives, properties,
-                    boundary_conditions, quadx, quadz, quadrature_points, field,
-                    field_dot, field_dot_dot, mass_matrix,
-                    isotropic_elements_stacey);
+  // // Allocate isotropic elements with stacey boundary conditions
+  // allocate_elements(assembly, quadrature_points, element_tags,
+  //                   isotropic_elements_stacey);
 
-  // Allocate isotropic elements with stacey dirichlet boundary conditions
-  allocate_elements(ibool, element_tags, partial_derivatives, properties,
-                    boundary_conditions, quadx, quadz, quadrature_points, field,
-                    field_dot, field_dot_dot, mass_matrix,
-                    isotropic_elements_stacey_dirichlet);
+  // // Allocate isotropic elements with stacey dirichlet boundary conditions
+  // allocate_elements(assembly, quadrature_points, element_tags,
+  //                   isotropic_elements_stacey_dirichlet);
 
-  // Allocate isotropic elements
+  // // Allocate isotropic elements
 
-  allocate_elements(ibool, element_tags, partial_derivatives, properties,
-                    boundary_conditions, quadx, quadz, quadrature_points, field,
-                    field_dot, field_dot_dot, mass_matrix, isotropic_elements);
+  allocate_elements(assembly, quadrature_points, element_tags,
+                    isotropic_elements);
 
-  // Allocate isotropic sources
+  // // Allocate isotropic sources
 
-  allocate_isotropic_sources(ibool, properties, sources, quadrature_points,
-                             field_dot_dot, isotropic_sources);
+  // allocate_isotropic_sources(assembly, quadrature_points, isotropic_sources);
 
-  // Allocate isotropic receivers
+  // // Allocate isotropic receivers
 
-  allocate_isotropic_receivers(
-      ibool, partial_derivatives, properties, receivers, field, field_dot,
-      field_dot_dot, quadx, quadz, quadrature_points, isotropic_receivers);
+  // allocate_isotropic_receivers(assembly, quadrature_points,
+  //                              isotropic_receivers);
 
   return;
 }

--- a/include/domain/impl/receivers/acoustic/acoustic2d_isotropic.hpp
+++ b/include/domain/impl/receivers/acoustic/acoustic2d_isotropic.hpp
@@ -45,6 +45,8 @@ public:
    */
   using quadrature_points_type =
       specfem::enums::element::quadrature::static_quadrature_points<NGLL>;
+
+  using property_type = specfem::enums::element::property::isotropic;
   /**
    * @brief Use the scratch view type from the quadrature points
    *
@@ -59,27 +61,29 @@ public:
   KOKKOS_FUNCTION
   receiver() = default;
 
-  /**
-   * @brief Construct a new elemental receiver object
-   *
-   * @param sin_rec sin of the receiver angle
-   * @param cos_rec cosine of the receiver angle
-   * @param receiver_array receiver array containing pre-computed lagrange
-   * interpolants
-   * @param partial_derivatives struct used to store partial derivatives at
-   * quadrature points
-   * @param properties struct used to store material properties at quadrature
-   * points
-   * @param receiver_field view to store compute receiver field at all GLL
-   * points where the receiver is located
-   */
-  KOKKOS_FUNCTION
-  receiver(const specfem::kokkos::DeviceView1d<type_real> sin_rec,
-           const specfem::kokkos::DeviceView1d<type_real> cos_rec,
-           const specfem::kokkos::DeviceView4d<type_real> receiver_array,
-           const specfem::compute::partial_derivatives &partial_derivatives,
-           const specfem::compute::properties &properties,
-           specfem::kokkos::DeviceView6d<type_real> receiver_field);
+  //   /**
+  //    * @brief Construct a new elemental receiver object
+  //    *
+  //    * @param sin_rec sin of the receiver angle
+  //    * @param cos_rec cosine of the receiver angle
+  //    * @param receiver_array receiver array containing pre-computed lagrange
+  //    * interpolants
+  //    * @param partial_derivatives struct used to store partial derivatives at
+  //    * quadrature points
+  //    * @param properties struct used to store material properties at
+  //    quadrature
+  //    * points
+  //    * @param receiver_field view to store compute receiver field at all GLL
+  //    * points where the receiver is located
+  //    */
+  //   KOKKOS_FUNCTION
+  //   receiver(const specfem::kokkos::DeviceView1d<type_real> sin_rec,
+  //            const specfem::kokkos::DeviceView1d<type_real> cos_rec,
+  //            const specfem::kokkos::DeviceView4d<type_real> receiver_array,
+  //            const specfem::compute::partial_derivatives
+  //            &partial_derivatives, const specfem::compute::properties
+  //            &properties, specfem::kokkos::DeviceView6d<type_real>
+  //            receiver_field);
 
   /**
    * @brief Compute and populate the receiver field at all GLL points where the
@@ -100,14 +104,15 @@ public:
    */
   KOKKOS_FUNCTION
   void get_field(
-      const int &ireceiver, const int &iseis, const int &ispec,
-      const specfem::enums::seismogram::type &siesmogram_type, const int &xz,
-      const int &isig_step,
-      const ScratchViewType<type_real, medium_type::components> field,
-      const ScratchViewType<type_real, medium_type::components> field_dot,
-      const ScratchViewType<type_real, medium_type::components> field_dot_dot,
-      const ScratchViewType<type_real, 1> hprime_xx,
-      const ScratchViewType<type_real, 1> hprime_zz) const;
+      const int iz, const int ix,
+      const specfem::point::partial_derivatives2 partial_derivatives,
+      const specfem::point::properties<medium_type::value, property_type::value>
+          properties,
+      const ScratchViewType<type_real, 1> hprime,
+      const ScratchViewType<type_real, medium_type::components> active_field,
+      Kokkos::View<type_real[2], Kokkos::LayoutStride,
+                   specfem::kokkos::DevMemSpace>
+          receiver_field) const;
 
   /**
    * @brief Compute the seismogram components for a given receiver and

--- a/include/domain/impl/receivers/acoustic/acoustic2d_isotropic.tpp
+++ b/include/domain/impl/receivers/acoustic/acoustic2d_isotropic.tpp
@@ -9,43 +9,43 @@
 #include "kokkos_abstractions.h"
 #include <Kokkos_Core.hpp>
 
-template <int NGLL>
-KOKKOS_FUNCTION specfem::domain::impl::receivers::receiver<
-    specfem::enums::element::dimension::dim2,
-    specfem::enums::element::medium::acoustic,
-    specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
-    specfem::enums::element::property::isotropic>::
-    receiver(const specfem::kokkos::DeviceView1d<type_real> sin_rec,
-             const specfem::kokkos::DeviceView1d<type_real> cos_rec,
-             const specfem::kokkos::DeviceView4d<type_real> receiver_array,
-             const specfem::compute::partial_derivatives &partial_derivatives,
-             const specfem::compute::properties &properties,
-             specfem::kokkos::DeviceView6d<type_real> receiver_field)
-    : sin_rec(sin_rec), cos_rec(cos_rec), receiver_array(receiver_array),
-      receiver_field(receiver_field) {
+// template <int NGLL>
+// KOKKOS_FUNCTION specfem::domain::impl::receivers::receiver<
+//     specfem::enums::element::dimension::dim2,
+//     specfem::enums::element::medium::acoustic,
+//     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
+//     specfem::enums::element::property::isotropic>::
+//     receiver(const specfem::kokkos::DeviceView1d<type_real> sin_rec,
+//              const specfem::kokkos::DeviceView1d<type_real> cos_rec,
+//              const specfem::kokkos::DeviceView4d<type_real> receiver_array,
+//              const specfem::compute::partial_derivatives &partial_derivatives,
+//              const specfem::compute::properties &properties,
+//              specfem::kokkos::DeviceView6d<type_real> receiver_field)
+//     : sin_rec(sin_rec), cos_rec(cos_rec), receiver_array(receiver_array),
+//       receiver_field(receiver_field) {
 
-#ifndef NDEBUG
-  assert(partial_derivatives.xix.extent(1) == NGLL);
-  assert(partial_derivatives.xix.extent(2) == NGLL);
-  assert(partial_derivatives.gammax.extent(1) == NGLL);
-  assert(partial_derivatives.gammax.extent(2) == NGLL);
-  assert(partial_derivatives.xiz.extent(1) == NGLL);
-  assert(partial_derivatives.xiz.extent(2) == NGLL);
-  assert(partial_derivatives.gammaz.extent(1) == NGLL);
-  assert(partial_derivatives.gammaz.extent(2) == NGLL);
+// #ifndef NDEBUG
+//   assert(partial_derivatives.xix.extent(1) == NGLL);
+//   assert(partial_derivatives.xix.extent(2) == NGLL);
+//   assert(partial_derivatives.gammax.extent(1) == NGLL);
+//   assert(partial_derivatives.gammax.extent(2) == NGLL);
+//   assert(partial_derivatives.xiz.extent(1) == NGLL);
+//   assert(partial_derivatives.xiz.extent(2) == NGLL);
+//   assert(partial_derivatives.gammaz.extent(1) == NGLL);
+//   assert(partial_derivatives.gammaz.extent(2) == NGLL);
 
-  // Properties
-  assert(properties.rho_inverse.extent(1) == NGLL);
-  assert(properties.rho_inverse.extent(2) == NGLL);
-#endif
+//   // Properties
+//   assert(properties.rho_inverse.extent(1) == NGLL);
+//   assert(properties.rho_inverse.extent(2) == NGLL);
+// #endif
 
-  this->xix = partial_derivatives.xix;
-  this->gammax = partial_derivatives.gammax;
-  this->xiz = partial_derivatives.xiz;
-  this->gammaz = partial_derivatives.gammaz;
-  this->rho_inverse = properties.rho_inverse;
-  return;
-}
+//   this->xix = partial_derivatives.xix;
+//   this->gammax = partial_derivatives.gammax;
+//   this->xiz = partial_derivatives.xiz;
+//   this->gammaz = partial_derivatives.gammaz;
+//   this->rho_inverse = properties.rho_inverse;
+//   return;
+// }
 
 template <int NGLL>
 KOKKOS_INLINE_FUNCTION void specfem::domain::impl::receivers::receiver<
@@ -54,55 +54,14 @@ KOKKOS_INLINE_FUNCTION void specfem::domain::impl::receivers::receiver<
     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
     specfem::enums::element::property::isotropic>::
     get_field(
-        const int &ireceiver, const int &iseis, const int &ispec,
-        const specfem::enums::seismogram::type &seismogram_type, const int &xz,
-        const int &isig_step,
-        const ScratchViewType<type_real, medium_type::components> field,
-        const ScratchViewType<type_real, medium_type::components> field_dot,
-        const ScratchViewType<type_real, medium_type::components> field_dot_dot,
-        const ScratchViewType<type_real, 1> hprime_xx,
-        const ScratchViewType<type_real, 1> hprime_zz) const {
-
-#ifndef NDEBUG
-  assert(field.extent(0) == NGLL);
-  assert(field.extent(1) == NGLL);
-  assert(field_dot.extent(0) == NGLL);
-  assert(field_dot.extent(1) == NGLL);
-  assert(field_dot_dot.extent(0) == NGLL);
-  assert(field_dot_dot.extent(1) == NGLL);
-  assert(hprime_xx.extent(0) == NGLL);
-  assert(hprime_xx.extent(1) == NGLL);
-  assert(hprime_zz.extent(0) == NGLL);
-  assert(hprime_zz.extent(1) == NGLL);
-#endif
-
-  int ix, iz;
-  sub2ind(xz, NGLL, iz, ix);
-
-  const type_real xixl = this->xix(ispec, iz, ix);
-  const type_real gammaxl = this->gammax(ispec, iz, ix);
-  const type_real xizl = this->xiz(ispec, iz, ix);
-  const type_real gammazl = this->gammaz(ispec, iz, ix);
-  const type_real rho_inversel = this->rho_inverse(ispec, iz, ix);
-
-  using sv_ScratchViewType =
-      Kokkos::Subview<ScratchViewType<type_real, medium_type::components>,
-                      std::remove_const_t<decltype(Kokkos::ALL)>,
-                      std::remove_const_t<decltype(Kokkos::ALL)>, int>;
-
-  sv_ScratchViewType active_field;
-
-  switch (seismogram_type) {
-  case specfem::enums::seismogram::type::displacement:
-    active_field = Kokkos::subview(field, Kokkos::ALL, Kokkos::ALL, 0);
-    break;
-  case specfem::enums::seismogram::type::velocity:
-    active_field = Kokkos::subview(field_dot, Kokkos::ALL, Kokkos::ALL, 0);
-    break;
-  case specfem::enums::seismogram::type::acceleration:
-    active_field = Kokkos::subview(field_dot_dot, Kokkos::ALL, Kokkos::ALL, 0);
-    break;
-  }
+        const int iz, const int ix,
+        const specfem::point::partial_derivatives2 partial_derivatives,
+        const specfem::point::properties<medium_type::value, property_type::value> properties,
+        const ScratchViewType<type_real, 1> hprime,
+        const ScratchViewType<type_real, medium_type::components> active_field,
+        Kokkos::View<type_real[2], Kokkos::LayoutStride,
+                     specfem::kokkos::DevMemSpace>
+            receiver_field) const {
 
   type_real dchi_dxi = 0.0;
   type_real dchi_dgamma = 0.0;
@@ -111,15 +70,17 @@ KOKKOS_INLINE_FUNCTION void specfem::domain::impl::receivers::receiver<
 #pragma unroll
 #endif
   for (int l = 0; l < NGLL; l++) {
-    dchi_dxi += hprime_xx(ix, l, 0) * active_field(iz, l);
-    dchi_dgamma += hprime_zz(iz, l, 0) * active_field(l, ix);
+    dchi_dxi += hprime(ix, l, 0) * active_field(iz, l, 0);
+    dchi_dgamma += hprime(iz, l, 0) * active_field(l, ix, 0);
   }
 
   // dchidx
-  type_real fieldx = (dchi_dxi * xixl + dchi_dgamma * gammaxl) * rho_inversel;
+  type_real fieldx = (dchi_dxi * partial_derivatives.xix +
+                      dchi_dgamma * partial_derivatives.gammax);
 
   // dchidz
-  type_real fieldz = (dchi_dxi * xizl + dchi_dgamma * gammazl) * rho_inversel;
+  type_real fieldz = (dchi_dxi * partial_derivatives.xiz +
+                      dchi_dgamma * partial_derivatives.gammaz);
 
   // Receiver field is probably not the best way of storing this, since this
   // would require global memory accesses. A better way for doing this would be
@@ -127,77 +88,82 @@ KOKKOS_INLINE_FUNCTION void specfem::domain::impl::receivers::receiver<
   // simulation people might require the field stored inside an element where a
   // receiver is located. If the number of receivers << nspec - hopefully this
   // shouldn't be a bottleneck.
-  this->receiver_field(isig_step, ireceiver, iseis, 0, iz, ix) = fieldx;
-  this->receiver_field(isig_step, ireceiver, iseis, 1, iz, ix) = fieldz;
-
-  return;
-}
-
-template <int NGLL>
-KOKKOS_INLINE_FUNCTION void specfem::domain::impl::receivers::receiver<
-    specfem::enums::element::dimension::dim2,
-    specfem::enums::element::medium::acoustic,
-    specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
-    specfem::enums::element::property::isotropic>::
-    compute_seismogram_components(
-        const int &ireceiver, const int &iseis,
-        const specfem::enums::seismogram::type &seismogram_type, const int &xz,
-        const int &isig_step,
-        specfem::kokkos::array_type<type_real, 2> &l_seismogram_components)
-        const {
-  int ix, iz;
-  sub2ind(xz, NGLL, iz, ix);
-
-  switch (seismogram_type) {
-  case specfem::enums::seismogram::type::displacement:
-  case specfem::enums::seismogram::type::velocity:
-  case specfem::enums::seismogram::type::acceleration:
-    if (specfem::globals::simulation_wave == specfem::wave::p_sv) {
-      l_seismogram_components[0] +=
-          this->receiver_array(ireceiver, iz, ix, 0) *
-          this->receiver_field(isig_step, ireceiver, iseis, 0, iz, ix);
-      l_seismogram_components[1] +=
-          this->receiver_array(ireceiver, iz, ix, 1) *
-          this->receiver_field(isig_step, ireceiver, iseis, 1, iz, ix);
-    } else if (specfem::globals::simulation_wave == specfem::wave::sh) {
-      l_seismogram_components[0] +=
-          this->receiver_array(ireceiver, iz, ix, 0) *
-          this->receiver_field(isig_step, ireceiver, iseis, 0, iz, ix);
-      l_seismogram_components[1] += 0;
-    }
-    break;
-
-  default:
-    // seismogram not supported
-    assert(false);
-    break;
-  }
-}
-
-template <int NGLL>
-KOKKOS_INLINE_FUNCTION void specfem::domain::impl::receivers::receiver<
-    specfem::enums::element::dimension::dim2,
-    specfem::enums::element::medium::acoustic,
-    specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
-    specfem::enums::element::property::isotropic>::
-    compute_seismogram(
-        const int &ireceiver,
-        const specfem::kokkos::array_type<type_real, 2> &seismogram_components,
-        specfem::kokkos::DeviceView1d<type_real> receiver_seismogram) const {
-
   if (specfem::globals::simulation_wave == specfem::wave::p_sv) {
-    receiver_seismogram(0) =
-        this->cos_rec(ireceiver) * seismogram_components[0] +
-        this->sin_rec(ireceiver) * seismogram_components[1];
-    receiver_seismogram(1) =
-        this->sin_rec(ireceiver) * seismogram_components[0] +
-        this->cos_rec(ireceiver) * seismogram_components[1];
+    receiver_field(0) = fieldx * properties.rho_inverse;
+    receiver_field(1) = fieldz * properties.rho_inverse;
   } else if (specfem::globals::simulation_wave == specfem::wave::sh) {
-    receiver_seismogram(0) = seismogram_components[0];
-    receiver_seismogram(1) = 0;
+    receiver_field(0) = fieldx * properties.rho_inverse;
+    receiver_field(1) = 0;
   }
 
   return;
 }
+
+// template <int NGLL>
+// KOKKOS_INLINE_FUNCTION void specfem::domain::impl::receivers::receiver<
+//     specfem::enums::element::dimension::dim2,
+//     specfem::enums::element::medium::acoustic,
+//     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
+//     specfem::enums::element::property::isotropic>::
+//     compute_seismogram_components(
+//         const int &ireceiver, const int &iseis,
+//         const specfem::enums::seismogram::type &seismogram_type, const int
+//         &xz, const int &isig_step, specfem::kokkos::array_type<type_real, 2>
+//         &l_seismogram_components) const {
+//   int ix, iz;
+//   sub2ind(xz, NGLL, iz, ix);
+
+//   switch (seismogram_type) {
+//   case specfem::enums::seismogram::type::displacement:
+//   case specfem::enums::seismogram::type::velocity:
+//   case specfem::enums::seismogram::type::acceleration:
+//     if (specfem::globals::simulation_wave == specfem::wave::p_sv) {
+//       l_seismogram_components[0] +=
+//           this->receiver_array(ireceiver, iz, ix, 0) *
+//           this->receiver_field(isig_step, ireceiver, iseis, 0, iz, ix);
+//       l_seismogram_components[1] +=
+//           this->receiver_array(ireceiver, iz, ix, 1) *
+//           this->receiver_field(isig_step, ireceiver, iseis, 1, iz, ix);
+//     } else if (specfem::globals::simulation_wave == specfem::wave::sh) {
+//       l_seismogram_components[0] +=
+//           this->receiver_array(ireceiver, iz, ix, 0) *
+//           this->receiver_field(isig_step, ireceiver, iseis, 0, iz, ix);
+//       l_seismogram_components[1] += 0;
+//     }
+//     break;
+
+//   default:
+//     // seismogram not supported
+//     assert(false);
+//     break;
+//   }
+// }
+
+// template <int NGLL>
+// KOKKOS_INLINE_FUNCTION void specfem::domain::impl::receivers::receiver<
+//     specfem::enums::element::dimension::dim2,
+//     specfem::enums::element::medium::acoustic,
+//     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
+//     specfem::enums::element::property::isotropic>::
+//     compute_seismogram(
+//         const int &ireceiver,
+//         const specfem::kokkos::array_type<type_real, 2>
+//         &seismogram_components, specfem::kokkos::DeviceView1d<type_real>
+//         receiver_seismogram) const {
+
+//   if (specfem::globals::simulation_wave == specfem::wave::p_sv) {
+//     receiver_seismogram(0) =
+//         this->cos_rec(ireceiver) * seismogram_components[0] +
+//         this->sin_rec(ireceiver) * seismogram_components[1];
+//     receiver_seismogram(1) =
+//         this->sin_rec(ireceiver) * seismogram_components[0] +
+//         this->cos_rec(ireceiver) * seismogram_components[1];
+//   } else if (specfem::globals::simulation_wave == specfem::wave::sh) {
+//     receiver_seismogram(0) = seismogram_components[0];
+//     receiver_seismogram(1) = 0;
+//   }
+
+//   return;
+// }
 
 #endif /* DOMAIN_IMPL_RECEIVERS_ACOUSTIC2D_ISOTROPIC_TPP_ */

--- a/include/domain/impl/receivers/elastic/elastic2d_isotropic.tpp
+++ b/include/domain/impl/receivers/elastic/elastic2d_isotropic.tpp
@@ -12,80 +12,36 @@
 #include "specfem_setup.hpp"
 #include <Kokkos_Core.hpp>
 
-template <int NGLL>
-KOKKOS_FUNCTION specfem::domain::impl::receivers::receiver<
-    specfem::enums::element::dimension::dim2,
-    specfem::enums::element::medium::elastic,
-    specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
-    specfem::enums::element::property::isotropic>::
-    receiver(const specfem::kokkos::DeviceView1d<type_real> sin_rec,
-             const specfem::kokkos::DeviceView1d<type_real> cos_rec,
-             const specfem::kokkos::DeviceView4d<type_real> receiver_array,
-             const specfem::compute::partial_derivatives &partial_derivatives,
-             const specfem::compute::properties &properties,
-             specfem::kokkos::DeviceView6d<type_real> receiver_field)
-    : sin_rec(sin_rec), cos_rec(cos_rec), receiver_array(receiver_array),
-      receiver_field(receiver_field) {}
+// template <int NGLL>
+// KOKKOS_FUNCTION specfem::domain::impl::receivers::receiver<
+//     specfem::enums::element::dimension::dim2,
+//     specfem::enums::element::medium::elastic,
+//     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
+//     specfem::enums::element::property::isotropic>::
+//     receiver(const specfem::kokkos::DeviceView1d<type_real> sin_rec,
+//              const specfem::kokkos::DeviceView1d<type_real> cos_rec,
+//              const specfem::kokkos::DeviceView4d<type_real> receiver_array,
+//              const specfem::compute::partial_derivatives &partial_derivatives,
+//              const specfem::compute::properties &properties,
+//              specfem::kokkos::DeviceView6d<type_real> receiver_field)
+//     : sin_rec(sin_rec), cos_rec(cos_rec), receiver_array(receiver_array),
+//       receiver_field(receiver_field) {}
 
 template <int NGLL>
-KOKKOS_FUNCTION void specfem::domain::impl::receivers::receiver<
+KOKKOS_INLINE_FUNCTION void specfem::domain::impl::receivers::receiver<
     specfem::enums::element::dimension::dim2,
     specfem::enums::element::medium::elastic,
     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
     specfem::enums::element::property::isotropic>::
     get_field(
-        const int &ireceiver, const int &iseis, const int &ispec,
-        const specfem::enums::seismogram::type &seismogram_type, const int &xz,
-        const int &isig_step,
-        const ScratchViewType<type_real, medium_type::components> field,
-        const ScratchViewType<type_real, medium_type::components> field_dot,
-        const ScratchViewType<type_real, medium_type::components> field_dot_dot,
-        const ScratchViewType<type_real, 1> s_hprime_xx,
-        const ScratchViewType<type_real, 1> s_hprime_zz) const {
-
-#ifndef NDEBUG
-  // check that the dimensions of the fields are correct
-  assert(field.extent(0) == NGLL);
-  assert(field.extent(1) == NGLL);
-  assert(field_dot.extent(0) == NGLL);
-  assert(field_dot.extent(1) == NGLL);
-  assert(field_dot_dot.extent(0) == NGLL);
-  assert(field_dot_dot.extent(1) == NGLL);
-  assert(s_hprime_xx.extent(0) == NGLL);
-  assert(s_hprime_xx.extent(1) == NGLL);
-  assert(s_hprime_zz.extent(0) == NGLL);
-  assert(s_hprime_zz.extent(1) == NGLL);
-#endif /* NDEBUG */
-
-  int ix, iz;
-  sub2ind(xz, NGLL, iz, ix);
-
-  using sv_ScratchViewType =
-      Kokkos::Subview<ScratchViewType<type_real, medium_type::components>,
-                      std::remove_const_t<decltype(Kokkos::ALL)>,
-                      std::remove_const_t<decltype(Kokkos::ALL)>, int>;
-
-  sv_ScratchViewType active_fieldx;
-  sv_ScratchViewType active_fieldz;
-
-  switch (seismogram_type) {
-  case specfem::enums::seismogram::type::displacement:
-    active_fieldx = Kokkos::subview(field, Kokkos::ALL, Kokkos::ALL, 0);
-    active_fieldz = Kokkos::subview(field, Kokkos::ALL, Kokkos::ALL, 1);
-    break;
-  case specfem::enums::seismogram::type::velocity:
-    active_fieldx = Kokkos::subview(field_dot, Kokkos::ALL, Kokkos::ALL, 0);
-    active_fieldz = Kokkos::subview(field_dot, Kokkos::ALL, Kokkos::ALL, 1);
-    break;
-  case specfem::enums::seismogram::type::acceleration:
-    active_fieldx = Kokkos::subview(field_dot_dot, Kokkos::ALL, Kokkos::ALL, 0);
-    active_fieldz = Kokkos::subview(field_dot_dot, Kokkos::ALL, Kokkos::ALL, 1);
-    break;
-  default:
-    // seismogram not supported
-    assert(false && "seismogram not supported");
-    break;
-  }
+        const int iz, const int ix,
+        const specfem::point::partial_derivatives2 partial_derivatives,
+        const specfem::point::properties<medium_type::value, property_type::value> properties,
+        const ScratchViewType<type_real, 1> hprime,
+        const ScratchViewType<type_real, medium_type::components> active_field,
+        Kokkos::View<type_real[2], Kokkos::LayoutStride,
+                     specfem::kokkos::DevMemSpace>
+            receiver_field) const {
 
   // Receiver field is probably not the best way of storing this, since this
   // would require global memory accesses. A better way for doing this would be
@@ -94,85 +50,83 @@ KOKKOS_FUNCTION void specfem::domain::impl::receivers::receiver<
   // receiver is located. If the number of receivers << nspec - hopefully this
   // shouldn't be a bottleneck.
   if (specfem::globals::simulation_wave == specfem::wave::p_sv) {
-    this->receiver_field(isig_step, ireceiver, iseis, 0, iz, ix) =
-        active_fieldx(iz, ix);
-    this->receiver_field(isig_step, ireceiver, iseis, 1, iz, ix) =
-        active_fieldz(iz, ix);
+    receiver_field(0) = active_field(iz, ix, 0);
+    receiver_field(1) = active_field(iz, ix, 1);
   } else if (specfem::globals::simulation_wave == specfem::wave::sh) {
-    this->receiver_field(isig_step, ireceiver, iseis, 0, iz, ix) =
-        active_fieldx(iz, ix);
+    receiver_field(0) = active_field(iz, ix, 0);
+    receiver_field(1) = 0;
   }
 
   return;
 }
 
-template <int NGLL>
-KOKKOS_FUNCTION void specfem::domain::impl::receivers::receiver<
-    specfem::enums::element::dimension::dim2,
-    specfem::enums::element::medium::elastic,
-    specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
-    specfem::enums::element::property::isotropic>::
-    compute_seismogram_components(
-        const int &ireceiver, const int &iseis,
-        const specfem::enums::seismogram::type &seismogram_type, const int &xz,
-        const int &isig_step,
-        specfem::kokkos::array_type<type_real, 2> &l_seismogram_components)
-        const {
-  int ix, iz;
-  sub2ind(xz, NGLL, iz, ix);
+// template <int NGLL>
+// KOKKOS_FUNCTION void specfem::domain::impl::receivers::receiver<
+//     specfem::enums::element::dimension::dim2,
+//     specfem::enums::element::medium::elastic,
+//     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
+//     specfem::enums::element::property::isotropic>::
+//     compute_seismogram_components(
+//         const int &ireceiver, const int &iseis,
+//         const specfem::enums::seismogram::type &seismogram_type, const int &xz,
+//         const int &isig_step,
+//         specfem::kokkos::array_type<type_real, 2> &l_seismogram_components)
+//         const {
+//   int ix, iz;
+//   sub2ind(xz, NGLL, iz, ix);
 
-  switch (seismogram_type) {
-  case specfem::enums::seismogram::type::displacement:
-  case specfem::enums::seismogram::type::velocity:
-  case specfem::enums::seismogram::type::acceleration:
-    if (specfem::globals::simulation_wave == specfem::wave::p_sv) {
-      l_seismogram_components[0] +=
-          this->receiver_array(ireceiver, iz, ix, 0) *
-          this->receiver_field(isig_step, ireceiver, iseis, 0, iz, ix);
-      l_seismogram_components[1] +=
-          this->receiver_array(ireceiver, iz, ix, 1) *
-          this->receiver_field(isig_step, ireceiver, iseis, 1, iz, ix);
-    } else if (specfem::globals::simulation_wave == specfem::wave::sh) {
-      l_seismogram_components[0] +=
-          this->receiver_array(ireceiver, iz, ix, 0) *
-          this->receiver_field(isig_step, ireceiver, iseis, 0, iz, ix);
-      l_seismogram_components[1] += 0;
-    }
-    break;
+//   switch (seismogram_type) {
+//   case specfem::enums::seismogram::type::displacement:
+//   case specfem::enums::seismogram::type::velocity:
+//   case specfem::enums::seismogram::type::acceleration:
+//     if (specfem::globals::simulation_wave == specfem::wave::p_sv) {
+//       l_seismogram_components[0] +=
+//           this->receiver_array(ireceiver, iz, ix, 0) *
+//           this->receiver_field(isig_step, ireceiver, iseis, 0, iz, ix);
+//       l_seismogram_components[1] +=
+//           this->receiver_array(ireceiver, iz, ix, 1) *
+//           this->receiver_field(isig_step, ireceiver, iseis, 1, iz, ix);
+//     } else if (specfem::globals::simulation_wave == specfem::wave::sh) {
+//       l_seismogram_components[0] +=
+//           this->receiver_array(ireceiver, iz, ix, 0) *
+//           this->receiver_field(isig_step, ireceiver, iseis, 0, iz, ix);
+//       l_seismogram_components[1] += 0;
+//     }
+//     break;
 
-  default:
-    // seismogram not supported
-    assert(false && "seismogram not supported");
-    break;
-  }
-}
+//   default:
+//     // seismogram not supported
+//     assert(false && "seismogram not supported");
+//     break;
+//   }
+// }
 
-template <int NGLL>
-KOKKOS_FUNCTION void specfem::domain::impl::receivers::receiver<
-    specfem::enums::element::dimension::dim2,
-    specfem::enums::element::medium::elastic,
-    specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
-    specfem::enums::element::property::isotropic>::
-    compute_seismogram(
-        const int &ireceiver,
-        const specfem::kokkos::array_type<type_real, 2> &seismogram_components,
-        specfem::kokkos::DeviceView1d<type_real> receiver_seismogram) const {
+// template <int NGLL>
+// KOKKOS_FUNCTION void specfem::domain::impl::receivers::receiver<
+//     specfem::enums::element::dimension::dim2,
+//     specfem::enums::element::medium::elastic,
+//     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
+//     specfem::enums::element::property::isotropic>::
+//     compute_seismogram(
+//         const int &ireceiver,
+//         const specfem::kokkos::array_type<type_real, 2> &seismogram_components,
+//         specfem::kokkos::DeviceView1d<type_real> receiver_seismogram) const {
 
-  if (specfem::globals::simulation_wave == specfem::wave::p_sv) {
-    receiver_seismogram(0) =
-        this->cos_rec(ireceiver) * seismogram_components[0] +
-        this->sin_rec(ireceiver) * seismogram_components[1];
-    receiver_seismogram(1) =
-        this->sin_rec(ireceiver) * seismogram_components[0] +
-        this->cos_rec(ireceiver) * seismogram_components[1];
-  } else if (specfem::globals::simulation_wave == specfem::wave::sh) {
-    receiver_seismogram(0) =
-        this->cos_rec(ireceiver) * seismogram_components[0] +
-        this->sin_rec(ireceiver) * seismogram_components[1];
-    receiver_seismogram(1) = 0;
-  }
+//   if (specfem::globals::simulation_wave == specfem::wave::p_sv) {
+//     receiver_seismogram(0) =
+//         this->cos_rec(ireceiver) * seismogram_components[0] +
+//         this->sin_rec(ireceiver) * seismogram_components[1];
+//     receiver_seismogram(1) =
+//         this->sin_rec(ireceiver) * seismogram_components[0] +
+//         this->cos_rec(ireceiver) * seismogram_components[1];
+//   } else if (specfem::globals::simulation_wave == specfem::wave::sh) {
+//     receiver_seismogram(0) =
+//         this->cos_rec(ireceiver) * seismogram_components[0] +
+//         this->sin_rec(ireceiver) * seismogram_components[1];
+//     receiver_seismogram(1) = 0;
+//   }
 
-  return;
-}
+//   return;
+// }
 
 #endif /* _DOMAIN_IMPL_RECEIVERS_ELASTIC2D_ISOTROPIC_TPP_ */

--- a/include/domain/impl/receivers/interface.hpp
+++ b/include/domain/impl/receivers/interface.hpp
@@ -1,15 +1,15 @@
 #ifndef _DOMAIN_RECEIVERS_INTERFACE_HPP
 #define _DOMAIN_RECEIVERS_INTERFACE_HPP
 
-#include "acoustic/acoustic2d.hpp"
-#include "acoustic/acoustic2d_isotropic.hpp"
-#include "acoustic/acoustic2d_isotropic.tpp"
-#include "container.hpp"
-#include "elastic/elastic2d.hpp"
-#include "elastic/elastic2d_isotropic.hpp"
-#include "elastic/elastic2d_isotropic.tpp"
-#include "kernel.hpp"
-#include "kernel.tpp"
-#include "receiver.hpp"
+// #include "acoustic/acoustic2d.hpp"
+// #include "acoustic/acoustic2d_isotropic.hpp"
+// #include "acoustic/acoustic2d_isotropic.tpp"
+// #include "container.hpp"
+// #include "elastic/elastic2d.hpp"
+// #include "elastic/elastic2d_isotropic.hpp"
+// #include "elastic/elastic2d_isotropic.tpp"
+// #include "kernel.hpp"
+// #include "kernel.tpp"
+// #include "receiver.hpp"
 
 #endif /* _DOMAIN_RECEIVERS_INTERFACE_HPP */

--- a/include/domain/impl/receivers/interface.hpp
+++ b/include/domain/impl/receivers/interface.hpp
@@ -1,15 +1,15 @@
 #ifndef _DOMAIN_RECEIVERS_INTERFACE_HPP
 #define _DOMAIN_RECEIVERS_INTERFACE_HPP
 
-// #include "acoustic/acoustic2d.hpp"
-// #include "acoustic/acoustic2d_isotropic.hpp"
-// #include "acoustic/acoustic2d_isotropic.tpp"
-// #include "container.hpp"
-// #include "elastic/elastic2d.hpp"
-// #include "elastic/elastic2d_isotropic.hpp"
-// #include "elastic/elastic2d_isotropic.tpp"
-// #include "kernel.hpp"
-// #include "kernel.tpp"
-// #include "receiver.hpp"
+#include "acoustic/acoustic2d.hpp"
+#include "acoustic/acoustic2d_isotropic.hpp"
+#include "acoustic/acoustic2d_isotropic.tpp"
+#include "container.hpp"
+#include "elastic/elastic2d.hpp"
+#include "elastic/elastic2d_isotropic.hpp"
+#include "elastic/elastic2d_isotropic.tpp"
+#include "kernel.hpp"
+#include "kernel.tpp"
+#include "receiver.hpp"
 
 #endif /* _DOMAIN_RECEIVERS_INTERFACE_HPP */

--- a/include/domain/impl/receivers/kernel.hpp
+++ b/include/domain/impl/receivers/kernel.hpp
@@ -13,49 +13,42 @@ namespace domain {
 namespace impl {
 namespace kernels {
 
-template <class medium, class qp_type, typename... elemental_properties>
-class receiver_kernel {
+template <class medium, class qp_type, class property> class receiver_kernel {
 public:
   using dimension = specfem::enums::element::dimension::dim2;
   using medium_type = medium;
+  using property_type = property;
   using quadrature_points_type = qp_type;
 
   receiver_kernel() = default;
 
   receiver_kernel(
-      const specfem::kokkos::DeviceView3d<int> ibool,
-      const specfem::kokkos::DeviceView1d<int> ispec,
-      const specfem::kokkos::DeviceView1d<int> ireceiver,
-      const specfem::compute::partial_derivatives &partial_derivatives,
-      const specfem::compute::properties &properties,
-      const specfem::compute::receivers &receivers,
-      const specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field,
-      const specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
-          field_dot,
-      const specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
-          field_dot_dot,
-      specfem::quadrature::quadrature *quadx,
-      specfem::quadrature::quadrature *quadz,
-      quadrature_points_type quadrature_points);
+      const specfem::compute::assembly &assembly,
+      const specfem::kokkos::HostView1d<int> h_receiver_kernel_index_mapping,
+      const specfem::kokkos::HostView1d<int> h_receiver_mapping,
+      const quadrature_points_type &quadrature_points);
 
   void compute_seismograms(const int &isig_step) const;
 
 private:
-  specfem::kokkos::DeviceView3d<int> ibool;
-  specfem::kokkos::DeviceView1d<int> ispec;
-  specfem::kokkos::DeviceView1d<int> ireceiver;
-  specfem::kokkos::DeviceView1d<int> iseis;
-  specfem::kokkos::DeviceView1d<specfem::enums::seismogram::type>
-      seismogram_types;
-  specfem::kokkos::DeviceView4d<type_real> receiver_seismogram;
+  int nreceivers;
+  int nseismograms;
+  specfem::compute::points points;
+  specfem::compute::quadrature quadrature;
+  specfem::compute::partial_derivatives partial_derivatives;
+  specfem::compute::properties properties;
+  specfem::kokkos::DeviceView1d<int> receiver_kernel_index_mapping;
+  specfem::kokkos::HostMirror1d<int> h_receiver_kernel_index_mapping;
+  specfem::kokkos::DeviceView1d<int> receiver_mapping;
+  specfem::compute::impl::field_impl<medium_type> field;
+  Kokkos::View<int * [specfem::enums::element::ntypes], Kokkos::LayoutLeft,
+               specfem::kokkos::DevMemSpace>
+      global_index_mapping;
+  specfem::compute::receivers receivers;
   quadrature_points_type quadrature_points;
-  specfem::quadrature::quadrature *quadx;
-  specfem::quadrature::quadrature *quadz;
-  specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field;
-  specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field_dot;
-  specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field_dot_dot;
+
   specfem::domain::impl::receivers::receiver<
-      dimension, medium_type, quadrature_points_type, elemental_properties...>
+      dimension, medium_type, quadrature_points_type, property_type>
       receiver;
 };
 } // namespace kernels

--- a/include/domain/impl/receivers/kernel.tpp
+++ b/include/domain/impl/receivers/kernel.tpp
@@ -1,6 +1,7 @@
 #ifndef _DOMAIN_IMPL_RECEIVERS_KERNEL_TPP
 #define _DOMAIN_IMPL_RECEIVERS_KERNEL_TPP
 
+#include "algorithms/interpolate.hpp"
 #include "domain/impl/receivers/acoustic/interface.hpp"
 #include "domain/impl/receivers/elastic/interface.hpp"
 #include "enumerations/interface.hpp"
@@ -9,54 +10,61 @@
 #include "quadrature/interface.hpp"
 #include "specfem_setup.hpp"
 
-template <class medium, class qp_type, typename... elemental_properties>
-specfem::domain::impl::kernels::
-    receiver_kernel<medium, qp_type, elemental_properties...>::receiver_kernel(
-        const specfem::kokkos::DeviceView3d<int> ibool,
-        const specfem::kokkos::DeviceView1d<int> ispec,
-        const specfem::kokkos::DeviceView1d<int> ireceiver,
-        const specfem::compute::partial_derivatives &partial_derivatives,
-        const specfem::compute::properties &properties,
-        const specfem::compute::receivers &receivers,
-        const specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
-            field,
-        const specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
-            field_dot,
-        const specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
-            field_dot_dot,
-        specfem::quadrature::quadrature *quadx,
-        specfem::quadrature::quadrature *quadz,
-        quadrature_points_type quadrature_points)
-    : ibool(ibool), ispec(ispec), ireceiver(ireceiver),
-      quadrature_points(quadrature_points), field(field), field_dot(field_dot),
-      field_dot_dot(field_dot_dot),
-      seismogram_types(receivers.seismogram_types), quadx(quadx), quadz(quadz),
-      receiver_seismogram(receivers.seismogram) {
+template <class medium, class qp_type, class property>
+specfem::domain::impl::kernels::receiver_kernel<medium, qp_type, property>::
+    receiver_kernel(
+        const specfem::compute::assembly &assembly,
+        const specfem::kokkos::HostView1d<int> h_receiver_kernel_index_mapping,
+        const specfem::kokkos::HostView1d<int> h_receiver_mapping,
+        const quadrature_points_type &quadrature_points)
+    : nreceivers(h_receiver_kernel_index_mapping.extent(0)),
+      nseismograms(assembly.receivers.seismogram_types.extent(0)),
+      h_receiver_kernel_index_mapping(h_receiver_kernel_index_mapping),
+      points(assembly.mesh.points), quadrature(assembly.mesh.quadratures),
+      partial_derivatives(assembly.partial_derivatives),
+      properties(assembly.properties), receivers(assembly.receivers),
+      field(assembly.fields.forward.get_field<medium_type>()),
+      global_index_mapping(assembly.fields.forward.assembly_index_mapping),
+      quadrature_points(quadrature_points) {
 
-#ifndef NDEBUG
-  assert(field.extent(1) == medium::components);
-  assert(field_dot.extent(1) == medium::components);
-  assert(field_dot_dot.extent(1) == medium::components);
-#endif
+  Kokkos::parallel_for(
+      "specfem::domain::impl::kernels::element_kernel::check_properties",
+      specfem::kokkos::HostRange(0, nreceivers),
+      KOKKOS_LAMBDA(const int isource) {
+        const int ispec = h_receiver_kernel_index_mapping(isource);
+        if ((assembly.properties.h_element_types(ispec) !=
+             medium_type::value) &&
+            (assembly.properties.h_element_property(ispec) !=
+             property_type::value)) {
+          throw std::runtime_error("Invalid element detected in kernel");
+        }
+      });
 
-  const auto sin_rec = receivers.sin_recs;
-  const auto cos_rec = receivers.cos_recs;
-  const auto receiver_array = receivers.receiver_array;
-  const auto receiver_field = receivers.receiver_field;
+  Kokkos::fence();
 
-  // Allocate receivers
-  this->receiver = specfem::domain::impl::receivers::receiver<
-      dimension, medium_type, quadrature_points_type, elemental_properties...>(
-      sin_rec, cos_rec, receiver_array, partial_derivatives, properties,
-      receiver_field);
+  receiver_kernel_index_mapping = specfem::kokkos::DeviceView1d<int>(
+      "specfem::domain::impl::kernels::element_kernel::element_kernel_index_"
+      "mapping",
+      nreceivers);
+
+  receiver_mapping = specfem::kokkos::DeviceView1d<int>(
+      "specfem::domain::impl::kernels::element_kernel::source_mapping",
+      nreceivers);
+
+  Kokkos::deep_copy(receiver_kernel_index_mapping,
+                    h_receiver_kernel_index_mapping);
+  Kokkos::deep_copy(receiver_mapping, h_receiver_mapping);
+
+  receiver = specfem::domain::impl::receivers::receiver<dimension, medium,
+                                                        qp_type, property>();
 
   return;
 }
 
-template <class medium, class qp_type, typename... elemental_properties>
+template <class medium, class qp_type, class property>
 void specfem::domain::impl::kernels::receiver_kernel<
-    medium, qp_type,
-    elemental_properties...>::compute_seismograms(const int &isig_step) const {
+    medium, qp_type, property>::compute_seismograms(const int &isig_step)
+    const {
 
   // Allocate scratch views for field, field_dot & field_dot_dot. Incase of
   // acostic domains when calculating displacement, velocity and acceleration
@@ -66,22 +74,19 @@ void specfem::domain::impl::kernels::receiver_kernel<
   // global memory accesses.
 
   constexpr int components = medium::components;
-  const int nreceivers = ispec.extent(0);
 
   if (nreceivers == 0)
     return;
 
-  const int nseismograms = seismogram_types.extent(0);
-  const auto ibool = this->ibool;
-  const auto hprime_xx = this->quadx->get_hprime();
-  const auto hprime_zz = this->quadz->get_hprime();
+  if (nseismograms == 0)
+    return;
+
+  const auto hprime = quadrature.gll.hprime;
+  const auto index_mapping = points.index_mapping;
+
   // hprime_xx
   int scratch_size = quadrature_points.template shmem_size<
       type_real, 1, specfem::enums::axes::x, specfem::enums::axes::x>();
-
-  // hprime_zz
-  scratch_size += quadrature_points.template shmem_size<
-      type_real, 1, specfem::enums::axes::z, specfem::enums::axes::z>();
 
   // field, field_dot, field_dot_dot
   scratch_size +=
@@ -96,37 +101,32 @@ void specfem::domain::impl::kernels::receiver_kernel<
           .set_scratch_size(0, Kokkos::PerTeam(scratch_size)),
       KOKKOS_CLASS_LAMBDA(
           const specfem::kokkos::DeviceTeam::member_type &team_member) {
+        // --- Get receiver index, seismogram type, and spectral element index
         int ngllx, ngllz;
         quadrature_points.get_ngll(&ngllx, &ngllz);
+        const auto iseis_l = team_member.league_rank() % nseismograms;
+        const auto seismogram_type_l = receivers.seismogram_types(iseis_l);
         const int ireceiver_l =
-            this->ireceiver(team_member.league_rank() / nseismograms);
-        const int ispec_l =
-            this->ispec(team_member.league_rank() / nseismograms);
-        const int iseis_l = team_member.league_rank() % nseismograms;
-        const auto seismogram_type_l = this->seismogram_types(iseis_l);
+            receiver_mapping(team_member.league_rank() / nseismograms);
+        const int ispec_l = receiver_kernel_index_mapping(
+            team_member.league_rank() / nseismograms);
+        // --------------------------------------------------------------------------
 
         // Instantiate shared views
         // ----------------------------------------------------------------
-        auto s_hprime_xx = quadrature_points.template ScratchView<
+        auto s_hprime = quadrature_points.template ScratchView<
             type_real, 1, specfem::enums::axes::x, specfem::enums::axes::x>(
             team_member.team_scratch(0));
-
-        auto s_hprime_zz = quadrature_points.template ScratchView<
-            type_real, 1, specfem::enums::axes::z, specfem::enums::axes::z>(
-            team_member.team_scratch(0));
-
         auto s_field =
             quadrature_points.template ScratchView<type_real, components,
                                                    specfem::enums::axes::z,
                                                    specfem::enums::axes::x>(
                 team_member.team_scratch(0));
-
         auto s_field_dot =
             quadrature_points.template ScratchView<type_real, components,
                                                    specfem::enums::axes::z,
                                                    specfem::enums::axes::x>(
                 team_member.team_scratch(0));
-
         auto s_field_dot_dot =
             quadrature_points.template ScratchView<type_real, components,
                                                    specfem::enums::axes::z,
@@ -135,44 +135,31 @@ void specfem::domain::impl::kernels::receiver_kernel<
 
         // Allocate shared views
         // ----------------------------------------------------------------
+
         Kokkos::parallel_for(
             quadrature_points.template TeamThreadRange<specfem::enums::axes::x,
-                                                       specfem::enums::axes::x>(
-                team_member),
-            [=](const int xz) {
-              int iz, ix;
-              sub2ind(xz, ngllx, iz, ix);
-              s_hprime_xx(iz, ix, 0) = hprime_xx(iz, ix);
-            });
-
-        Kokkos::parallel_for(
-            quadrature_points.template TeamThreadRange<specfem::enums::axes::z,
                                                        specfem::enums::axes::z>(
                 team_member),
-            [=](const int xz) {
-              int iz, ix;
-              sub2ind(xz, ngllz, iz, ix);
-              s_hprime_zz(iz, ix, 0) = hprime_zz(iz, ix);
-            });
-
-        Kokkos::parallel_for(
-            quadrature_points.template TeamThreadRange<specfem::enums::axes::z,
-                                                       specfem::enums::axes::x>(
-                team_member),
-            [=](const int xz) {
-              int iz, ix;
+            [&](const int xz) {
+              int ix, iz;
               sub2ind(xz, ngllx, iz, ix);
-              int iglob = ibool(ispec_l, iz, ix);
+              s_hprime(iz, ix, 0) = hprime(iz, ix);
+              const int iglob =
+                  global_index_mapping(index_mapping(ispec_l, iz, ix),
+                                       static_cast<int>(medium::value));
 #ifdef KOKKOS_ENABLE_CUDA
 #pragma unroll
 #endif
-              for (int icomponent = 0; icomponent < components; icomponent++) {
-                s_field(iz, ix, icomponent) = field(iglob, icomponent);
-                s_field_dot(iz, ix, icomponent) = field_dot(iglob, icomponent);
+              for (int icomponent = 0; icomponent < components; ++icomponent) {
+                s_field(iz, ix, icomponent) = field.field(iglob, icomponent);
+                s_field_dot(iz, ix, icomponent) =
+                    field.field_dot(iglob, icomponent);
                 s_field_dot_dot(iz, ix, icomponent) =
-                    field_dot_dot(iglob, icomponent);
+                    field.field_dot_dot(iglob, icomponent);
               }
             });
+
+        team_member.team_barrier();
 
         // Get seismogram field
         // ----------------------------------------------------------------
@@ -182,40 +169,104 @@ void specfem::domain::impl::kernels::receiver_kernel<
                                                        specfem::enums::axes::x>(
                 team_member),
             [=](const int xz) {
-              receiver.get_field(ireceiver_l, iseis_l, ispec_l,
-                                 seismogram_type_l, xz, isig_step, s_field,
-                                 s_field_dot, s_field_dot_dot, s_hprime_xx,
-                                 s_hprime_zz);
+              int iz, ix;
+              sub2ind(xz, ngllx, iz, ix);
+              const auto point_partial_derivatives =
+                  partial_derivatives.template load_device_derivatives<false>(
+                      ispec_l, iz, ix);
+
+              const auto point_properties =
+                  properties.template load_device_properties<
+                      medium_type::value, property_type::value>(ispec_l, iz,
+                                                                ix);
+
+              const auto active_field = [&]() {
+                switch (seismogram_type_l) {
+                case specfem::enums::seismogram::type::displacement:
+                  return s_field;
+                  break;
+                case specfem::enums::seismogram::type::velocity:
+                  return s_field_dot;
+                  break;
+                case specfem::enums::seismogram::type::acceleration:
+                  return s_field_dot_dot;
+                  break;
+                default:
+                  ASSERT(false, "seismogram not supported");
+                  return decltype(s_field){};
+                  break;
+                }
+              }();
+
+              const auto sv_receiver_field =
+                  Kokkos::subview(receivers.receiver_field, iz, ix, iseis_l,
+                                  ireceiver_l, isig_step, Kokkos::ALL);
+
+              receiver.get_field(iz, ix, point_partial_derivatives,
+                                 point_properties, s_hprime, active_field,
+                                 sv_receiver_field);
+              // receiver.get_field(ireceiver_l, iseis_l, ispec_l,
+              //                    seismogram_type_l, xz, isig_step, s_field,
+              //                    s_field_dot, s_field_dot_dot);
             });
+
+        team_member.team_barrier();
 
         // compute seismograms components
         //-------------------------------------------------------------------
-        switch (seismogram_type_l) {
-        case specfem::enums::seismogram::type::displacement:
-        case specfem::enums::seismogram::type::velocity:
-        case specfem::enums::seismogram::type::acceleration:
-          specfem::kokkos::array_type<type_real, 2> seismogram_components;
-          Kokkos::parallel_reduce(
-              quadrature_points.template TeamThreadRange<
-                  specfem::enums::axes::z, specfem::enums::axes::x>(
-                  team_member),
-              [=](const int xz, specfem::kokkos::array_type<type_real, 2>
-                                    &l_seismogram_components) {
-                receiver.compute_seismogram_components(
-                    ireceiver_l, iseis_l, seismogram_type_l, xz, isig_step,
-                    l_seismogram_components);
-              },
-              specfem::kokkos::Sum<specfem::kokkos::array_type<type_real, 2> >(
-                  seismogram_components));
-          auto sv_receiver_seismogram =
-              Kokkos::subview(receiver_seismogram, isig_step, iseis_l,
-                              ireceiver_l, Kokkos::ALL);
-          Kokkos::single(Kokkos::PerTeam(team_member), [=] {
-            receiver.compute_seismogram(ireceiver_l, seismogram_components,
-                                        sv_receiver_seismogram);
-          });
-          break;
-        }
+        const auto sv_receiver_field =
+            Kokkos::subview(receivers.receiver_field, Kokkos::ALL, Kokkos::ALL,
+                            iseis_l, ireceiver_l, isig_step, Kokkos::ALL);
+        const auto polynomial = Kokkos::subview(
+            receivers.receiver_array, ireceiver_l, 0, Kokkos::ALL, Kokkos::ALL);
+
+        const auto seismogram_components =
+            specfem::algorithms::interpolate_function(team_member, polynomial,
+                                                      sv_receiver_field);
+
+        Kokkos::single(Kokkos::PerTeam(team_member), [=] {
+          if (specfem::globals::simulation_wave == specfem::wave::p_sv) {
+            receivers.seismogram(isig_step, iseis_l, ireceiver_l, 0) =
+                receivers.cos_recs(ireceiver_l) * seismogram_components[0] +
+                receivers.sin_recs(ireceiver_l) * seismogram_components[1];
+            receivers.seismogram(isig_step, iseis_l, ireceiver_l, 1) =
+                receivers.sin_recs(ireceiver_l) * seismogram_components[0] +
+                receivers.cos_recs(ireceiver_l) * seismogram_components[1];
+          } else if (specfem::globals::simulation_wave == specfem::wave::sh) {
+            receivers.seismogram(isig_step, iseis_l, ireceiver_l, 0) =
+                receivers.cos_recs(ireceiver_l) * seismogram_components[0] +
+                receivers.sin_recs(ireceiver_l) * seismogram_components[1];
+            receivers.seismogram(isig_step, iseis_l, ireceiver_l, 0) = 0;
+          }
+        });
+
+        // case specfem::enums::seismogram::type::displacement:
+        // case specfem::enums::seismogram::type::velocity:
+        // case specfem::enums::seismogram::type::acceleration:
+        //   specfem::kokkos::array_type<type_real, 2> seismogram_components;
+        //   Kokkos::parallel_reduce(
+        //       quadrature_points.template
+        //       TeamThreadRange<specfem::enums::axes::z,
+        //                                                  specfem::enums::axes::x>(
+        //           team_member),
+        //       [=](const int xz, specfem::kokkos::array_type<type_real, 2>
+        //                             &l_seismogram_components) {
+        //         receiver.compute_seismogram_components(
+        //             ireceiver_l, iseis_l, seismogram_type_l, xz, isig_step,
+        //             l_seismogram_components);
+        //       },
+        //       specfem::kokkos::Sum<specfem::kokkos::array_type<type_real, 2>
+        //       >(
+        //           seismogram_components));
+        //   auto sv_receiver_seismogram = Kokkos::subview(
+        //       receiver_seismogram, isig_step, iseis_l, ireceiver_l,
+        //       Kokkos::ALL);
+        //   Kokkos::single(Kokkos::PerTeam(team_member), [=] {
+        //     receiver.compute_seismogram(ireceiver_l, seismogram_components,
+        //                                 sv_receiver_seismogram);
+        //   });
+        //   break;
+        //       }
       });
 }
 

--- a/include/domain/impl/sources/acoustic/acoustic2d_isotropic.hpp
+++ b/include/domain/impl/sources/acoustic/acoustic2d_isotropic.hpp
@@ -42,6 +42,8 @@ public:
    *
    */
   using medium_type = specfem::enums::element::medium::acoustic;
+
+  using property_type = specfem::enums::element::property::isotropic;
   /**
    * @brief Number of Gauss-Lobatto-Legendre quadrature points
    */
@@ -61,16 +63,16 @@ public:
    */
   KOKKOS_FUNCTION source(const source &) = default;
 
-  /**
-   * @brief Construct a new elemental source object
-   *
-   * @param properties struct used to store material properties
-   * @param source_array Source array containing pre-computed lagrange
-   * interpolants
-   */
-  KOKKOS_FUNCTION
-  source(const specfem::compute::properties &properties,
-         const specfem::kokkos::DeviceView4d<type_real> source_array);
+  //   /**
+  //    * @brief Construct a new elemental source object
+  //    *
+  //    * @param properties struct used to store material properties
+  //    * @param source_array Source array containing pre-computed lagrange
+  //    * interpolants
+  //    */
+  //   KOKKOS_FUNCTION
+  //   source(const specfem::compute::properties &properties,
+  //          const specfem::kokkos::DeviceView4d<type_real> source_array);
 
   /**
    * @brief Compute the interaction of the source with the medium computed at
@@ -84,18 +86,12 @@ public:
    * the source
    */
   KOKKOS_INLINE_FUNCTION void compute_interaction(
-      const int &isource, const int &ispec, const int &xz,
-      const type_real &stf_value,
+      const type_real &stf,
+      const specfem::kokkos::array_type<type_real, 2> &lagrange_interpolant,
+      const specfem::point::properties<medium_type::value, property_type::value>
+          &properties,
       specfem::kokkos::array_type<type_real, medium_type::components>
           &acceleration) const;
-
-private:
-  specfem::kokkos::DeviceView3d<type_real> kappa;        /// kappa array
-  specfem::kokkos::DeviceView4d<type_real> source_array; ///< Source array
-                                                         ///< containing
-                                                         ///< pre-computed
-                                                         ///< lagrange
-                                                         ///< interpolants
 };
 } // namespace sources
 } // namespace impl

--- a/include/domain/impl/sources/acoustic/acoustic2d_isotropic.tpp
+++ b/include/domain/impl/sources/acoustic/acoustic2d_isotropic.tpp
@@ -4,10 +4,10 @@
 #include "compute/interface.hpp"
 #include "domain/impl/sources/acoustic/acoustic2d_isotropic.hpp"
 #include "domain/impl/sources/source.hpp"
+#include "enumerations/interface.hpp"
 #include "globals.h"
 #include "kokkos_abstractions.h"
 #include "source_time_function/source_time_function.hpp"
-#include "enumerations/interface.hpp"
 #include "specfem_setup.hpp"
 #include <Kokkos_Core.hpp>
 
@@ -19,25 +19,25 @@ using field_type = Kokkos::Subview<
 //                     SPECIALIZED ELEMENT
 // -----------------------------------------------------------------------------
 
-template <int NGLL>
-KOKKOS_FUNCTION specfem::domain::impl::sources::source<
-    specfem::enums::element::dimension::dim2,
-    specfem::enums::element::medium::acoustic,
-    specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
-    specfem::enums::element::property::isotropic>::
-    source(const specfem::compute::properties &properties,
-           const specfem::kokkos::DeviceView4d<type_real> source_array)
-    : source_array(source_array), kappa(properties.kappa) {
+// template <int NGLL>
+// KOKKOS_FUNCTION specfem::domain::impl::sources::source<
+//     specfem::enums::element::dimension::dim2,
+//     specfem::enums::element::medium::acoustic,
+//     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
+//     specfem::enums::element::property::isotropic>::
+//     source(const specfem::compute::properties &properties,
+//            const specfem::kokkos::DeviceView4d<type_real> source_array)
+//     : source_array(source_array), kappa(properties.kappa) {
 
-// #ifndef NDEBUG
-//   assert(source_array.extent(1) == NGLL);
-//   assert(source_array.extent(2) == NGLL);
-//   assert(properties.kappa.extent(1) == NGLL);
-//   assert(properties.kappa.extent(2) == NGLL);
-// #endif
+//   // #ifndef NDEBUG
+//   //   assert(source_array.extent(1) == NGLL);
+//   //   assert(source_array.extent(2) == NGLL);
+//   //   assert(properties.kappa.extent(1) == NGLL);
+//   //   assert(properties.kappa.extent(2) == NGLL);
+//   // #endif
 
-  return;
-}
+//   return;
+// }
 
 template <int NGLL>
 KOKKOS_INLINE_FUNCTION void specfem::domain::impl::sources::source<
@@ -45,18 +45,16 @@ KOKKOS_INLINE_FUNCTION void specfem::domain::impl::sources::source<
     specfem::enums::element::medium::acoustic,
     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
     specfem::enums::element::property::isotropic>::
-    compute_interaction(const int &isource, const int &ispec, const int &xz, const type_real &stf_value,
-                        specfem::kokkos::array_type<type_real, medium_type::components> &acceleration) const {
-  int ix, iz;
-  sub2ind(xz, NGLL, iz, ix);
+    compute_interaction(
+        const type_real &stf,
+        const specfem::kokkos::array_type<type_real, 2>
+            &lagrange_interpolant,
+        const specfem::point::properties<medium_type::value,
+                                         property_type::value> &properties,
+        specfem::kokkos::array_type<type_real, medium_type::components>
+            &acceleration) const {
 
-  static_assert(medium_type::components == 1,
-                "Acoustic medium must have 1 component");
-
-  type_real sal = source_array(isource, iz, ix, 0);
-  type_real kap = kappa(ispec, iz, ix);
-
-  acceleration[0] = source_array(isource, iz, ix, 0) * stf_value / kappa(ispec, iz, ix);
+  acceleration[0] = lagrange_interpolant[0] * stf / properties.kappa;
 
   return;
 }

--- a/include/domain/impl/sources/elastic/elastic2d_isotropic.hpp
+++ b/include/domain/impl/sources/elastic/elastic2d_isotropic.hpp
@@ -42,6 +42,8 @@ public:
    *
    */
   using medium_type = specfem::enums::element::medium::elastic;
+
+  using property_type = specfem::enums::element::property::isotropic;
   /**
    * @brief Number of Gauss-Lobatto-Legendre quadrature points
    */
@@ -61,14 +63,15 @@ public:
    */
   KOKKOS_FUNCTION source(const source &) = default;
 
-  /**
-   * @brief Construct a new elemental source object
-   *
-   * @param source_array Source array containing pre-computed lagrange
-   * interpolants
-   */
-  KOKKOS_FUNCTION source(const specfem::compute::properties &properties,
-                         specfem::kokkos::DeviceView4d<type_real> source_array);
+  //   /**
+  //    * @brief Construct a new elemental source object
+  //    *
+  //    * @param source_array Source array containing pre-computed lagrange
+  //    * interpolants
+  //    */
+  //   KOKKOS_FUNCTION source(const specfem::compute::properties &properties,
+  //                          specfem::kokkos::DeviceView4d<type_real>
+  //                          source_array);
 
   /**
    * @brief Compute the interaction of the source with the medium computed at
@@ -82,17 +85,12 @@ public:
    * the source
    */
   KOKKOS_INLINE_FUNCTION void compute_interaction(
-      const int &isource, const int &ispec, const int &xz,
-      const type_real &stf_value,
+      const type_real &stf,
+      const specfem::kokkos::array_type<type_real, 2> &lagrange_interpolant,
+      const specfem::point::properties<medium_type::value, property_type::value>
+          &properties,
       specfem::kokkos::array_type<type_real, medium_type::components>
           &acceleration) const;
-
-private:
-  specfem::kokkos::DeviceView4d<type_real> source_array; ///< Source array
-                                                         ///< containing
-                                                         ///< pre-computed
-                                                         ///< lagrange
-                                                         ///< interpolants
 };
 } // namespace sources
 } // namespace impl

--- a/include/domain/impl/sources/elastic/elastic2d_isotropic.tpp
+++ b/include/domain/impl/sources/elastic/elastic2d_isotropic.tpp
@@ -4,10 +4,10 @@
 #include "compute/interface.hpp"
 #include "domain/impl/sources/elastic/elastic2d_isotropic.hpp"
 #include "domain/impl/sources/source.hpp"
+#include "enumerations/interface.hpp"
 #include "globals.h"
 #include "kokkos_abstractions.h"
 #include "source_time_function/source_time_function.hpp"
-#include "enumerations/interface.hpp"
 #include "specfem_setup.hpp"
 #include <Kokkos_Core.hpp>
 
@@ -15,23 +15,22 @@
 //                     SPECIALIZED ELEMENT
 // -----------------------------------------------------------------------------
 
-template <int NGLL>
-KOKKOS_FUNCTION specfem::domain::impl::sources::source<
-    specfem::enums::element::dimension::dim2,
-    specfem::enums::element::medium::elastic,
-    specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
-    specfem::enums::element::property::isotropic>::
-    source(const specfem::compute::properties &properties,
-           specfem::kokkos::DeviceView4d<type_real> source_array)
-    : source_array(source_array) {
+// template <int NGLL>
+// KOKKOS_FUNCTION specfem::domain::impl::sources::source<
+//     specfem::enums::element::dimension::dim2,
+//     specfem::enums::element::medium::elastic,
+//     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
+//     specfem::enums::element::property::isotropic>::
+//     source(const specfem::compute::properties &properties,
+//            specfem::kokkos::DeviceView4d<type_real> source_array) {
 
-// #ifndef NDEBUG
-//   assert(source_array.extent(1) == NGLL);
-//   assert(source_array.extent(2) == NGLL);
-// #endif
+//   // #ifndef NDEBUG
+//   //   assert(source_array.extent(1) == NGLL);
+//   //   assert(source_array.extent(2) == NGLL);
+//   // #endif
 
-  return;
-}
+//   return;
+// }
 
 template <int NGLL>
 KOKKOS_INLINE_FUNCTION void specfem::domain::impl::sources::source<
@@ -39,19 +38,20 @@ KOKKOS_INLINE_FUNCTION void specfem::domain::impl::sources::source<
     specfem::enums::element::medium::elastic,
     specfem::enums::element::quadrature::static_quadrature_points<NGLL>,
     specfem::enums::element::property::isotropic>::
-    compute_interaction(const int &isource, const int &ispec, const int &xz,
-                        const type_real &stf_value, specfem::kokkos::array_type<type_real, medium_type::components> &acceleration) const {
-  int ix, iz;
-  sub2ind(xz, NGLL, iz, ix);
+    compute_interaction(
+        const type_real &stf,
+        const specfem::kokkos::array_type<type_real, 2>
+            &lagrange_interpolant,
+        const specfem::point::properties<medium_type::value,
+                                         property_type::value> &properties,
+        specfem::kokkos::array_type<type_real, medium_type::components>
+            &acceleration) const {
 
-  static_assert(medium_type::components == 2,
-                "Elastic medium must have 2 components");
-
-  if (specfem::globals::simulation_wave == specfem::wave::p_sv) {
-    acceleration[0] = source_array(isource, iz, ix, 0) * stf_value;
-    acceleration[1] = source_array(isource, iz, ix, 1) * stf_value;
-  } else if (specfem::globals::simulation_wave == specfem::wave::sh) {
-    acceleration[0] = source_array(isource, iz, ix, 0) * stf_value;
+  if constexpr (specfem::globals::simulation_wave == specfem::wave::p_sv) {
+    acceleration[0] = lagrange_interpolant[0] * stf;
+    acceleration[1] = lagrange_interpolant[1] * stf;
+  } else if constexpr (specfem::globals::simulation_wave == specfem::wave::sh) {
+    acceleration[0] = lagrange_interpolant[0] * stf;
     acceleration[1] = 0;
   }
 

--- a/include/domain/impl/sources/interface.hpp
+++ b/include/domain/impl/sources/interface.hpp
@@ -1,15 +1,15 @@
 #ifndef _DOMAIN_SOURCES_INTERFACE_HPP
 #define _DOMAIN_SOURCES_INTERFACE_HPP
 
-#include "acoustic/acoustic2d.hpp"
-#include "acoustic/acoustic2d_isotropic.hpp"
-#include "acoustic/acoustic2d_isotropic.tpp"
-#include "container.hpp"
-#include "elastic/elastic2d.hpp"
-#include "elastic/elastic2d_isotropic.hpp"
-#include "elastic/elastic2d_isotropic.tpp"
-#include "kernel.hpp"
-#include "kernel.tpp"
-#include "source.hpp"
+// #include "acoustic/acoustic2d.hpp"
+// #include "acoustic/acoustic2d_isotropic.hpp"
+// #include "acoustic/acoustic2d_isotropic.tpp"
+// #include "container.hpp"
+// #include "elastic/elastic2d.hpp"
+// #include "elastic/elastic2d_isotropic.hpp"
+// #include "elastic/elastic2d_isotropic.tpp"
+// #include "kernel.hpp"
+// #include "kernel.tpp"
+// #include "source.hpp"
 
 #endif

--- a/include/domain/impl/sources/interface.hpp
+++ b/include/domain/impl/sources/interface.hpp
@@ -1,15 +1,15 @@
 #ifndef _DOMAIN_SOURCES_INTERFACE_HPP
 #define _DOMAIN_SOURCES_INTERFACE_HPP
 
-// #include "acoustic/acoustic2d.hpp"
-// #include "acoustic/acoustic2d_isotropic.hpp"
-// #include "acoustic/acoustic2d_isotropic.tpp"
-// #include "container.hpp"
-// #include "elastic/elastic2d.hpp"
-// #include "elastic/elastic2d_isotropic.hpp"
-// #include "elastic/elastic2d_isotropic.tpp"
-// #include "kernel.hpp"
-// #include "kernel.tpp"
-// #include "source.hpp"
+#include "acoustic/acoustic2d.hpp"
+#include "acoustic/acoustic2d_isotropic.hpp"
+#include "acoustic/acoustic2d_isotropic.tpp"
+#include "container.hpp"
+#include "elastic/elastic2d.hpp"
+#include "elastic/elastic2d_isotropic.hpp"
+#include "elastic/elastic2d_isotropic.tpp"
+#include "kernel.hpp"
+#include "kernel.tpp"
+#include "source.hpp"
 
 #endif

--- a/include/domain/impl/sources/kernel.hpp
+++ b/include/domain/impl/sources/kernel.hpp
@@ -14,35 +14,38 @@ namespace domain {
 namespace impl {
 namespace kernels {
 
-template <class medium, class qp_type, typename... elemental_properties>
-class source_kernel {
+template <class medium, class qp_type, class property> class source_kernel {
 public:
   using dimension = specfem::enums::element::dimension::dim2;
   using medium_type = medium;
+  using property_type = property;
   using quadrature_point_type = qp_type;
 
   source_kernel() = default;
-  source_kernel(const specfem::kokkos::DeviceView3d<int> ibool,
-                const specfem::kokkos::DeviceView1d<int> ispec,
-                const specfem::kokkos::DeviceView1d<int> isource,
-                const specfem::compute::properties &properties,
-                const specfem::compute::sources &sources,
-                quadrature_point_type quadrature_points,
-                specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
-                    field_dot_dot);
+  source_kernel(
+      const specfem::compute::assembly &assembly,
+      const specfem::kokkos::HostView1d<int> h_source_kernel_index_mapping,
+      const specfem::kokkos::HostView1d<int> h_source_mapping,
+      const quadrature_point_type quadrature_points);
 
-  void compute_source_interaction(const type_real timeval) const;
+  void compute_source_interaction(const int timestep) const;
 
 private:
-  specfem::kokkos::DeviceView1d<int> ispec;
-  specfem::kokkos::DeviceView3d<int> ibool;
-  specfem::kokkos::DeviceView1d<int> isource;
-  specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft> field_dot_dot;
-  specfem::kokkos::DeviceView1d<specfem::forcing_function::stf_storage>
-      stf_array;
+  int nsources;
+  specfem::compute::points points;
+  specfem::compute::quadrature quadrature;
+  specfem::kokkos::DeviceView1d<int> source_kernel_index_mapping;
+  specfem::kokkos::HostMirror1d<int> h_source_kernel_index_mapping;
+  specfem::kokkos::DeviceView1d<int> source_mapping;
+  Kokkos::View<int * [specfem::enums::element::ntypes], Kokkos::LayoutLeft,
+               specfem::kokkos::DevMemSpace>
+      global_index_mapping;
+  specfem::compute::properties properties;
+  specfem::compute::impl::field_impl<medium_type> field;
+  specfem::compute::sources sources;
   quadrature_point_type quadrature_points;
-  specfem::domain::impl::sources::source<
-      dimension, medium_type, quadrature_point_type, elemental_properties...>
+  specfem::domain::impl::sources::source<dimension, medium_type,
+                                         quadrature_point_type, property_type>
       source;
 };
 } // namespace kernels

--- a/include/domain/impl/sources/kernel.tpp
+++ b/include/domain/impl/sources/kernel.tpp
@@ -96,8 +96,8 @@ void specfem::domain::impl::kernels::source_kernel<medium, qp_type, property>::
                   medium_type::value, property_type::value>(ispec_l, iz, ix);
 
               specfem::kokkos::array_type<type_real, 2> lagrange_interpolant(
-                  sources.source_array(isource_l, iz, ix, 0),
-                  sources.source_array(isource_l, iz, ix, 1));
+                  sources.source_array(isource_l, 0, iz, ix),
+                  sources.source_array(isource_l, 1, iz, ix));
 
               specfem::kokkos::array_type<type_real, components> acceleration;
 

--- a/include/domain/impl/sources/kernel.tpp
+++ b/include/domain/impl/sources/kernel.tpp
@@ -4,52 +4,70 @@
 #include "compute/interface.hpp"
 #include "domain/impl/sources/acoustic/interface.hpp"
 #include "domain/impl/sources/elastic/interface.hpp"
+#include "enumerations/interface.hpp"
 #include "kernel.hpp"
 #include "kokkos_abstractions.h"
-#include "enumerations/interface.hpp"
 #include "specfem_setup.hpp"
 #include <Kokkos_Core.hpp>
 
-template <class medium, class qp_type, typename... elemental_properties>
-specfem::domain::impl::kernels::
-    source_kernel<medium, qp_type, elemental_properties...>::source_kernel(
-        const specfem::kokkos::DeviceView3d<int> ibool,
-        const specfem::kokkos::DeviceView1d<int> ispec,
-        const specfem::kokkos::DeviceView1d<int> isource,
-        const specfem::compute::properties &properties,
-        const specfem::compute::sources &sources,
-        quadrature_point_type quadrature_points,
-        specfem::kokkos::DeviceView2d<type_real, Kokkos::LayoutLeft>
-            field_dot_dot)
-    : ibool(ibool), ispec(ispec), isource(isource),
-      quadrature_points(quadrature_points), stf_array(sources.stf_array),
-      field_dot_dot(field_dot_dot) {
+template <class medium, class qp_type, class property>
+specfem::domain::impl::kernels::source_kernel<medium, qp_type, property>::
+    source_kernel(
+        const specfem::compute::assembly &assembly,
+        const specfem::kokkos::HostView1d<int> h_source_kernel_index_mapping,
+        const specfem::kokkos::HostView1d<int> h_source_mapping,
+        const quadrature_point_type quadrature_points)
+    : nsources(h_source_kernel_index_mapping.extent(0)),
+      h_source_kernel_index_mapping(h_source_kernel_index_mapping),
+      points(assembly.mesh.points), quadrature(assembly.mesh.quadratures),
+      properties(assembly.properties), sources(assembly.sources),
+      quadrature_points(quadrature_points),
+      global_index_mapping(assembly.fields.forward.assembly_index_mapping),
+      field(assembly.fields.forward.get_field<medium>()) {
 
-#ifndef NDEBUG
-  assert(field_dot_dot.extent(1) == medium::components);
-#endif
+  Kokkos::parallel_for(
+      "specfem::domain::impl::kernels::element_kernel::check_properties",
+      specfem::kokkos::HostRange(0, nsources),
+      KOKKOS_LAMBDA(const int isource) {
+        const int ispec = h_source_kernel_index_mapping(isource);
+        if ((assembly.properties.h_element_types(ispec) !=
+             medium_type::value) &&
+            (assembly.properties.h_element_property(ispec) !=
+             property_type::value)) {
+          throw std::runtime_error("Invalid element detected in kernel");
+        }
+      });
 
-  const auto source_array = sources.source_array;
+  Kokkos::fence();
+
+  source_kernel_index_mapping = specfem::kokkos::DeviceView1d<int>(
+      "specfem::domain::impl::kernels::element_kernel::element_kernel_index_"
+      "mapping",
+      nsources);
+
+  source_mapping = specfem::kokkos::DeviceView1d<int>(
+      "specfem::domain::impl::kernels::element_kernel::source_mapping",
+      nsources);
+
+  Kokkos::deep_copy(source_kernel_index_mapping, h_source_kernel_index_mapping);
+  Kokkos::deep_copy(source_mapping, h_source_mapping);
 
   source = specfem::domain::impl::sources::source<dimension, medium, qp_type,
-                                                  elemental_properties...>(
-      properties, source_array);
+                                                  property>();
 
   return;
 }
 
-template <class medium, class qp_type, typename... elemental_properties>
-void specfem::domain::impl::kernels::source_kernel<medium, qp_type,
-                                                   elemental_properties...>::
-    compute_source_interaction(const type_real timeval) const {
+template <class medium, class qp_type, class property>
+void specfem::domain::impl::kernels::source_kernel<medium, qp_type, property>::
+    compute_source_interaction(const int timestep) const {
 
   constexpr int components = medium::components;
-  const int nsources = this->ispec.extent(0);
 
   if (nsources == 0)
     return;
 
-  const auto ibool = this->ibool;
+  const auto index_mapping = points.index_mapping;
 
   Kokkos::parallel_for(
       "specfem::domain::domain::compute_source_interaction",
@@ -58,19 +76,9 @@ void specfem::domain::impl::kernels::source_kernel<medium, qp_type,
           const specfem::kokkos::DeviceTeam::member_type &team_member) {
         int ngllx, ngllz;
         quadrature_points.get_ngll(&ngllx, &ngllz);
-        int isource_l = isource(team_member.league_rank());
-        const int ispec_l = ispec(team_member.league_rank());
-
-        type_real stf;
-
-        Kokkos::parallel_reduce(
-            Kokkos::TeamThreadRange(team_member, 1),
-            [=](const int &, type_real &lsum) {
-              lsum = stf_array(isource_l).compute(timeval);
-            },
-            stf);
-
-        team_member.team_barrier();
+        int isource_l = source_mapping(team_member.league_rank());
+        const int ispec_l =
+            source_kernel_index_mapping(team_member.league_rank());
 
         Kokkos::parallel_for(
             quadrature_points.template TeamThreadRange<specfem::enums::axes::z,
@@ -79,19 +87,34 @@ void specfem::domain::impl::kernels::source_kernel<medium, qp_type,
             [=](const int xz) {
               int iz, ix;
               sub2ind(xz, ngllx, iz, ix);
-              int iglob = ibool(ispec_l, iz, ix);
+              int iglob = index_mapping(ispec_l, iz, ix);
+              int iglob_l = global_index_mapping(
+                  iglob, static_cast<int>(medium_type::value));
+
+              const type_real stf = sources.stf_array(isource_l, timestep);
+              const auto point_properties =
+                  properties
+                      .load_properties<medium_type::value, property_type::value,
+                                       specfem::kokkos::DevExecSpace>(ispec_l,
+                                                                      iz, ix);
+
+              specfem::kokkos::array_type<type_real, components>
+                  lagrange_interpolant(
+                      sources.source_array(isource_l, iz, ix, 0),
+                      sources.source_array(isource_l, iz, ix, 1));
 
               specfem::kokkos::array_type<type_real, components> acceleration;
 
-              source.compute_interaction(isource_l, ispec_l, xz, stf,
-                                         acceleration);
+              source.compute_interaction(stf, lagrange_interpolant,
+                                         point_properties, acceleration);
 
 #ifndef KOKKOS_ENABLE_CUDA
 #pragma unroll
 #endif
               for (int i = 0; i < components; i++) {
                 Kokkos::single(Kokkos::PerThread(team_member), [&] {
-                  Kokkos::atomic_add(&field_dot_dot(iglob, i), acceleration[i]);
+                  Kokkos::atomic_add(&field.field_dot_dot(iglob_l, i),
+                                     acceleration[i]);
                 });
               }
             });

--- a/include/domain/impl/sources/kernel.tpp
+++ b/include/domain/impl/sources/kernel.tpp
@@ -92,16 +92,12 @@ void specfem::domain::impl::kernels::source_kernel<medium, qp_type, property>::
                   iglob, static_cast<int>(medium_type::value));
 
               const type_real stf = sources.stf_array(isource_l, timestep);
-              const auto point_properties =
-                  properties
-                      .load_properties<medium_type::value, property_type::value,
-                                       specfem::kokkos::DevExecSpace>(ispec_l,
-                                                                      iz, ix);
+              const auto point_properties = properties.load_device_properties<
+                  medium_type::value, property_type::value>(ispec_l, iz, ix);
 
-              specfem::kokkos::array_type<type_real, components>
-                  lagrange_interpolant(
-                      sources.source_array(isource_l, iz, ix, 0),
-                      sources.source_array(isource_l, iz, ix, 1));
+              specfem::kokkos::array_type<type_real, 2> lagrange_interpolant(
+                  sources.source_array(isource_l, iz, ix, 0),
+                  sources.source_array(isource_l, iz, ix, 1));
 
               specfem::kokkos::array_type<type_real, components> acceleration;
 

--- a/include/edge/interface.hpp
+++ b/include/edge/interface.hpp
@@ -22,13 +22,13 @@ int num_points_on_interface(const specfem::edge::interface &interface);
 
 KOKKOS_FUNCTION
 void locate_point_on_self_edge(const int &ipoint,
-                               const specfem::edge::interface &edge, int &i,
-                               int &j);
+                               const specfem::edge::interface &edge, int &iz,
+                               int &ix);
 
 KOKKOS_FUNCTION
 void locate_point_on_coupled_edge(const int &ipoint,
-                                  const specfem::edge::interface &edge, int &i,
-                                  int &j);
+                                  const specfem::edge::interface &edge, int &iz,
+                                  int &ix);
 } // namespace edge
 } // namespace specfem
 

--- a/include/edge/interface.hpp
+++ b/include/edge/interface.hpp
@@ -9,26 +9,25 @@ namespace edge {
 
 struct interface {
   specfem::enums::edge::type type;
+  int ngll;
 
   interface() = default;
 
-  interface(const specfem::enums::edge::type type) : type(type) {}
+  interface(const specfem::enums::edge::type type, const int ngll)
+      : type(type), ngll(ngll) {}
 };
 
 KOKKOS_FUNCTION
-int num_points_on_interface(const specfem::edge::interface &interface,
-                            const int ngllz, const int ngllx);
+int num_points_on_interface(const specfem::edge::interface &interface);
 
 KOKKOS_FUNCTION
 void locate_point_on_self_edge(const int &ipoint,
-                               const specfem::edge::interface &edge,
-                               const int ngllx, const int ngllz, int &i,
+                               const specfem::edge::interface &edge, int &i,
                                int &j);
 
 KOKKOS_FUNCTION
 void locate_point_on_coupled_edge(const int &ipoint,
-                                  const specfem::edge::interface &edge,
-                                  const int ngllx, const int ngllz, int &i,
+                                  const specfem::edge::interface &edge, int &i,
                                   int &j);
 } // namespace edge
 } // namespace specfem

--- a/include/enumerations/boundary_conditions/composite_boundary.hpp
+++ b/include/enumerations/boundary_conditions/composite_boundary.hpp
@@ -59,6 +59,23 @@ public:
       specfem::enums::element::boundary_tag::
           composite_stacey_dirichlet; ///< boundary tag
 
+  static_assert(
+      std::is_same<typename stacey_type::medium_type,
+                   typename dirichlet_type::medium_type>::value,
+      "Medium types must be the same for composite boundary conditions.");
+  static_assert(
+      std::is_same<typename stacey_type::dimension,
+                   typename dirichlet_type::dimension>::value,
+      "Dimensions must be the same for composite boundary conditions.");
+  static_assert(
+      std::is_same<typename stacey_type::quadrature_points_type,
+                   typename dirichlet_type::quadrature_points_type>::value,
+      "Quadrature points must be the same for composite boundary conditions.");
+  static_assert(
+      std::is_same<typename stacey_type::property_type,
+                   typename dirichlet_type::property_type>::value,
+      "Property types must be the same for composite boundary conditions.");
+
   /**
    * @brief Construct a new composite boundary object
    *
@@ -73,7 +90,7 @@ public:
    * @param quadrature_points Quadrature points object
    */
   composite_boundary(const specfem::compute::boundaries &boundary_conditions,
-                     const quadrature_points_type &quadrature_points);
+                     const quadrature_points_type &quadrature_points){};
 
   /**
    * @brief Compute the contribution of composite boundaries to the mass term

--- a/include/enumerations/boundary_conditions/composite_boundary.tpp
+++ b/include/enumerations/boundary_conditions/composite_boundary.tpp
@@ -8,33 +8,33 @@
 #include "enumerations/quadrature.hpp"
 #include "enumerations/specfem_enums.hpp"
 
-template <typename... properties>
-specfem::enums::boundary_conditions::composite_boundary<
-    specfem::enums::boundary_conditions::stacey<properties...>,
-    specfem::enums::boundary_conditions::dirichlet<properties...> >::
-    composite_boundary(const specfem::compute::boundaries &boundary_conditions,
-                       const quadrature_points_type &quadrature_points)
-    : stacey(quadrature_points,
-             boundary_conditions.composite_stacey_dirichlet.type),
-      dirichlet(quadrature_points,
-                boundary_conditions.composite_stacey_dirichlet.type) {
+// template <typename... properties>
+// specfem::enums::boundary_conditions::composite_boundary<
+//     specfem::enums::boundary_conditions::stacey<properties...>,
+//     specfem::enums::boundary_conditions::dirichlet<properties...> >::
+//     composite_boundary(const specfem::compute::boundaries &boundary_conditions,
+//                        const quadrature_points_type &quadrature_points)
+//     : stacey(quadrature_points,
+//              boundary_conditions.composite_stacey_dirichlet.type),
+//       dirichlet(quadrature_points,
+//                 boundary_conditions.composite_stacey_dirichlet.type) {
 
-  static_assert(
-      std::is_same<typename stacey_type::medium_type,
-                   typename dirichlet_type::medium_type>::value,
-      "Medium types must be the same for composite boundary conditions.");
-  static_assert(
-      std::is_same<typename stacey_type::dimension,
-                   typename dirichlet_type::dimension>::value,
-      "Dimensions must be the same for composite boundary conditions.");
-  static_assert(
-      std::is_same<typename stacey_type::quadrature_points_type,
-                   typename dirichlet_type::quadrature_points_type>::value,
-      "Quadrature points must be the same for composite boundary conditions.");
-  static_assert(
-      std::is_same<typename stacey_type::property_type,
-                   typename dirichlet_type::property_type>::value,
-      "Property types must be the same for composite boundary conditions.");
-}
+//   static_assert(
+//       std::is_same<typename stacey_type::medium_type,
+//                    typename dirichlet_type::medium_type>::value,
+//       "Medium types must be the same for composite boundary conditions.");
+//   static_assert(
+//       std::is_same<typename stacey_type::dimension,
+//                    typename dirichlet_type::dimension>::value,
+//       "Dimensions must be the same for composite boundary conditions.");
+//   static_assert(
+//       std::is_same<typename stacey_type::quadrature_points_type,
+//                    typename dirichlet_type::quadrature_points_type>::value,
+//       "Quadrature points must be the same for composite boundary conditions.");
+//   static_assert(
+//       std::is_same<typename stacey_type::property_type,
+//                    typename dirichlet_type::property_type>::value,
+//       "Property types must be the same for composite boundary conditions.");
+// }
 
 #endif /* _ENUMS_BOUNDARY_CONDITIONS_COMPOSITE_BOUNDARY_TPP_ */

--- a/include/enumerations/boundary_conditions/dirichlet.hpp
+++ b/include/enumerations/boundary_conditions/dirichlet.hpp
@@ -164,11 +164,12 @@ public:
    * @return KOKKOS_INLINE_FUNCTION
    */
   KOKKOS_FUNCTION void enforce_traction(
-      const int &ielement, const int &xz,
+      const int &xz,
       const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
       const specfem::point::partial_derivatives2 &partial_derivatives,
       const specfem::point::properties<medium_type::value, property_type::value>
           &properties,
+      const specfem::point::boundary &boundary_type,
       const specfem::kokkos::array_type<type_real, medium_type::components>
           &field_dot,
       specfem::kokkos::array_type<type_real, medium_type::components>

--- a/include/enumerations/boundary_conditions/dirichlet.hpp
+++ b/include/enumerations/boundary_conditions/dirichlet.hpp
@@ -6,6 +6,8 @@
 #include "enumerations/interface.hpp"
 #include "enumerations/quadrature.hpp"
 #include "enumerations/specfem_enums.hpp"
+#include "point/partial_derivatives.hpp"
+#include "point/properties.hpp"
 #include <Kokkos_Core.hpp>
 
 namespace specfem {
@@ -100,11 +102,12 @@ public:
    */
   template <specfem::enums::time_scheme::type time_scheme>
   KOKKOS_INLINE_FUNCTION void mass_time_contribution(
-      const int &ielement, const int &xz, const type_real &dt,
+      const int &xz, const type_real &dt,
       const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
       const specfem::point::partial_derivatives2 &partial_derivatives,
       const specfem::point::properties<medium_type::value, property_type::value>
           &properties,
+      const specfem::point::boundary &boundary_type,
       specfem::kokkos::array_type<type_real, medium_type::components>
           &rmass_inverse) const {};
 

--- a/include/enumerations/boundary_conditions/dirichlet.hpp
+++ b/include/enumerations/boundary_conditions/dirichlet.hpp
@@ -1,7 +1,7 @@
 #ifndef _ENUMS_BOUNDARY_CONDITIONS_DIRICHLET_HPP_
 #define _ENUMS_BOUNDARY_CONDITIONS_DIRICHLET_HPP_
 
-#include "compute/compute_boundaries.hpp"
+// #include "compute/compute_boundaries.hpp"
 #include "enumerations/dimension.hpp"
 #include "enumerations/interface.hpp"
 #include "enumerations/quadrature.hpp"

--- a/include/enumerations/boundary_conditions/dirichlet.hpp
+++ b/include/enumerations/boundary_conditions/dirichlet.hpp
@@ -121,8 +121,9 @@ public:
    * @param df_dz Gradient of field in z-direction to update
    */
   KOKKOS_INLINE_FUNCTION void enforce_gradient(
-      const int &ielement, const int &xz,
+      const int &xz,
       const specfem::point::partial_derivatives2 &partial_derivatives,
+      const specfem::point::boundary &boundary_type,
       specfem::kokkos::array_type<type_real, medium_type::components> &df_dx,
       specfem::kokkos::array_type<type_real, medium_type::components> &df_dz)
       const {};
@@ -139,10 +140,11 @@ public:
    * @return KOKKOS_INLINE_FUNCTION
    */
   KOKKOS_INLINE_FUNCTION void enforce_stress(
-      const int &ielement, const int &xz,
+      const int &xz,
       const specfem::point::partial_derivatives2 &partial_derivatives,
       const specfem::point::properties<medium_type::value, property_type::value>
           &properties,
+      const specfem::point::boundary &boundary_type,
       specfem::kokkos::array_type<type_real, medium_type::components>
           &stress_integrand_xi,
       specfem::kokkos::array_type<type_real, medium_type::components>

--- a/include/enumerations/boundary_conditions/dirichlet.hpp
+++ b/include/enumerations/boundary_conditions/dirichlet.hpp
@@ -71,8 +71,7 @@ public:
    * @param type type of the edge on an element on the boundary.
    */
   dirichlet(const quadrature_points_type &quadrature_points,
-            const specfem::kokkos::DeviceView1d<
-                specfem::compute::access::boundary_types> &type)
+            const specfem::kokkos::DeviceView1d<specfem::point::boundary> &type)
       : quadrature_points(quadrature_points), type(type) {}
 
   /**
@@ -84,7 +83,7 @@ public:
    * points either at compile time or run time.
    */
   dirichlet(const specfem::compute::boundaries &boundary_conditions,
-            const quadrature_points_type &quadrature_points);
+            const quadrature_points_type &quadrature_points){};
 
   /**
    * @brief Compute the mass time contribution for the boundary condition
@@ -103,9 +102,9 @@ public:
   KOKKOS_INLINE_FUNCTION void mass_time_contribution(
       const int &ielement, const int &xz, const type_real &dt,
       const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
-      const specfem::compute::element_partial_derivatives &partial_derivatives,
-      const specfem::compute::element_properties<
-          medium_type::value, property_type::value> &properties,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
+      const specfem::point::properties<medium_type::value, property_type::value>
+          &properties,
       specfem::kokkos::array_type<type_real, medium_type::components>
           &rmass_inverse) const {};
 
@@ -120,7 +119,7 @@ public:
    */
   KOKKOS_INLINE_FUNCTION void enforce_gradient(
       const int &ielement, const int &xz,
-      const specfem::compute::element_partial_derivatives &partial_derivatives,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
       specfem::kokkos::array_type<type_real, medium_type::components> &df_dx,
       specfem::kokkos::array_type<type_real, medium_type::components> &df_dz)
       const {};
@@ -138,9 +137,9 @@ public:
    */
   KOKKOS_INLINE_FUNCTION void enforce_stress(
       const int &ielement, const int &xz,
-      const specfem::compute::element_partial_derivatives &partial_derivatives,
-      const specfem::compute::element_properties<
-          medium_type::value, property_type::value> &properties,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
+      const specfem::point::properties<medium_type::value, property_type::value>
+          &properties,
       specfem::kokkos::array_type<type_real, medium_type::components>
           &stress_integrand_xi,
       specfem::kokkos::array_type<type_real, medium_type::components>
@@ -162,9 +161,9 @@ public:
   KOKKOS_FUNCTION void enforce_traction(
       const int &ielement, const int &xz,
       const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
-      const specfem::compute::element_partial_derivatives &partial_derivatives,
-      const specfem::compute::element_properties<
-          medium_type::value, property_type::value> &properties,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
+      const specfem::point::properties<medium_type::value, property_type::value>
+          &properties,
       const specfem::kokkos::array_type<type_real, medium_type::components>
           &field_dot,
       specfem::kokkos::array_type<type_real, medium_type::components>
@@ -177,7 +176,7 @@ public:
   inline static std::string to_string() { return "Dirichlet"; }
 
 private:
-  specfem::kokkos::DeviceView1d<specfem::compute::access::boundary_types>
+  specfem::kokkos::DeviceView1d<specfem::point::boundary>
       type; ///< type of the edge on an element on the boundary.
   quadrature_points_type quadrature_points; ///< Quadrature points object.
 };

--- a/include/enumerations/boundary_conditions/dirichlet.tpp
+++ b/include/enumerations/boundary_conditions/dirichlet.tpp
@@ -23,11 +23,12 @@
 template <typename dim, typename medium, typename property, typename qp_type>
 KOKKOS_INLINE_FUNCTION void specfem::enums::boundary_conditions::
     dirichlet<dim, medium, property, qp_type>::enforce_traction(
-        const int &ielement, const int &xz,
+        const int &xz,
         const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
         const specfem::point::partial_derivatives2 &partial_derivatives,
         const specfem::point::properties<medium_type::value,
                                          property_type::value> &properties,
+        const specfem::point::boundary &boundary_type,
         const specfem::kokkos::array_type<type_real, medium_type::components>
             &field_dot,
         specfem::kokkos::array_type<type_real, medium_type::components>
@@ -42,8 +43,8 @@ KOKKOS_INLINE_FUNCTION void specfem::enums::boundary_conditions::
   int ix, iz;
   sub2ind(xz, ngllx, iz, ix);
 
-  const auto itype = this->type(ielement);
-  if (!specfem::point::is_on_boundary(value_t, itype, iz, ix, ngllz, ngllx)) {
+  if (!specfem::point::is_on_boundary(value_t, boundary_type, iz, ix, ngllz,
+                                      ngllx)) {
     return;
   }
 

--- a/include/enumerations/boundary_conditions/dirichlet.tpp
+++ b/include/enumerations/boundary_conditions/dirichlet.tpp
@@ -6,10 +6,13 @@
 #include "enumerations/dimension.hpp"
 #include "enumerations/quadrature.hpp"
 #include "enumerations/specfem_enums.hpp"
+#include "point/partial_derivatives.hpp"
+#include "point/properties.hpp"
 #include <Kokkos_Core.hpp>
 
 // template <typename dim, typename medium, typename property, typename qp_type>
-// specfem::enums::boundary_conditions::dirichlet<dim, medium, property, qp_type>::
+// specfem::enums::boundary_conditions::dirichlet<dim, medium, property,
+// qp_type>::
 //     dirichlet(const specfem::compute::boundaries &boundary_conditions,
 //               const quadrature_points_type &quadrature_points)
 //     : quadrature_points(quadrature_points),
@@ -22,10 +25,9 @@ KOKKOS_INLINE_FUNCTION void specfem::enums::boundary_conditions::
     dirichlet<dim, medium, property, qp_type>::enforce_traction(
         const int &ielement, const int &xz,
         const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
-        const specfem::compute::element_partial_derivatives
-            &partial_derivatives,
-        const specfem::compute::element_properties<
-            medium_type::value, property_type::value> &properties,
+        const specfem::point::partial_derivatives2 &partial_derivatives,
+        const specfem::point::properties<medium_type::value,
+                                         property_type::value> &properties,
         const specfem::kokkos::array_type<type_real, medium_type::components>
             &field_dot,
         specfem::kokkos::array_type<type_real, medium_type::components>
@@ -41,8 +43,7 @@ KOKKOS_INLINE_FUNCTION void specfem::enums::boundary_conditions::
   sub2ind(xz, ngllx, iz, ix);
 
   const auto itype = this->type(ielement);
-  if (!specfem::compute::access::is_on_boundary(value_t, itype, iz, ix, ngllz,
-                                                ngllx)) {
+  if (!specfem::point::is_on_boundary(value_t, itype, iz, ix, ngllz, ngllx)) {
     return;
   }
 

--- a/include/enumerations/boundary_conditions/dirichlet.tpp
+++ b/include/enumerations/boundary_conditions/dirichlet.tpp
@@ -8,14 +8,14 @@
 #include "enumerations/specfem_enums.hpp"
 #include <Kokkos_Core.hpp>
 
-template <typename dim, typename medium, typename property, typename qp_type>
-specfem::enums::boundary_conditions::dirichlet<dim, medium, property, qp_type>::
-    dirichlet(const specfem::compute::boundaries &boundary_conditions,
-              const quadrature_points_type &quadrature_points)
-    : quadrature_points(quadrature_points),
-      type(boundary_conditions.acoustic_free_surface.type) {
-  return;
-}
+// template <typename dim, typename medium, typename property, typename qp_type>
+// specfem::enums::boundary_conditions::dirichlet<dim, medium, property, qp_type>::
+//     dirichlet(const specfem::compute::boundaries &boundary_conditions,
+//               const quadrature_points_type &quadrature_points)
+//     : quadrature_points(quadrature_points),
+//       type(boundary_conditions.acoustic_free_surface.type) {
+//   return;
+// }
 
 template <typename dim, typename medium, typename property, typename qp_type>
 KOKKOS_INLINE_FUNCTION void specfem::enums::boundary_conditions::

--- a/include/enumerations/boundary_conditions/interface.hpp
+++ b/include/enumerations/boundary_conditions/interface.hpp
@@ -1,11 +1,11 @@
 #ifndef _ENUMS_BOUNDARY_CONDITIONS_INTERFACE_HPP_
 #define _ENUMS_BOUNDARY_CONDITIONS_INTERFACE_HPP_
 
-#include "composite_boundary.hpp"
-#include "composite_boundary.tpp"
-#include "dirichlet.hpp"
-#include "dirichlet.tpp"
-#include "none.hpp"
-#include "stacey/interface.hpp"
+// #include "composite_boundary.hpp"
+// #include "composite_boundary.tpp"
+// #include "dirichlet.hpp"
+// #include "dirichlet.tpp"
+// #include "none.hpp"
+// #include "stacey/interface.hpp"
 
 #endif /* _ENUMS_BOUNDARY_CONDITIONS_INTERFACE_HPP_ */

--- a/include/enumerations/boundary_conditions/interface.hpp
+++ b/include/enumerations/boundary_conditions/interface.hpp
@@ -1,11 +1,11 @@
 #ifndef _ENUMS_BOUNDARY_CONDITIONS_INTERFACE_HPP_
 #define _ENUMS_BOUNDARY_CONDITIONS_INTERFACE_HPP_
 
-// #include "composite_boundary.hpp"
-// #include "composite_boundary.tpp"
-// #include "dirichlet.hpp"
-// #include "dirichlet.tpp"
-// #include "none.hpp"
-// #include "stacey/interface.hpp"
+#include "composite_boundary.hpp"
+#include "composite_boundary.tpp"
+#include "dirichlet.hpp"
+#include "dirichlet.tpp"
+#include "none.hpp"
+#include "stacey/interface.hpp"
 
 #endif /* _ENUMS_BOUNDARY_CONDITIONS_INTERFACE_HPP_ */

--- a/include/enumerations/boundary_conditions/none.hpp
+++ b/include/enumerations/boundary_conditions/none.hpp
@@ -148,11 +148,12 @@ public:
    * @return KOKKOS_INLINE_FUNCTION
    */
   KOKKOS_INLINE_FUNCTION void enforce_traction(
-      const int &ielement, const int &xz,
+      const int &xz,
       const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
       const specfem::point::partial_derivatives2 &partial_derivatives,
       const specfem::point::properties<medium_type::value, property_type::value>
           &properties,
+      const specfem::point::boundary &boundary_type,
       const specfem::kokkos::array_type<type_real, medium_type::components>
           &field_dot,
       specfem::kokkos::array_type<type_real, medium_type::components>

--- a/include/enumerations/boundary_conditions/none.hpp
+++ b/include/enumerations/boundary_conditions/none.hpp
@@ -105,8 +105,9 @@ public:
    * @param df_dz Gradient of field in z-direction to update
    */
   KOKKOS_INLINE_FUNCTION void enforce_gradient(
-      const int &ielement, const int &xz,
+      const int &xz,
       const specfem::point::partial_derivatives2 &partial_derivatives,
+      const specfem::point::boundary &boundary_type,
       specfem::kokkos::array_type<type_real, medium_type::components> &df_dx,
       specfem::kokkos::array_type<type_real, medium_type::components> &df_dz)
       const {};
@@ -123,10 +124,11 @@ public:
    * @return KOKKOS_INLINE_FUNCTION
    */
   KOKKOS_INLINE_FUNCTION void enforce_stress(
-      const int &ielement, const int &xz,
+      const int &xz,
       const specfem::point::partial_derivatives2 &partial_derivatives,
       const specfem::point::properties<medium_type::value, property_type::value>
           &properties,
+      const specfem::point::boundary &boundary_type,
       specfem::kokkos::array_type<type_real, medium_type::components>
           &stress_integrand_xi,
       specfem::kokkos::array_type<type_real, medium_type::components>

--- a/include/enumerations/boundary_conditions/none.hpp
+++ b/include/enumerations/boundary_conditions/none.hpp
@@ -88,9 +88,9 @@ public:
   KOKKOS_INLINE_FUNCTION void mass_time_contribution(
       const int &ielement, const int &xz, const type_real &dt,
       const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
-      const specfem::compute::element_partial_derivatives &partial_derivatives,
-      const specfem::compute::element_properties<
-          medium_type::value, property_type::value> &properties,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
+      const specfem::point::properties<medium_type::value, property_type::value>
+          &properties,
       specfem::kokkos::array_type<type_real, medium_type::components>
           &rmass_inverse) const {};
 
@@ -105,7 +105,7 @@ public:
    */
   KOKKOS_INLINE_FUNCTION void enforce_gradient(
       const int &ielement, const int &xz,
-      const specfem::compute::element_partial_derivatives &partial_derivatives,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
       specfem::kokkos::array_type<type_real, medium_type::components> &df_dx,
       specfem::kokkos::array_type<type_real, medium_type::components> &df_dz)
       const {};
@@ -123,9 +123,9 @@ public:
    */
   KOKKOS_INLINE_FUNCTION void enforce_stress(
       const int &ielement, const int &xz,
-      const specfem::compute::element_partial_derivatives &partial_derivatives,
-      const specfem::compute::element_properties<
-          medium_type::value, property_type::value> &properties,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
+      const specfem::point::properties<medium_type::value, property_type::value>
+          &properties,
       specfem::kokkos::array_type<type_real, medium_type::components>
           &stress_integrand_xi,
       specfem::kokkos::array_type<type_real, medium_type::components>
@@ -147,9 +147,9 @@ public:
   KOKKOS_INLINE_FUNCTION void enforce_traction(
       const int &ielement, const int &xz,
       const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
-      const specfem::compute::element_partial_derivatives &partial_derivatives,
-      const specfem::compute::element_properties<
-          medium_type::value, property_type::value> &properties,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
+      const specfem::point::properties<medium_type::value, property_type::value>
+          &properties,
       const specfem::kokkos::array_type<type_real, medium_type::components>
           &field_dot,
       specfem::kokkos::array_type<type_real, medium_type::components>

--- a/include/enumerations/boundary_conditions/none.hpp
+++ b/include/enumerations/boundary_conditions/none.hpp
@@ -86,11 +86,12 @@ public:
    */
   template <specfem::enums::time_scheme::type time_scheme>
   KOKKOS_INLINE_FUNCTION void mass_time_contribution(
-      const int &ielement, const int &xz, const type_real &dt,
+      const int &xz, const type_real &dt,
       const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
       const specfem::point::partial_derivatives2 &partial_derivatives,
       const specfem::point::properties<medium_type::value, property_type::value>
           &properties,
+      const specfem::point::boundary &boundary_type,
       specfem::kokkos::array_type<type_real, medium_type::components>
           &rmass_inverse) const {};
 

--- a/include/enumerations/boundary_conditions/stacey/stacey2d_acoustic.hpp
+++ b/include/enumerations/boundary_conditions/stacey/stacey2d_acoustic.hpp
@@ -70,8 +70,7 @@ public:
    * left, right etc.)
    */
   stacey(const quadrature_points_type &quadrature_points,
-         const specfem::kokkos::DeviceView1d<
-             specfem::compute::access::boundary_types> &type)
+         const specfem::kokkos::DeviceView1d<specfem::point::boundary> &type)
       : quadrature_points(quadrature_points), type(type) {}
 
   /**
@@ -82,7 +81,7 @@ public:
    * @param quadrature_points Quadrature points object
    */
   stacey(const specfem::compute::boundaries &boundary_conditions,
-         const quadrature_points_type &quadrature_points);
+         const quadrature_points_type &quadrature_points){};
 
   /**
    * @brief Compute the mass time contribution for the boundary condition
@@ -99,11 +98,12 @@ public:
    */
   template <specfem::enums::time_scheme::type time_scheme>
   KOKKOS_INLINE_FUNCTION void mass_time_contribution(
-      const int &ielement, const int &xz, const type_real &dt,
+      const int &xz, const type_real &dt,
       const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
-      const specfem::compute::element_partial_derivatives &partial_derivatives,
-      const specfem::compute::element_properties<
-          medium_type::value, property_type::value> &properties,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
+      const specfem::point::properties<medium_type::value, property_type::value>
+          &properties,
+      const specfem::point::boundary &boundary_type,
       specfem::kokkos::array_type<type_real, medium_type::components>
           &mass_matrix) const;
 
@@ -119,7 +119,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   void enforce_gradient(
       const int &ielement, const int &xz,
-      const specfem::compute::element_partial_derivatives &partial_derivatives,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
       specfem::kokkos::array_type<type_real, medium_type::components> &df_dx,
       specfem::kokkos::array_type<type_real, medium_type::components> &df_dz)
       const {};
@@ -137,9 +137,9 @@ public:
    */
   KOKKOS_INLINE_FUNCTION void enforce_stress(
       const int &ielement, const int &xz,
-      const specfem::compute::element_partial_derivatives &partial_derivatives,
-      const specfem::compute::element_properties<
-          medium_type::value, property_type::value> &properties,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
+      const specfem::point::properties<medium_type::value, property_type::value>
+          &properties,
       specfem::kokkos::array_type<type_real, medium_type::components>
           &stress_integrand_xi,
       specfem::kokkos::array_type<type_real, medium_type::components>
@@ -161,9 +161,9 @@ public:
   KOKKOS_INLINE_FUNCTION void enforce_traction(
       const int &ielement, const int &xz,
       const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
-      const specfem::compute::element_partial_derivatives &partial_derivatives,
-      const specfem::compute::element_properties<
-          medium_type::value, property_type::value> &properties,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
+      const specfem::point::properties<medium_type::value, property_type::value>
+          &properties,
       const specfem::kokkos::array_type<type_real, medium_type::components>
           &velocity,
       specfem::kokkos::array_type<type_real, medium_type::components>
@@ -178,7 +178,7 @@ public:
 
 private:
   quadrature_points_type quadrature_points; ///< Quadrature points object.
-  specfem::kokkos::DeviceView1d<specfem::compute::access::boundary_types>
+  specfem::kokkos::DeviceView1d<specfem::point::boundary>
       type; ///< type of the edge on an element on the boundary.
 };
 } // namespace boundary_conditions

--- a/include/enumerations/boundary_conditions/stacey/stacey2d_acoustic.hpp
+++ b/include/enumerations/boundary_conditions/stacey/stacey2d_acoustic.hpp
@@ -118,8 +118,9 @@ public:
    */
   KOKKOS_INLINE_FUNCTION
   void enforce_gradient(
-      const int &ielement, const int &xz,
+      const int &xz,
       const specfem::point::partial_derivatives2 &partial_derivatives,
+      const specfem::point::boundary &boundary_type,
       specfem::kokkos::array_type<type_real, medium_type::components> &df_dx,
       specfem::kokkos::array_type<type_real, medium_type::components> &df_dz)
       const {};
@@ -136,10 +137,11 @@ public:
    * @return KOKKOS_INLINE_FUNCTION
    */
   KOKKOS_INLINE_FUNCTION void enforce_stress(
-      const int &ielement, const int &xz,
+      const int &xz,
       const specfem::point::partial_derivatives2 &partial_derivatives,
       const specfem::point::properties<medium_type::value, property_type::value>
           &properties,
+      const specfem::point::boundary &boundary_type,
       specfem::kokkos::array_type<type_real, medium_type::components>
           &stress_integrand_xi,
       specfem::kokkos::array_type<type_real, medium_type::components>

--- a/include/enumerations/boundary_conditions/stacey/stacey2d_acoustic.hpp
+++ b/include/enumerations/boundary_conditions/stacey/stacey2d_acoustic.hpp
@@ -161,11 +161,12 @@ public:
    * @return KOKKOS_INLINE_FUNCTION
    */
   KOKKOS_INLINE_FUNCTION void enforce_traction(
-      const int &ielement, const int &xz,
+      const int &xz,
       const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
       const specfem::point::partial_derivatives2 &partial_derivatives,
       const specfem::point::properties<medium_type::value, property_type::value>
           &properties,
+      const specfem::point::boundary &boundary_type,
       const specfem::kokkos::array_type<type_real, medium_type::components>
           &velocity,
       specfem::kokkos::array_type<type_real, medium_type::components>

--- a/include/enumerations/boundary_conditions/stacey/stacey2d_acoustic.tpp
+++ b/include/enumerations/boundary_conditions/stacey/stacey2d_acoustic.tpp
@@ -58,11 +58,14 @@ KOKKOS_FUNCTION void newmark_mass_terms(
     case specfem::enums::edge::type::LEFT:
     case specfem::enums::edge::type::RIGHT:
       return weight[1];
+      break;
     case specfem::enums::edge::type::BOTTOM:
     case specfem::enums::edge::type::TOP:
       return weight[0];
+      break;
     default:
       return static_cast<type_real>(0.0);
+      break;
     }
   }();
 
@@ -223,11 +226,14 @@ KOKKOS_INLINE_FUNCTION void specfem::enums::boundary_conditions::stacey<
     case specfem::enums::edge::type::LEFT:
     case specfem::enums::edge::type::RIGHT:
       return weight[1];
+      break;
     case specfem::enums::edge::type::BOTTOM:
     case specfem::enums::edge::type::TOP:
       return weight[0];
+      break;
     default:
       return static_cast<type_real>(0.0);
+      break;
     }
   }();
 

--- a/include/enumerations/boundary_conditions/stacey/stacey2d_elastic.hpp
+++ b/include/enumerations/boundary_conditions/stacey/stacey2d_elastic.hpp
@@ -117,8 +117,9 @@ public:
    */
   KOKKOS_INLINE_FUNCTION
   void enforce_gradient(
-      const int &ielement, const int &xz,
+      const int &xz,
       const specfem::point::partial_derivatives2 &partial_derivatives,
+      const specfem::point::boundary &boundary_type,
       specfem::kokkos::array_type<type_real, medium_type::components> &df_dx,
       specfem::kokkos::array_type<type_real, medium_type::components> &df_dz)
       const {};
@@ -135,10 +136,11 @@ public:
    * @return KOKKOS_INLINE_FUNCTION
    */
   KOKKOS_INLINE_FUNCTION void enforce_stress(
-      const int &ielement, const int &xz,
+      const int &xz,
       const specfem::point::partial_derivatives2 &partial_derivatives,
       const specfem::point::properties<medium_type::value, property_type::value>
           &properties,
+      const specfem::point::boundary &boundary_type,
       specfem::kokkos::array_type<type_real, medium_type::components>
           &stress_integrand_xi,
       specfem::kokkos::array_type<type_real, medium_type::components>

--- a/include/enumerations/boundary_conditions/stacey/stacey2d_elastic.hpp
+++ b/include/enumerations/boundary_conditions/stacey/stacey2d_elastic.hpp
@@ -160,11 +160,12 @@ public:
    * @return KOKKOS_INLINE_FUNCTION
    */
   KOKKOS_INLINE_FUNCTION void enforce_traction(
-      const int &ielement, const int &xz,
+      const int &xz,
       const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
       const specfem::point::partial_derivatives2 &partial_derivatives,
       const specfem::point::properties<medium_type::value, property_type::value>
           &properties,
+      const specfem::point::boundary &boundary_type,
       const specfem::kokkos::array_type<type_real, medium_type::components>
           &velocity,
       specfem::kokkos::array_type<type_real, medium_type::components>

--- a/include/enumerations/boundary_conditions/stacey/stacey2d_elastic.hpp
+++ b/include/enumerations/boundary_conditions/stacey/stacey2d_elastic.hpp
@@ -69,8 +69,7 @@ public:
    * @param type Type of the boundary
    */
   stacey(const quadrature_points_type &quadrature_points,
-         const specfem::kokkos::DeviceView1d<
-             specfem::compute::access::boundary_types> &type)
+         const specfem::kokkos::DeviceView1d<specfem::point::boundary> &type)
       : quadrature_points(quadrature_points), type(type) {}
 
   /**
@@ -81,7 +80,7 @@ public:
    * @param quadrature_points Quadrature points object
    */
   stacey(const specfem::compute::boundaries &boundary_conditions,
-         const quadrature_points_type &quadrature_points);
+         const quadrature_points_type &quadrature_points){};
 
   /**
    * @brief Compute the mass time contribution for the boundary condition
@@ -98,11 +97,12 @@ public:
    */
   template <specfem::enums::time_scheme::type time_scheme>
   KOKKOS_INLINE_FUNCTION void mass_time_contribution(
-      const int &ielement, const int &xz, const type_real &dt,
+      const int &xz, const type_real &dt,
       const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
-      const specfem::compute::element_partial_derivatives &partial_derivatives,
-      const specfem::compute::element_properties<
-          medium_type::value, property_type::value> &properties,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
+      const specfem::point::properties<medium_type::value, property_type::value>
+          &properties,
+      const specfem::point::boundary &boundary_type,
       specfem::kokkos::array_type<type_real, medium_type::components>
           &mass_matrix) const;
 
@@ -118,7 +118,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   void enforce_gradient(
       const int &ielement, const int &xz,
-      const specfem::compute::element_partial_derivatives &partial_derivatives,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
       specfem::kokkos::array_type<type_real, medium_type::components> &df_dx,
       specfem::kokkos::array_type<type_real, medium_type::components> &df_dz)
       const {};
@@ -136,9 +136,9 @@ public:
    */
   KOKKOS_INLINE_FUNCTION void enforce_stress(
       const int &ielement, const int &xz,
-      const specfem::compute::element_partial_derivatives &partial_derivatives,
-      const specfem::compute::element_properties<
-          medium_type::value, property_type::value> &properties,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
+      const specfem::point::properties<medium_type::value, property_type::value>
+          &properties,
       specfem::kokkos::array_type<type_real, medium_type::components>
           &stress_integrand_xi,
       specfem::kokkos::array_type<type_real, medium_type::components>
@@ -160,9 +160,9 @@ public:
   KOKKOS_INLINE_FUNCTION void enforce_traction(
       const int &ielement, const int &xz,
       const specfem::kokkos::array_type<type_real, dimension::dim> &weight,
-      const specfem::compute::element_partial_derivatives &partial_derivatives,
-      const specfem::compute::element_properties<
-          medium_type::value, property_type::value> &properties,
+      const specfem::point::partial_derivatives2 &partial_derivatives,
+      const specfem::point::properties<medium_type::value, property_type::value>
+          &properties,
       const specfem::kokkos::array_type<type_real, medium_type::components>
           &velocity,
       specfem::kokkos::array_type<type_real, medium_type::components>
@@ -177,7 +177,7 @@ public:
 
 private:
   quadrature_points_type quadrature_points; ///< Quadrature points object.
-  specfem::kokkos::DeviceView1d<specfem::compute::access::boundary_types>
+  specfem::kokkos::DeviceView1d<specfem::point::boundary>
       type; ///< type of the edge on an element on the boundary.
 };
 } // namespace boundary_conditions

--- a/include/enumerations/boundary_conditions/stacey/stacey2d_elastic.tpp
+++ b/include/enumerations/boundary_conditions/stacey/stacey2d_elastic.tpp
@@ -14,7 +14,7 @@ namespace {
 KOKKOS_FUNCTION void enforce_traction_boundary(
     const type_real &weight,
     const specfem::kokkos::array_type<type_real, 2> &dn,
-    const specfem::compute::element_properties<
+    const specfem::point::properties<
         specfem::enums::element::type::elastic,
         specfem::enums::element::property_tag::isotropic> &properties,
     const specfem::kokkos::array_type<type_real, 2> &field_dot,
@@ -43,12 +43,12 @@ KOKKOS_FUNCTION void enforce_traction_boundary(
 template <specfem::enums::element::property_tag property>
 KOKKOS_FUNCTION void newmark_mass_terms(
     const int &ix, const int &iz, const int &ngllx, const int &ngllz,
-    const type_real &dt, const specfem::compute::access::boundary_types &itype,
+    const type_real &dt, const specfem::point::boundary &boundary_type,
     const specfem::enums::element::boundary_tag &tag,
     const specfem::kokkos::array_type<type_real, 2> &weight,
-    const specfem::compute::element_partial_derivatives &partial_derivatives,
-    const specfem::compute::element_properties<
-        specfem::enums::element::type::elastic, property> &properties,
+    const specfem::point::partial_derivatives2 &partial_derivatives,
+    const specfem::point::properties<specfem::enums::element::type::elastic,
+                                     property> &properties,
     specfem::kokkos::array_type<type_real, 2> &rmass_inverse) {
 
   specfem::kokkos::array_type<type_real, 2> velocity;
@@ -59,7 +59,7 @@ KOKKOS_FUNCTION void newmark_mass_terms(
   specfem::kokkos::array_type<type_real, 2> dn;
 
   // Left Boundary
-  if (itype.left == tag && ix == 0) {
+  if (boundary_type.left == tag && ix == 0) {
     dn = partial_derivatives
              .compute_normal<specfem::enums::boundaries::type::LEFT>();
     enforce_traction_boundary(weight[1], dn, properties, velocity,
@@ -68,7 +68,7 @@ KOKKOS_FUNCTION void newmark_mass_terms(
   }
 
   // Right Boundary
-  if (itype.right == tag && ix == ngllx - 1) {
+  if (boundary_type.right == tag && ix == ngllx - 1) {
     dn = partial_derivatives
              .compute_normal<specfem::enums::boundaries::type::RIGHT>();
     enforce_traction_boundary(weight[1], dn, properties, velocity,
@@ -77,7 +77,7 @@ KOKKOS_FUNCTION void newmark_mass_terms(
   }
 
   // Top Boundary
-  if (itype.top == tag && iz == ngllz - 1) {
+  if (boundary_type.top == tag && iz == ngllz - 1) {
     dn = partial_derivatives
              .compute_normal<specfem::enums::boundaries::type::TOP>();
     enforce_traction_boundary(weight[0], dn, properties, velocity,
@@ -86,7 +86,7 @@ KOKKOS_FUNCTION void newmark_mass_terms(
   }
 
   // Bottom Boundary
-  if (itype.bottom == tag && iz == 0) {
+  if (boundary_type.bottom == tag && iz == 0) {
     dn = partial_derivatives
              .compute_normal<specfem::enums::boundaries::type::BOTTOM>();
     enforce_traction_boundary(weight[0], dn, properties, velocity,
@@ -98,16 +98,16 @@ KOKKOS_FUNCTION void newmark_mass_terms(
 }
 } // namespace
 
-template <typename property, typename qp_type>
-specfem::enums::boundary_conditions::stacey<
-    specfem::enums::element::dimension::dim2,
-    specfem::enums::element::medium::elastic, property,
-    qp_type>::stacey(const specfem::compute::boundaries &boundary_conditions,
-                     const quadrature_points_type &quadrature_points)
-    : quadrature_points(quadrature_points),
-      type(boundary_conditions.stacey.elastic.type) {
-  return;
-}
+// template <typename property, typename qp_type>
+// specfem::enums::boundary_conditions::stacey<
+//     specfem::enums::element::dimension::dim2,
+//     specfem::enums::element::medium::elastic, property,
+//     qp_type>::stacey(const specfem::compute::boundaries &boundary_conditions,
+//                      const quadrature_points_type &quadrature_points)
+//     : quadrature_points(quadrature_points),
+//       type(boundary_conditions.stacey.elastic.type) {
+//   return;
+// }
 
 template <typename property, typename qp_type>
 template <specfem::enums::time_scheme::type time_scheme>
@@ -115,13 +115,12 @@ KOKKOS_INLINE_FUNCTION void specfem::enums::boundary_conditions::stacey<
     specfem::enums::element::dimension::dim2,
     specfem::enums::element::medium::elastic, property, qp_type>::
     mass_time_contribution(
-        const int &ielement, const int &xz, const type_real &dt,
+        const int &xz, const type_real &dt,
         const specfem::kokkos::array_type<type_real, 2> &weight,
-        const specfem::compute::element_partial_derivatives
-            &partial_derivatives,
-        const specfem::compute::element_properties<
-            specfem::enums::element::type::elastic, property_type::value>
-            &properties,
+        const specfem::point::partial_derivatives2 &partial_derivatives,
+        const specfem::point::properties<specfem::enums::element::type::elastic,
+                                         property_type::value> &properties,
+        const specfem::point::boundary &boundary_type,
         specfem::kokkos::array_type<type_real, medium_type::components>
             &rmass_inverse) const {
 
@@ -137,14 +136,14 @@ KOKKOS_INLINE_FUNCTION void specfem::enums::boundary_conditions::stacey<
   int ix, iz;
   sub2ind(xz, ngllx, iz, ix);
 
-  const auto itype = this->type(ielement);
-  if (!specfem::compute::access::is_on_boundary(value_t, itype, iz, ix, ngllz, ngllx)) {
+  if (!specfem::point::is_on_boundary(value_t, boundary_type, iz, ix, ngllz,
+                                      ngllx)) {
     return;
   }
   //--------------------------------------------------------------------------
 
   if constexpr (time_scheme == specfem::enums::time_scheme::type::newmark) {
-    newmark_mass_terms(ix, iz, ngllx, ngllz, dt, itype, value_t, weight,
+    newmark_mass_terms(ix, iz, ngllx, ngllz, dt, boundary_type, value_t, weight,
                        partial_derivatives, properties, rmass_inverse);
     return;
   }
@@ -159,11 +158,9 @@ KOKKOS_INLINE_FUNCTION void specfem::enums::boundary_conditions::stacey<
     enforce_traction(
         const int &ielement, const int &xz,
         const specfem::kokkos::array_type<type_real, 2> &weight,
-        const specfem::compute::element_partial_derivatives
-            &partial_derivatives,
-        const specfem::compute::element_properties<
-            specfem::enums::element::type::elastic, property_type::value>
-            &properties,
+        const specfem::point::partial_derivatives2 &partial_derivatives,
+        const specfem::point::properties<specfem::enums::element::type::elastic,
+                                         property_type::value> &properties,
         const specfem::kokkos::array_type<type_real, 2> &field_dot,
         specfem::kokkos::array_type<type_real, 2> &field_dot_dot) const {
 
@@ -180,8 +177,7 @@ KOKKOS_INLINE_FUNCTION void specfem::enums::boundary_conditions::stacey<
   sub2ind(xz, ngllx, iz, ix);
 
   const auto itype = this->type(ielement);
-  if (!specfem::compute::access::is_on_boundary(value_t, itype, iz, ix,
-                                                ngllz, ngllx)) {
+  if (!specfem::point::is_on_boundary(value_t, itype, iz, ix, ngllz, ngllx)) {
     return;
   }
   //--------------------------------------------------------------------------

--- a/include/enumerations/boundary_conditions/stacey/stacey2d_elastic.tpp
+++ b/include/enumerations/boundary_conditions/stacey/stacey2d_elastic.tpp
@@ -71,11 +71,14 @@ KOKKOS_FUNCTION void newmark_mass_terms(
     case specfem::enums::edge::type::LEFT:
     case specfem::enums::edge::type::RIGHT:
       return weight[1];
+      break;
     case specfem::enums::edge::type::TOP:
     case specfem::enums::edge::type::BOTTOM:
       return weight[0];
+      break;
     default:
       return static_cast<type_real>(0.0);
+      break;
     }
   }();
 
@@ -234,11 +237,14 @@ KOKKOS_INLINE_FUNCTION void specfem::enums::boundary_conditions::stacey<
     case specfem::enums::edge::type::LEFT:
     case specfem::enums::edge::type::RIGHT:
       return weight[1];
+      break;
     case specfem::enums::edge::type::TOP:
     case specfem::enums::edge::type::BOTTOM:
       return weight[0];
+      break;
     default:
       return static_cast<type_real>(0.0);
+      break;
     }
   }();
 

--- a/include/enumerations/boundary_conditions/stacey/stacey2d_elastic.tpp
+++ b/include/enumerations/boundary_conditions/stacey/stacey2d_elastic.tpp
@@ -51,48 +51,77 @@ KOKKOS_FUNCTION void newmark_mass_terms(
                                      property> &properties,
     specfem::kokkos::array_type<type_real, 2> &rmass_inverse) {
 
-  specfem::kokkos::array_type<type_real, 2> velocity;
+  specfem::kokkos::array_type<type_real, 2> velocity(
+      static_cast<type_real>(-1.0 * dt * 0.5));
 
-  velocity[0] = -1.0 * dt * 0.5;
-  velocity[1] = -1.0 * dt * 0.5;
+  const specfem::enums::edge::type edge = [&]() -> specfem::enums::edge::type {
+    if (boundary_type.left == tag && ix == 0)
+      return specfem::enums::edge::type::LEFT;
+    if (boundary_type.right == tag && ix == ngllx - 1)
+      return specfem::enums::edge::type::RIGHT;
+    if (boundary_type.top == tag && iz == ngllz - 1)
+      return specfem::enums::edge::type::TOP;
+    if (boundary_type.bottom == tag && iz == 0)
+      return specfem::enums::edge::type::BOTTOM;
+    return specfem::enums::edge::type::NONE;
+  }();
 
-  specfem::kokkos::array_type<type_real, 2> dn;
+  const type_real factor = [&]() -> type_real {
+    switch (edge) {
+    case specfem::enums::edge::type::LEFT:
+    case specfem::enums::edge::type::RIGHT:
+      return weight[1];
+    case specfem::enums::edge::type::TOP:
+    case specfem::enums::edge::type::BOTTOM:
+      return weight[0];
+    default:
+      return static_cast<type_real>(0.0);
+    }
+  }();
 
-  // Left Boundary
-  if (boundary_type.left == tag && ix == 0) {
-    dn = partial_derivatives
-             .compute_normal<specfem::enums::boundaries::type::LEFT>();
-    enforce_traction_boundary(weight[1], dn, properties, velocity,
-                              rmass_inverse);
+  if (edge == specfem::enums::edge::type::NONE)
     return;
-  }
 
-  // Right Boundary
-  if (boundary_type.right == tag && ix == ngllx - 1) {
-    dn = partial_derivatives
-             .compute_normal<specfem::enums::boundaries::type::RIGHT>();
-    enforce_traction_boundary(weight[1], dn, properties, velocity,
-                              rmass_inverse);
-    return;
-  }
+  const auto dn = partial_derivatives.compute_normal(edge);
+  enforce_traction_boundary(factor, dn, properties, velocity, rmass_inverse);
 
-  // Top Boundary
-  if (boundary_type.top == tag && iz == ngllz - 1) {
-    dn = partial_derivatives
-             .compute_normal<specfem::enums::boundaries::type::TOP>();
-    enforce_traction_boundary(weight[0], dn, properties, velocity,
-                              rmass_inverse);
-    return;
-  }
+  // specfem::kokkos::array_type<type_real, 2> dn;
 
-  // Bottom Boundary
-  if (boundary_type.bottom == tag && iz == 0) {
-    dn = partial_derivatives
-             .compute_normal<specfem::enums::boundaries::type::BOTTOM>();
-    enforce_traction_boundary(weight[0], dn, properties, velocity,
-                              rmass_inverse);
-    return;
-  }
+  // // Left Boundary
+  // if (boundary_type.left == tag && ix == 0) {
+  //   dn = partial_derivatives
+  //            .compute_normal<specfem::enums::boundaries::type::LEFT>();
+  //   enforce_traction_boundary(weight[1], dn, properties, velocity,
+  //                             rmass_inverse);
+  //   return;
+  // }
+
+  // // Right Boundary
+  // if (boundary_type.right == tag && ix == ngllx - 1) {
+  //   dn = partial_derivatives
+  //            .compute_normal<specfem::enums::boundaries::type::RIGHT>();
+  //   enforce_traction_boundary(weight[1], dn, properties, velocity,
+  //                             rmass_inverse);
+  //   return;
+  // }
+
+  // // Top Boundary
+  // if (boundary_type.top == tag && iz == ngllz - 1) {
+  //   dn = partial_derivatives
+  //            .compute_normal<specfem::enums::boundaries::type::TOP>();
+  //   enforce_traction_boundary(weight[0], dn, properties, velocity,
+  //                             rmass_inverse);
+  //   return;
+  // }
+
+  // // Bottom Boundary
+  // if (boundary_type.bottom == tag && iz == 0) {
+  //   dn = partial_derivatives
+  //            .compute_normal<specfem::enums::boundaries::type::BOTTOM>();
+  //   enforce_traction_boundary(weight[0], dn, properties, velocity,
+  //                             rmass_inverse);
+  //   return;
+  // }
 
   return;
 }
@@ -156,11 +185,11 @@ KOKKOS_INLINE_FUNCTION void specfem::enums::boundary_conditions::stacey<
     specfem::enums::element::dimension::dim2,
     specfem::enums::element::medium::elastic, property, qp_type>::
     enforce_traction(
-        const int &ielement, const int &xz,
-        const specfem::kokkos::array_type<type_real, 2> &weight,
+        const int &xz, const specfem::kokkos::array_type<type_real, 2> &weight,
         const specfem::point::partial_derivatives2 &partial_derivatives,
         const specfem::point::properties<specfem::enums::element::type::elastic,
                                          property_type::value> &properties,
+        const specfem::point::boundary &boundary_type,
         const specfem::kokkos::array_type<type_real, 2> &field_dot,
         specfem::kokkos::array_type<type_real, 2> &field_dot_dot) const {
 
@@ -176,8 +205,8 @@ KOKKOS_INLINE_FUNCTION void specfem::enums::boundary_conditions::stacey<
   int ix, iz;
   sub2ind(xz, ngllx, iz, ix);
 
-  const auto itype = this->type(ielement);
-  if (!specfem::point::is_on_boundary(value_t, itype, iz, ix, ngllz, ngllx)) {
+  if (!specfem::point::is_on_boundary(value_t, boundary_type, iz, ix, ngllz,
+                                      ngllx)) {
     return;
   }
   //--------------------------------------------------------------------------
@@ -188,43 +217,74 @@ KOKKOS_INLINE_FUNCTION void specfem::enums::boundary_conditions::stacey<
   // applied top or bottom traction conditions are ignored in this case. This
   // ensures there is no conflict in calculating the normal
 
-  specfem::kokkos::array_type<type_real, dimension::dim> dn;
+  const specfem::enums::edge::type edge = [&]() -> specfem::enums::edge::type {
+    if (boundary_type.left == value_t && ix == 0)
+      return specfem::enums::edge::type::LEFT;
+    if (boundary_type.right == value_t && ix == ngllx - 1)
+      return specfem::enums::edge::type::RIGHT;
+    if (boundary_type.top == value_t && iz == ngllz - 1)
+      return specfem::enums::edge::type::TOP;
+    if (boundary_type.bottom == value_t && iz == 0)
+      return specfem::enums::edge::type::BOTTOM;
+    return specfem::enums::edge::type::NONE;
+  }();
 
-  // Left Boundary
-  if (itype.left == value_t && ix == 0) {
-    dn = partial_derivatives
-             .compute_normal<specfem::enums::boundaries::type::LEFT>();
-    enforce_traction_boundary(weight[1], dn, properties, field_dot,
-                              field_dot_dot);
-    return;
-  }
+  const type_real factor = [&]() -> type_real {
+    switch (edge) {
+    case specfem::enums::edge::type::LEFT:
+    case specfem::enums::edge::type::RIGHT:
+      return weight[1];
+    case specfem::enums::edge::type::TOP:
+    case specfem::enums::edge::type::BOTTOM:
+      return weight[0];
+    default:
+      return static_cast<type_real>(0.0);
+    }
+  }();
 
-  // Right Boundary
-  if (itype.right == value_t && ix == ngllx - 1) {
-    dn = partial_derivatives
-             .compute_normal<specfem::enums::boundaries::type::RIGHT>();
-    enforce_traction_boundary(weight[1], dn, properties, field_dot,
-                              field_dot_dot);
+  if (edge == specfem::enums::edge::type::NONE)
     return;
-  }
 
-  // Top Boundary
-  if (itype.top == value_t && iz == ngllz - 1) {
-    dn = partial_derivatives
-             .compute_normal<specfem::enums::boundaries::type::TOP>();
-    enforce_traction_boundary(weight[0], dn, properties, field_dot,
-                              field_dot_dot);
-    return;
-  }
+  const auto dn = partial_derivatives.compute_normal(edge);
+  enforce_traction_boundary(factor, dn, properties, field_dot, field_dot_dot);
 
-  // Bottom Boundary
-  if (itype.bottom == value_t && iz == 0) {
-    dn = partial_derivatives
-             .compute_normal<specfem::enums::boundaries::type::BOTTOM>();
-    enforce_traction_boundary(weight[0], dn, properties, field_dot,
-                              field_dot_dot);
-    return;
-  }
+  // specfem::kokkos::array_type<type_real, dimension::dim> dn;
+
+  // // Left Boundary
+  // if (itype.left == value_t && ix == 0) {
+  //   dn = partial_derivatives
+  //            .compute_normal<specfem::enums::boundaries::type::LEFT>();
+  //   enforce_traction_boundary(weight[1], dn, properties, field_dot,
+  //                             field_dot_dot);
+  //   return;
+  // }
+
+  // // Right Boundary
+  // if (itype.right == value_t && ix == ngllx - 1) {
+  //   dn = partial_derivatives
+  //            .compute_normal<specfem::enums::boundaries::type::RIGHT>();
+  //   enforce_traction_boundary(weight[1], dn, properties, field_dot,
+  //                             field_dot_dot);
+  //   return;
+  // }
+
+  // // Top Boundary
+  // if (itype.top == value_t && iz == ngllz - 1) {
+  //   dn = partial_derivatives
+  //            .compute_normal<specfem::enums::boundaries::type::TOP>();
+  //   enforce_traction_boundary(weight[0], dn, properties, field_dot,
+  //                             field_dot_dot);
+  //   return;
+  // }
+
+  // // Bottom Boundary
+  // if (itype.bottom == value_t && iz == 0) {
+  //   dn = partial_derivatives
+  //            .compute_normal<specfem::enums::boundaries::type::BOTTOM>();
+  //   enforce_traction_boundary(weight[0], dn, properties, field_dot,
+  //                             field_dot_dot);
+  //   return;
+  // }
   // --------------------------------------------------------------------------
 
   return;

--- a/include/enumerations/specfem_enums.hpp
+++ b/include/enumerations/specfem_enums.hpp
@@ -213,13 +213,14 @@ namespace edge {
  *
  */
 enum type {
-  TOP,    ///< Top edge
-  BOTTOM, ///< Bottom edge
-  LEFT,   ///< Left edge
-  RIGHT   ///< Right edge
+  NONE = 0,   /// Not an edge
+  TOP = 1,    ///< Top edge
+  BOTTOM = 2, ///< Bottom edge
+  LEFT = 3,   ///< Left edge
+  RIGHT = 4   ///< Right edge
 };
 
-constexpr int num_edges = 4; ///< Number of edges in the mesh
+constexpr int num_edges = 5; ///< Number of edges in the mesh
 } // namespace edge
 
 /**

--- a/include/kokkos_abstractions.h
+++ b/include/kokkos_abstractions.h
@@ -569,6 +569,20 @@ template <typename T, int N> struct array_type {
             typename std::enable_if<sizeof...(Args) == N, bool>::type = true>
   KOKKOS_INLINE_FUNCTION array_type(const Args &...args) : data{ args... } {}
 
+  template <typename MemorySpace, typename Layout, typename MemoryTraits>
+  KOKKOS_INLINE_FUNCTION
+  array_type(const Kokkos::View<T *, Layout, MemorySpace, MemoryTraits> view) {
+    for (int i = 0; i < N; ++i) {
+      data[i] = view(i);
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION array_type(const T value) {
+    for (int i = 0; i < N; ++i) {
+      data[i] = value;
+    }
+  }
+
   /**
    * @brief operator [] to access the data array
    *
@@ -598,7 +612,7 @@ template <typename T, int N> struct array_type {
 #ifdef KOKKOS_ENABLE_CUDA
 #pragma unroll
 #endif
-    for (int i = 0; i < N; i++) {
+    for (int i = 0; i < N; ++i) {
       data[i] += rhs[i];
     }
     return *this;
@@ -612,7 +626,7 @@ template <typename T, int N> struct array_type {
 #ifdef KOKKOS_ENABLE_CUDA
 #pragma unroll
 #endif
-    for (int i = 0; i < N; i++) {
+    for (int i = 0; i < N; ++i) {
       data[i] = 0.0;
     }
   }
@@ -634,7 +648,7 @@ template <typename T, int N> struct array_type {
 #ifdef KOKKOS_ENABLE_CUDA
 #pragma unroll
 #endif
-    for (int i = 0; i < N; i++) {
+    for (int i = 0; i < N; ++i) {
       data[i] = other[i];
     }
   }
@@ -644,7 +658,7 @@ template <typename T, int N> struct array_type {
 #ifdef KOKKOS_ENABLE_CUDA
 #pragma unroll
 #endif
-    for (int i = 0; i < N; i++) {
+    for (int i = 0; i < N; ++i) {
       norm += data[i] * data[i];
     }
     return sqrt(norm);
@@ -657,7 +671,7 @@ template <typename T, int N> struct array_type {
 #ifdef KOKKOS_ENABLE_CUDA
 #pragma unroll
 #endif
-    for (int i = 0; i < N; i++) {
+    for (int i = 0; i < N; ++i) {
       dot += a[i] * b[i];
     }
     return dot;

--- a/include/kokkos_abstractions.h
+++ b/include/kokkos_abstractions.h
@@ -565,7 +565,8 @@ using simd_type = Kokkos::Experimental::simd<T, simd_abi>;
 template <typename T, int N> struct array_type {
   T data[N]; ///< Data array
 
-  template <typename... Args>
+  template <typename... Args,
+            typename std::enable_if<sizeof...(Args) == N, bool>::type = true>
   KOKKOS_INLINE_FUNCTION array_type(const Args &...args) : data{ args... } {}
 
   /**

--- a/include/kokkos_abstractions.h
+++ b/include/kokkos_abstractions.h
@@ -583,6 +583,12 @@ template <typename T, int N> struct array_type {
     }
   }
 
+  KOKKOS_INLINE_FUNCTION array_type(const T *values) {
+    for (int i = 0; i < N; ++i) {
+      data[i] = values[i];
+    }
+  }
+
   /**
    * @brief operator [] to access the data array
    *

--- a/include/parameter_parser/quadrature.hpp
+++ b/include/parameter_parser/quadrature.hpp
@@ -22,11 +22,10 @@ public:
    * specfem::quadrature::quadrature class
    * @param beta beta value used to instantiate a
    * specfem::quadrature::quadrature class
-   * @param ngllx number of quadrature points in x-dimension
-   * @param ngllz number of quadrature points in z-dimension
+   * @param ngllx number of quadrature points
    */
-  quadrature(type_real alpha, type_real beta, int ngllx, int ngllz)
-      : alpha(alpha), beta(beta), ngllx(ngllx), ngllz(ngllz){};
+  quadrature(type_real alpha, type_real beta, int ngll)
+      : alpha(alpha), beta(beta), ngll(ngll){};
   /**
    * @brief Construct a new quadrature object
    *
@@ -46,17 +45,14 @@ public:
    * @return std::tuple<specfem::quadrature::quadrature,
    * specfem::quadrature::quadrature> Quadrature objects in x and z dimensions
    */
-  std::tuple<specfem::quadrature::quadrature *,
-             specfem::quadrature::quadrature *>
-  instantiate();
+  specfem::quadrature::quadratures instantiate();
 
 private:
   type_real alpha; ///< alpha value used to instantiate a
                    ///< specfem::quadrature::quadrature class
   type_real beta;  ///< beta value used to instantiate a
                    ///< specfem::quadrature::quadrature class
-  int ngllx;       ///< number of quadrature points in x-dimension
-  int ngllz;       ///< number of quadrature points in z-dimension
+  int ngll;        ///< number of quadrature points
 };
 
 } // namespace runtime_configuration

--- a/include/parameter_parser/setup.hpp
+++ b/include/parameter_parser/setup.hpp
@@ -49,12 +49,10 @@ public:
   //  object
   //  * used in the solver algorithm
   //  */
-  // std::shared_ptr<specfem::TimeScheme::TimeScheme> instantiate_solver() {
-  //   auto it =
-  //       this->solver->instantiate(this->receivers->get_nstep_between_samples());
-
-  //   return it;
-  // }
+  std::shared_ptr<specfem::TimeScheme::TimeScheme> instantiate_solver() {
+    return this->solver->instantiate(
+        this->receivers->get_nstep_between_samples());
+  }
   // /**
   //  * @brief Update simulation start time.
   //  *
@@ -65,7 +63,7 @@ public:
   //  *
   //  * @param t0 Simulation start time
   //  */
-  // void update_t0(type_real t0) { this->solver->update_t0(t0); }
+  void update_t0(type_real t0) { this->solver->update_t0(t0); }
   /**
    * @brief Log the header and description of the simulation
    */

--- a/include/parameter_parser/setup.hpp
+++ b/include/parameter_parser/setup.hpp
@@ -72,12 +72,12 @@ public:
   std::string
   print_header(std::chrono::time_point<std::chrono::high_resolution_clock> now);
 
-  // /**
-  //  * @brief Get delta time value
-  //  *
-  //  * @return type_real
-  //  */
-  // type_real get_dt() const { return solver->get_dt(); }
+  /**
+   * @brief Get delta time value
+   *
+   * @return type_real
+   */
+  type_real get_dt() const { return solver->get_dt(); }
 
   /**
    * @brief Get the path to mesh database and source yaml file
@@ -144,9 +144,9 @@ private:
   std::unique_ptr<specfem::runtime_configuration::header> header; ///< Pointer
                                                                   ///< to header
                                                                   ///< object
-  // std::unique_ptr<specfem::runtime_configuration::solver::solver>
-  //     solver; ///< Pointer to solver
-  //             ///< object
+  std::unique_ptr<specfem::runtime_configuration::solver::solver>
+      solver; ///< Pointer to solver
+              ///< object
   std::unique_ptr<specfem::runtime_configuration::run_setup>
       run_setup; ///< Pointer to
                  ///< run_setup object

--- a/include/parameter_parser/setup.hpp
+++ b/include/parameter_parser/setup.hpp
@@ -39,47 +39,45 @@ public:
    * @return std::tuple<specfem::quadrature::quadrature,
    * specfem::quadrature::quadrature> Quadrature objects in x and z dimensions
    */
-  std::tuple<specfem::quadrature::quadrature *,
-             specfem::quadrature::quadrature *>
-  instantiate_quadrature() {
+  specfem::quadrature::quadratures instantiate_quadrature() {
     return this->quadrature->instantiate();
   }
-  /**
-   * @brief Instantiate the Timescheme
-   *
-   * @return specfem::TimeScheme::TimeScheme* Pointer to the TimeScheme
-   object
-   * used in the solver algorithm
-   */
-  std::shared_ptr<specfem::TimeScheme::TimeScheme> instantiate_solver() {
-    auto it =
-        this->solver->instantiate(this->receivers->get_nstep_between_samples());
+  // /**
+  //  * @brief Instantiate the Timescheme
+  //  *
+  //  * @return specfem::TimeScheme::TimeScheme* Pointer to the TimeScheme
+  //  object
+  //  * used in the solver algorithm
+  //  */
+  // std::shared_ptr<specfem::TimeScheme::TimeScheme> instantiate_solver() {
+  //   auto it =
+  //       this->solver->instantiate(this->receivers->get_nstep_between_samples());
 
-    return it;
-  }
-  /**
-   * @brief Update simulation start time.
-   *
-   * If user has not defined start time then we need to update the simulation
-   * start time based on source frequencies and time shift
-   *
-   * @note This might be specific to only time-marching solvers
-   *
-   * @param t0 Simulation start time
-   */
-  void update_t0(type_real t0) { this->solver->update_t0(t0); }
+  //   return it;
+  // }
+  // /**
+  //  * @brief Update simulation start time.
+  //  *
+  //  * If user has not defined start time then we need to update the simulation
+  //  * start time based on source frequencies and time shift
+  //  *
+  //  * @note This might be specific to only time-marching solvers
+  //  *
+  //  * @param t0 Simulation start time
+  //  */
+  // void update_t0(type_real t0) { this->solver->update_t0(t0); }
   /**
    * @brief Log the header and description of the simulation
    */
   std::string
   print_header(std::chrono::time_point<std::chrono::high_resolution_clock> now);
 
-  /**
-   * @brief Get delta time value
-   *
-   * @return type_real
-   */
-  type_real get_dt() const { return solver->get_dt(); }
+  // /**
+  //  * @brief Get delta time value
+  //  *
+  //  * @return type_real
+  //  */
+  // type_real get_dt() const { return solver->get_dt(); }
 
   /**
    * @brief Get the path to mesh database and source yaml file
@@ -117,37 +115,38 @@ public:
     return this->receivers->get_seismogram_types();
   }
 
-  /**
-   * @brief Instantiate a seismogram writer object
-   *
-   * @param receivers Vector of pointers to receiver objects used to
-   instantiate
-   * the writer
-   * @param compute_receivers Pointer to specfem::compute::receivers struct
-   used
-   * to instantiate the writer
-   * @return specfem::writer::writer* Pointer to an instantiated writer
-   object
-   */
-  std::shared_ptr<specfem::writer::writer> instantiate_seismogram_writer(
-      std::vector<std::shared_ptr<specfem::receivers::receiver> > &receivers,
-      specfem::compute::receivers &compute_receivers) const {
-    if (this->seismogram) {
-      return this->seismogram->instantiate_seismogram_writer(
-          receivers, compute_receivers, this->solver->get_dt(),
-          this->solver->get_t0(), this->receivers->get_nstep_between_samples());
-    } else {
-      return NULL;
-    }
-  }
+  // /**
+  //  * @brief Instantiate a seismogram writer object
+  //  *
+  //  * @param receivers Vector of pointers to receiver objects used to
+  //  instantiate
+  //  * the writer
+  //  * @param compute_receivers Pointer to specfem::compute::receivers struct
+  //  used
+  //  * to instantiate the writer
+  //  * @return specfem::writer::writer* Pointer to an instantiated writer
+  //  object
+  //  */
+  // std::shared_ptr<specfem::writer::writer> instantiate_seismogram_writer(
+  //     std::vector<std::shared_ptr<specfem::receivers::receiver> > &receivers,
+  //     specfem::compute::receivers &compute_receivers) const {
+  //   if (this->seismogram) {
+  //     return this->seismogram->instantiate_seismogram_writer(
+  //         receivers, compute_receivers, this->solver->get_dt(),
+  //         this->solver->get_t0(),
+  //         this->receivers->get_nstep_between_samples());
+  //   } else {
+  //     return NULL;
+  //   }
+  // }
 
 private:
   std::unique_ptr<specfem::runtime_configuration::header> header; ///< Pointer
                                                                   ///< to header
                                                                   ///< object
-  std::unique_ptr<specfem::runtime_configuration::solver::solver>
-      solver; ///< Pointer to solver
-              ///< object
+  // std::unique_ptr<specfem::runtime_configuration::solver::solver>
+  //     solver; ///< Pointer to solver
+  //             ///< object
   std::unique_ptr<specfem::runtime_configuration::run_setup>
       run_setup; ///< Pointer to
                  ///< run_setup object
@@ -156,9 +155,9 @@ private:
                   ///< quadrature object
   std::unique_ptr<specfem::runtime_configuration::receivers>
       receivers; ///< Pointer to receivers object
-  std::unique_ptr<specfem::runtime_configuration::seismogram>
-      seismogram; ///< Pointer to
-                  ///< seismogram object
+  // std::unique_ptr<specfem::runtime_configuration::seismogram>
+  //     seismogram; ///< Pointer to
+  //                 ///< seismogram object
   std::unique_ptr<specfem::runtime_configuration::database_configuration>
       databases; ///< Get database filenames
 };

--- a/include/parameter_parser/solver/solver.hpp
+++ b/include/parameter_parser/solver/solver.hpp
@@ -2,7 +2,7 @@
 #define _PARAMETER_SOLVER_HPP
 
 #include "specfem_setup.hpp"
-#include "timescheme/interface.hpp"
+// #include "timescheme/interface.hpp"
 #include "yaml-cpp/yaml.h"
 #include <tuple>
 
@@ -21,14 +21,15 @@ namespace solver {
 class solver {
 
 public:
-  /**
-   * @brief Instantiate the Timescheme
-   *
-   * @return specfem::TimeScheme::TimeScheme* Pointer to the TimeScheme object
-   * used in the solver algorithm
-   */
-  virtual std::shared_ptr<specfem::TimeScheme::TimeScheme>
-  instantiate(const int nstep_between_samples);
+  // /**
+  //  * @brief Instantiate the Timescheme
+  //  *
+  //  * @return specfem::TimeScheme::TimeScheme* Pointer to the TimeScheme
+  //  object
+  //  * used in the solver algorithm
+  //  */
+  // virtual std::shared_ptr<specfem::TimeScheme::TimeScheme>
+  // instantiate(const int nstep_between_samples);
   /**
    * @brief Update simulation start time.
    *

--- a/include/parameter_parser/solver/solver.hpp
+++ b/include/parameter_parser/solver/solver.hpp
@@ -2,7 +2,7 @@
 #define _PARAMETER_SOLVER_HPP
 
 #include "specfem_setup.hpp"
-// #include "timescheme/interface.hpp"
+#include "timescheme/interface.hpp"
 #include "yaml-cpp/yaml.h"
 #include <tuple>
 
@@ -21,15 +21,15 @@ namespace solver {
 class solver {
 
 public:
-  // /**
-  //  * @brief Instantiate the Timescheme
-  //  *
-  //  * @return specfem::TimeScheme::TimeScheme* Pointer to the TimeScheme
-  //  object
-  //  * used in the solver algorithm
-  //  */
-  // virtual std::shared_ptr<specfem::TimeScheme::TimeScheme>
-  // instantiate(const int nstep_between_samples);
+  /**
+   * @brief Instantiate the Timescheme
+   *
+   * @return specfem::TimeScheme::TimeScheme* Pointer to the TimeScheme
+   object
+   * used in the solver algorithm
+   */
+  virtual std::shared_ptr<specfem::TimeScheme::TimeScheme>
+  instantiate(const int nstep_between_samples);
   /**
    * @brief Update simulation start time.
    *

--- a/include/parameter_parser/solver/time_marching.hpp
+++ b/include/parameter_parser/solver/time_marching.hpp
@@ -42,15 +42,15 @@ public:
    * @param t0 Simulation start time
    */
   void update_t0(type_real t0) override { this->t0 = t0; }
-  // /**
-  //  * @brief Instantiate the Timescheme
-  //  *
-  //  * @return specfem::TimeScheme::TimeScheme* Pointer to the TimeScheme
-  //  object
-  //  * used in the solver algorithm
-  //  */
-  // std::shared_ptr<specfem::TimeScheme::TimeScheme>
-  // instantiate(const int nstep_between_samples) override;
+  /**
+   * @brief Instantiate the Timescheme
+   *
+   * @return specfem::TimeScheme::TimeScheme* Pointer to the TimeScheme
+   object
+   * used in the solver algorithm
+   */
+  std::shared_ptr<specfem::TimeScheme::TimeScheme>
+  instantiate(const int nstep_between_samples) override;
   /**
    * @brief Get the value of time increment
    *

--- a/include/parameter_parser/solver/time_marching.hpp
+++ b/include/parameter_parser/solver/time_marching.hpp
@@ -2,7 +2,7 @@
 #define _PARAMETER_TIME_MARCHING_HPP
 
 #include "specfem_setup.hpp"
-#include "timescheme/interface.hpp"
+// #include "timescheme/interface.hpp"
 #include "yaml-cpp/yaml.h"
 #include <tuple>
 
@@ -42,14 +42,15 @@ public:
    * @param t0 Simulation start time
    */
   void update_t0(type_real t0) override { this->t0 = t0; }
-  /**
-   * @brief Instantiate the Timescheme
-   *
-   * @return specfem::TimeScheme::TimeScheme* Pointer to the TimeScheme object
-   * used in the solver algorithm
-   */
-  std::shared_ptr<specfem::TimeScheme::TimeScheme>
-  instantiate(const int nstep_between_samples) override;
+  // /**
+  //  * @brief Instantiate the Timescheme
+  //  *
+  //  * @return specfem::TimeScheme::TimeScheme* Pointer to the TimeScheme
+  //  object
+  //  * used in the solver algorithm
+  //  */
+  // std::shared_ptr<specfem::TimeScheme::TimeScheme>
+  // instantiate(const int nstep_between_samples) override;
   /**
    * @brief Get the value of time increment
    *

--- a/include/point/partial_derivatives.hpp
+++ b/include/point/partial_derivatives.hpp
@@ -49,12 +49,15 @@ struct partial_derivatives2 {
   KOKKOS_FUNCTION
   partial_derivatives2(const partial_derivatives2 &rhs) = default;
 
-  template <specfem::enums::boundaries::type type>
+  template <specfem::enums::edge::type type>
   KOKKOS_INLINE_FUNCTION specfem::kokkos::array_type<type_real, 2>
   compute_normal() const {
     ASSERT(false, "Invalid boundary type");
     return specfem::kokkos::array_type<type_real, 2>();
   };
+
+  KOKKOS_FUNCTION specfem::kokkos::array_type<type_real, 2>
+  compute_normal(const specfem::enums::edge::type &type) const;
 
   KOKKOS_FUNCTION specfem::kokkos::array_type<type_real, 2>
   compute_normal(const specfem::edge::interface &interface) const;

--- a/include/point/partial_derivatives.hpp
+++ b/include/point/partial_derivatives.hpp
@@ -1,6 +1,7 @@
 #ifndef _POINT_PARTIAL_DERIVATIVES_HPP
 #define _POINT_PARTIAL_DERIVATIVES_HPP
 
+#include "edge/interface.hpp"
 #include "enumerations/specfem_enums.hpp"
 #include "kokkos_abstractions.h"
 #include "macros.hpp"
@@ -54,6 +55,9 @@ struct partial_derivatives2 {
     ASSERT(false, "Invalid boundary type");
     return specfem::kokkos::array_type<type_real, 2>();
   };
+
+  KOKKOS_FUNCTION specfem::kokkos::array_type<type_real, 2>
+  compute_normal(const specfem::edge::interface &interface) const;
 };
 
 // operator+

--- a/include/point/partial_derivatives.tpp
+++ b/include/point/partial_derivatives.tpp
@@ -9,7 +9,7 @@
 template <>
 KOKKOS_INLINE_FUNCTION specfem::kokkos::array_type<type_real, 2>
 specfem::point::partial_derivatives2::compute_normal<
-    specfem::enums::boundaries::type::BOTTOM>() const {
+    specfem::enums::edge::type::BOTTOM>() const {
   specfem::kokkos::array_type<type_real, 2> dn;
   dn[0] = -1.0 * this->gammax * this->jacobian;
   dn[1] = -1.0 * this->gammaz * this->jacobian;
@@ -19,7 +19,7 @@ specfem::point::partial_derivatives2::compute_normal<
 template <>
 KOKKOS_INLINE_FUNCTION specfem::kokkos::array_type<type_real, 2>
 specfem::point::partial_derivatives2::compute_normal<
-    specfem::enums::boundaries::type::TOP>() const {
+    specfem::enums::edge::type::TOP>() const {
   specfem::kokkos::array_type<type_real, 2> dn;
   dn[0] = this->gammax * this->jacobian;
   dn[1] = this->gammaz * this->jacobian;
@@ -29,7 +29,7 @@ specfem::point::partial_derivatives2::compute_normal<
 template <>
 KOKKOS_INLINE_FUNCTION specfem::kokkos::array_type<type_real, 2>
 specfem::point::partial_derivatives2::compute_normal<
-    specfem::enums::boundaries::type::LEFT>() const {
+    specfem::enums::edge::type::LEFT>() const {
   specfem::kokkos::array_type<type_real, 2> dn;
   dn[0] = -1.0 * this->xix * this->jacobian;
   dn[1] = -1.0 * this->xiz * this->jacobian;
@@ -39,7 +39,7 @@ specfem::point::partial_derivatives2::compute_normal<
 template <>
 KOKKOS_INLINE_FUNCTION specfem::kokkos::array_type<type_real, 2>
 specfem::point::partial_derivatives2::compute_normal<
-    specfem::enums::boundaries::type::RIGHT>() const {
+    specfem::enums::edge::type::RIGHT>() const {
   specfem::kokkos::array_type<type_real, 2> dn;
   dn[0] = this->xix * this->jacobian;
   dn[1] = this->xiz * this->jacobian;

--- a/include/solver/time_marching.hpp
+++ b/include/solver/time_marching.hpp
@@ -22,6 +22,9 @@ template <typename qp_type>
 class time_marching : public specfem::solver::solver {
 
 public:
+  using elastic_type = specfem::enums::element::medium::elastic;
+  using acoustic_type = specfem::enums::element::medium::acoustic;
+  using forward_type = specfem::enums::simulation::forward;
   /**
    * @brief Construct a new time marching solver object
    *
@@ -31,22 +34,16 @@ public:
    * @param it Pointer to time scheme object (it stands for iterator)
    */
   time_marching(
-      specfem::domain::domain<specfem::enums::element::medium::acoustic,
-                              qp_type> &acoustic_domain,
-      specfem::domain::domain<specfem::enums::element::medium::elastic, qp_type>
-          &elastic_domain,
-      specfem::coupled_interface::coupled_interface<
-          specfem::domain::domain<specfem::enums::element::medium::acoustic,
-                                  qp_type>,
-          specfem::domain::domain<specfem::enums::element::medium::elastic,
-                                  qp_type> > &acoustic_elastic_interface,
-      specfem::coupled_interface::coupled_interface<
-          specfem::domain::domain<specfem::enums::element::medium::elastic,
-                                  qp_type>,
-          specfem::domain::domain<specfem::enums::element::medium::acoustic,
-                                  qp_type> > &elastic_acoustic_interface,
+      const specfem::compute::assembly &assembly,
+      const specfem::domain::domain<acoustic_type, qp_type> &acoustic_domain,
+      const specfem::domain::domain<elastic_type, qp_type> &elastic_domain,
+      const specfem::coupled_interface::coupled_interface<
+          acoustic_type, elastic_type> &acoustic_elastic_interface,
+      const specfem::coupled_interface::coupled_interface<
+          elastic_type, acoustic_type> &elastic_acoustic_interface,
       std::shared_ptr<specfem::TimeScheme::TimeScheme> it)
-      : acoustic_domain(acoustic_domain), elastic_domain(elastic_domain),
+      : forward_field(assembly.fields.forward),
+        acoustic_domain(acoustic_domain), elastic_domain(elastic_domain),
         acoustic_elastic_interface(acoustic_elastic_interface),
         elastic_acoustic_interface(elastic_acoustic_interface), it(it){};
   /**
@@ -56,22 +53,18 @@ public:
   void run() override;
 
 private:
-  specfem::domain::domain<specfem::enums::element::medium::acoustic, qp_type>
-      acoustic_domain; ///< Acoustic domain
-  specfem::domain::domain<specfem::enums::element::medium::elastic, qp_type>
-      elastic_domain; ///< Acoustic domain
-  specfem::coupled_interface::coupled_interface<
-      specfem::domain::domain<specfem::enums::element::medium::acoustic,
-                              qp_type>,
-      specfem::domain::domain<specfem::enums::element::medium::elastic,
-                              qp_type> >
-      acoustic_elastic_interface; /// Acoustic elastic interface
-  specfem::coupled_interface::coupled_interface<
-      specfem::domain::domain<specfem::enums::element::medium::elastic,
-                              qp_type>,
-      specfem::domain::domain<specfem::enums::element::medium::acoustic,
-                              qp_type> >
-      elastic_acoustic_interface; /// Elastic acoustic interface
+  specfem::compute::simulation_field<forward_type> forward_field;  ///< Fields
+                                                                   ///< object
+  specfem::domain::domain<acoustic_type, qp_type> acoustic_domain; ///< Acoustic
+                                                                   ///< domain
+                                                                   ///< object
+  specfem::domain::domain<elastic_type, qp_type> elastic_domain;   ///< Elastic
+                                                                   ///< domain
+                                                                   ///< object
+  specfem::coupled_interface::coupled_interface<acoustic_type, elastic_type>
+      acoustic_elastic_interface; ///< Acoustic-elastic interface object
+  specfem::coupled_interface::coupled_interface<elastic_type, acoustic_type>
+      elastic_acoustic_interface; ///< Elastic-acoustic interface object
   std::shared_ptr<specfem::TimeScheme::TimeScheme>
       it; ///< Pointer to
           ///< spectem::TimeScheme::TimeScheme

--- a/include/solver/time_marching.tpp
+++ b/include/solver/time_marching.tpp
@@ -30,8 +30,6 @@ void specfem::solver::time_marching<qp_type>::run() {
   while (it->status()) {
     int istep = it->get_timestep();
 
-    type_real timeval = it->get_time();
-
     Kokkos::Profiling::pushRegion("Stiffness calculation");
     it->apply_predictor_phase(acoustic_field.field, acoustic_field.field_dot,
                               acoustic_field.field_dot_dot);
@@ -39,7 +37,7 @@ void specfem::solver::time_marching<qp_type>::run() {
                               elastic_field.field_dot_dot);
 
     acoustic_elastic_interface.compute_coupling();
-    acoustic_domain.compute_source_interaction(timeval);
+    acoustic_domain.compute_source_interaction(istep);
     acoustic_domain.compute_stiffness_interaction();
     acoustic_domain.divide_mass_matrix();
 
@@ -47,7 +45,7 @@ void specfem::solver::time_marching<qp_type>::run() {
                               acoustic_field.field_dot_dot);
 
     elastic_acoustic_interface.compute_coupling();
-    elastic_domain.compute_source_interaction(timeval);
+    elastic_domain.compute_source_interaction(istep);
     elastic_domain.compute_stiffness_interaction();
     elastic_domain.divide_mass_matrix();
 

--- a/include/solver/time_marching.tpp
+++ b/include/solver/time_marching.tpp
@@ -53,12 +53,12 @@ void specfem::solver::time_marching<qp_type>::run() {
                               elastic_field.field_dot_dot);
     Kokkos::Profiling::popRegion();
 
-    // if (it->compute_seismogram()) {
-    //   int isig_step = it->get_seismogram_step();
-    //   acoustic_domain.compute_seismogram(isig_step);
-    //   elastic_domain.compute_seismogram(isig_step);
-    //   it->increment_seismogram_step();
-    // }
+    if (it->compute_seismogram()) {
+      int isig_step = it->get_seismogram_step();
+      acoustic_domain.compute_seismogram(isig_step);
+      elastic_domain.compute_seismogram(isig_step);
+      it->increment_seismogram_step();
+    }
 
     it->increment_time();
 

--- a/include/solver/time_marching.tpp
+++ b/include/solver/time_marching.tpp
@@ -10,10 +10,6 @@
 template <typename qp_type>
 void specfem::solver::time_marching<qp_type>::run() {
 
-  auto it = this->it;
-  auto acoustic_domain = this->acoustic_domain;
-  auto elastic_domain = this->elastic_domain;
-
   // Special contributions to mass matrix inverse in case of Newmark scheme
   if (it->timescheme() == specfem::enums::time_scheme::type::newmark) {
     elastic_domain.template mass_time_contribution<
@@ -28,13 +24,8 @@ void specfem::solver::time_marching<qp_type>::run() {
 
   const int nstep = it->get_max_timestep();
 
-  auto acoustic_field = acoustic_domain.get_field();
-  auto acoustic_field_dot = acoustic_domain.get_field_dot();
-  auto acoustic_field_dot_dot = acoustic_domain.get_field_dot_dot();
-
-  auto elastic_field = elastic_domain.get_field();
-  auto elastic_field_dot = elastic_domain.get_field_dot();
-  auto elastic_field_dot_dot = elastic_domain.get_field_dot_dot();
+  auto acoustic_field = forward_field.get_field<acoustic_type>();
+  auto elastic_field = forward_field.get_field<elastic_type>();
 
   while (it->status()) {
     int istep = it->get_timestep();
@@ -42,34 +33,34 @@ void specfem::solver::time_marching<qp_type>::run() {
     type_real timeval = it->get_time();
 
     Kokkos::Profiling::pushRegion("Stiffness calculation");
-    it->apply_predictor_phase(acoustic_field, acoustic_field_dot,
-                              acoustic_field_dot_dot);
-    it->apply_predictor_phase(elastic_field, elastic_field_dot,
-                              elastic_field_dot_dot);
+    it->apply_predictor_phase(acoustic_field.field, acoustic_field.field_dot,
+                              acoustic_field.field_dot_dot);
+    it->apply_predictor_phase(elastic_field.field, elastic_field.field_dot,
+                              elastic_field.field_dot_dot);
 
     acoustic_elastic_interface.compute_coupling();
     acoustic_domain.compute_source_interaction(timeval);
     acoustic_domain.compute_stiffness_interaction();
     acoustic_domain.divide_mass_matrix();
 
-    it->apply_corrector_phase(acoustic_field, acoustic_field_dot,
-                              acoustic_field_dot_dot);
+    it->apply_corrector_phase(acoustic_field.field, acoustic_field.field_dot,
+                              acoustic_field.field_dot_dot);
 
     elastic_acoustic_interface.compute_coupling();
     elastic_domain.compute_source_interaction(timeval);
     elastic_domain.compute_stiffness_interaction();
     elastic_domain.divide_mass_matrix();
 
-    it->apply_corrector_phase(elastic_field, elastic_field_dot,
-                              elastic_field_dot_dot);
+    it->apply_corrector_phase(elastic_field.field, elastic_field.field_dot,
+                              elastic_field.field_dot_dot);
     Kokkos::Profiling::popRegion();
 
-    if (it->compute_seismogram()) {
-      int isig_step = it->get_seismogram_step();
-      acoustic_domain.compute_seismogram(isig_step);
-      elastic_domain.compute_seismogram(isig_step);
-      it->increment_seismogram_step();
-    }
+    // if (it->compute_seismogram()) {
+    //   int isig_step = it->get_seismogram_step();
+    //   acoustic_domain.compute_seismogram(isig_step);
+    //   elastic_domain.compute_seismogram(isig_step);
+    //   it->increment_seismogram_step();
+    // }
 
     it->increment_time();
 

--- a/include/source_time_function/dirac.hpp
+++ b/include/source_time_function/dirac.hpp
@@ -21,10 +21,10 @@ public:
    * @param factor factor to scale source time function
    * @param use_trick_for_better_pressure
    */
-  Dirac(type_real f0, type_real tshift, type_real factor,
-        bool use_trick_for_better_pressure);
+  Dirac(const type_real dt, const type_real f0, const type_real tshift,
+        const type_real factor, const bool use_trick_for_better_pressure);
 
-  Dirac(YAML::Node &Dirac, const int dt,
+  Dirac(YAML::Node &Dirac, const type_real dt,
         const bool use_trick_for_better_pressure);
 
   /**

--- a/include/source_time_function/ricker.hpp
+++ b/include/source_time_function/ricker.hpp
@@ -20,10 +20,10 @@ public:
    * @param factor factor to scale source time function
    * @param use_trick_for_better_pressure
    */
-  Ricker(type_real f0, type_real tshift, type_real factor,
-         bool use_trick_for_better_pressure);
+  Ricker(const type_real dt, const type_real f0, const type_real tshift,
+         const type_real factor, const bool use_trick_for_better_pressure);
 
-  Ricker(YAML::Node &Ricker, const int dt,
+  Ricker(YAML::Node &Ricker, const type_real dt,
          const bool use_trick_for_better_pressure);
 
   /**

--- a/src/compute/compute_assembly.cpp
+++ b/src/compute/compute_assembly.cpp
@@ -17,14 +17,14 @@ specfem::compute::assembly::assembly(
     const std::vector<std::shared_ptr<specfem::receivers::receiver> >
         &receivers,
     const std::vector<specfem::enums::seismogram::type> &stypes,
-    const int max_sig_step) {
+    const int max_timesteps, const int max_sig_step) {
   this->mesh = specfem::compute::mesh(mesh.control_nodes, quadratures);
   this->partial_derivatives = specfem::compute::partial_derivatives(this->mesh);
   this->properties = specfem::compute::properties(
       this->mesh.nspec, this->mesh.ngllz, this->mesh.ngllx, mesh.materials);
   this->sources =
       specfem::compute::sources(sources, this->mesh, this->partial_derivatives,
-                                this->properties, max_sig_step);
+                                this->properties, max_timesteps);
   this->receivers =
       specfem::compute::receivers(max_sig_step, receivers, stypes, this->mesh);
   this->boundaries =

--- a/src/compute/compute_properties.cpp
+++ b/src/compute/compute_properties.cpp
@@ -13,6 +13,8 @@ specfem::compute::properties::properties(
       h_element_types(Kokkos::create_mirror_view(element_types)),
       property_index_mapping(
           "specfem::compute::properties::property_index_mapping", nspec),
+      element_property("specfem::compute::properties::element_property", nspec),
+      h_element_property(Kokkos::create_mirror_view(element_property)),
       h_property_index_mapping(
           Kokkos::create_mirror_view(property_index_mapping)) {
 
@@ -27,10 +29,14 @@ specfem::compute::properties::properties(
             specfem::enums::element::type::elastic) {
           n_elastic++;
           h_element_types(ispec) = specfem::enums::element::type::elastic;
+          h_element_property(ispec) =
+              specfem::enums::element::property_tag::isotropic;
         } else if (materials.material_index_mapping(ispec).type ==
                    specfem::enums::element::type::acoustic) {
           n_acoustic++;
           h_element_types(ispec) = specfem::enums::element::type::acoustic;
+          h_element_property(ispec) =
+              specfem::enums::element::property_tag::isotropic;
         }
       },
       n_elastic, n_acoustic);
@@ -49,6 +55,7 @@ specfem::compute::properties::properties(
 
   Kokkos::deep_copy(property_index_mapping, h_property_index_mapping);
   Kokkos::deep_copy(element_types, h_element_types);
+  Kokkos::deep_copy(element_property, h_element_property);
 
   return;
 }

--- a/src/compute/compute_receivers.cpp
+++ b/src/compute/compute_receivers.cpp
@@ -27,8 +27,8 @@ specfem::compute::receivers::receivers(const int nreceivers,
       seismogram_types("specfem::compute::receivers::seismogram_types",
                        n_seis_types),
       h_seismogram_types(Kokkos::create_mirror_view(seismogram_types)),
-      receiver_field("specfem::compute::receivers::receiver_field",
-                     max_sig_step, nreceivers, n_seis_types, ndim, N, N),
+      receiver_field("specfem::compute::receivers::receiver_field", N, N,
+                     n_seis_types, nreceivers, max_sig_step),
       h_receiver_field(Kokkos::create_mirror_view(receiver_field)) {}
 
 specfem::compute::receivers::receivers(

--- a/src/compute/coupled_interfaces.cpp
+++ b/src/compute/coupled_interfaces.cpp
@@ -1,6 +1,7 @@
 // #include "compute/coupled_interfaces.hpp"
 // #include "compute/coupled_interfaces.tpp"
 #include "compute/coupled_interfaces/coupled_interfaces.hpp"
+#include "compute/coupled_interfaces/coupled_interfaces.tpp"
 #include "compute/coupled_interfaces/interface_container.hpp"
 #include "compute/coupled_interfaces/interface_container.tpp"
 #include "enumerations/specfem_enums.hpp"
@@ -550,24 +551,142 @@ template class specfem::compute::interface_container<
     specfem::enums::element::type::elastic,
     specfem::enums::element::type::poroelastic>;
 
+template specfem::compute::interface_container<
+    specfem::enums::element::type::elastic,
+    specfem::enums::element::type::acoustic>
+specfem::compute::coupled_interfaces::get_interface_container<
+    specfem::enums::element::type::elastic,
+    specfem::enums::element::type::acoustic>() const;
+
+template specfem::compute::interface_container<
+    specfem::enums::element::type::acoustic,
+    specfem::enums::element::type::elastic>
+specfem::compute::coupled_interfaces::get_interface_container<
+    specfem::enums::element::type::acoustic,
+    specfem::enums::element::type::elastic>() const;
+
+template specfem::compute::interface_container<
+    specfem::enums::element::type::elastic,
+    specfem::enums::element::type::poroelastic>
+specfem::compute::coupled_interfaces::get_interface_container<
+    specfem::enums::element::type::elastic,
+    specfem::enums::element::type::poroelastic>() const;
+
+template specfem::compute::interface_container<
+    specfem::enums::element::type::poroelastic,
+    specfem::enums::element::type::elastic>
+specfem::compute::coupled_interfaces::get_interface_container<
+    specfem::enums::element::type::poroelastic,
+    specfem::enums::element::type::elastic>() const;
+
+template specfem::compute::interface_container<
+    specfem::enums::element::type::acoustic,
+    specfem::enums::element::type::poroelastic>
+specfem::compute::coupled_interfaces::get_interface_container<
+    specfem::enums::element::type::acoustic,
+    specfem::enums::element::type::poroelastic>() const;
+
+template specfem::compute::interface_container<
+    specfem::enums::element::type::poroelastic,
+    specfem::enums::element::type::acoustic>
+specfem::compute::coupled_interfaces::get_interface_container<
+    specfem::enums::element::type::poroelastic,
+    specfem::enums::element::type::acoustic>() const;
+
 // Explicit template member function instantiation
 
-template specfem::kokkos::DeviceView1d<int>
+template KOKKOS_FUNCTION int
 specfem::compute::interface_container<specfem::enums::element::type::elastic,
                                       specfem::enums::element::type::acoustic>::
-    get_index_mapping_view<specfem::enums::element::type::elastic>() const;
+    load_device_index_mapping<specfem::enums::element::type::elastic>(
+        const int iedge) const;
 
-template specfem::kokkos::DeviceView1d<int>
-specfem::compute::interface_container<specfem::enums::element::type::elastic,
-                                      specfem::enums::element::type::acoustic>::
-    get_index_mapping_view<specfem::enums::element::type::acoustic>() const;
+template KOKKOS_FUNCTION int
+specfem::compute::interface_container<specfem::enums::element::type::acoustic,
+                                      specfem::enums::element::type::elastic>::
+    load_device_index_mapping<specfem::enums::element::type::acoustic>(
+        const int iedge) const;
 
-template specfem::kokkos::DeviceView1d<specfem::edge::interface>
+template KOKKOS_FUNCTION int
 specfem::compute::interface_container<specfem::enums::element::type::elastic,
                                       specfem::enums::element::type::acoustic>::
-    get_edge_type_view<specfem::enums::element::type::elastic>() const;
+    load_device_index_mapping<specfem::enums::element::type::acoustic>(
+        const int iedge) const;
 
-template specfem::kokkos::DeviceView1d<specfem::edge::interface>
+template KOKKOS_FUNCTION int
+specfem::compute::interface_container<specfem::enums::element::type::acoustic,
+                                      specfem::enums::element::type::elastic>::
+    load_device_index_mapping<specfem::enums::element::type::elastic>(
+        const int iedge) const;
+
+template int
 specfem::compute::interface_container<specfem::enums::element::type::elastic,
                                       specfem::enums::element::type::acoustic>::
-    get_edge_type_view<specfem::enums::element::type::acoustic>() const;
+    load_host_index_mapping<specfem::enums::element::type::elastic>(
+        const int iedge) const;
+
+template int
+specfem::compute::interface_container<specfem::enums::element::type::acoustic,
+                                      specfem::enums::element::type::elastic>::
+    load_host_index_mapping<specfem::enums::element::type::acoustic>(
+        const int iedge) const;
+
+template int
+specfem::compute::interface_container<specfem::enums::element::type::elastic,
+                                      specfem::enums::element::type::acoustic>::
+    load_host_index_mapping<specfem::enums::element::type::acoustic>(
+        const int iedge) const;
+
+template int
+specfem::compute::interface_container<specfem::enums::element::type::acoustic,
+                                      specfem::enums::element::type::elastic>::
+    load_host_index_mapping<specfem::enums::element::type::elastic>(
+        const int iedge) const;
+
+template KOKKOS_FUNCTION specfem::edge::interface specfem::compute::
+    interface_container<specfem::enums::element::type::elastic,
+                        specfem::enums::element::type::acoustic>::
+        load_device_edge_type<specfem::enums::element::type::elastic>(
+            const int iedge) const;
+
+template KOKKOS_FUNCTION specfem::edge::interface specfem::compute::
+    interface_container<specfem::enums::element::type::acoustic,
+                        specfem::enums::element::type::elastic>::
+        load_device_edge_type<specfem::enums::element::type::acoustic>(
+            const int iedge) const;
+
+template specfem::edge::interface specfem::compute::interface_container<
+    specfem::enums::element::type::elastic,
+    specfem::enums::element::type::acoustic>::
+    load_host_edge_type<specfem::enums::element::type::elastic>(
+        const int iedge) const;
+
+template specfem::edge::interface specfem::compute::interface_container<
+    specfem::enums::element::type::acoustic,
+    specfem::enums::element::type::elastic>::
+    load_host_edge_type<specfem::enums::element::type::acoustic>(
+        const int iedge) const;
+
+template KOKKOS_FUNCTION specfem::edge::interface specfem::compute::
+    interface_container<specfem::enums::element::type::elastic,
+                        specfem::enums::element::type::acoustic>::
+        load_device_edge_type<specfem::enums::element::type::acoustic>(
+            const int iedge) const;
+
+template KOKKOS_FUNCTION specfem::edge::interface specfem::compute::
+    interface_container<specfem::enums::element::type::acoustic,
+                        specfem::enums::element::type::elastic>::
+        load_device_edge_type<specfem::enums::element::type::elastic>(
+            const int iedge) const;
+
+template specfem::edge::interface specfem::compute::interface_container<
+    specfem::enums::element::type::elastic,
+    specfem::enums::element::type::acoustic>::
+    load_host_edge_type<specfem::enums::element::type::acoustic>(
+        const int iedge) const;
+
+template specfem::edge::interface specfem::compute::interface_container<
+    specfem::enums::element::type::acoustic,
+    specfem::enums::element::type::elastic>::
+    load_host_edge_type<specfem::enums::element::type::elastic>(
+        const int iedge) const;

--- a/src/edge/interface.cpp
+++ b/src/edge/interface.cpp
@@ -4,43 +4,30 @@
 
 KOKKOS_FUNCTION
 int specfem::edge::num_points_on_interface(
-    const specfem::edge::interface &interface, const int ngllz,
-    const int ngllx) {
-  switch (interface.type) {
-  case specfem::enums::edge::type::BOTTOM:
-  case specfem::enums::edge::type::TOP:
-    return ngllx;
-    break;
-  case specfem::enums::edge::type::LEFT:
-  case specfem::enums::edge::type::RIGHT:
-    return ngllz;
-    break;
-  default:
-    assert(false && "Invalid edge type");
-    return 0;
-  }
+    const specfem::edge::interface &interface) {
+  return interface.ngll;
 }
 
 KOKKOS_FUNCTION
 void specfem::edge::locate_point_on_self_edge(
-    const int &ipoint, const specfem::edge::interface &interface,
-    const int ngllx, const int ngllz, int &i, int &j) {
+    const int &ipoint, const specfem::edge::interface &interface, int &i,
+    int &j) {
   switch (interface.type) {
   case specfem::enums::edge::type::BOTTOM:
     i = ipoint;
     j = 0;
     break;
   case specfem::enums::edge::type::TOP:
-    i = ngllx - 1 - ipoint;
-    j = ngllz - 1;
+    i = interface.ngll - 1 - ipoint;
+    j = interface.ngll - 1;
     break;
   case specfem::enums::edge::type::LEFT:
     i = 0;
     j = ipoint;
     break;
   case specfem::enums::edge::type::RIGHT:
-    i = ngllx - 1;
-    j = ngllz - 1 - ipoint;
+    i = interface.ngll - 1;
+    j = interface.ngll - 1 - ipoint;
     break;
   default:
     assert(false && "Invalid edge type");
@@ -49,20 +36,20 @@ void specfem::edge::locate_point_on_self_edge(
 
 KOKKOS_FUNCTION
 void specfem::edge::locate_point_on_coupled_edge(
-    const int &ipoint, const specfem::edge::interface &interface,
-    const int ngllx, const int ngllz, int &i, int &j) {
+    const int &ipoint, const specfem::edge::interface &interface, int &i,
+    int &j) {
   switch (interface.type) {
   case specfem::enums::edge::type::BOTTOM:
-    i = ngllx - 1 - ipoint;
+    i = interface.ngll - 1 - ipoint;
     j = 0;
     break;
   case specfem::enums::edge::type::TOP:
     i = ipoint;
-    j = ngllz - 1;
+    j = interface.ngll - 1;
     break;
   case specfem::enums::edge::type::LEFT:
-    i = ngllx - 1;
-    j = ngllz - 1 - ipoint;
+    i = interface.ngll - 1;
+    j = interface.ngll - 1 - ipoint;
     break;
   case specfem::enums::edge::type::RIGHT:
     i = 0;

--- a/src/edge/interface.cpp
+++ b/src/edge/interface.cpp
@@ -10,24 +10,24 @@ int specfem::edge::num_points_on_interface(
 
 KOKKOS_FUNCTION
 void specfem::edge::locate_point_on_self_edge(
-    const int &ipoint, const specfem::edge::interface &interface, int &i,
-    int &j) {
+    const int &ipoint, const specfem::edge::interface &interface, int &iz,
+    int &ix) {
   switch (interface.type) {
   case specfem::enums::edge::type::BOTTOM:
-    i = ipoint;
-    j = 0;
+    ix = ipoint;
+    iz = 0;
     break;
   case specfem::enums::edge::type::TOP:
-    i = interface.ngll - 1 - ipoint;
-    j = interface.ngll - 1;
+    ix = interface.ngll - 1 - ipoint;
+    iz = interface.ngll - 1;
     break;
   case specfem::enums::edge::type::LEFT:
-    i = 0;
-    j = ipoint;
+    ix = 0;
+    iz = ipoint;
     break;
   case specfem::enums::edge::type::RIGHT:
-    i = interface.ngll - 1;
-    j = interface.ngll - 1 - ipoint;
+    ix = interface.ngll - 1;
+    iz = interface.ngll - 1 - ipoint;
     break;
   default:
     assert(false && "Invalid edge type");
@@ -36,24 +36,24 @@ void specfem::edge::locate_point_on_self_edge(
 
 KOKKOS_FUNCTION
 void specfem::edge::locate_point_on_coupled_edge(
-    const int &ipoint, const specfem::edge::interface &interface, int &i,
-    int &j) {
+    const int &ipoint, const specfem::edge::interface &interface, int &iz,
+    int &ix) {
   switch (interface.type) {
   case specfem::enums::edge::type::BOTTOM:
-    i = interface.ngll - 1 - ipoint;
-    j = 0;
+    ix = interface.ngll - 1 - ipoint;
+    iz = 0;
     break;
   case specfem::enums::edge::type::TOP:
-    i = ipoint;
-    j = interface.ngll - 1;
+    ix = ipoint;
+    iz = interface.ngll - 1;
     break;
   case specfem::enums::edge::type::LEFT:
-    i = interface.ngll - 1;
-    j = interface.ngll - 1 - ipoint;
+    ix = interface.ngll - 1;
+    iz = interface.ngll - 1 - ipoint;
     break;
   case specfem::enums::edge::type::RIGHT:
-    i = 0;
-    j = ipoint;
+    ix = 0;
+    iz = ipoint;
     break;
   default:
     assert(false && "Invalid edge type");

--- a/src/parameter_parser/quadrature.cpp
+++ b/src/parameter_parser/quadrature.cpp
@@ -5,30 +5,30 @@
 #include <string>
 #include <tuple>
 
-std::tuple<specfem::quadrature::quadrature *, specfem::quadrature::quadrature *>
+specfem::quadrature::quadratures
 specfem::runtime_configuration::quadrature::instantiate() {
 
-  specfem::quadrature::quadrature *gllx =
-      new specfem::quadrature::gll::gll(this->alpha, this->beta, this->ngllx);
-  specfem::quadrature::quadrature *gllz =
-      new specfem::quadrature::gll::gll(this->alpha, this->beta, this->ngllz);
+  std::cout << this->alpha << " " << this->beta << " " << this->ngll
+            << std::endl;
+
+  specfem::quadrature::gll::gll gll(this->alpha, this->beta, this->ngll);
 
   std::cout << " Quadrature in X-dimension \n";
-  std::cout << *gllx << std::endl;
+  std::cout << gll << std::endl;
 
   std::cout << " Quadrature in Z-dimension \n";
-  std::cout << *gllz << std::endl;
+  std::cout << gll << std::endl;
 
-  return std::make_tuple(gllx, gllz);
+  return specfem::quadrature::quadratures(gll);
 }
 
 specfem::runtime_configuration::quadrature::quadrature(
     const std::string quadrature) {
 
   if (quadrature == "GLL4") {
-    *this = specfem::runtime_configuration::quadrature(0.0, 0.0, 5, 5);
+    *this = specfem::runtime_configuration::quadrature(0.0, 0.0, 5);
   } else if (quadrature == "GLL7") {
-    *this = specfem::runtime_configuration::quadrature(0.0, 0.0, 8, 8);
+    *this = specfem::runtime_configuration::quadrature(0.0, 0.0, 8);
   } else {
     std::ostringstream message;
     message << "Error reading quadrature argument. " << quadrature
@@ -43,7 +43,7 @@ specfem::runtime_configuration::quadrature::quadrature(const YAML::Node &Node) {
   try {
     *this = specfem::runtime_configuration::quadrature(
         Node["alpha"].as<type_real>(), Node["beta"].as<type_real>(),
-        Node["ngllx"].as<int>(), Node["ngllz"].as<int>());
+        Node["ngll"].as<int>());
   } catch (YAML::InvalidNode &e) {
     try {
       *this = specfem::runtime_configuration::quadrature(

--- a/src/parameter_parser/setup.cpp
+++ b/src/parameter_parser/setup.cpp
@@ -103,18 +103,18 @@ specfem::runtime_configuration::setup::setup(const std::string &parameter_file,
   //           seismogram);
   // }
 
-  // try {
-  //   const YAML::Node &n_time_marching = n_solver["time-marching"];
-  //   const YAML::Node &n_timescheme = n_time_marching["time-scheme"];
+  try {
+    const YAML::Node &n_time_marching = n_solver["time-marching"];
+    const YAML::Node &n_timescheme = n_time_marching["time-scheme"];
 
-  //   this->solver =
-  //       std::make_unique<specfem::runtime_configuration::solver::time_marching>(
-  //           n_timescheme);
-  // } catch (YAML::InvalidNode &e) {
-  //   std::ostringstream message;
-  //   message << "Error reading specfem solver configuration. \n" << e.what();
-  //   throw std::runtime_error(message.str());
-  // }
+    this->solver =
+        std::make_unique<specfem::runtime_configuration::solver::time_marching>(
+            n_timescheme);
+  } catch (YAML::InvalidNode &e) {
+    std::ostringstream message;
+    message << "Error reading specfem solver configuration. \n" << e.what();
+    throw std::runtime_error(message.str());
+  }
 }
 
 std::string specfem::runtime_configuration::setup::print_header(

--- a/src/parameter_parser/setup.cpp
+++ b/src/parameter_parser/setup.cpp
@@ -88,33 +88,33 @@ specfem::runtime_configuration::setup::setup(const std::string &parameter_file,
     throw std::runtime_error(message.str());
   }
 
-  try {
-    this->seismogram =
-        std::make_unique<specfem::runtime_configuration::seismogram>(
-            runtime_config["seismogram"]);
-  } catch (YAML::InvalidNode &e) {
-    YAML::Node seismogram;
-    seismogram["seismogram-format"] = "ascii";
-    std::string folder_name = "results";
-    create_folder_if_not_exists(folder_name);
-    seismogram["output-folder"] = folder_name;
-    this->seismogram =
-        std::make_unique<specfem::runtime_configuration::seismogram>(
-            seismogram);
-  }
+  // try {
+  //   this->seismogram =
+  //       std::make_unique<specfem::runtime_configuration::seismogram>(
+  //           runtime_config["seismogram"]);
+  // } catch (YAML::InvalidNode &e) {
+  //   YAML::Node seismogram;
+  //   seismogram["seismogram-format"] = "ascii";
+  //   std::string folder_name = "results";
+  //   create_folder_if_not_exists(folder_name);
+  //   seismogram["output-folder"] = folder_name;
+  //   this->seismogram =
+  //       std::make_unique<specfem::runtime_configuration::seismogram>(
+  //           seismogram);
+  // }
 
-  try {
-    const YAML::Node &n_time_marching = n_solver["time-marching"];
-    const YAML::Node &n_timescheme = n_time_marching["time-scheme"];
+  // try {
+  //   const YAML::Node &n_time_marching = n_solver["time-marching"];
+  //   const YAML::Node &n_timescheme = n_time_marching["time-scheme"];
 
-    this->solver =
-        std::make_unique<specfem::runtime_configuration::solver::time_marching>(
-            n_timescheme);
-  } catch (YAML::InvalidNode &e) {
-    std::ostringstream message;
-    message << "Error reading specfem solver configuration. \n" << e.what();
-    throw std::runtime_error(message.str());
-  }
+  //   this->solver =
+  //       std::make_unique<specfem::runtime_configuration::solver::time_marching>(
+  //           n_timescheme);
+  // } catch (YAML::InvalidNode &e) {
+  //   std::ostringstream message;
+  //   message << "Error reading specfem solver configuration. \n" << e.what();
+  //   throw std::runtime_error(message.str());
+  // }
 }
 
 std::string specfem::runtime_configuration::setup::print_header(

--- a/src/parameter_parser/solver/solver.cpp
+++ b/src/parameter_parser/solver/solver.cpp
@@ -2,13 +2,13 @@
 #include "timescheme/interface.hpp"
 #include "yaml-cpp/yaml.h"
 
-std::shared_ptr<specfem::TimeScheme::TimeScheme>
-specfem::runtime_configuration::solver::solver::instantiate(
-    const int nstep_between_samples) {
-  std::shared_ptr<specfem::TimeScheme::TimeScheme> it;
+// std::shared_ptr<specfem::TimeScheme::TimeScheme>
+// specfem::runtime_configuration::solver::solver::instantiate(
+//     const int nstep_between_samples) {
+//   std::shared_ptr<specfem::TimeScheme::TimeScheme> it;
 
-  throw std::runtime_error(
-      "Could not instantiate solver : Error reading parameter file");
+//   throw std::runtime_error(
+//       "Could not instantiate solver : Error reading parameter file");
 
-  return it;
-};
+//   return it;
+// };

--- a/src/parameter_parser/solver/solver.cpp
+++ b/src/parameter_parser/solver/solver.cpp
@@ -2,13 +2,13 @@
 #include "timescheme/interface.hpp"
 #include "yaml-cpp/yaml.h"
 
-// std::shared_ptr<specfem::TimeScheme::TimeScheme>
-// specfem::runtime_configuration::solver::solver::instantiate(
-//     const int nstep_between_samples) {
-//   std::shared_ptr<specfem::TimeScheme::TimeScheme> it;
+std::shared_ptr<specfem::TimeScheme::TimeScheme>
+specfem::runtime_configuration::solver::solver::instantiate(
+    const int nstep_between_samples) {
+  std::shared_ptr<specfem::TimeScheme::TimeScheme> it;
 
-//   throw std::runtime_error(
-//       "Could not instantiate solver : Error reading parameter file");
+  throw std::runtime_error(
+      "Could not instantiate solver : Error reading parameter file");
 
-//   return it;
-// };
+  return it;
+};

--- a/src/parameter_parser/solver/time_marching.cpp
+++ b/src/parameter_parser/solver/time_marching.cpp
@@ -4,21 +4,21 @@
 #include <memory>
 #include <ostream>
 
-// std::shared_ptr<specfem::TimeScheme::TimeScheme>
-// specfem::runtime_configuration::solver::time_marching::instantiate(
-//     const int nstep_between_samples) {
+std::shared_ptr<specfem::TimeScheme::TimeScheme>
+specfem::runtime_configuration::solver::time_marching::instantiate(
+    const int nstep_between_samples) {
 
-//   std::shared_ptr<specfem::TimeScheme::TimeScheme> it;
-//   if (this->timescheme == "Newmark") {
-//     it = std::make_shared<specfem::TimeScheme::Newmark>(
-//         this->nstep, this->t0, this->dt, nstep_between_samples);
-//   }
+  std::shared_ptr<specfem::TimeScheme::TimeScheme> it;
+  if (this->timescheme == "Newmark") {
+    it = std::make_shared<specfem::TimeScheme::Newmark>(
+        this->nstep, this->t0, this->dt, nstep_between_samples);
+  }
 
-//   // User output
-//   std::cout << *it << "\n";
+  // User output
+  std::cout << *it << "\n";
 
-//   return it;
-// }
+  return it;
+}
 
 specfem::runtime_configuration::solver::time_marching::time_marching(
     const YAML::Node &timescheme) {

--- a/src/parameter_parser/solver/time_marching.cpp
+++ b/src/parameter_parser/solver/time_marching.cpp
@@ -4,21 +4,21 @@
 #include <memory>
 #include <ostream>
 
-std::shared_ptr<specfem::TimeScheme::TimeScheme>
-specfem::runtime_configuration::solver::time_marching::instantiate(
-    const int nstep_between_samples) {
+// std::shared_ptr<specfem::TimeScheme::TimeScheme>
+// specfem::runtime_configuration::solver::time_marching::instantiate(
+//     const int nstep_between_samples) {
 
-  std::shared_ptr<specfem::TimeScheme::TimeScheme> it;
-  if (this->timescheme == "Newmark") {
-    it = std::make_shared<specfem::TimeScheme::Newmark>(
-        this->nstep, this->t0, this->dt, nstep_between_samples);
-  }
+//   std::shared_ptr<specfem::TimeScheme::TimeScheme> it;
+//   if (this->timescheme == "Newmark") {
+//     it = std::make_shared<specfem::TimeScheme::Newmark>(
+//         this->nstep, this->t0, this->dt, nstep_between_samples);
+//   }
 
-  // User output
-  std::cout << *it << "\n";
+//   // User output
+//   std::cout << *it << "\n";
 
-  return it;
-}
+//   return it;
+// }
 
 specfem::runtime_configuration::solver::time_marching::time_marching(
     const YAML::Node &timescheme) {

--- a/src/point/boundaries.cpp
+++ b/src/point/boundaries.cpp
@@ -1,6 +1,8 @@
+#include "enumerations/specfem_enums.hpp"
+#include "macros.hpp"
+#include "point/boundary.hpp"
 
-
-void specfem::point::boundary::update_boundary_type(
+void specfem::point::boundary::update_boundary(
     const specfem::enums::boundaries::type &type,
     const specfem::enums::element::boundary_tag &tag) {
   if (type == specfem::enums::boundaries::type::TOP) {
@@ -20,15 +22,15 @@ void specfem::point::boundary::update_boundary_type(
   } else if (type == specfem::enums::boundaries::type::TOP_LEFT) {
     top_left = tag;
   } else {
-    DEVICE_ASSERT(false, "Error: Unknown boundary type");
+    ASSERT(false, "Error: Unknown boundary type");
   }
 }
 
 KOKKOS_FUNCTION
 bool specfem::point::is_on_boundary(
     const specfem::enums::element::boundary_tag &tag,
-    const specfem::compute::access::boundary_types &type, const int &iz,
-    const int &ix, const int &ngllz, const int &ngllx) {
+    const specfem::point::boundary &type, const int &iz, const int &ix,
+    const int &ngllz, const int &ngllx) {
 
   return (type.top == tag && iz == ngllz - 1) ||
          (type.bottom == tag && iz == 0) || (type.left == tag && ix == 0) ||

--- a/src/point/partial_derivatives.cpp
+++ b/src/point/partial_derivatives.cpp
@@ -1,5 +1,6 @@
 
 #include "point/partial_derivatives.hpp"
+#include "point/partial_derivatives.tpp"
 #include <Kokkos_Core.hpp>
 
 // operator+
@@ -42,21 +43,27 @@ specfem::point::operator*(const specfem::point::partial_derivatives2 &lhs,
                                               lhs.xiz * rhs, lhs.gammaz * rhs);
 }
 
-// compute_normal
 KOKKOS_FUNCTION specfem::kokkos::array_type<type_real, 2>
 specfem::point::partial_derivatives2::compute_normal(
-    const specfem::edge::interface &interface) const {
-  switch (interface.type) {
+    const specfem::enums::edge::type &type) const {
+  switch (type) {
   case specfem::enums::edge::type::BOTTOM:
-    return this->compute_normal<specfem::enums::boundaries::type::BOTTOM>();
+    return this->compute_normal<specfem::enums::edge::type::BOTTOM>();
   case specfem::enums::edge::type::TOP:
-    return this->compute_normal<specfem::enums::boundaries::type::TOP>();
+    return this->compute_normal<specfem::enums::edge::type::TOP>();
   case specfem::enums::edge::type::LEFT:
-    return this->compute_normal<specfem::enums::boundaries::type::LEFT>();
+    return this->compute_normal<specfem::enums::edge::type::LEFT>();
   case specfem::enums::edge::type::RIGHT:
-    return this->compute_normal<specfem::enums::boundaries::type::RIGHT>();
+    return this->compute_normal<specfem::enums::edge::type::RIGHT>();
   default:
     ASSERT(false, "Invalid boundary type");
     return specfem::kokkos::array_type<type_real, 2>();
   }
+}
+
+// compute_normal
+KOKKOS_FUNCTION specfem::kokkos::array_type<type_real, 2>
+specfem::point::partial_derivatives2::compute_normal(
+    const specfem::edge::interface &interface) const {
+  return specfem::point::partial_derivatives2::compute_normal(interface.type);
 }

--- a/src/point/partial_derivatives.cpp
+++ b/src/point/partial_derivatives.cpp
@@ -5,8 +5,8 @@
 // operator+
 KOKKOS_FUNCTION
 specfem::point::partial_derivatives2
-operator+(const specfem::point::partial_derivatives2 &lhs,
-          const specfem::point::partial_derivatives2 &rhs) {
+specfem::point::operator+(const specfem::point::partial_derivatives2 &lhs,
+                          const specfem::point::partial_derivatives2 &rhs) {
   return specfem::point::partial_derivatives2(
       lhs.xix + rhs.xix, lhs.gammax + rhs.gammax, lhs.xiz + rhs.xiz,
       lhs.gammaz + rhs.gammaz);
@@ -15,8 +15,8 @@ operator+(const specfem::point::partial_derivatives2 &lhs,
 // operator+=
 KOKKOS_FUNCTION
 specfem::point::partial_derivatives2 &
-operator+=(specfem::point::partial_derivatives2 &lhs,
-           const specfem::point::partial_derivatives2 &rhs) {
+specfem::point::operator+=(specfem::point::partial_derivatives2 &lhs,
+                           const specfem::point::partial_derivatives2 &rhs) {
   lhs.xix += rhs.xix;
   lhs.gammax += rhs.gammax;
   lhs.xiz += rhs.xiz;
@@ -27,8 +27,8 @@ operator+=(specfem::point::partial_derivatives2 &lhs,
 // operator*
 KOKKOS_FUNCTION
 specfem::point::partial_derivatives2
-operator*(const type_real &lhs,
-          const specfem::point::partial_derivatives2 &rhs) {
+specfem::point::operator*(const type_real &lhs,
+                          const specfem::point::partial_derivatives2 &rhs) {
   return specfem::point::partial_derivatives2(lhs * rhs.xix, lhs * rhs.gammax,
                                               lhs * rhs.xiz, lhs * rhs.gammaz);
 }
@@ -36,8 +36,27 @@ operator*(const type_real &lhs,
 // operator*
 KOKKOS_FUNCTION
 specfem::point::partial_derivatives2
-operator*(const specfem::point::partial_derivatives2 &lhs,
-          const type_real &rhs) {
+specfem::point::operator*(const specfem::point::partial_derivatives2 &lhs,
+                          const type_real &rhs) {
   return specfem::point::partial_derivatives2(lhs.xix * rhs, lhs.gammax * rhs,
                                               lhs.xiz * rhs, lhs.gammaz * rhs);
+}
+
+// compute_normal
+KOKKOS_FUNCTION specfem::kokkos::array_type<type_real, 2>
+specfem::point::partial_derivatives2::compute_normal(
+    const specfem::edge::interface &interface) const {
+  switch (interface.type) {
+  case specfem::enums::edge::type::BOTTOM:
+    return this->compute_normal<specfem::enums::boundaries::type::BOTTOM>();
+  case specfem::enums::edge::type::TOP:
+    return this->compute_normal<specfem::enums::boundaries::type::TOP>();
+  case specfem::enums::edge::type::LEFT:
+    return this->compute_normal<specfem::enums::boundaries::type::LEFT>();
+  case specfem::enums::edge::type::RIGHT:
+    return this->compute_normal<specfem::enums::boundaries::type::RIGHT>();
+  default:
+    ASSERT(false, "Invalid boundary type");
+    return specfem::kokkos::array_type<type_real, 2>();
+  }
 }

--- a/src/source/force_source.cpp
+++ b/src/source/force_source.cpp
@@ -11,7 +11,7 @@
 #include "source_time_function/interface.hpp"
 #include "specfem_mpi/interface.hpp"
 #include "specfem_setup.hpp"
-#include "utilities.cpp"
+// #include "utilities.cpp"
 #include "yaml-cpp/yaml.h"
 #include <cmath>
 

--- a/src/source/moment_tensor_source.cpp
+++ b/src/source/moment_tensor_source.cpp
@@ -7,6 +7,7 @@
 #include "kokkos_abstractions.h"
 #include "point/coordinates.hpp"
 #include "point/partial_derivatives.hpp"
+#include "point/partial_derivatives.tpp"
 #include "quadrature/interface.hpp"
 #include "source/interface.hpp"
 #include "source_time_function/interface.hpp"
@@ -47,10 +48,8 @@ void specfem::sources::moment_tensor::compute_source_array(
       specfem::kokkos::HostMDrange<2>({ 0, 0 }, { N, N }),
       KOKKOS_LAMBDA(const int iz, const int ix) {
         type_real hlagrange = hxi_source(ix) * hgamma_source(iz);
-        auto derivatives =
-            partial_derivatives
-                .load_derivatives<false, specfem::kokkos::HostExecSpace>(
-                    lcoord.ispec, iz, ix);
+        auto derivatives = partial_derivatives.load_host_derivatives<false>(
+            lcoord.ispec, iz, ix);
         source_polynomial(iz, ix) = hlagrange;
         element_derivatives(iz, ix) = derivatives;
       });

--- a/src/source/moment_tensor_source.cpp
+++ b/src/source/moment_tensor_source.cpp
@@ -13,7 +13,7 @@
 #include "source_time_function/interface.hpp"
 #include "specfem_mpi/interface.hpp"
 #include "specfem_setup.hpp"
-#include "utilities.cpp"
+// #include "utilities.cpp"
 #include "yaml-cpp/yaml.h"
 #include <cmath>
 

--- a/src/source_time_function/dirac.cpp
+++ b/src/source_time_function/dirac.cpp
@@ -4,24 +4,26 @@
 #include <Kokkos_Core.hpp>
 #include <cmath>
 
-specfem::forcing_function::Dirac::Dirac(type_real f0, type_real tshift,
-                                        type_real factor,
+specfem::forcing_function::Dirac::Dirac(const type_real dt, const type_real f0,
+                                        const type_real tshift,
+                                        const type_real factor,
                                         bool use_trick_for_better_pressure)
-    : f0(f0), factor(factor), tshift(tshift),
+    : dt(dt), f0(f0), factor(factor), tshift(tshift),
       use_trick_for_better_pressure(use_trick_for_better_pressure) {
 
   type_real hdur = 1.0 / this->f0;
 
-  this->t0 = 1.2 * hdur + this->tshift;
+  this->t0 = -1.2 * hdur + this->tshift;
 }
 
 specfem::forcing_function::Dirac::Dirac(
-    YAML::Node &Dirac, const int dt, const bool use_trick_for_better_pressure) {
+    YAML::Node &Dirac, const type_real dt,
+    const bool use_trick_for_better_pressure) {
   type_real f0 = 1.0 / (10.0 * dt);
   type_real tshift = Dirac["tshift"].as<type_real>();
   type_real factor = Dirac["factor"].as<type_real>();
 
-  *this = specfem::forcing_function::Dirac(f0, tshift, factor,
+  *this = specfem::forcing_function::Dirac(dt, f0, tshift, factor,
                                            use_trick_for_better_pressure);
 }
 

--- a/src/source_time_function/ricker.cpp
+++ b/src/source_time_function/ricker.cpp
@@ -14,7 +14,7 @@ specfem::forcing_function::Ricker::Ricker(const type_real dt,
 
   type_real hdur = 1.0 / this->f0;
 
-  this->t0 = 1.2 * hdur + this->tshift;
+  this->t0 = -1.2 * hdur + this->tshift;
 }
 
 specfem::forcing_function::Ricker::Ricker(

--- a/src/source_time_function/ricker.cpp
+++ b/src/source_time_function/ricker.cpp
@@ -4,10 +4,12 @@
 #include <Kokkos_Core.hpp>
 #include <cmath>
 
-specfem::forcing_function::Ricker::Ricker(type_real f0, type_real tshift,
-                                          type_real factor,
+specfem::forcing_function::Ricker::Ricker(const type_real dt,
+                                          const type_real f0,
+                                          const type_real tshift,
+                                          const type_real factor,
                                           bool use_trick_for_better_pressure)
-    : f0(f0), factor(factor), tshift(tshift),
+    : dt(dt), f0(f0), factor(factor), tshift(tshift),
       use_trick_for_better_pressure(use_trick_for_better_pressure) {
 
   type_real hdur = 1.0 / this->f0;
@@ -16,13 +18,13 @@ specfem::forcing_function::Ricker::Ricker(type_real f0, type_real tshift,
 }
 
 specfem::forcing_function::Ricker::Ricker(
-    YAML::Node &Ricker, const int dt,
+    YAML::Node &Ricker, const type_real dt,
     const bool use_trick_for_better_pressure) {
   type_real f0 = Ricker["f0"].as<type_real>();
   type_real tshift = Ricker["tshift"].as<type_real>();
   type_real factor = Ricker["factor"].as<type_real>();
 
-  *this = specfem::forcing_function::Ricker(f0, tshift, factor,
+  *this = specfem::forcing_function::Ricker(dt, f0, tshift, factor,
                                             use_trick_for_better_pressure);
 }
 

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -271,41 +271,41 @@ target_link_libraries(
   -lpthread -lm
 )
 
-# add_executable(
-#   seismogram_elastic_tests
-#   seismogram/elastic/seismogram_tests.cpp
-# )
+add_executable(
+  seismogram_elastic_tests
+  seismogram/elastic/seismogram_tests.cpp
+)
 
-# target_link_libraries(
-#   seismogram_elastic_tests
-#   quadrature
-#   mesh
-#   yaml-cpp
-#   kokkos_environment
-#   mpi_environment
-#   compute
-#   parameter_reader
-#   writer
-#   -lpthread -lm
-# )
+target_link_libraries(
+  seismogram_elastic_tests
+  quadrature
+  mesh
+  yaml-cpp
+  kokkos_environment
+  mpi_environment
+  compute
+  parameter_reader
+  # writer
+  -lpthread -lm
+)
 
-# add_executable(
-#   seismogram_acoustic_tests
-#   seismogram/acoustic/seismogram_tests.cpp
-# )
+add_executable(
+  seismogram_acoustic_tests
+  seismogram/acoustic/seismogram_tests.cpp
+)
 
-# target_link_libraries(
-#   seismogram_acoustic_tests
-#   quadrature
-#   mesh
-#   yaml-cpp
-#   kokkos_environment
-#   mpi_environment
-#   compute
-#   parameter_reader
-#   writer
-#   -lpthread -lm
-# )
+target_link_libraries(
+  seismogram_acoustic_tests
+  quadrature
+  mesh
+  yaml-cpp
+  kokkos_environment
+  mpi_environment
+  compute
+  parameter_reader
+  # writer
+  -lpthread -lm
+)
 
 add_executable(
   compute_coupled_interfaces_tests
@@ -342,6 +342,6 @@ if (NOT MPI_PARALLEL)
   gtest_discover_tests(interpolate_function)
   gtest_discover_tests(rmass_inverse_tests)
   gtest_discover_tests(displacement_newmark_tests)
-  # gtest_discover_tests(seismogram_elastic_tests)
-  # gtest_discover_tests(seismogram_acoustic_tests)
+  gtest_discover_tests(seismogram_elastic_tests)
+  gtest_discover_tests(seismogram_acoustic_tests)
 endif(NOT MPI_PARALLEL)

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -248,25 +248,28 @@ target_link_libraries(
   -lpthread -lm
 )
 
-# add_executable(
-#   displacement_newmark_tests
-#   displacement_tests/Newmark/newmark_tests.cpp
-# )
+add_executable(
+  displacement_newmark_tests
+  displacement_tests/Newmark/newmark_tests.cpp
+)
 
-# target_link_libraries(
-#   displacement_newmark_tests
-#   quadrature
-#   mesh
-#   material_class
-#   yaml-cpp
-#   kokkos_environment
-#   mpi_environment
-#   compute
-#   parameter_reader
-#   compare_arrays
-#   timescheme
-#   -lpthread -lm
-# )
+target_link_libraries(
+  displacement_newmark_tests
+  quadrature
+  mesh
+  # material_class
+  yaml-cpp
+  kokkos_environment
+  mpi_environment
+  compute
+  parameter_reader
+  compare_arrays
+  timescheme
+  point
+  edge
+  algorithms
+  -lpthread -lm
+)
 
 # add_executable(
 #   seismogram_elastic_tests
@@ -338,7 +341,7 @@ if (NOT MPI_PARALLEL)
   gtest_discover_tests(locate_point)
   gtest_discover_tests(interpolate_function)
   gtest_discover_tests(rmass_inverse_tests)
-  # gtest_discover_tests(displacement_newmark_tests)
+  gtest_discover_tests(displacement_newmark_tests)
   # gtest_discover_tests(seismogram_elastic_tests)
   # gtest_discover_tests(seismogram_acoustic_tests)
 endif(NOT MPI_PARALLEL)

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -227,24 +227,26 @@ target_link_libraries(
 #   -lpthread -lm
 # )
 
-# add_executable(
-#   rmass_inverse_tests
-#   domain/rmass_inverse_tests.cpp
-# )
+add_executable(
+  rmass_inverse_tests
+  domain/rmass_inverse_tests.cpp
+)
 
-# target_link_libraries(
-#   rmass_inverse_tests
-#   quadrature
-#   mesh
-#   material_class
-#   yaml-cpp
-#   kokkos_environment
-#   mpi_environment
-#   compute
-#   parameter_reader
-#   compare_arrays
-#   -lpthread -lm
-# )
+target_link_libraries(
+  rmass_inverse_tests
+  quadrature
+  mesh
+  # material_class
+  yaml-cpp
+  kokkos_environment
+  mpi_environment
+  compute
+  parameter_reader
+  compare_arrays
+  point
+  algorithms
+  -lpthread -lm
+)
 
 # add_executable(
 #   displacement_newmark_tests
@@ -335,7 +337,7 @@ if (NOT MPI_PARALLEL)
   gtest_discover_tests(compute_tests)
   gtest_discover_tests(locate_point)
   gtest_discover_tests(interpolate_function)
-  # gtest_discover_tests(rmass_inverse_tests)
+  gtest_discover_tests(rmass_inverse_tests)
   # gtest_discover_tests(displacement_newmark_tests)
   # gtest_discover_tests(seismogram_elastic_tests)
   # gtest_discover_tests(seismogram_acoustic_tests)

--- a/tests/unit-tests/compute/coupled_interfaces/coupled_interfaces_tests.cpp
+++ b/tests/unit-tests/compute/coupled_interfaces/coupled_interfaces_tests.cpp
@@ -133,20 +133,18 @@ void test_edges(
     const auto edge2l = edge2(interface);
 
     // iterate over the edge
-    int npoints = specfem::edge::num_points_on_interface(edge1l, ngllx, ngllz);
+    int npoints = specfem::edge::num_points_on_interface(edge1l);
 
     for (int ipoint = 0; ipoint < npoints; ipoint++) {
       // Get ipoint along the edge in element1
       int i1, j1;
-      specfem::edge::locate_point_on_self_edge(ipoint, edge1l, ngllx, ngllz, i1,
-                                               j1);
+      specfem::edge::locate_point_on_self_edge(ipoint, edge1l, i1, j1);
       const specfem::point::gcoord2 self_point(coordinates(0, ispec1l, j1, i1),
                                                coordinates(1, ispec1l, j1, i1));
 
       // Get ipoint along the edge in element2
       int i2, j2;
-      specfem::edge::locate_point_on_coupled_edge(ipoint, edge2l, ngllx, ngllz,
-                                                  i2, j2);
+      specfem::edge::locate_point_on_coupled_edge(ipoint, edge2l, i2, j2);
       const specfem::point::gcoord2 coupled_point(
           coordinates(0, ispec2l, j2, i2), coordinates(1, ispec2l, j2, i2));
 

--- a/tests/unit-tests/compute/coupled_interfaces/coupled_interfaces_tests.cpp
+++ b/tests/unit-tests/compute/coupled_interfaces/coupled_interfaces_tests.cpp
@@ -138,13 +138,13 @@ void test_edges(
     for (int ipoint = 0; ipoint < npoints; ipoint++) {
       // Get ipoint along the edge in element1
       int i1, j1;
-      specfem::edge::locate_point_on_self_edge(ipoint, edge1l, i1, j1);
+      specfem::edge::locate_point_on_self_edge(ipoint, edge1l, j1, i1);
       const specfem::point::gcoord2 self_point(coordinates(0, ispec1l, j1, i1),
                                                coordinates(1, ispec1l, j1, i1));
 
       // Get ipoint along the edge in element2
       int i2, j2;
-      specfem::edge::locate_point_on_coupled_edge(ipoint, edge2l, i2, j2);
+      specfem::edge::locate_point_on_coupled_edge(ipoint, edge2l, j2, i2);
       const specfem::point::gcoord2 coupled_point(
           coordinates(0, ispec2l, j2, i2), coordinates(1, ispec2l, j2, i2));
 

--- a/tests/unit-tests/displacement_tests/Newmark/newmark_tests.cpp
+++ b/tests/unit-tests/displacement_tests/Newmark/newmark_tests.cpp
@@ -95,20 +95,20 @@ specfem::testing::array1d<type_real, Kokkos::LayoutLeft> compact_array(
 
   assert(n1 == nglob);
 
-  int count = 0;
+  int max_global_index = std::numeric_limits<int>::min();
+
   for (int i = 0; i < nglob; ++i) {
     if (index_mapping(i) != -1) {
-      count++;
+      max_global_index = std::max(max_global_index, index_mapping(i));
     }
   }
 
-  specfem::testing::array1d<type_real, Kokkos::LayoutLeft> local_array(count);
+  specfem::testing::array1d<type_real, Kokkos::LayoutLeft> local_array(
+      max_global_index + 1);
 
-  count = 0;
   for (int i = 0; i < nglob; ++i) {
     if (index_mapping(i) != -1) {
-      local_array.data(count) = global.data(i);
-      count++;
+      local_array.data(index_mapping(i)) = global.data(i);
     }
   }
 
@@ -126,23 +126,22 @@ specfem::testing::array2d<type_real, Kokkos::LayoutLeft> compact_array(
 
   assert(n1 == nglob);
 
-  int count = 0;
+  int max_global_index = std::numeric_limits<int>::min();
+
   for (int i = 0; i < nglob; ++i) {
     if (index_mapping(i) != -1) {
-      count++;
+      max_global_index = std::max(max_global_index, index_mapping(i));
     }
   }
 
-  specfem::testing::array2d<type_real, Kokkos::LayoutLeft> local_array(count,
-                                                                       n2);
+  specfem::testing::array2d<type_real, Kokkos::LayoutLeft> local_array(
+      max_global_index + 1, n2);
 
-  count = 0;
   for (int i = 0; i < nglob; ++i) {
     if (index_mapping(i) != -1) {
       for (int j = 0; j < n2; ++j) {
-        local_array.data(count, j) = global.data(i, j);
+        local_array.data(index_mapping(i), j) = global.data(i, j);
       }
-      count++;
     }
   }
 

--- a/tests/unit-tests/displacement_tests/Newmark/newmark_tests.cpp
+++ b/tests/unit-tests/displacement_tests/Newmark/newmark_tests.cpp
@@ -1,6 +1,6 @@
 #include "../../Kokkos_Environment.hpp"
 #include "../../MPI_environment.hpp"
-#include "../../utilities/include/compare_array.h"
+#include "../../utilities/include/interface.hpp"
 #include "compute/interface.hpp"
 #include "constants.hpp"
 #include "domain/interface.hpp"
@@ -107,50 +107,29 @@ TEST(DISPLACEMENT_TESTS, newmark_scheme_tests) {
     const auto [database_file, sources_file] = setup.get_databases();
 
     // Set up GLL quadrature points
-    auto [gllx, gllz] = setup.instantiate_quadrature();
+    const auto quadratures = setup.instantiate_quadrature();
 
     // Read mesh generated MESHFEM
-    std::vector<std::shared_ptr<specfem::material::material> > materials;
-    specfem::mesh::mesh mesh(database_file, materials, mpi);
+    specfem::mesh::mesh mesh(database_file, mpi);
+    const type_real dt = setup.get_dt();
 
     // Read sources
     //    if start time is not explicitly specified then t0 is determined using
     //    source frequencies and time shift
-    auto [sources, t0] =
-        specfem::sources::read_sources(sources_file, setup.get_dt(), mpi);
+    auto [sources, t0] = specfem::sources::read_sources(sources_file, dt);
 
-    // Generate compute structs to be used by the solver
-    specfem::compute::compute compute(mesh.coorg, mesh.material_ind.knods, gllx,
-                                      gllz);
-    specfem::compute::partial_derivatives partial_derivatives(
-        mesh.coorg, mesh.material_ind.knods, gllx, gllz);
-    specfem::compute::properties material_properties(
-        mesh.material_ind.kmato, materials, mesh.nspec, gllx->get_N(),
-        gllz->get_N());
-    specfem::compute::coupled_interfaces::coupled_interfaces coupled_interfaces(
-        compute.h_ibool, compute.coordinates.coord,
-        material_properties.h_ispec_type, mesh.coupled_interfaces);
-
-    // Set up boundary conditions
-    specfem::compute::boundaries boundary_conditions(
-        mesh.material_ind.kmato, materials, mesh.acfree_surface,
-        mesh.abs_boundary);
-
-    // Locate the sources
-    for (auto &source : sources)
-      source->locate(compute.coordinates.coord, compute.h_ibool,
-                     gllx->get_hxi(), gllz->get_hxi(), mesh.nproc, mesh.coorg,
-                     mesh.material_ind.knods, mesh.npgeo,
-                     material_properties.h_ispec_type, mpi);
-
-    // User output
     for (auto &source : sources) {
       if (mpi->main_proc())
-        std::cout << *source << std::endl;
+        std::cout << source->print() << std::endl;
     }
 
-    // Update solver intialization time
     setup.update_t0(-1.0 * t0);
+
+    std::vector<std::shared_ptr<specfem::receivers::receiver> > receivers(0);
+    std::vector<specfem::enums::seismogram::type> seismogram_types(0);
+
+    specfem::compute::assembly assembly(mesh, quadratures, sources, receivers,
+                                        seismogram_types, 0);
 
     // Instantiate the solver and timescheme
     auto it = setup.instantiate_solver();
@@ -159,83 +138,65 @@ TEST(DISPLACEMENT_TESTS, newmark_scheme_tests) {
     if (mpi->main_proc())
       std::cout << *it << std::endl;
 
-    // Setup solver compute struct
-    const type_real xmax = compute.coordinates.xmax;
-    const type_real xmin = compute.coordinates.xmin;
-    const type_real zmax = compute.coordinates.zmax;
-    const type_real zmin = compute.coordinates.zmin;
-
-    specfem::compute::sources compute_sources(sources, gllx, gllz, xmax, xmin,
-                                              zmax, zmin, mpi);
-
-    specfem::compute::receivers compute_receivers;
-
     // Instantiate domain classes
 
     try {
 
-      const int nglob = specfem::utilities::compute_nglob(compute.h_ibool);
       specfem::enums::element::quadrature::static_quadrature_points<5> qp5;
 
       specfem::domain::domain<
           specfem::enums::element::medium::elastic,
           specfem::enums::element::quadrature::static_quadrature_points<5> >
-          elastic_domain_static(nglob, qp5, &compute, material_properties,
-                                partial_derivatives, boundary_conditions,
-                                compute_sources, compute_receivers, gllx, gllz);
+          elastic_domain_static(assembly, qp5);
 
       specfem::domain::domain<
           specfem::enums::element::medium::acoustic,
           specfem::enums::element::quadrature::static_quadrature_points<5> >
-          acoustic_domain_static(nglob, qp5, &compute, material_properties,
-                                 partial_derivatives, boundary_conditions,
-                                 compute_sources, compute_receivers, gllx,
-                                 gllz);
+          acoustic_domain_static(assembly, qp5);
 
       // Instantiate coupled interfaces
-      specfem::coupled_interface::coupled_interface acoustic_elastic_interface(
-          acoustic_domain_static, elastic_domain_static, coupled_interfaces,
-          qp5, partial_derivatives, compute.ibool, gllx->get_w(),
-          gllz->get_w());
+      specfem::coupled_interface::coupled_interface<
+          specfem::enums::element::medium::acoustic,
+          specfem::enums::element::medium::elastic>
+          acoustic_elastic_interface(assembly);
 
-      specfem::coupled_interface::coupled_interface elastic_acoustic_interface(
-          elastic_domain_static, acoustic_domain_static, coupled_interfaces,
-          qp5, partial_derivatives, compute.ibool, gllx->get_w(),
-          gllz->get_w());
+      specfem::coupled_interface::coupled_interface<
+          specfem::enums::element::medium::elastic,
+          specfem::enums::element::medium::acoustic>
+          elastic_acoustic_interface(assembly);
 
       std::shared_ptr<specfem::solver::solver> solver = std::make_shared<
           specfem::solver::time_marching<specfem::enums::element::quadrature::
                                              static_quadrature_points<5> > >(
-          acoustic_domain_static, elastic_domain_static,
+          assembly, acoustic_domain_static, elastic_domain_static,
           acoustic_elastic_interface, elastic_acoustic_interface, it);
 
       solver->run();
 
-      elastic_domain_static.sync_field(specfem::sync::DeviceToHost);
-      acoustic_domain_static.sync_field(specfem::sync::DeviceToHost);
+      assembly.fields.sync_fields<specfem::sync::kind::DeviceToHost>();
 
-      if (Test.database.elastic_domain_field != "NULL") {
-        specfem::kokkos::HostView2d<type_real, Kokkos::LayoutLeft>
-            field_elastic = elastic_domain_static.get_host_field();
+      // if (Test.database.elastic_domain_field != "NULL") {
+      //   specfem::kokkos::HostView2d<type_real, Kokkos::LayoutLeft>
+      //       field_elastic = elastic_domain_static.get_host_field();
 
-        type_real tolerance = 0.01;
+      //   type_real tolerance = 0.01;
 
-        specfem::testing::compare_norm(field_elastic,
-                                       Test.database.elastic_domain_field,
-                                       nglob, ndim, tolerance);
-      }
+      //   specfem::testing::compare_norm(field_elastic,
+      //                                  Test.database.elastic_domain_field,
+      //                                  nglob, ndim, tolerance);
+      // }
 
-      if (Test.database.acoustic_domain_field != "NULL") {
-        specfem::kokkos::HostView1d<type_real, Kokkos::LayoutLeft>
-            field_acoustic = Kokkos::subview(
-                acoustic_domain_static.get_host_field(), Kokkos::ALL(), 0);
+      // if (Test.database.acoustic_domain_field != "NULL") {
+      //   specfem::kokkos::HostView1d<type_real, Kokkos::LayoutLeft>
+      //       field_acoustic = Kokkos::subview(
+      //           acoustic_domain_static.get_host_field(), Kokkos::ALL(), 0);
 
-        type_real tolerance = 0.0001;
+      //   type_real tolerance = 0.0001;
 
-        specfem::testing::compare_norm(field_acoustic,
-                                       Test.database.acoustic_domain_field,
-                                       nglob, tolerance);
-      }
+      //   specfem::testing::compare_norm(field_acoustic,
+      //                                  Test.database.acoustic_domain_field,
+      //                                  nglob, tolerance);
+      // }
 
       std::cout << "--------------------------------------------------\n"
                 << "\033[0;32m[PASSED]\033[0m Test: " << Test.name << "\n"

--- a/tests/unit-tests/displacement_tests/Newmark/serial/test1/specfem_config.yaml
+++ b/tests/unit-tests/displacement_tests/Newmark/serial/test1/specfem_config.yaml
@@ -13,10 +13,7 @@ parameters:
   simulation-setup:
     ## quadrature setup
     quadrature:
-      alpha: 0.0
-      beta: 0.0
-      ngllx: 5
-      ngllz: 5
+      quadrature-type: GLL4
 
     ## Solver setup
     solver:

--- a/tests/unit-tests/displacement_tests/Newmark/serial/test2/specfem_config.yaml
+++ b/tests/unit-tests/displacement_tests/Newmark/serial/test2/specfem_config.yaml
@@ -13,10 +13,7 @@ parameters:
   simulation-setup:
     ## quadrature setup
     quadrature:
-      alpha: 0.0
-      beta: 0.0
-      ngllx: 5
-      ngllz: 5
+      quadrature-type: GLL4
 
     ## Solver setup
     solver:

--- a/tests/unit-tests/displacement_tests/Newmark/serial/test3/specfem_config.yaml
+++ b/tests/unit-tests/displacement_tests/Newmark/serial/test3/specfem_config.yaml
@@ -16,10 +16,7 @@ parameters:
   simulation-setup:
     ## quadrature setup
     quadrature:
-      alpha: 0.0
-      beta: 0.0
-      ngllx: 5
-      ngllz: 5
+      quadrature-type: GLL4
 
     ## Solver setup
     solver:

--- a/tests/unit-tests/displacement_tests/Newmark/serial/test4/specfem_config.yaml
+++ b/tests/unit-tests/displacement_tests/Newmark/serial/test4/specfem_config.yaml
@@ -16,10 +16,7 @@ parameters:
   simulation-setup:
     ## quadrature setup
     quadrature:
-      alpha: 0.0
-      beta: 0.0
-      ngllx: 5
-      ngllz: 5
+      quadrature-type: GLL4
 
     ## Solver setup
     solver:

--- a/tests/unit-tests/displacement_tests/Newmark/serial/test5/specfem_config.yaml
+++ b/tests/unit-tests/displacement_tests/Newmark/serial/test5/specfem_config.yaml
@@ -14,10 +14,7 @@ parameters:
   simulation-setup:
     ## quadrature setup
     quadrature:
-      alpha: 0.0
-      beta: 0.0
-      ngllx: 5
-      ngllz: 5
+      quadrature-type: GLL4
 
     ## Solver setup
     solver:

--- a/tests/unit-tests/displacement_tests/Newmark/serial/test6/specfem_config.yaml
+++ b/tests/unit-tests/displacement_tests/Newmark/serial/test6/specfem_config.yaml
@@ -14,10 +14,7 @@ parameters:
   simulation-setup:
     ## quadrature setup
     quadrature:
-      alpha: 0.0
-      beta: 0.0
-      ngllx: 5
-      ngllz: 5
+      quadrature-type: GLL4
 
     ## Solver setup
     solver:

--- a/tests/unit-tests/displacement_tests/Newmark/serial/test7/specfem_config.yaml
+++ b/tests/unit-tests/displacement_tests/Newmark/serial/test7/specfem_config.yaml
@@ -14,10 +14,7 @@ parameters:
   simulation-setup:
     ## quadrature setup
     quadrature:
-      alpha: 0.0
-      beta: 0.0
-      ngllx: 5
-      ngllz: 5
+      quadrature-type: GLL4
 
     ## Solver setup
     solver:

--- a/tests/unit-tests/displacement_tests/Newmark/serial/test8/specfem_config.yaml
+++ b/tests/unit-tests/displacement_tests/Newmark/serial/test8/specfem_config.yaml
@@ -14,10 +14,7 @@ parameters:
   simulation-setup:
     ## quadrature setup
     quadrature:
-      alpha: 0.0
-      beta: 0.0
-      ngllx: 5
-      ngllz: 5
+      quadrature-type: GLL4
 
     ## Solver setup
     solver:

--- a/tests/unit-tests/domain/rmass_inverse_tests.cpp
+++ b/tests/unit-tests/domain/rmass_inverse_tests.cpp
@@ -185,7 +185,7 @@ TEST(DOMAIN_TESTS, rmass_inverse) {
 
     // Generate compute structs to be used by the solver
     specfem::compute::assembly assembly(mesh, quadratures, sources, receivers,
-                                        stypes, 0);
+                                        stypes, 0, 0);
 
     try {
 

--- a/tests/unit-tests/domain/rmass_inverse_tests.cpp
+++ b/tests/unit-tests/domain/rmass_inverse_tests.cpp
@@ -97,20 +97,20 @@ specfem::testing::array1d<type_real, Kokkos::LayoutLeft> compact_array(
 
   assert(n1 == nglob);
 
-  int count = 0;
+  int max_global_index = std::numeric_limits<int>::min();
+
   for (int i = 0; i < nglob; ++i) {
     if (index_mapping(i) != -1) {
-      count++;
+      max_global_index = std::max(max_global_index, index_mapping(i));
     }
   }
 
-  specfem::testing::array1d<type_real, Kokkos::LayoutLeft> local_array(count);
+  specfem::testing::array1d<type_real, Kokkos::LayoutLeft> local_array(
+      max_global_index + 1);
 
-  count = 0;
   for (int i = 0; i < nglob; ++i) {
     if (index_mapping(i) != -1) {
-      local_array.data(count) = global.data(i);
-      count++;
+      local_array.data(index_mapping(i)) = global.data(i);
     }
   }
 
@@ -128,23 +128,22 @@ specfem::testing::array2d<type_real, Kokkos::LayoutLeft> compact_array(
 
   assert(n1 == nglob);
 
-  int count = 0;
+  int max_global_index = std::numeric_limits<int>::min();
+
   for (int i = 0; i < nglob; ++i) {
     if (index_mapping(i) != -1) {
-      count++;
+      max_global_index = std::max(max_global_index, index_mapping(i));
     }
   }
 
-  specfem::testing::array2d<type_real, Kokkos::LayoutLeft> local_array(count,
-                                                                       n2);
+  specfem::testing::array2d<type_real, Kokkos::LayoutLeft> local_array(
+      max_global_index + 1, n2);
 
-  count = 0;
   for (int i = 0; i < nglob; ++i) {
     if (index_mapping(i) != -1) {
       for (int j = 0; j < n2; ++j) {
-        local_array.data(count, j) = global.data(i, j);
+        local_array.data(index_mapping(i), j) = global.data(i, j);
       }
-      count++;
     }
   }
 

--- a/tests/unit-tests/domain/rmass_inverse_tests.cpp
+++ b/tests/unit-tests/domain/rmass_inverse_tests.cpp
@@ -201,10 +201,10 @@ TEST(DOMAIN_TESTS, rmass_inverse) {
           specfem::enums::element::quadrature::static_quadrature_points<5> >
           acoustic_domain_static(assembly, qp5);
 
-      // elastic_domain_static.template mass_time_contribution<
-      //     specfem::enums::time_scheme::type::newmark>(setup.get_dt());
-      // acoustic_domain_static.template mass_time_contribution<
-      //     specfem::enums::time_scheme::type::newmark>(setup.get_dt());
+      elastic_domain_static.template mass_time_contribution<
+          specfem::enums::time_scheme::type::newmark>(setup.get_dt());
+      acoustic_domain_static.template mass_time_contribution<
+          specfem::enums::time_scheme::type::newmark>(setup.get_dt());
 
       elastic_domain_static.invert_mass_matrix();
       acoustic_domain_static.invert_mass_matrix();

--- a/tests/unit-tests/domain/serial/test1/specfem_config.yaml
+++ b/tests/unit-tests/domain/serial/test1/specfem_config.yaml
@@ -8,10 +8,7 @@ parameters:
   simulation-setup:
     ## quadrature setup
     quadrature:
-      alpha: 0.0
-      beta: 0.0
-      ngllx: 5
-      ngllz: 5
+      quadrature-type: GLL4
 
     ## Solver setup
     solver:

--- a/tests/unit-tests/domain/serial/test2/specfem_config.yaml
+++ b/tests/unit-tests/domain/serial/test2/specfem_config.yaml
@@ -8,10 +8,7 @@ parameters:
   simulation-setup:
     ## quadrature setup
     quadrature:
-      alpha: 0.0
-      beta: 0.0
-      ngllx: 5
-      ngllz: 5
+      quadrature-type: GLL4
 
     ## Solver setup
     solver:

--- a/tests/unit-tests/domain/serial/test3/specfem_config.yaml
+++ b/tests/unit-tests/domain/serial/test3/specfem_config.yaml
@@ -8,10 +8,7 @@ parameters:
   simulation-setup:
     ## quadrature setup
     quadrature:
-      alpha: 0.0
-      beta: 0.0
-      ngllx: 5
-      ngllz: 5
+      quadrature-type: GLL4
 
     ## Solver setup
     solver:

--- a/tests/unit-tests/domain/serial/test4/specfem_config.yaml
+++ b/tests/unit-tests/domain/serial/test4/specfem_config.yaml
@@ -8,10 +8,7 @@ parameters:
   simulation-setup:
     ## quadrature setup
     quadrature:
-      alpha: 0.0
-      beta: 0.0
-      ngllx: 5
-      ngllz: 5
+      quadrature-type: GLL4
 
     ## Solver setup
     solver:

--- a/tests/unit-tests/domain/test_config.yaml
+++ b/tests/unit-tests/domain/test_config.yaml
@@ -17,20 +17,20 @@ Tests:
       specfem_config: "../../../tests/unit-tests/domain/serial/test2/specfem_config.yaml"
       acoustic_mass_matrix: "../../../tests/unit-tests/domain/serial/test2/rmass_inverse_acoustic.bin"
 
-  # - name : "SerialTest3 : Homogeneous acoustic domain (stacey BC)"
-  #   description: >
-  #     Testing inverse of mass matrix on a homogeneous acoustic domain with no interfaces. Test is run on a single MPI process. Stacey BC are applied on top/right/left/bottom boundaries.
-  #   config:
-  #     nproc : 1
-  #   databases:
-  #     specfem_config: "../../../tests/unit-tests/domain/serial/test3/specfem_config.yaml"
-  #     acoustic_domain_field: "../../../tests/unit-tests/domain/serial/test3/potential_acoustic.bin"
+  - name : "SerialTest3 : Homogeneous acoustic domain (stacey BC)"
+    description: >
+      Testing inverse of mass matrix on a homogeneous acoustic domain with no interfaces. Test is run on a single MPI process. Stacey BC are applied on top/right/left/bottom boundaries.
+    config:
+      nproc : 1
+    databases:
+      specfem_config: "../../../tests/unit-tests/domain/serial/test3/specfem_config.yaml"
+      acoustic_domain_field: "../../../tests/unit-tests/domain/serial/test3/potential_acoustic.bin"
 
-  # - name : "SerialTest4 : Homogeneous elastic domain (stacey BC)"
-  #   description: >
-  #     Testing inverse of mass matrix on a homogeneous elastic domain with no interfaces. Test is run on a single MPI process. Stacey BC are applied on top/right/left/bottom boundaries.
-  #   config:
-  #     nproc : 1
-  #   databases:
-  #     specfem_config: "../../../tests/unit-tests/domain/serial/test4/specfem_config.yaml"
-  #     elastic_domain_field: "../../../tests/unit-tests/domain/serial/test4/displacement.bin"
+  - name : "SerialTest4 : Homogeneous elastic domain (stacey BC)"
+    description: >
+      Testing inverse of mass matrix on a homogeneous elastic domain with no interfaces. Test is run on a single MPI process. Stacey BC are applied on top/right/left/bottom boundaries.
+    config:
+      nproc : 1
+    databases:
+      specfem_config: "../../../tests/unit-tests/domain/serial/test4/specfem_config.yaml"
+      elastic_domain_field: "../../../tests/unit-tests/domain/serial/test4/displacement.bin"

--- a/tests/unit-tests/domain/test_config.yaml
+++ b/tests/unit-tests/domain/test_config.yaml
@@ -6,7 +6,7 @@ Tests:
       nproc : 1
     databases:
       specfem_config: "../../../tests/unit-tests/domain/serial/test1/specfem_config.yaml"
-      elastic_domain_field: "../../../tests/unit-tests/domain/serial/test1/displacement.bin"
+      elastic_mass_matrix: "../../../tests/unit-tests/domain/serial/test1/rmass_inverse_elastic.bin"
 
   - name : "SerialTest2 : Homogeneous acoustic domain"
     description: >
@@ -15,22 +15,22 @@ Tests:
       nproc : 1
     databases:
       specfem_config: "../../../tests/unit-tests/domain/serial/test2/specfem_config.yaml"
-      acoustic_domain_field: "../../../tests/unit-tests/domain/serial/test2/potential_acoustic.bin"
+      acoustic_mass_matrix: "../../../tests/unit-tests/domain/serial/test2/rmass_inverse_acoustic.bin"
 
-  - name : "SerialTest3 : Homogeneous acoustic domain (stacey BC)"
-    description: >
-      Testing inverse of mass matrix on a homogeneous acoustic domain with no interfaces. Test is run on a single MPI process. Stacey BC are applied on top/right/left/bottom boundaries.
-    config:
-      nproc : 1
-    databases:
-      specfem_config: "../../../tests/unit-tests/domain/serial/test3/specfem_config.yaml"
-      acoustic_domain_field: "../../../tests/unit-tests/domain/serial/test3/potential_acoustic.bin"
+  # - name : "SerialTest3 : Homogeneous acoustic domain (stacey BC)"
+  #   description: >
+  #     Testing inverse of mass matrix on a homogeneous acoustic domain with no interfaces. Test is run on a single MPI process. Stacey BC are applied on top/right/left/bottom boundaries.
+  #   config:
+  #     nproc : 1
+  #   databases:
+  #     specfem_config: "../../../tests/unit-tests/domain/serial/test3/specfem_config.yaml"
+  #     acoustic_domain_field: "../../../tests/unit-tests/domain/serial/test3/potential_acoustic.bin"
 
-  - name : "SerialTest4 : Homogeneous elastic domain (stacey BC)"
-    description: >
-      Testing inverse of mass matrix on a homogeneous elastic domain with no interfaces. Test is run on a single MPI process. Stacey BC are applied on top/right/left/bottom boundaries.
-    config:
-      nproc : 1
-    databases:
-      specfem_config: "../../../tests/unit-tests/domain/serial/test4/specfem_config.yaml"
-      elastic_domain_field: "../../../tests/unit-tests/domain/serial/test4/displacement.bin"
+  # - name : "SerialTest4 : Homogeneous elastic domain (stacey BC)"
+  #   description: >
+  #     Testing inverse of mass matrix on a homogeneous elastic domain with no interfaces. Test is run on a single MPI process. Stacey BC are applied on top/right/left/bottom boundaries.
+  #   config:
+  #     nproc : 1
+  #   databases:
+  #     specfem_config: "../../../tests/unit-tests/domain/serial/test4/specfem_config.yaml"
+  #     elastic_domain_field: "../../../tests/unit-tests/domain/serial/test4/displacement.bin"

--- a/tests/unit-tests/seismogram/acoustic/seismogram_tests.cpp
+++ b/tests/unit-tests/seismogram/acoustic/seismogram_tests.cpp
@@ -1,6 +1,6 @@
 #include "../../Kokkos_Environment.hpp"
 #include "../../MPI_environment.hpp"
-#include "../../utilities/include/compare_array.h"
+// #include "../../utilities/include/compare_array.h"
 #include "compute/interface.hpp"
 #include "constants.hpp"
 #include "domain/interface.hpp"
@@ -71,7 +71,7 @@ void read_field(
   return;
 }
 
-TEST(SEISMOGRAM_TESTS, elastic_seismograms_test) {
+TEST(SEISMOGRAM_TESTS, acoustic_seismograms_test) {
   std::string config_filename =
       "../../../tests/unit-tests/seismogram/acoustic/test_config.yaml";
 
@@ -87,74 +87,44 @@ TEST(SEISMOGRAM_TESTS, elastic_seismograms_test) {
   // mpi->cout(setup.print_header());
 
   // Set up GLL quadrature points
-  auto [gllx, gllz] = setup.instantiate_quadrature();
+  const auto quadratures = setup.instantiate_quadrature();
+
+  // Read mesh generated MESHFEM
+  specfem::mesh::mesh mesh(database_file, mpi);
+
+  std::vector<std::shared_ptr<specfem::sources::source> > sources(0);
 
   const auto angle = setup.get_receiver_angle();
   const auto stations_filename = setup.get_stations_file();
   auto receivers = specfem::receivers::read_receivers(stations_filename, angle);
-
-  // Read mesh generated MESHFEM
-  std::vector<std::shared_ptr<specfem::material::material> > materials;
-  specfem::mesh::mesh mesh(database_file, materials, mpi);
-
-  // Generate compute structs to be used by the solver
-  specfem::compute::compute compute(mesh.coorg, mesh.material_ind.knods, gllx,
-                                    gllz);
-  specfem::compute::partial_derivatives partial_derivatives(
-      mesh.coorg, mesh.material_ind.knods, gllx, gllz);
-  specfem::compute::properties material_properties(
-      mesh.material_ind.kmato, materials, mesh.nspec, gllx->get_N(),
-      gllz->get_N());
-
-  specfem::compute::boundaries boundary_conditions(
-      mesh.material_ind.kmato, materials, mesh.acfree_surface,
-      mesh.abs_boundary);
-
-  // locate the recievers
-  for (auto &receiver : receivers)
-    receiver->locate(compute.coordinates.coord, compute.h_ibool,
-                     gllx->get_hxi(), gllz->get_hxi(), mesh.nproc, mesh.coorg,
-                     mesh.material_ind.knods, mesh.npgeo,
-                     material_properties.h_ispec_type, mpi);
-
-  // Setup solver compute struct
-
-  const type_real xmax = compute.coordinates.xmax;
-  const type_real xmin = compute.coordinates.xmin;
-  const type_real zmax = compute.coordinates.zmax;
-  const type_real zmin = compute.coordinates.zmin;
-
   const auto stypes = setup.get_seismogram_types();
 
-  specfem::compute::receivers compute_receivers(receivers, stypes, gllx, gllz,
-                                                xmax, xmin, zmax, zmin, 1, mpi);
+  specfem::compute::assembly assembly(mesh, quadratures, sources, receivers,
+                                      stypes, 0, 1);
 
-  const int nglob = specfem::utilities::compute_nglob(compute.h_ibool);
-  specfem::enums::element::quadrature::static_quadrature_points<5> qp5;
-  specfem::domain::domain<
-      specfem::enums::element::medium::acoustic,
-      specfem::enums::element::quadrature::static_quadrature_points<5> >
-      acoustic_domain_static(nglob, qp5, &compute, material_properties,
-                             partial_derivatives, boundary_conditions,
-                             specfem::compute::sources(), compute_receivers,
-                             gllx, gllz);
-
-  const auto displacement_field = acoustic_domain_static.get_host_field();
-  const auto velocity_field = acoustic_domain_static.get_host_field_dot();
+  const auto displacement_field = assembly.fields.forward.acoustic.field;
+  const auto velocity_field = assembly.fields.forward.acoustic.field_dot;
   const auto acceleration_field =
-      acoustic_domain_static.get_host_field_dot_dot();
+      assembly.fields.forward.acoustic.field_dot_dot;
+
+  const int nglob = assembly.fields.forward.nglob;
 
   read_field(test_config.displacement_field, displacement_field, nglob, 1);
   read_field(test_config.velocity_field, velocity_field, nglob, 1);
   read_field(test_config.acceleration_field, acceleration_field, nglob, 1);
 
-  acoustic_domain_static.sync_field(specfem::sync::HostToDevice);
-  acoustic_domain_static.sync_field_dot(specfem::sync::HostToDevice);
-  acoustic_domain_static.sync_field_dot_dot(specfem::sync::HostToDevice);
+  assembly.fields.sync_fields<specfem::sync::kind::HostToDevice>();
+
+  specfem::enums::element::quadrature::static_quadrature_points<5> qp5;
+
+  specfem::domain::domain<
+      specfem::enums::element::medium::acoustic,
+      specfem::enums::element::quadrature::static_quadrature_points<5> >
+      acoustic_domain_static(assembly, qp5);
 
   acoustic_domain_static.compute_seismogram(0);
 
-  compute_receivers.sync_seismograms();
+  assembly.receivers.sync_seismograms();
 
   type_real tol = 1e-5;
 
@@ -178,7 +148,7 @@ TEST(SEISMOGRAM_TESTS, elastic_seismograms_test) {
   for (int isys = 0; isys < stypes.size(); isys++) {
     for (int irec = 0; irec < receivers.size(); irec++) {
       for (int idim = 0; idim < 2; idim++) {
-        EXPECT_NEAR(compute_receivers.h_seismogram(0, isys, irec, idim),
+        EXPECT_NEAR(assembly.receivers.h_seismogram(0, isys, irec, idim),
                     ground_truth[index], std::fabs(tol * ground_truth[index]));
         index++;
       }

--- a/tests/unit-tests/seismogram/acoustic/serial/specfem_config.yaml
+++ b/tests/unit-tests/seismogram/acoustic/serial/specfem_config.yaml
@@ -11,10 +11,7 @@ parameters:
   simulation-setup:
     ## quadrature setup
     quadrature:
-      alpha: 0.0
-      beta: 0.0
-      ngllx: 5
-      ngllz: 5
+      quadrature-type: GLL4
 
     ## Solver setup
     solver:

--- a/tests/unit-tests/seismogram/elastic/seismogram_tests.cpp
+++ b/tests/unit-tests/seismogram/elastic/seismogram_tests.cpp
@@ -1,6 +1,6 @@
 #include "../../Kokkos_Environment.hpp"
 #include "../../MPI_environment.hpp"
-#include "../../utilities/include/compare_array.h"
+// #include "../../utilities/include/compare_array.h"
 #include "compute/interface.hpp"
 #include "constants.hpp"
 #include "domain/interface.hpp"
@@ -87,75 +87,43 @@ TEST(SEISMOGRAM_TESTS, elastic_seismograms_test) {
   // mpi->cout(setup.print_header());
 
   // Set up GLL quadrature points
-  auto [gllx, gllz] = setup.instantiate_quadrature();
+  const auto quadratures = setup.instantiate_quadrature();
+
+  // Read mesh generated MESHFEM
+  specfem::mesh::mesh mesh(database_file, mpi);
+
+  std::vector<std::shared_ptr<specfem::sources::source> > sources(0);
 
   const auto angle = setup.get_receiver_angle();
   const auto stations_filename = setup.get_stations_file();
   auto receivers = specfem::receivers::read_receivers(stations_filename, angle);
-
-  // Read mesh generated MESHFEM
-  std::vector<std::shared_ptr<specfem::material::material> > materials;
-  specfem::mesh::mesh mesh(database_file, materials, mpi);
-
-  // Generate compute structs to be used by the solver
-  specfem::compute::compute compute(mesh.coorg, mesh.material_ind.knods, gllx,
-                                    gllz);
-  specfem::compute::partial_derivatives partial_derivatives(
-      mesh.coorg, mesh.material_ind.knods, gllx, gllz);
-  specfem::compute::properties material_properties(
-      mesh.material_ind.kmato, materials, mesh.nspec, gllx->get_N(),
-      gllz->get_N());
-
-  // Setup boundary conditions
-  specfem::compute::boundaries boundary_conditions(
-      mesh.material_ind.kmato, materials, mesh.acfree_surface,
-      mesh.abs_boundary);
-
-  // locate the recievers
-  for (auto &receiver : receivers)
-    receiver->locate(compute.coordinates.coord, compute.h_ibool,
-                     gllx->get_hxi(), gllz->get_hxi(), mesh.nproc, mesh.coorg,
-                     mesh.material_ind.knods, mesh.npgeo,
-                     material_properties.h_ispec_type, mpi);
-
-  // Setup solver compute struct
-
-  const type_real xmax = compute.coordinates.xmax;
-  const type_real xmin = compute.coordinates.xmin;
-  const type_real zmax = compute.coordinates.zmax;
-  const type_real zmin = compute.coordinates.zmin;
-
   const auto stypes = setup.get_seismogram_types();
 
-  specfem::compute::receivers compute_receivers(receivers, stypes, gllx, gllz,
-                                                xmax, xmin, zmax, zmin, 1, mpi);
+  specfem::compute::assembly assembly(mesh, quadratures, sources, receivers,
+                                      stypes, 0, 1);
 
-  const int nglob = specfem::utilities::compute_nglob(compute.h_ibool);
-  specfem::enums::element::quadrature::static_quadrature_points<5> qp5;
-  specfem::domain::domain<
-      specfem::enums::element::medium::elastic,
-      specfem::enums::element::quadrature::static_quadrature_points<5> >
-      elastic_domain_static(nglob, qp5, &compute, material_properties,
-                            partial_derivatives, boundary_conditions,
-                            specfem::compute::sources(), compute_receivers,
-                            gllx, gllz);
+  const auto displacement_field = assembly.fields.forward.elastic.field;
+  const auto velocity_field = assembly.fields.forward.elastic.field_dot;
+  const auto acceleration_field = assembly.fields.forward.elastic.field_dot_dot;
 
-  const auto displacement_field = elastic_domain_static.get_host_field();
-  const auto velocity_field = elastic_domain_static.get_host_field_dot();
-  const auto acceleration_field =
-      elastic_domain_static.get_host_field_dot_dot();
+  const int nglob = assembly.fields.forward.nglob;
 
   read_field(test_config.displacement_field, displacement_field, nglob, 2);
   read_field(test_config.velocity_field, velocity_field, nglob, 2);
   read_field(test_config.acceleration_field, acceleration_field, nglob, 2);
 
-  elastic_domain_static.sync_field(specfem::sync::HostToDevice);
-  elastic_domain_static.sync_field_dot(specfem::sync::HostToDevice);
-  elastic_domain_static.sync_field_dot_dot(specfem::sync::HostToDevice);
+  assembly.fields.sync_fields<specfem::sync::kind::HostToDevice>();
+
+  specfem::enums::element::quadrature::static_quadrature_points<5> qp5;
+
+  specfem::domain::domain<
+      specfem::enums::element::medium::elastic,
+      specfem::enums::element::quadrature::static_quadrature_points<5> >
+      elastic_domain_static(assembly, qp5);
 
   elastic_domain_static.compute_seismogram(0);
 
-  compute_receivers.sync_seismograms();
+  assembly.receivers.sync_seismograms();
 
   type_real tol = 1e-6;
 
@@ -179,7 +147,7 @@ TEST(SEISMOGRAM_TESTS, elastic_seismograms_test) {
   for (int isys = 0; isys < stypes.size(); isys++) {
     for (int irec = 0; irec < receivers.size(); irec++) {
       for (int idim = 0; idim < 2; idim++) {
-        EXPECT_NEAR(compute_receivers.h_seismogram(0, isys, irec, idim),
+        EXPECT_NEAR(assembly.receivers.h_seismogram(0, isys, irec, idim),
                     ground_truth[index], std::fabs(tol * ground_truth[index]));
         index++;
       }

--- a/tests/unit-tests/seismogram/elastic/serial/specfem_config.yaml
+++ b/tests/unit-tests/seismogram/elastic/serial/specfem_config.yaml
@@ -11,10 +11,7 @@ parameters:
   simulation-setup:
     ## quadrature setup
     quadrature:
-      alpha: 0.0
-      beta: 0.0
-      ngllx: 5
-      ngllz: 5
+      quadrature-type: GLL4
 
     ## Solver setup
     solver:

--- a/tests/unit-tests/utilities/include/compare_array.tpp
+++ b/tests/unit-tests/utilities/include/compare_array.tpp
@@ -311,6 +311,9 @@ bool specfem::testing::compare_norm(
     computed_norm += std::abs(computed_array.data(i1));
   }
 
+  std::cout << "Error norm = " << error_norm << " computed norm = "
+            << computed_norm << std::endl;
+
   return equate_norm(error_norm, computed_norm, tolerance);
 }
 
@@ -333,6 +336,9 @@ bool specfem::testing::compare_norm(
       computed_norm += std::abs(computed_array.data(i1, i2));
     }
   }
+
+  std::cout << "Error norm = " << error_norm << " computed norm = "
+            << computed_norm << std::endl;
 
   return equate_norm(error_norm, computed_norm, tolerance);
 }


### PR DESCRIPTION
# Description

Please describe the changes/features in this pull request. 

This PR reimplements element, sources and receiver kernels for the newer assembly formulation

- Major changes
   - element, source, receiver classes are now exclusive method classes. This is a pre-cursor to replacing element, source and receiver classes to templated functions. This will simplify the interface. 
   - Coupled interfaces are templated on medium types and not on domains. Simplifies the interface. 

# Issue Number

If there is an issue created for these changes, link it here

# Checklist

Please make sure to check developer documentation on specfem docs. 

[x] I ran the code through pre-commit to check style
[] My code passes all the integration tests
[x] I have added sufficient unittests to test my changes
[x] I have added/updated documentation for the changes I am proposing
[x] I have updated CMakeLists to ensure my code builds
[x] My code builds across all platforms 
