### PR TITLE
Implements a dimension templated mesh struct.

### DIFF
--- a/include/IO/interface.hpp
+++ b/include/IO/interface.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "enumerations/interface.hpp"
 #include "enumerations/simulation.hpp"
 #include "mesh/mesh.hpp"
 #include "receiver/interface.hpp"
@@ -19,8 +20,8 @@ namespace IO {
  * @return specfem::mesh::mesh Specfem mesh object
  *
  */
-specfem::mesh::mesh read_mesh(const std::string filename,
-                              const specfem::MPI::MPI *mpi);
+specfem::mesh::mesh<specfem::dimension::type::dim2>
+read_mesh(const std::string filename, const specfem::MPI::MPI *mpi);
 
 /**
  * @brief Read receiver station file

--- a/include/compute/assembly/assembly.hpp
+++ b/include/compute/assembly/assembly.hpp
@@ -13,7 +13,7 @@
 #include "compute/properties/interface.hpp"
 #include "compute/sources/sources.hpp"
 #include "enumerations/display.hpp"
-#include "enumerations/specfem_enums.hpp"
+#include "enumerations/interface.hpp"
 #include "mesh/mesh.hpp"
 #include "receiver/interface.hpp"
 #include "source/interface.hpp"
@@ -67,7 +67,7 @@ struct assembly {
    * @param simulation Type of simulation (forward, adjoint, etc.)
    */
   assembly(
-      const specfem::mesh::mesh &mesh,
+      const specfem::mesh::mesh<specfem::dimension::type::dim2> &mesh,
       const specfem::quadrature::quadratures &quadratures,
       const std::vector<std::shared_ptr<specfem::sources::source> > &sources,
       const std::vector<std::shared_ptr<specfem::receivers::receiver> >

--- a/include/compute/boundaries/boundaries.hpp
+++ b/include/compute/boundaries/boundaries.hpp
@@ -3,7 +3,7 @@
 
 #include "compute/compute_mesh.hpp"
 #include "compute/properties/properties.hpp"
-#include "enumerations/specfem_enums.hpp"
+#include "enumerations/interface.hpp"
 #include "impl/acoustic_free_surface.hpp"
 #include "impl/stacey.hpp"
 #include "macros.hpp"
@@ -69,7 +69,7 @@ public:
    * quadrature point
    */
   boundaries(const int nspec, const int ngllz, const int ngllx,
-             const specfem::mesh::mesh &mesh,
+             const specfem::mesh::mesh<specfem::dimension::type::dim2> &mesh,
              const specfem::compute::mesh_to_compute_mapping &mapping,
              const specfem::compute::quadrature &quadrature,
              const specfem::compute::properties &properties,

--- a/include/compute/coupled_interfaces/coupled_interfaces.hpp
+++ b/include/compute/coupled_interfaces/coupled_interfaces.hpp
@@ -4,7 +4,7 @@
 #include "compute/compute_partial_derivatives.hpp"
 #include "compute/coupled_interfaces/interface_container.hpp"
 #include "compute/properties/properties.hpp"
-#include "enumerations/specfem_enums.hpp"
+#include "enumerations/interface.hpp"
 #include "interface_container.hpp"
 #include "mesh/coupled_interfaces/coupled_interfaces.hpp"
 
@@ -39,7 +39,8 @@ struct coupled_interfaces {
    * @param mapping Mapping between mesh and compute spectral element indexing
    */
   coupled_interfaces(
-      const specfem::mesh::mesh &mesh, const specfem::compute::points &points,
+      const specfem::mesh::mesh<specfem::dimension::type::dim2> &mesh,
+      const specfem::compute::points &points,
       const specfem::compute::quadrature &quadrature,
       const specfem::compute::partial_derivatives &partial_derivatives,
       const specfem::compute::properties &properties,

--- a/include/compute/coupled_interfaces/interface_container.hpp
+++ b/include/compute/coupled_interfaces/interface_container.hpp
@@ -5,7 +5,7 @@
 #include "compute/coupled_interfaces/interface_container.hpp"
 #include "compute/properties/properties.hpp"
 #include "edge/interface.hpp"
-#include "enumerations/specfem_enums.hpp"
+#include "enumerations/interface.hpp"
 #include "kokkos_abstractions.h"
 
 namespace specfem {
@@ -76,7 +76,8 @@ public:
    * @param mapping Mapping between mesh and compute spectral element indexing
    */
   interface_container(
-      const specfem::mesh::mesh &mesh, const specfem::compute::points &points,
+      const specfem::mesh::mesh<specfem::dimension::type::dim2> &mesh,
+      const specfem::compute::points &points,
       const specfem::compute::quadrature &quadrature,
       const specfem::compute::partial_derivatives &partial_derivatives,
       const specfem::compute::properties &properties,

--- a/include/compute/coupled_interfaces/interface_container.tpp
+++ b/include/compute/coupled_interfaces/interface_container.tpp
@@ -5,6 +5,7 @@
 #include "compute/coupled_interfaces/interface_container.hpp"
 #include "compute/properties/properties.hpp"
 #include "edge/interface.hpp"
+#include "enumerations/interface.hpp"
 #include "kokkos_abstractions.h"
 #include "mesh/coupled_interfaces/coupled_interfaces.hpp"
 #include "mesh/coupled_interfaces/interface_container.hpp"
@@ -514,7 +515,7 @@ template <specfem::element::medium_tag MediumTag1,
           specfem::element::medium_tag MediumTag2>
 specfem::compute::interface_container<MediumTag1, MediumTag2>::
     interface_container(
-        const specfem::mesh::mesh &mesh, const specfem::compute::points &points,
+        const specfem::mesh::mesh<specfem::dimension::type::dim2> &mesh, const specfem::compute::points &points,
         const specfem::compute::quadrature &quadratures,
         const specfem::compute::partial_derivatives &partial_derivatives,
         const specfem::compute::properties &properties,

--- a/include/mesh/mesh.hpp
+++ b/include/mesh/mesh.hpp
@@ -20,41 +20,48 @@ namespace mesh {
  * @brief Struct to store information about the mesh read from the database
  *
  */
-struct mesh {
+template <specfem::dimension::type DimensionType> struct mesh;
+
+template <> struct mesh<specfem::dimension::type::dim2> {
+
+  constexpr static auto dimension =
+      specfem::dimension::type::dim2; ///< Dimension
 
   int npgeo; ///< Total number of spectral element control nodes
   int nspec; ///< Total number of spectral elements
   int nproc; ///< Total number of processors
-  specfem::mesh::control_nodes<specfem::dimension::type::dim2>
-      control_nodes; ///< Defines control nodes
+  specfem::mesh::control_nodes<dimension> control_nodes; ///< Defines control
+                                                         ///< nodes
 
-  specfem::mesh::parameters<specfem::dimension::type::dim2>
-      parameters; ///< Struct to store simulation launch
-                  ///< parameters (never used)
+  specfem::mesh::parameters<dimension> parameters; ///< Struct to store
+                                                   ///< simulation launch
+                                                   ///< parameters (never used)
 
-  specfem::mesh::coupled_interfaces<specfem::dimension::type::dim2>
+  specfem::mesh::coupled_interfaces<dimension>
       coupled_interfaces; ///< Struct to store
                           ///< coupled interfaces
 
-  specfem::mesh::boundaries<specfem::dimension::type::dim2>
-      boundaries; ///< Struct to store information at the
-                  ///< boundaries
+  specfem::mesh::boundaries<dimension> boundaries; ///< Struct to store
+                                                   ///< information at the
+                                                   ///< boundaries
 
-  specfem::mesh::tags<specfem::dimension::type::dim2> tags; ///< Struct to store
-                                                            ///< tags for every
-                                                            ///< spectral
-                                                            ///< element
+  specfem::mesh::tags<dimension> tags; ///< Struct to store
+                                       ///< tags for every
+                                       ///< spectral
+                                       ///< element
 
-  specfem::mesh::elements::tangential_elements<specfem::dimension::type::dim2>
+  specfem::mesh::elements::tangential_elements<dimension>
       tangential_nodes; ///< Defines
                         ///< tangential
                         ///< nodes
                         ///< (never
                         ///< used)
 
-  specfem::mesh::elements::axial_elements<specfem::dimension::type::dim2>
-      axial_nodes;                    ///< Defines axial nodes
-                                      ///< (never used)
+  specfem::mesh::elements::axial_elements<dimension> axial_nodes; ///< Defines
+                                                                  ///< axial
+                                                                  ///< nodes
+                                                                  ///< (never
+                                                                  ///< used)
   specfem::mesh::materials materials; ///< Defines material properties
 
   /**

--- a/src/IO/mesh.cpp
+++ b/src/IO/mesh.cpp
@@ -23,11 +23,12 @@
 #include <tuple>
 #include <vector>
 
-specfem::mesh::mesh specfem::IO::read_mesh(const std::string filename,
-                                           const specfem::MPI::MPI *mpi) {
+specfem::mesh::mesh<specfem::dimension::type::dim2>
+specfem::IO::read_mesh(const std::string filename,
+                       const specfem::MPI::MPI *mpi) {
 
   // Declaring empty mesh objects
-  specfem::mesh::mesh mesh;
+  specfem::mesh::mesh<specfem::dimension::type::dim2> mesh;
 
   // Open the database file
   std::ifstream stream;

--- a/src/compute/assembly/assembly.cpp
+++ b/src/compute/assembly/assembly.cpp
@@ -1,9 +1,9 @@
-
 #include "compute/assembly/assembly.hpp"
+#include "enumerations/interface.hpp"
 #include "mesh/mesh.hpp"
 
 specfem::compute::assembly::assembly(
-    const specfem::mesh::mesh &mesh,
+    const specfem::mesh::mesh<specfem::dimension::type::dim2> &mesh,
     const specfem::quadrature::quadratures &quadratures,
     const std::vector<std::shared_ptr<specfem::sources::source> > &sources,
     const std::vector<std::shared_ptr<specfem::receivers::receiver> >

--- a/src/compute/boundaries/boundaries.cpp
+++ b/src/compute/boundaries/boundaries.cpp
@@ -1,9 +1,9 @@
-
 #include "compute/boundaries/boundaries.hpp"
+#include "enumerations/interface.hpp"
 
 specfem::compute::boundaries::boundaries(
     const int nspec, const int ngllz, const int ngllx,
-    const specfem::mesh::mesh &mesh,
+    const specfem::mesh::mesh<specfem::dimension::type::dim2> &mesh,
     const specfem::compute::mesh_to_compute_mapping &mapping,
     const specfem::compute::quadrature &quadrature,
     const specfem::compute::properties &properties,

--- a/src/compute/coupled_interfaces.cpp
+++ b/src/compute/coupled_interfaces.cpp
@@ -528,7 +528,8 @@
 //               coupled_interfaces.acoustic_poroelastic)) {}
 
 specfem::compute::coupled_interfaces::coupled_interfaces(
-    const specfem::mesh::mesh &mesh, const specfem::compute::points &points,
+    const specfem::mesh::mesh<specfem::dimension::type::dim2> &mesh,
+    const specfem::compute::points &points,
     const specfem::compute::quadrature &quadrature,
     const specfem::compute::partial_derivatives &partial_derivatives,
     const specfem::compute::properties &properties,

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1,5 +1,5 @@
 #include "mesh/mesh.hpp"
-#include "enumerations/specfem_enums.hpp"
+#include "enumerations/interface.hpp"
 #include "kokkos_abstractions.h"
 #include "material/material.hpp"
 #include "specfem_mpi/interface.hpp"
@@ -10,7 +10,7 @@
 #include <memory>
 #include <vector>
 
-std::string specfem::mesh::mesh::print() const {
+std::string specfem::mesh::mesh<specfem::dimension::type::dim2>::print() const {
 
   int n_elastic;
   int n_acoustic;

--- a/src/specfem2d.cpp
+++ b/src/specfem2d.cpp
@@ -93,16 +93,13 @@ void execute(const std::string &parameter_file, const std::string &default_file,
   const auto [database_filename, source_filename] = setup.get_databases();
   mpi->cout(setup.print_header(start_time));
 
-  // Setting the dimension gfor the
-  constexpr auto dimension = specfem::dimension::type::dim2;
   // --------------------------------------------------------------
 
   // --------------------------------------------------------------
   //                   Read mesh and materials
   // --------------------------------------------------------------
   const auto quadrature = setup.instantiate_quadrature();
-  const specfem::mesh::mesh<dimension> mesh =
-      specfem::IO::read_mesh(database_filename, mpi);
+  const auto mesh = specfem::IO::read_mesh(database_filename, mpi);
   // --------------------------------------------------------------
 
   // --------------------------------------------------------------

--- a/src/specfem2d.cpp
+++ b/src/specfem2d.cpp
@@ -92,13 +92,16 @@ void execute(const std::string &parameter_file, const std::string &default_file,
   specfem::runtime_configuration::setup setup(parameter_file, default_file);
   const auto [database_filename, source_filename] = setup.get_databases();
   mpi->cout(setup.print_header(start_time));
+
+  // Setting the dimension gfor the
+  constexpr auto dimension = specfem::dimension::type::dim2;
   // --------------------------------------------------------------
 
   // --------------------------------------------------------------
   //                   Read mesh and materials
   // --------------------------------------------------------------
   const auto quadrature = setup.instantiate_quadrature();
-  const specfem::mesh::mesh mesh =
+  const specfem::mesh::mesh<dimension> mesh =
       specfem::IO::read_mesh(database_filename, mpi);
   // --------------------------------------------------------------
 


### PR DESCRIPTION
# Description

After all elements of the mesh were fixed to be templated as a function of dimension, the `mesh` struct was the last thing remaining. This address that "shortcoming".

# Issue Number

Closes #221 

# Checklist

Please make sure to check developer documentation on specfem docs. 

- [x] I ran the code through pre-commit to check style
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms 
