### PR TITLE
Issue 188

### DIFF
--- a/python/specfempp/__init__.py
+++ b/python/specfempp/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from ._core import __doc__, __version__, add, subtract
+from ._core import __doc__, __version__, run
 
-__all__ = ["__doc__", "__version__", "add", "subtract"]
+__all__ = ["__doc__", "__version__", "run"]

--- a/python/specfempp/__init__.py
+++ b/python/specfempp/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from ._core import __doc__, __version__, run
+from ._core import __doc__, __version__, _run
 
-__all__ = ["__doc__", "__version__", "run"]
+__all__ = ["__doc__", "__version__", "_run"]

--- a/src/specfem2d.cpp
+++ b/src/specfem2d.cpp
@@ -249,55 +249,7 @@ void execute(const std::string &parameter_file, const std::string &default_file,
   return;
 }
 
-#ifdef SPECFEMPP_ENABLE_PYTHON
-
-namespace py = pybind11;
-
-void run(py::str parameters_file) {
-  int argc = 0;
-  char **argv = NULL;
-  // Initialize MPI
-  specfem::MPI::MPI *mpi = new specfem::MPI::MPI(&argc, &argv);
-  // Initialize Kokkos
-  Kokkos::initialize(argc, argv);
-  {
-    execute(parameters_file.cast<std::string>(),
-            parameters_file.cast<std::string>(), mpi);
-  }
-  // Finalize Kokkos
-  Kokkos::finalize();
-  // Finalize MPI
-  delete mpi;
-}
-
-PYBIND11_MODULE(_core, m) {
-    m.doc() = R"pbdoc(
-        SPECfem++ core module
-        -----------------------
-
-        .. currentmodule:: specfempp
-
-        .. autosummary::
-           :toctree: _generate
-
-           run
-    )pbdoc";
-
-    m.def("run", &run, R"pbdoc(
-        Execute the main SPECFEM++ workflow.
-    )pbdoc");
-
-#ifdef VERSION_INFO
-    m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);
-#else
-    m.attr("__version__") = "dev";
-#endif
-}
-
-#endif
-
-int main(int argc, char **argv) {
-
+int run(int argc, char **argv) {
   // Initialize MPI
   specfem::MPI::MPI *mpi = new specfem::MPI::MPI(&argc, &argv);
   // Initialize Kokkos
@@ -317,3 +269,55 @@ int main(int argc, char **argv) {
   delete mpi;
   return 0;
 }
+
+#ifdef SPECFEMPP_ENABLE_PYTHON
+
+namespace py = pybind11;
+
+int _run(py::list argv_py) {
+  // parse argc and argv from Python
+  int argc = argv_py.size();
+  char **argv = new char *[argc];
+
+  for (size_t i = 0; i < argc; i++) {
+    std::string str =
+        argv_py[i].cast<std::string>(); // Convert Python string to std::string
+    argv[i] =
+        new char[str.length() + 1]; // Allocate memory for each C-style string
+    std::strcpy(argv[i], str.c_str()); // Copy the string content
+  }
+
+  int return_code = run(argc, argv);
+
+  delete[] argv;
+
+  return return_code;
+}
+
+PYBIND11_MODULE(_core, m) {
+    m.doc() = R"pbdoc(
+        SPECfem++ core module
+        -----------------------
+
+        .. currentmodule:: specfempp
+
+        .. autosummary::
+           :toctree: _generate
+
+           _run
+    )pbdoc";
+
+    m.def("_run", &_run, R"pbdoc(
+        Execute the main SPECFEM++ workflow.
+    )pbdoc");
+
+#ifdef VERSION_INFO
+    m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);
+#else
+    m.attr("__version__") = "dev";
+#endif
+}
+
+#endif
+
+int main(int argc, char **argv) { return run(argc, argv); }


### PR DESCRIPTION
# Description

Call base specfem workflow from Python
Input of the function is argv, e.g.
```py
from specfempp._core import _run
 _run(['', '-p','specfem_config.yaml'])
```
The function is named _run because it's not intended to be used directly. Instead, the Python library will call _run internally.

# Issue Number

#188

# Checklist

Please make sure to check developer documentation on specfem docs. 

- [x] I ran the code through pre-commit to check style
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [x] My code builds across all platforms 
