### PR TITLE
Implemented templates for specfem::mesh::parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ add_library(
         src/IO/mesh/impl/fortran/read_material_properties.cpp
         src/IO/mesh/impl/fortran/read_mesh_database.cpp
         src/IO/mesh/impl/fortran/read_interfaces.cpp
-        src/IO/mesh/impl/fortran/read_properties.cpp
+        src/IO/mesh/impl/fortran/read_parameters.cpp
 )
 
 if (NOT HDF5_CXX_BUILD)

--- a/include/IO/mesh/impl/fortran/read_parameters.hpp
+++ b/include/IO/mesh/impl/fortran/read_parameters.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "IO/fortranio/interface.hpp"
-#include "mesh/properties/properties.hpp"
+#include "mesh/parameters/parameters.hpp"
 #include "specfem_mpi/interface.hpp"
 
 namespace specfem {
@@ -11,14 +11,15 @@ namespace impl {
 namespace fortran {
 
 /*
- * @brief Read properties from mesh database
+ * @brief Read paramters from 2D mesh database
  *
  * @param stream Input stream
  * @param mpi MPI object
- * @return specfem::mesh::properties Property object
+ * @return specfem::mesh::parameters<specfem::dimension::type::dim2> Mesh
+ * parameters
  */
-specfem::mesh::properties read_properties(std::ifstream &stream,
-                                          const specfem::MPI::MPI *mpi);
+specfem::mesh::parameters<specfem::dimension::type::dim2>
+read_mesh_parameters(std::ifstream &stream, const specfem::MPI::MPI *mpi);
 
 } // namespace fortran
 } // namespace impl

--- a/include/mesh/mesh.hpp
+++ b/include/mesh/mesh.hpp
@@ -7,7 +7,7 @@
 #include "elements/tangential_elements.hpp"
 #include "materials/materials.hpp"
 #include "mesh/tags/tags.hpp"
-#include "properties/properties.hpp"
+#include "parameters/parameters.hpp"
 #include "specfem_mpi/interface.hpp"
 #include "specfem_setup.hpp"
 #include <Kokkos_Core.hpp>
@@ -26,8 +26,9 @@ struct mesh {
   int nproc; ///< Total number of processors
   specfem::mesh::control_nodes control_nodes; ///< Defines control nodes
 
-  specfem::mesh::properties parameters; ///< Struct to store simulation launch
-                                        ///< parameters (never used)
+  specfem::mesh::parameters<specfem::dimension::type::dim2>
+      parameters; ///< Struct to store simulation launch
+                  ///< parameters (never used)
 
   specfem::mesh::coupled_interfaces coupled_interfaces; ///< Struct to store
                                                         ///< coupled interfaces
@@ -60,7 +61,8 @@ struct mesh {
 
   mesh(const int npgeo, const int nspec, const int nproc,
        const specfem::mesh::control_nodes &control_nodes,
-       const specfem::mesh::properties &parameters,
+       const specfem::mesh::parameters<specfem::dimension::type::dim2>
+           &parameters,
        const specfem::mesh::coupled_interfaces &coupled_interfaces,
        const specfem::mesh::boundaries &boundaries,
        const specfem::mesh::tags &tags,

--- a/include/mesh/parameters/parameters.hpp
+++ b/include/mesh/parameters/parameters.hpp
@@ -1,18 +1,23 @@
 #ifndef _MESH_PROPERTIES_HPP
 #define _MESH_PROPERTIES_HPP
 
+#include "enumerations/dimension.hpp"
 #include "specfem_mpi/interface.hpp"
 
 namespace specfem {
 
 namespace mesh {
 /**
- * @brief Mesh properties
+ * @brief Mesh parameters
  *
- * Mesh properties stores meta-data used to allocate other structs within the
- * Mesh interface.
+ * @tparam DimensionType Dimension type for the mesh (2D or 3D)
  */
-struct properties {
+template <specfem::dimension::type DimensionType> struct parameters;
+
+/**
+ * @brief Template specialization for 2D mesh parameters
+ */
+template <> struct parameters<specfem::dimension::type::dim2> {
   int numat;           ///< Total number of different materials
   int ngnod;           ///< Number of control nodes
   int nspec;           ///< Number of spectral elements
@@ -32,7 +37,7 @@ struct properties {
    * @brief Default constructor
    *
    */
-  properties(){};
+  parameters(){};
 
   /**
    * @brief Construct a properties object
@@ -52,7 +57,7 @@ struct properties {
    * @param plot_lowerleft_corner_only Flag to plot only lower left corner
    */
 
-  properties(const int numat, const int ngnod, const int nspec,
+  parameters(const int numat, const int ngnod, const int nspec,
              const int pointsdisp, const int nelemabs,
              const int nelem_acforcing, const int nelem_acoustic_surface,
              const int num_fluid_solid_edges, const int num_fluid_poro_edges,

--- a/include/mesh/parameters/parameters.hpp
+++ b/include/mesh/parameters/parameters.hpp
@@ -18,9 +18,12 @@ template <specfem::dimension::type DimensionType> struct parameters;
  * @brief Template specialization for 2D mesh parameters
  */
 template <> struct parameters<specfem::dimension::type::dim2> {
-  int numat;           ///< Total number of different materials
-  int ngnod;           ///< Number of control nodes
-  int nspec;           ///< Number of spectral elements
+  constexpr static auto dimension =
+      specfem::dimension::type::dim2; ///< Dimension
+                                      ///< type
+  int numat;                          ///< Total number of different materials
+  int ngnod;                          ///< Number of control nodes
+  int nspec;                          ///< Number of spectral elements
   int pointsdisp;      // Total number of points to display (Only used for
                        // visualization)
   int nelemabs;        ///< Number of elements on absorbing boundary

--- a/src/IO/mesh.cpp
+++ b/src/IO/mesh.cpp
@@ -7,7 +7,7 @@
 #include "IO/mesh/impl/fortran/read_interfaces.hpp"
 #include "IO/mesh/impl/fortran/read_material_properties.hpp"
 #include "IO/mesh/impl/fortran/read_mesh_database.hpp"
-#include "IO/mesh/impl/fortran/read_properties.hpp"
+#include "IO/mesh/impl/fortran/read_parameters.hpp"
 #include "enumerations/specfem_enums.hpp"
 #include "kokkos_abstractions.h"
 #include "material/material.hpp"
@@ -60,7 +60,7 @@ specfem::mesh::mesh specfem::IO::read_mesh(const std::string filename,
 
   try {
     mesh.parameters =
-        specfem::IO::mesh::impl::fortran::read_properties(stream, mpi);
+        specfem::IO::mesh::impl::fortran::read_mesh_parameters(stream, mpi);
   } catch (std::runtime_error &e) {
     throw;
   }

--- a/src/IO/mesh/impl/fortran/read_parameters.cpp
+++ b/src/IO/mesh/impl/fortran/read_parameters.cpp
@@ -1,8 +1,9 @@
-#include "IO/mesh/impl/fortran/read_properties.hpp"
+#include "IO/mesh/impl/fortran/read_parameters.hpp"
 #include "IO/fortranio/interface.hpp"
-#include "mesh/properties/properties.hpp"
+#include "mesh/parameters/parameters.hpp"
 
-specfem::mesh::properties specfem::IO::mesh::impl::fortran::read_properties(
+specfem::mesh::parameters<specfem::dimension::type::dim2>
+specfem::IO::mesh::impl::fortran::read_mesh_parameters(
     std::ifstream &stream, const specfem::MPI::MPI *mpi) {
   // ---------------------------------------------------------------------
   // reading mesh properties
@@ -42,9 +43,17 @@ specfem::mesh::properties specfem::IO::mesh::impl::fortran::read_properties(
 
   mpi->sync_all();
 
-  return specfem::mesh::properties(
-      numat, ngnod, nspec, pointsdisp, nelemabs, nelem_acforcing,
-      nelem_acoustic_surface, num_fluid_solid_edges, num_fluid_poro_edges,
-      num_solid_poro_edges, nnodes_tangential_curve, nelem_on_the_axis,
-      plot_lowerleft_corner_only);
+  return { numat,
+           ngnod,
+           nspec,
+           pointsdisp,
+           nelemabs,
+           nelem_acforcing,
+           nelem_acoustic_surface,
+           num_fluid_solid_edges,
+           num_fluid_poro_edges,
+           num_solid_poro_edges,
+           nnodes_tangential_curve,
+           nelem_on_the_axis,
+           plot_lowerleft_corner_only };
 }


### PR DESCRIPTION
# Description

Implements #202 

- renamed `specfem::mesh::properties` to `specfem::mesh::parameters`

# Issue Number

Closes #202 

# Checklist

Please make sure to check developer documentation on specfem docs. 

- [x] I ran the code through pre-commit to check style
- [ ] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [x] My code builds across all platforms 
