### PR TITLE
Implements mesh reading as specfem::IO::read_mesh(...)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,11 @@ else()
         )
 endif()
 
+target_link_libraries(
+  IO
+  mesh
+)
+
 add_library(
         point
         src/point/coordinates.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -508,31 +508,6 @@ target_link_libraries(
         Boost::program_options
 )
 
-add_executable(
-        homo2d
-        examples/homogeneous-medium-flat-topography/homo2d.cpp
-)
-
-target_link_libraries(
-        homo2d
-        specfem_mpi
-        Kokkos::kokkos
-        mesh
-        quadrature
-        compute
-        source_class
-        parameter_reader
-        receiver_class
-        writer
-        reader
-        domain
-        coupled_interface
-        kernels
-        solver
-        Boost::program_options
-        ${HDF5_LIBRARIES}
-)
-
 # Include tests
 if (BUILD_TESTS)
         message("-- Including tests.")

--- a/docs/api/IO/Libraries/index.rst
+++ b/docs/api/IO/Libraries/index.rst
@@ -39,5 +39,6 @@ The snippet below shows how to use these modules to write and read a Kokkos::Vie
 .. toctree::
     :maxdepth: 1
 
+    mesh/index
     ASCII/index
     HDF5/index

--- a/docs/api/IO/Libraries/mesh/index.rst
+++ b/docs/api/IO/Libraries/mesh/index.rst
@@ -28,5 +28,6 @@ functions are called in the order of appearance in the code:
 
 .. doxygenfunction:: specfem::IO::mesh::fortran::read_axial_elements
 
-.. doxygenclass:: specfem::mesh::tags
-  :members:
+Finally, we add tags to the :cpp:struct:`specfem::mesh::mesh` using the
+:cpp:struct:`specfem::mesh::tags` struct. The description of which can be found
+here: :ref:`mesh_tags`.

--- a/docs/api/IO/Libraries/mesh/index.rst
+++ b/docs/api/IO/Libraries/mesh/index.rst
@@ -1,0 +1,32 @@
+.. _mesh_reader:
+
+Mesh Reader
+===========
+
+.. doxygenfunction:: specfem::IO::read_mesh
+
+
+The above function reads the fortran binary mesh database and the following
+functions are called in the order of appearance in the code:
+
+
+.. doxygenfunction:: specfem::IO::mesh::fortran::read_mesh_database_header
+
+.. doxygenfunction:: specfem::IO::mesh::fortran::read_coorg_elements
+
+.. doxygenfunction:: specfem::IO::mesh::fortran::read_properties
+
+.. doxygenfunction:: specfem::IO::mesh::fortran::read_mesh_database_attenuation
+
+.. doxygenfunction:: specfem::IO::mesh::fortran::read_material_properties
+
+.. doxygenfunction:: specfem::IO::mesh::fortran::read_boundaries
+
+.. doxygenfunction:: specfem::IO::mesh::fortran::read_coupled_interfaces
+
+.. doxygenfunction:: specfem::IO::mesh::fortran::read_tangential_elements
+
+.. doxygenfunction:: specfem::IO::mesh::fortran::read_axial_elements
+
+.. doxygenclass:: specfem::mesh::tags
+  :members:

--- a/docs/api/IO/index.rst
+++ b/docs/api/IO/index.rst
@@ -6,6 +6,6 @@ Input/Output modules
     :maxdepth: 2
 
     fortran_io
-    Library/index
+    Libraries/index
     writer/index
     reader/index

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -16,6 +16,7 @@ API documentation
     datatypes/index
     assembly/index
     policies/index
+    IO/index
     operators/index
     compute_kernels/index
     coupling_physics/coupled_interface

--- a/docs/developer_documentation/tutorials/tutorial1/Chapter1/index.rst
+++ b/docs/developer_documentation/tutorials/tutorial1/Chapter1/index.rst
@@ -2,7 +2,7 @@
 .. _Chapter1:
 
 Chapter 1: Generating the mesh, sources and receivers
-====================================================
+=====================================================
 
 Before we start writing the solver, we need to generate an hexahedral mesh, and define our sources and receivers. To do this we will use the Fortran package ``MESHFEM2D``.
 
@@ -11,7 +11,7 @@ Before we start writing the solver, we need to generate an hexahedral mesh, and 
     Since ``MESHFEM2D`` is a dependency for SPECFEM++, it is should already be installed as part of the SPECFEM++ installation.
 
 Defining the MESHFEM2D Parameter File
---------------------------------------
+-------------------------------------
 
 Let us generate a Hex mesh for 2D elastic domain using the following parameter file. You will also need a topography file to define the surface topography of the mesh, see :ref:`Topgraphy File <homogeneous-medium-flat-topography-topography-file>`
 

--- a/include/IO/mesh/fortran/read_interfaces.hpp
+++ b/include/IO/mesh/fortran/read_interfaces.hpp
@@ -15,6 +15,15 @@ specfem::mesh::interface_container<medium1, medium2>
 read_interfaces(const int num_interfaces, std::ifstream &stream,
                 const specfem::MPI::MPI *mpi);
 
+/* @brief Read the coupled interfaces from the database file
+ *
+ * @param stream input file stream
+ * @param num_interfaces_elastic_acoustic
+ * @param num_interfaces_acoustic_poroelastic
+ * @param num_interfaces_elastic_poroelastic
+ * @param mpi
+ * @return specfem::mesh::coupled_interfaces
+ */
 specfem::mesh::coupled_interfaces read_coupled_interfaces(
     std::ifstream &stream, const int num_interfaces_elastic_acoustic,
     const int num_interfaces_acoustic_poroelastic,

--- a/include/IO/mesh/fortran/read_mesh_database.hpp
+++ b/include/IO/mesh/fortran/read_mesh_database.hpp
@@ -32,8 +32,7 @@ read_mesh_database_header(std::ifstream &stream, const specfem::MPI::MPI *mpi);
  * section
  * @param npgeo Total number of control nodes in simulation box
  * @param mpi Pointer to MPI object
- * @return specfem::kokkos::HostView2d<type_real> coorg values as read from
- * fortran binary database file
+ * @return std::tuple<int, int, int>  nspec, npgeo, nproc values read from
  */
 specfem::kokkos::HostView2d<type_real>
 read_coorg_elements(std::ifstream &stream, const int npgeo,

--- a/include/IO/mesh/fortran/read_properties.hpp
+++ b/include/IO/mesh/fortran/read_properties.hpp
@@ -14,7 +14,7 @@ namespace fortran {
  *
  * @param stream Input stream
  * @param mpi MPI object
- * @return specfem::mesh::properties
+ * @return specfem::mesh::properties Property object
  */
 specfem::mesh::properties read_properties(std::ifstream &stream,
                                           const specfem::MPI::MPI *mpi);

--- a/include/IO/mesh/read_mesh.hpp
+++ b/include/IO/mesh/read_mesh.hpp
@@ -12,6 +12,7 @@ namespace IO {
  *
  * @param filename Fortran binary database filename
  * @param mpi pointer to MPI object to manage communication
+ * @return specfem::mesh::mesh Specfem mesh object
  */
 specfem::mesh::mesh read_mesh(const std::string filename,
                               const specfem::MPI::MPI *mpi);

--- a/include/IO/mesh/read_mesh.hpp
+++ b/include/IO/mesh/read_mesh.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "mesh/mesh.hpp"
+#include "specfem_mpi/interface.hpp"
+#include "specfem_setup.hpp"
+
+namespace specfem {
+
+namespace IO {
+
+/* @brief Construct a mesh object from a Fortran binary database file
+ *
+ * @param filename Fortran binary database filename
+ * @param mpi pointer to MPI object to manage communication
+ */
+specfem::mesh::mesh read_mesh(const std::string filename,
+                              const specfem::MPI::MPI *mpi);
+
+} // namespace IO
+} // namespace specfem

--- a/include/policies/range.hpp
+++ b/include/policies/range.hpp
@@ -6,9 +6,7 @@
 namespace specfem {
 
 namespace iterator {
-
 namespace impl {
-
 /**
  * @brief Index type for the range iterator.
  *
@@ -21,7 +19,7 @@ template <bool UseSIMD> struct range_index_type;
  *
  */
 template <> struct range_index_type<false> {
-  specfem::point::assembly_index index; ///< Assembly index
+  specfem::point::assembly_index<false> index; ///< Assembly index
 
   KOKKOS_INLINE_FUNCTION
   range_index_type(const specfem::point::assembly_index<false> index)

--- a/src/IO/mesh/fortran/read_material_properties.cpp
+++ b/src/IO/mesh/fortran/read_material_properties.cpp
@@ -181,16 +181,16 @@ specfem::mesh::materials specfem::IO::mesh::fortran::read_material_properties(
     const specfem::MPI::MPI *mpi) {
 
   // Create materials instances
-  specfem::mesh::materials material(nspec, numat);
+  specfem::mesh::materials materials(nspec, numat);
 
   // Read material properties
   auto index_mapping =
-      ::read_materials(stream, numat, material.elastic_isotropic,
-                       material.acoustic_isotropic, mpi);
+      ::read_materials(stream, numat, materials.elastic_isotropic,
+                       materials.acoustic_isotropic, mpi);
 
   // Read material indices
   ::read_material_indices(stream, nspec, numat, index_mapping,
-                          material.material_index_mapping, knods, mpi);
+                          materials.material_index_mapping, knods, mpi);
 
-  return material;
+  return materials;
 }

--- a/src/IO/mesh/fortran/read_material_properties.cpp
+++ b/src/IO/mesh/fortran/read_material_properties.cpp
@@ -1,12 +1,13 @@
 #include "IO/mesh/fortran/read_material_properties.hpp"
 #include "IO/fortranio/interface.hpp"
-#include "mesh/materials/materials.hpp"
+// #include "mesh/materials/materials.hpp"
+#include "mesh/materials/materials.tpp"
 #include "specfem_mpi/interface.hpp"
 #include "utilities/interface.hpp"
 #include <memory>
 #include <vector>
 
-namespace {
+// namespace {
 constexpr auto elastic = specfem::element::medium_tag::elastic;
 constexpr auto isotropic = specfem::element::property_tag::isotropic;
 constexpr auto acoustic = specfem::element::medium_tag::acoustic;
@@ -172,7 +173,7 @@ void read_material_indices(
   return;
 }
 
-} // namespace
+// } // namespace
 
 specfem::mesh::materials specfem::IO::mesh::fortran::read_material_properties(
     std::ifstream &stream, const int numat, const int nspec,
@@ -180,16 +181,15 @@ specfem::mesh::materials specfem::IO::mesh::fortran::read_material_properties(
     const specfem::MPI::MPI *mpi) {
 
   // Create materials instances
-  specfem::mesh::materials materials(nspec, numat);
+  specfem::mesh::materials material(nspec, numat);
 
   // Read material properties
-  auto index_mapping =
-      read_materials(stream, numat, materials.elastic_isotropic,
-                     materials.acoustic_isotropic, mpi);
+  auto index_mapping = read_materials(stream, numat, material.elastic_isotropic,
+                                      material.acoustic_isotropic, mpi);
 
   // Read material indices
   read_material_indices(stream, nspec, numat, index_mapping,
-                        materials.material_index_mapping, knods, mpi);
+                        material.material_index_mapping, knods, mpi);
 
-  return materials;
+  return material;
 }

--- a/src/IO/mesh/fortran/read_material_properties.cpp
+++ b/src/IO/mesh/fortran/read_material_properties.cpp
@@ -7,7 +7,7 @@
 #include <memory>
 #include <vector>
 
-// namespace {
+namespace {
 constexpr auto elastic = specfem::element::medium_tag::elastic;
 constexpr auto isotropic = specfem::element::property_tag::isotropic;
 constexpr auto acoustic = specfem::element::medium_tag::acoustic;
@@ -173,7 +173,7 @@ void read_material_indices(
   return;
 }
 
-// } // namespace
+} // namespace
 
 specfem::mesh::materials specfem::IO::mesh::fortran::read_material_properties(
     std::ifstream &stream, const int numat, const int nspec,
@@ -184,12 +184,13 @@ specfem::mesh::materials specfem::IO::mesh::fortran::read_material_properties(
   specfem::mesh::materials material(nspec, numat);
 
   // Read material properties
-  auto index_mapping = read_materials(stream, numat, material.elastic_isotropic,
-                                      material.acoustic_isotropic, mpi);
+  auto index_mapping =
+      ::read_materials(stream, numat, material.elastic_isotropic,
+                       material.acoustic_isotropic, mpi);
 
   // Read material indices
-  read_material_indices(stream, nspec, numat, index_mapping,
-                        material.material_index_mapping, knods, mpi);
+  ::read_material_indices(stream, nspec, numat, index_mapping,
+                          material.material_index_mapping, knods, mpi);
 
   return material;
 }

--- a/src/IO/mesh/read_mesh.cpp
+++ b/src/IO/mesh/read_mesh.cpp
@@ -10,6 +10,7 @@
 #include "kokkos_abstractions.h"
 #include "material/material.hpp"
 #include "mesh/mesh.hpp"
+#include "mesh/tags/tags.hpp"
 #include "specfem_mpi/interface.hpp"
 #include "specfem_setup.hpp"
 #include <Kokkos_Core.hpp>
@@ -200,7 +201,7 @@ specfem::mesh::mesh specfem::IO::read_mesh(const std::string filename,
   assert(l_elastic_isotropic.size() + l_acoustic_isotropic.size() ==
          materials.n_materials);
 
-  auto tags = specfem::mesh::tags(materials, boundaries);
+  specfem::mesh::tags tags(materials, boundaries);
 
   return specfem::mesh::mesh(npgeo, nspec, nproc, control_nodes, parameters,
                              coupled_interfaces, boundaries, tags,

--- a/src/IO/mesh/read_mesh.cpp
+++ b/src/IO/mesh/read_mesh.cpp
@@ -17,59 +17,62 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <tuple>
 #include <vector>
 
 specfem::mesh::mesh specfem::IO::read_mesh(const std::string filename,
                                            const specfem::MPI::MPI *mpi) {
 
+  // Declaring empty mesh objects
+  specfem::mesh::mesh mesh;
+
+  // Open the database file
   std::ifstream stream;
   stream.open(filename);
-  int nspec, npgeo, nproc;
-
-  specfem::mesh::control_nodes control_nodes;
-  specfem::mesh::properties parameters;
-  specfem::mesh::materials materials;
-  specfem::mesh::boundaries boundaries;
-  specfem::mesh::elements::axial_elements axial_nodes;
-  specfem::mesh::elements::tangential_elements tangential_nodes;
-  specfem::mesh::coupled_interfaces coupled_interfaces;
 
   if (!stream.is_open()) {
     throw std::runtime_error("Could not open database file");
   }
+  int nspec, npgeo, nproc;
 
   try {
-    auto [nspec, npgeo, nproc] =
+    std::tie(nspec, npgeo, nproc) =
         specfem::IO::mesh::fortran::read_mesh_database_header(stream, mpi);
+    mesh.nspec = nspec;
+    mesh.npgeo = npgeo;
+    mesh.nproc = nproc;
   } catch (std::runtime_error &e) {
     throw;
   }
 
+  std::cout << "nspec = " << mesh.nspec << std::endl;
+  std::cout << "npgeo = " << mesh.npgeo << std::endl;
+  std::cout << "nproc = " << mesh.nproc << std::endl;
+
   // Mesh class to be populated from the database file.
   try {
-
-    control_nodes.coord =
+    mesh.control_nodes.coord =
         specfem::IO::mesh::fortran::read_coorg_elements(stream, npgeo, mpi);
   } catch (std::runtime_error &e) {
     throw;
   }
 
   try {
-    auto parameters = specfem::IO::mesh::fortran::read_properties(stream, mpi);
+    mesh.parameters = specfem::IO::mesh::fortran::read_properties(stream, mpi);
   } catch (std::runtime_error &e) {
     throw;
   }
 
-  control_nodes.ngnod = parameters.ngnod;
-  control_nodes.nspec = nspec;
-  control_nodes.knods = specfem::kokkos::HostView2d<int>(
-      "specfem::mesh::knods", parameters.ngnod, nspec);
+  mesh.control_nodes.ngnod = mesh.parameters.ngnod;
+  mesh.control_nodes.nspec = mesh.nspec;
+  mesh.control_nodes.knods = specfem::kokkos::HostView2d<int>(
+      "specfem::mesh::knods", mesh.parameters.ngnod, mesh.nspec);
 
-  int nspec_all = mpi->reduce(parameters.nspec, specfem::MPI::sum);
+  int nspec_all = mpi->reduce(mesh.parameters.nspec, specfem::MPI::sum);
   int nelem_acforcing_all =
-      mpi->reduce(parameters.nelem_acforcing, specfem::MPI::sum);
+      mpi->reduce(mesh.parameters.nelem_acforcing, specfem::MPI::sum);
   int nelem_acoustic_surface_all =
-      mpi->reduce(parameters.nelem_acoustic_surface, specfem::MPI::sum);
+      mpi->reduce(mesh.parameters.nelem_acoustic_surface, specfem::MPI::sum);
 
   try {
     auto [n_sls, attenuation_f0_reference, read_velocities_at_f0] =
@@ -79,8 +82,9 @@ specfem::mesh::mesh specfem::IO::read_mesh(const std::string filename,
   }
 
   try {
-    auto materials = specfem::IO::mesh::fortran::read_material_properties(
-        stream, nspec, parameters.numat, control_nodes.knods, mpi);
+    mesh.materials = specfem::IO::mesh::fortran::read_material_properties(
+        stream, mesh.nspec, mesh.parameters.numat, mesh.control_nodes.knods,
+        mpi);
   } catch (std::runtime_error &e) {
     throw;
   }
@@ -112,10 +116,10 @@ specfem::mesh::mesh specfem::IO::read_mesh(const std::string filename,
   specfem::IO::fortran_read_line(stream, &ninterfaces, &max_interface_size);
 
   try {
-    auto boundaries = specfem::IO::mesh::fortran::read_boundaries(
-        stream, parameters.nspec, parameters.nelemabs,
-        parameters.nelem_acoustic_surface, parameters.nelem_acforcing,
-        control_nodes.knods, mpi);
+    mesh.boundaries = specfem::IO::mesh::fortran::read_boundaries(
+        stream, mesh.parameters.nspec, mesh.parameters.nelemabs,
+        mesh.parameters.nelem_acoustic_surface, mesh.parameters.nelem_acforcing,
+        mesh.control_nodes.knods, mpi);
   } catch (std::runtime_error &e) {
     throw;
   }
@@ -145,26 +149,26 @@ specfem::mesh::mesh specfem::IO::read_mesh(const std::string filename,
   // }
 
   try {
-    auto coupled_interfaces =
+    mesh.coupled_interfaces =
         specfem::IO::mesh::fortran::read_coupled_interfaces(
-            stream, parameters.num_fluid_solid_edges,
-            parameters.num_fluid_poro_edges, parameters.num_solid_poro_edges,
-            mpi);
+            stream, mesh.parameters.num_fluid_solid_edges,
+            mesh.parameters.num_fluid_poro_edges,
+            mesh.parameters.num_solid_poro_edges, mpi);
   } catch (std::runtime_error &e) {
     throw;
   }
 
   try {
-    auto tangential_nodes =
+    mesh.tangential_nodes =
         specfem::IO::mesh::fortran::read_tangential_elements(
-            stream, parameters.nnodes_tangential_curve);
+            stream, mesh.parameters.nnodes_tangential_curve);
   } catch (std::runtime_error &e) {
     throw;
   }
 
   try {
-    auto axial_nodes = specfem::IO::mesh::fortran::read_axial_elements(
-        stream, parameters.nelem_on_the_axis, nspec, mpi);
+    mesh.axial_nodes = specfem::IO::mesh::fortran::read_axial_elements(
+        stream, mesh.parameters.nelem_on_the_axis, mesh.nspec, mpi);
   } catch (std::runtime_error &e) {
     throw;
   }
@@ -183,12 +187,12 @@ specfem::mesh::mesh specfem::IO::read_mesh(const std::string filename,
             "------------------------------");
 
   mpi->cout("Number of material systems = " +
-            std::to_string(materials.n_materials) + "\n\n");
+            std::to_string(mesh.materials.n_materials) + "\n\n");
 
   const auto l_elastic_isotropic =
-      materials.elastic_isotropic.material_properties;
+      mesh.materials.elastic_isotropic.material_properties;
   const auto l_acoustic_isotropic =
-      materials.acoustic_isotropic.material_properties;
+      mesh.materials.acoustic_isotropic.material_properties;
 
   for (const auto material : l_elastic_isotropic) {
     mpi->cout(material.print());
@@ -199,11 +203,9 @@ specfem::mesh::mesh specfem::IO::read_mesh(const std::string filename,
   }
 
   assert(l_elastic_isotropic.size() + l_acoustic_isotropic.size() ==
-         materials.n_materials);
+         mesh.materials.n_materials);
 
-  specfem::mesh::tags tags(materials, boundaries);
+  specfem::mesh::tags tags(mesh.materials, mesh.boundaries);
 
-  return specfem::mesh::mesh(npgeo, nspec, nproc, control_nodes, parameters,
-                             coupled_interfaces, boundaries, tags,
-                             tangential_nodes, axial_nodes, materials);
+  return mesh;
 }

--- a/src/IO/mesh/read_mesh.cpp
+++ b/src/IO/mesh/read_mesh.cpp
@@ -45,14 +45,10 @@ specfem::mesh::mesh specfem::IO::read_mesh(const std::string filename,
     throw;
   }
 
-  std::cout << "nspec = " << mesh.nspec << std::endl;
-  std::cout << "npgeo = " << mesh.npgeo << std::endl;
-  std::cout << "nproc = " << mesh.nproc << std::endl;
-
   // Mesh class to be populated from the database file.
   try {
-    mesh.control_nodes.coord =
-        specfem::IO::mesh::fortran::read_coorg_elements(stream, npgeo, mpi);
+    mesh.control_nodes.coord = specfem::IO::mesh::fortran::read_coorg_elements(
+        stream, mesh.npgeo, mpi);
   } catch (std::runtime_error &e) {
     throw;
   }
@@ -83,7 +79,7 @@ specfem::mesh::mesh specfem::IO::read_mesh(const std::string filename,
 
   try {
     mesh.materials = specfem::IO::mesh::fortran::read_material_properties(
-        stream, mesh.nspec, mesh.parameters.numat, mesh.control_nodes.knods,
+        stream, mesh.parameters.numat, mesh.nspec, mesh.control_nodes.knods,
         mpi);
   } catch (std::runtime_error &e) {
     throw;
@@ -205,7 +201,7 @@ specfem::mesh::mesh specfem::IO::read_mesh(const std::string filename,
   assert(l_elastic_isotropic.size() + l_acoustic_isotropic.size() ==
          mesh.materials.n_materials);
 
-  specfem::mesh::tags tags(mesh.materials, mesh.boundaries);
+  mesh.tags = specfem::mesh::tags(mesh.materials, mesh.boundaries);
 
   return mesh;
 }

--- a/src/mesh/coupled_interfaces/coupled_interfaces.cpp
+++ b/src/mesh/coupled_interfaces/coupled_interfaces.cpp
@@ -2,18 +2,18 @@
 #include "mesh/coupled_interfaces/interface_container.hpp"
 #include "mesh/coupled_interfaces/interface_container.tpp"
 
-specfem::mesh::coupled_interfaces coupled_interfaces(
-    specfem::mesh::interface_container<specfem::element::medium_tag::elastic,
-                                       specfem::element::medium_tag::acoustic>
-        elastic_acoustic,
-    specfem::mesh::interface_container<
-        specfem::element::medium_tag::acoustic,
-        specfem::element::medium_tag::poroelastic>
-        acoustic_poroelastic,
-    specfem::mesh::interface_container<
-        specfem::element::medium_tag::elastic,
-        specfem::element::medium_tag::poroelastic>
-        elastic_poroelastic) {}
+// specfem::mesh::coupled_interfaces::coupled_interfaces(
+//     specfem::mesh::interface_container<specfem::element::medium_tag::elastic,
+//                                        specfem::element::medium_tag::acoustic>
+//         elastic_acoustic,
+//     specfem::mesh::interface_container<
+//         specfem::element::medium_tag::acoustic,
+//         specfem::element::medium_tag::poroelastic>
+//         acoustic_poroelastic,
+//     specfem::mesh::interface_container<
+//         specfem::element::medium_tag::elastic,
+//         specfem::element::medium_tag::poroelastic>
+//         elastic_poroelastic) {}
 
 template <specfem::element::medium_tag medium1,
           specfem::element::medium_tag medium2>

--- a/tests/unit-tests/algorithms/interpolate_function.cpp
+++ b/tests/unit-tests/algorithms/interpolate_function.cpp
@@ -1,3 +1,4 @@
+#include "IO/mesh/read_mesh.hpp"
 #include "Kokkos_Environment.hpp"
 #include "MPI_environment.hpp"
 #include "algorithms/interpolate.hpp"
@@ -20,7 +21,7 @@ TEST(ALGORITHMS, interpolate_function) {
 
   // Read Mesh database
   specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
-  specfem::mesh::mesh mesh(database_file, mpi);
+  specfem::mesh::mesh mesh = specfem::IO::read_mesh(database_file, mpi);
 
   constexpr int N = 5;
 

--- a/tests/unit-tests/algorithms/locate.cpp
+++ b/tests/unit-tests/algorithms/locate.cpp
@@ -1,3 +1,4 @@
+#include "IO/mesh/read_mesh.hpp"
 #include "Kokkos_Environment.hpp"
 #include "MPI_environment.hpp"
 #include "algorithms/locate_point.hpp"
@@ -13,7 +14,7 @@ TEST(ALGORITHMS, locate_point) {
 
   // Read Mesh database
   specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
-  specfem::mesh::mesh mesh(database_file, mpi);
+  specfem::mesh::mesh mesh = specfem::IO::read_mesh(database_file, mpi);
 
   // Quadratures
   specfem::quadrature::gll::gll gll(0.0, 0.0, 5);

--- a/tests/unit-tests/assembly/test_fixture.hpp
+++ b/tests/unit-tests/assembly/test_fixture.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../MPI_environment.hpp"
+#include "IO/mesh/read_mesh.hpp"
 #include "compute/assembly/assembly.hpp"
 #include "enumerations/specfem_enums.hpp"
 #include "mesh/mesh.hpp"
@@ -145,7 +146,7 @@ protected:
     for (auto &Test : Tests) {
       const auto [database_file, sources_file, stations_file] =
           Test.get_databases();
-      specfem::mesh::mesh mesh(database_file, mpi);
+      specfem::mesh::mesh mesh = specfem::IO::read_mesh(database_file, mpi);
 
       const auto [sources, t0] = specfem::sources::read_sources(
           sources_file, 0, 0, 0, specfem::simulation::type::forward);

--- a/tests/unit-tests/compute/acoustic/compute_properties_tests.cpp
+++ b/tests/unit-tests/compute/acoustic/compute_properties_tests.cpp
@@ -1,6 +1,7 @@
 #include "../../Kokkos_Environment.hpp"
 #include "../../MPI_environment.hpp"
 #include "../../utilities/include/interface.hpp"
+#include "IO/mesh/read_mesh.hpp"
 #include "compute/interface.hpp"
 #include "material/interface.hpp"
 #include "mesh/mesh.hpp"
@@ -121,7 +122,8 @@ TEST(COMPUTE_TESTS, compute_acoustic_properties) {
   specfem::quadrature::gll::gll gll(0.0, 0.0, 5);
   specfem::quadrature::quadratures quadratures(gll);
 
-  specfem::mesh::mesh mesh(test_config.database_filename, mpi);
+  specfem::mesh::mesh mesh =
+      specfem::IO::read_mesh(test_config.database_filename, mpi);
 
   const int nspec = mesh.nspec;
   const int ngllz = gll.get_N();

--- a/tests/unit-tests/compute/coupled_interfaces/coupled_interfaces_tests.cpp
+++ b/tests/unit-tests/compute/coupled_interfaces/coupled_interfaces_tests.cpp
@@ -1,6 +1,7 @@
 #include "../../Kokkos_Environment.hpp"
 #include "../../MPI_environment.hpp"
 #include "../../utilities/include/interface.hpp"
+#include "IO/mesh/read_mesh.hpp"
 #include "compute/interface.hpp"
 #include "edge/interface.hpp"
 #include "material/interface.hpp"
@@ -177,7 +178,8 @@ TEST(COMPUTE_TESTS, coupled_interfaces_tests) {
     std::cout << "Executing test: " << Test.name << std::endl;
 
     // Read mesh generated MESHFEM
-    specfem::mesh::mesh mesh(Test.databases.mesh.database_filename, mpi);
+    specfem::mesh::mesh mesh =
+        specfem::IO::read_mesh(Test.databases.mesh.database_filename, mpi);
 
     // Generate compute structs to be used by the solver
     specfem::compute::mesh assembly(mesh.control_nodes, quadratures);

--- a/tests/unit-tests/compute/elastic/compute_properties_tests.cpp
+++ b/tests/unit-tests/compute/elastic/compute_properties_tests.cpp
@@ -1,6 +1,7 @@
 #include "../../Kokkos_Environment.hpp"
 #include "../../MPI_environment.hpp"
 #include "../../utilities/include/interface.hpp"
+#include "IO/mesh/read_mesh.hpp"
 #include "compute/interface.hpp"
 #include "mesh/mesh.hpp"
 #include "quadrature/interface.hpp"
@@ -75,7 +76,8 @@ TEST(COMPUTE_TESTS, compute_elastic_properties) {
   specfem::quadrature::gll::gll gll(0.0, 0.0, 5);
   specfem::quadrature::quadratures quadratures(gll);
 
-  specfem::mesh::mesh mesh(test_config.database_filename, mpi);
+  specfem::mesh::mesh mesh =
+      specfem::IO::read_mesh(test_config.database_filename, mpi);
 
   std::cout << mesh.print() << std::endl;
 

--- a/tests/unit-tests/compute/index/compute_tests.cpp
+++ b/tests/unit-tests/compute/index/compute_tests.cpp
@@ -1,6 +1,7 @@
 #include "../../Kokkos_Environment.hpp"
 #include "../../MPI_environment.hpp"
 #include "../../utilities/include/interface.hpp"
+#include "IO/mesh/read_mesh.hpp"
 #include "compute/interface.hpp"
 #include "mesh/mesh.hpp"
 #include "quadrature/interface.hpp"
@@ -80,7 +81,8 @@ TEST(COMPUTE_TESTS, compute_ibool) {
   specfem::quadrature::quadratures quadratures(gll);
 
   // Read mesh generated MESHFEM
-  specfem::mesh::mesh mesh(test_config.database_filename, mpi);
+  specfem::mesh::mesh mesh =
+      specfem::IO::read_mesh(test_config.database_filename, mpi);
 
   // Setup compute structs
   specfem::compute::mesh assembly(mesh.tags, mesh.control_nodes,

--- a/tests/unit-tests/compute/partial_derivatives/compute_partial_derivatives_tests.cpp
+++ b/tests/unit-tests/compute/partial_derivatives/compute_partial_derivatives_tests.cpp
@@ -1,8 +1,8 @@
 #include "../../Kokkos_Environment.hpp"
 #include "../../MPI_environment.hpp"
 #include "../../utilities/include/interface.hpp"
+#include "IO/mesh/read_mesh.hpp"
 #include "compute/interface.hpp"
-#include "mesh/mesh.hpp"
 #include "quadrature/interface.hpp"
 #include "yaml-cpp/yaml.h"
 #include <fstream>
@@ -74,7 +74,8 @@ TEST(COMPUTE_TESTS, compute_partial_derivatives) {
   specfem::quadrature::gll::gll gll(0.0, 0.0, 5);
   specfem::quadrature::quadratures quadratures(gll);
 
-  specfem::mesh::mesh mesh(test_config.database_filename, mpi);
+  specfem::mesh::mesh mesh =
+      specfem::IO::read_mesh(test_config.database_filename, mpi);
 
   specfem::compute::mesh compute_mesh(mesh.tags, mesh.control_nodes,
                                       quadratures);

--- a/tests/unit-tests/displacement_tests/Newmark/acoustic/newmark_tests.cpp
+++ b/tests/unit-tests/displacement_tests/Newmark/acoustic/newmark_tests.cpp
@@ -1,6 +1,7 @@
 #include "../../../Kokkos_Environment.hpp"
 #include "../../../MPI_environment.hpp"
 #include "../../../utilities/include/compare_array.h"
+#include "IO/mesh/read_mesh.hpp"
 #include "compute/interface.hpp"
 #include "constants.hpp"
 #include "domain/interface.hpp"
@@ -62,7 +63,7 @@ TEST(DISPLACEMENT_TESTS, newmark_scheme_tests) {
 
   // Read mesh generated MESHFEM
   std::vector<specfem::material::material *> materials;
-  specfem::mesh::mesh mesh(database_file, materials, mpi);
+  specfem::mesh::mesh mesh = specfem::IO::read_mesh(database_file, mpi);
 
   // Read sources
   //    if start time is not explicitly specified then t0 is determined using

--- a/tests/unit-tests/displacement_tests/Newmark/elastic/newmark_tests.cpp
+++ b/tests/unit-tests/displacement_tests/Newmark/elastic/newmark_tests.cpp
@@ -1,6 +1,7 @@
 #include "../../../Kokkos_Environment.hpp"
 #include "../../../MPI_environment.hpp"
 #include "../../../utilities/include/compare_array.h"
+#include "IO/mesh/read_mesh.hpp"
 #include "compute/interface.hpp"
 #include "constants.hpp"
 #include "domain/interface.hpp"
@@ -62,7 +63,7 @@ TEST(DISPLACEMENT_TESTS, newmark_scheme_tests) {
 
   // Read mesh generated MESHFEM
   std::vector<specfem::material::material *> materials;
-  specfem::mesh::mesh mesh(database_file, materials, mpi);
+  specfem::mesh::mesh mesh = specfem::IO::read_mesh(database_file, mpi);
 
   // Read sources
   //    if start time is not explicitly specified then t0 is determined using

--- a/tests/unit-tests/displacement_tests/Newmark/newmark_tests.cpp
+++ b/tests/unit-tests/displacement_tests/Newmark/newmark_tests.cpp
@@ -1,6 +1,7 @@
 #include "../../Kokkos_Environment.hpp"
 #include "../../MPI_environment.hpp"
 #include "../../utilities/include/interface.hpp"
+#include "IO/mesh/read_mesh.hpp"
 #include "compute/interface.hpp"
 #include "constants.hpp"
 #include "domain/domain.hpp"
@@ -174,7 +175,7 @@ TEST(DISPLACEMENT_TESTS, newmark_scheme_tests) {
     const auto quadratures = setup.instantiate_quadrature();
 
     // Read mesh generated MESHFEM
-    specfem::mesh::mesh mesh(database_file, mpi);
+    specfem::mesh::mesh mesh = specfem::IO::read_mesh(database_file, mpi);
     const type_real dt = setup.get_dt();
     const int nsteps = setup.get_nsteps();
 

--- a/tests/unit-tests/domain/acoustic/rmass_inverse_tests.cpp
+++ b/tests/unit-tests/domain/acoustic/rmass_inverse_tests.cpp
@@ -1,6 +1,7 @@
 #include "../../Kokkos_Environment.hpp"
 #include "../../MPI_environment.hpp"
 #include "../../utilities/include/compare_array.h"
+#include "IO/mesh/read_mesh.hpp"
 #include "compute/interface.hpp"
 #include "constants.hpp"
 #include "domain/interface.hpp"
@@ -59,7 +60,7 @@ TEST(DOMAIN_TESTS, rmass_inverse_elastic_test) {
 
   // Read mesh generated MESHFEM
   std::vector<specfem::material::material *> materials;
-  specfem::mesh::mesh mesh(database_file, materials, mpi);
+  specfem::mesh::mesh mesh = specfem::IO::read_mesh(database_file, mpi);
 
   // Read sources
   //    if start time is not explicitly specified then t0 is determined using

--- a/tests/unit-tests/domain/elastic/rmass_inverse_tests.cpp
+++ b/tests/unit-tests/domain/elastic/rmass_inverse_tests.cpp
@@ -1,6 +1,7 @@
 #include "../../Kokkos_Environment.hpp"
 #include "../../MPI_environment.hpp"
 #include "../../utilities/include/compare_array.h"
+#include "IO/mesh/read_mesh.hpp"
 #include "compute/interface.hpp"
 #include "constants.hpp"
 #include "domain/interface.hpp"
@@ -59,7 +60,7 @@ TEST(DOMAIN_TESTS, rmass_inverse_elastic_test) {
 
   // Read mesh generated MESHFEM
   std::vector<specfem::material::material *> materials;
-  specfem::mesh::mesh mesh(database_file, materials, mpi);
+  specfem::mesh::mesh mesh = specfem::IO::read_mesh(database_file, mpi);
 
   // Read sources
   //    if start time is not explicitly specified then t0 is determined using

--- a/tests/unit-tests/domain/rmass_inverse_tests.cpp
+++ b/tests/unit-tests/domain/rmass_inverse_tests.cpp
@@ -1,6 +1,7 @@
 #include "../Kokkos_Environment.hpp"
 #include "../MPI_environment.hpp"
 #include "../utilities/include/interface.hpp"
+#include "IO/mesh/read_mesh.hpp"
 #include "compute/interface.hpp"
 #include "constants.hpp"
 #include "domain/domain.hpp"
@@ -116,7 +117,7 @@ TEST(DOMAIN_TESTS, rmass_inverse) {
     std::cout << "Reading mesh file: " << database_file << std::endl;
 
     // Read mesh generated MESHFEM
-    specfem::mesh::mesh mesh(database_file, mpi);
+    specfem::mesh::mesh mesh = specfem::IO::read_mesh(database_file, mpi);
 
     std::cout << "Setting up sources and receivers" << std::endl;
 

--- a/tests/unit-tests/mesh/mesh_tests.cpp
+++ b/tests/unit-tests/mesh/mesh_tests.cpp
@@ -1,5 +1,6 @@
 #include "../Kokkos_Environment.hpp"
 #include "../MPI_environment.hpp"
+#include "IO/mesh/fortran/read_mesh_database.hpp"
 #include "IO/mesh/read_mesh.hpp"
 #include "mesh/mesh.hpp"
 #include "yaml-cpp/yaml.h"
@@ -74,6 +75,60 @@ void parse_test_config(const YAML::Node &yaml,
   for (auto N : all_tests)
     tests.push_back(test_configuration::Test(N));
 
+  return;
+}
+
+// ---------------------------------------------------------------------------
+
+/**
+ *
+ * Check if we can read fortran binary files correctly. TEST one just reading
+ * the header
+ *
+ * This test should be run on single and multiple nodes
+ *
+ */
+TEST(MESH_TESTS, fortran_binary_reader_header) {
+
+  specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
+  std::string config_filename =
+      "../../../tests/unit-tests/mesh/test_config.yaml";
+  std::vector<test_configuration::Test> Tests;
+  parse_test_config(YAML::LoadFile(config_filename), Tests);
+  int nspec, npgeo, nproc;
+
+  for (auto Test : Tests) {
+    std::cout << "-------------------------------------------------------\n"
+              << "\033[0;32m[RUNNING]\033[0m Test: " << Test.name << "\n"
+              << "-------------------------------------------------------\n\n"
+              << std::endl;
+    try {
+
+      std::ifstream stream;
+      stream.open(Test.databases.filenames[Test.configuration.processors - 1]);
+
+      auto [nspec, npgeo, nproc] =
+          specfem::IO::mesh::fortran::read_mesh_database_header(stream, mpi);
+      stream.close();
+      std::cout << "nspec = " << nspec << std::endl;
+      std::cout << "npgeo = " << npgeo << std::endl;
+      std::cout << "nproc = " << nproc << std::endl;
+
+      std::cout << "--------------------------------------------------\n"
+                << "\033[0;32m[PASSED]\033[0m Test name: " << Test.name << "\n"
+                << "--------------------------------------------------\n\n"
+                << std::endl;
+    } catch (std::runtime_error &e) {
+      std::cout << " - Error: " << e.what() << std::endl;
+      FAIL() << "--------------------------------------------------\n"
+             << "\033[0;31m[FAILED]\033[0m Test failed\n"
+             << " - Test name: " << Test.name << "\n"
+             << " - Error: " << e.what() << "\n"
+             << "--------------------------------------------------\n\n"
+             << std::endl;
+    }
+  }
+  SUCCEED();
   return;
 }
 

--- a/tests/unit-tests/mesh/mesh_tests.cpp
+++ b/tests/unit-tests/mesh/mesh_tests.cpp
@@ -100,7 +100,7 @@ TEST(MESH_TESTS, fortran_binary_reader) {
               << "-------------------------------------------------------\n\n"
               << std::endl;
     try {
-      specfem::mesh::mesh mesh(
+      specfem::IO::read_mesh(
           Test.databases.filenames[Test.configuration.processors - 1], mpi);
       std::cout << "--------------------------------------------------\n"
                 << "\033[0;32m[PASSED]\033[0m Test name: " << Test.name << "\n"

--- a/tests/unit-tests/seismogram/acoustic/seismogram_tests.cpp
+++ b/tests/unit-tests/seismogram/acoustic/seismogram_tests.cpp
@@ -2,6 +2,7 @@
 #include "../../MPI_environment.hpp"
 // #include "../../utilities/include/compare_array.h"
 #include "IO/fortranio/interface.hpp"
+#include "IO/mesh/read_mesh.hpp"
 #include "compute/interface.hpp"
 #include "constants.hpp"
 #include "domain/domain.hpp"
@@ -90,7 +91,7 @@ TEST(SEISMOGRAM_TESTS, acoustic_seismograms_test) {
   const auto quadratures = setup.instantiate_quadrature();
 
   // Read mesh generated MESHFEM
-  specfem::mesh::mesh mesh(database_file, mpi);
+  specfem::mesh::mesh mesh = specfem::IO::read_mesh(database_file, mpi);
 
   std::vector<std::shared_ptr<specfem::sources::source> > sources(0);
 

--- a/tests/unit-tests/seismogram/elastic/seismogram_tests.cpp
+++ b/tests/unit-tests/seismogram/elastic/seismogram_tests.cpp
@@ -2,6 +2,7 @@
 #include "../../MPI_environment.hpp"
 // #include "../../utilities/include/compare_array.h"
 #include "IO/fortranio/interface.hpp"
+#include "IO/mesh/read_mesh.hpp"
 #include "compute/interface.hpp"
 #include "constants.hpp"
 #include "domain/domain.hpp"
@@ -90,7 +91,7 @@ TEST(SEISMOGRAM_TESTS, elastic_seismograms_test) {
   const auto quadratures = setup.instantiate_quadrature();
 
   // Read mesh generated MESHFEM
-  specfem::mesh::mesh mesh(database_file, mpi);
+  specfem::mesh::mesh mesh = specfem::IO::read_mesh(database_file, mpi);
 
   std::vector<std::shared_ptr<specfem::sources::source> > sources(0);
 

--- a/tests/unit-tests/source/source_location_tests.cpp
+++ b/tests/unit-tests/source/source_location_tests.cpp
@@ -1,5 +1,6 @@
 #include "../Kokkos_Environment.hpp"
 #include "../MPI_environment.hpp"
+#include "IO/mesh/read_mesh.hpp"
 #include "compute/interface.hpp"
 #include "material/interface.hpp"
 #include "mesh/mesh.hpp"
@@ -161,7 +162,8 @@ TEST(SOURCE_LOCATION_TESTS, compute_source_locations) {
 
   // Read mesh for binary database for the test
   std::vector<std::shared_ptr<specfem::material::material> > materials;
-  specfem::mesh::mesh mesh(test_config.database_file, materials, mpi);
+  specfem::mesh::mesh mesh =
+      specfem::IO::read_mesh(test_config.database_file, mpi);
 
   // read sources file
   auto [sources, t0] =


### PR DESCRIPTION
# Description

Implements the reading of mesh in form of a read_mesh(filename, mpi) function.

The updates are quite vast since everything had to be moved from the mesh() constructor to all other constructors

# Issue Number

Addresses #146 of superissue #108

# Checklist

Please make sure to check developer documentation on specfem docs. 

- [x] I ran the code through pre-commit to check style
- [x] My code passes all the integration tests
- [x] Exisiting unit tests are testing my build, but have added one that just reads the header
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [x] My code builds across all platforms 
