### PR TITLE
Rename lambdaplus2mu to kappa for acoustic

### DIFF
--- a/include/compute/impl/value_containers.hpp
+++ b/include/compute/impl/value_containers.hpp
@@ -44,8 +44,9 @@ struct value_containers {
    */
   template <specfem::element::medium_tag MediumTag,
             specfem::element::property_tag PropertyTag>
-  KOKKOS_INLINE_FUNCTION constexpr containers_type<MediumTag, PropertyTag> const&
-  get_container() const {
+  KOKKOS_INLINE_FUNCTION
+      constexpr containers_type<MediumTag, PropertyTag> const &
+      get_container() const {
     if constexpr ((MediumTag == specfem::element::medium_tag::elastic) &&
                   (PropertyTag == specfem::element::property_tag::isotropic)) {
       return elastic_isotropic;

--- a/include/compute/properties/impl/properties_container.hpp
+++ b/include/compute/properties/impl/properties_container.hpp
@@ -583,8 +583,6 @@ struct properties_container<specfem::element::medium_tag::acoustic,
   int ngllx; ///< number of quadrature points in x dimension
   ViewType rho_inverse;
   ViewType::HostMirror h_rho_inverse;
-  ViewType kappa_inverse;
-  ViewType::HostMirror h_kappa_inverse;
   ViewType kappa;
   ViewType::HostMirror h_kappa;
 
@@ -595,9 +593,6 @@ struct properties_container<specfem::element::medium_tag::acoustic,
         rho_inverse("specfem::compute::properties::rho_inverse", nspec, ngllz,
                     ngllx),
         h_rho_inverse(Kokkos::create_mirror_view(rho_inverse)),
-        kappa_inverse("specfem::compute::properties::kappa_inverse", nspec,
-                      ngllz, ngllx),
-        h_kappa_inverse(Kokkos::create_mirror_view(kappa_inverse)),
         kappa("specfem::compute::properties::kappa", nspec, ngllz, ngllx),
         h_kappa(Kokkos::create_mirror_view(kappa)) {}
 
@@ -620,8 +615,8 @@ struct properties_container<specfem::element::medium_tag::acoustic,
     const int ix = index.ix;
 
     property.rho_inverse = rho_inverse(ispec, iz, ix);
-    property.kappa_inverse = kappa_inverse(ispec, iz, ix);
     property.kappa = kappa(ispec, iz, ix);
+    property.kappa_inverse = static_cast<type_real>(1.0) / property.kappa;
     property.rho_vpinverse =
         sqrt(property.rho_inverse * property.kappa_inverse);
   }
@@ -652,11 +647,10 @@ struct properties_container<specfem::element::medium_tag::acoustic,
 
     Kokkos::Experimental::where(mask, property.rho_inverse)
         .copy_from(&rho_inverse(ispec, iz, ix), tag_type());
-    Kokkos::Experimental::where(mask, property.kappa_inverse)
-        .copy_from(&kappa_inverse(ispec, iz, ix), tag_type());
     Kokkos::Experimental::where(mask, property.kappa)
         .copy_from(&kappa(ispec, iz, ix), tag_type());
 
+    property.kappa_inverse = static_cast<type_real>(1.0) / property.kappa;
     property.rho_vpinverse =
         Kokkos::sqrt(property.rho_inverse * property.kappa_inverse);
   }
@@ -680,8 +674,8 @@ struct properties_container<specfem::element::medium_tag::acoustic,
     const int ix = index.ix;
 
     property.rho_inverse = h_rho_inverse(ispec, iz, ix);
-    property.kappa_inverse = h_kappa_inverse(ispec, iz, ix);
     property.kappa = h_kappa(ispec, iz, ix);
+    property.kappa_inverse = static_cast<type_real>(1.0) / property.kappa;
     property.rho_vpinverse =
         sqrt(property.rho_inverse * property.kappa_inverse);
   }
@@ -712,24 +706,21 @@ struct properties_container<specfem::element::medium_tag::acoustic,
 
     Kokkos::Experimental::where(mask, property.rho_inverse)
         .copy_from(&h_rho_inverse(ispec, iz, ix), tag_type());
-    Kokkos::Experimental::where(mask, property.kappa_inverse)
-        .copy_from(&h_kappa_inverse(ispec, iz, ix), tag_type());
     Kokkos::Experimental::where(mask, property.kappa)
         .copy_from(&h_kappa(ispec, iz, ix), tag_type());
 
+    property.kappa_inverse = static_cast<type_real>(1.0) / property.kappa;
     property.rho_vpinverse =
         Kokkos::sqrt(property.rho_inverse * property.kappa_inverse);
   }
 
   void copy_to_device() {
     Kokkos::deep_copy(rho_inverse, h_rho_inverse);
-    Kokkos::deep_copy(kappa_inverse, h_kappa_inverse);
     Kokkos::deep_copy(kappa, h_kappa);
   }
 
   void copy_to_host() {
     Kokkos::deep_copy(h_rho_inverse, rho_inverse);
-    Kokkos::deep_copy(h_kappa_inverse, kappa_inverse);
     Kokkos::deep_copy(h_kappa, kappa);
   }
 
@@ -751,7 +742,6 @@ struct properties_container<specfem::element::medium_tag::acoustic,
     const int ix = index.ix;
 
     h_rho_inverse(ispec, iz, ix) = property.rho_inverse;
-    h_kappa_inverse(ispec, iz, ix) = property.kappa_inverse;
     h_kappa(ispec, iz, ix) = property.kappa;
   }
 
@@ -780,8 +770,6 @@ struct properties_container<specfem::element::medium_tag::acoustic,
 
     Kokkos::Experimental::where(mask, property.rho_inverse)
         .copy_to(&h_rho_inverse(ispec, iz, ix), tag_type());
-    Kokkos::Experimental::where(mask, property.kappa_inverse)
-        .copy_to(&h_kappa_inverse(ispec, iz, ix), tag_type());
     Kokkos::Experimental::where(mask, property.kappa)
         .copy_to(&h_kappa(ispec, iz, ix), tag_type());
   }

--- a/include/compute/properties/impl/properties_container.hpp
+++ b/include/compute/properties/impl/properties_container.hpp
@@ -583,8 +583,8 @@ struct properties_container<specfem::element::medium_tag::acoustic,
   int ngllx; ///< number of quadrature points in x dimension
   ViewType rho_inverse;
   ViewType::HostMirror h_rho_inverse;
-  ViewType lambdaplus2mu_inverse;
-  ViewType::HostMirror h_lambdaplus2mu_inverse;
+  ViewType kappa_inverse;
+  ViewType::HostMirror h_kappa_inverse;
   ViewType kappa;
   ViewType::HostMirror h_kappa;
 
@@ -595,11 +595,9 @@ struct properties_container<specfem::element::medium_tag::acoustic,
         rho_inverse("specfem::compute::properties::rho_inverse", nspec, ngllz,
                     ngllx),
         h_rho_inverse(Kokkos::create_mirror_view(rho_inverse)),
-        lambdaplus2mu_inverse(
-            "specfem::compute::properties::lambdaplus2mu_inverse", nspec, ngllz,
-            ngllx),
-        h_lambdaplus2mu_inverse(
-            Kokkos::create_mirror_view(lambdaplus2mu_inverse)),
+        kappa_inverse("specfem::compute::properties::kappa_inverse", nspec,
+                      ngllz, ngllx),
+        h_kappa_inverse(Kokkos::create_mirror_view(kappa_inverse)),
         kappa("specfem::compute::properties::kappa", nspec, ngllz, ngllx),
         h_kappa(Kokkos::create_mirror_view(kappa)) {}
 
@@ -622,10 +620,10 @@ struct properties_container<specfem::element::medium_tag::acoustic,
     const int ix = index.ix;
 
     property.rho_inverse = rho_inverse(ispec, iz, ix);
-    property.lambdaplus2mu_inverse = lambdaplus2mu_inverse(ispec, iz, ix);
+    property.kappa_inverse = kappa_inverse(ispec, iz, ix);
     property.kappa = kappa(ispec, iz, ix);
     property.rho_vpinverse =
-        sqrt(property.rho_inverse * property.lambdaplus2mu_inverse);
+        sqrt(property.rho_inverse * property.kappa_inverse);
   }
 
   template <
@@ -654,13 +652,13 @@ struct properties_container<specfem::element::medium_tag::acoustic,
 
     Kokkos::Experimental::where(mask, property.rho_inverse)
         .copy_from(&rho_inverse(ispec, iz, ix), tag_type());
-    Kokkos::Experimental::where(mask, property.lambdaplus2mu_inverse)
-        .copy_from(&lambdaplus2mu_inverse(ispec, iz, ix), tag_type());
+    Kokkos::Experimental::where(mask, property.kappa_inverse)
+        .copy_from(&kappa_inverse(ispec, iz, ix), tag_type());
     Kokkos::Experimental::where(mask, property.kappa)
         .copy_from(&kappa(ispec, iz, ix), tag_type());
 
     property.rho_vpinverse =
-        Kokkos::sqrt(property.rho_inverse * property.lambdaplus2mu_inverse);
+        Kokkos::sqrt(property.rho_inverse * property.kappa_inverse);
   }
 
   template <
@@ -682,10 +680,10 @@ struct properties_container<specfem::element::medium_tag::acoustic,
     const int ix = index.ix;
 
     property.rho_inverse = h_rho_inverse(ispec, iz, ix);
-    property.lambdaplus2mu_inverse = h_lambdaplus2mu_inverse(ispec, iz, ix);
+    property.kappa_inverse = h_kappa_inverse(ispec, iz, ix);
     property.kappa = h_kappa(ispec, iz, ix);
     property.rho_vpinverse =
-        sqrt(property.rho_inverse * property.lambdaplus2mu_inverse);
+        sqrt(property.rho_inverse * property.kappa_inverse);
   }
 
   template <
@@ -714,24 +712,24 @@ struct properties_container<specfem::element::medium_tag::acoustic,
 
     Kokkos::Experimental::where(mask, property.rho_inverse)
         .copy_from(&h_rho_inverse(ispec, iz, ix), tag_type());
-    Kokkos::Experimental::where(mask, property.lambdaplus2mu_inverse)
-        .copy_from(&h_lambdaplus2mu_inverse(ispec, iz, ix), tag_type());
+    Kokkos::Experimental::where(mask, property.kappa_inverse)
+        .copy_from(&h_kappa_inverse(ispec, iz, ix), tag_type());
     Kokkos::Experimental::where(mask, property.kappa)
         .copy_from(&h_kappa(ispec, iz, ix), tag_type());
 
     property.rho_vpinverse =
-        Kokkos::sqrt(property.rho_inverse * property.lambdaplus2mu_inverse);
+        Kokkos::sqrt(property.rho_inverse * property.kappa_inverse);
   }
 
   void copy_to_device() {
     Kokkos::deep_copy(rho_inverse, h_rho_inverse);
-    Kokkos::deep_copy(lambdaplus2mu_inverse, h_lambdaplus2mu_inverse);
+    Kokkos::deep_copy(kappa_inverse, h_kappa_inverse);
     Kokkos::deep_copy(kappa, h_kappa);
   }
 
   void copy_to_host() {
     Kokkos::deep_copy(h_rho_inverse, rho_inverse);
-    Kokkos::deep_copy(h_lambdaplus2mu_inverse, lambdaplus2mu_inverse);
+    Kokkos::deep_copy(h_kappa_inverse, kappa_inverse);
     Kokkos::deep_copy(h_kappa, kappa);
   }
 
@@ -753,7 +751,7 @@ struct properties_container<specfem::element::medium_tag::acoustic,
     const int ix = index.ix;
 
     h_rho_inverse(ispec, iz, ix) = property.rho_inverse;
-    h_lambdaplus2mu_inverse(ispec, iz, ix) = property.lambdaplus2mu_inverse;
+    h_kappa_inverse(ispec, iz, ix) = property.kappa_inverse;
     h_kappa(ispec, iz, ix) = property.kappa;
   }
 
@@ -782,8 +780,8 @@ struct properties_container<specfem::element::medium_tag::acoustic,
 
     Kokkos::Experimental::where(mask, property.rho_inverse)
         .copy_to(&h_rho_inverse(ispec, iz, ix), tag_type());
-    Kokkos::Experimental::where(mask, property.lambdaplus2mu_inverse)
-        .copy_to(&h_lambdaplus2mu_inverse(ispec, iz, ix), tag_type());
+    Kokkos::Experimental::where(mask, property.kappa_inverse)
+        .copy_to(&h_kappa_inverse(ispec, iz, ix), tag_type());
     Kokkos::Experimental::where(mask, property.kappa)
         .copy_to(&h_kappa(ispec, iz, ix), tag_type());
   }

--- a/include/material/acoustic_properties.hpp
+++ b/include/material/acoustic_properties.hpp
@@ -98,8 +98,7 @@ public:
    */
   inline specfem::point::properties<dimension, medium_tag, property_tag, false>
   get_properties() const {
-    return { static_cast<type_real>(1.0) / static_cast<type_real>(kappa),
-             static_cast<type_real>(1.0) / static_cast<type_real>(density),
+    return { static_cast<type_real>(1.0) / static_cast<type_real>(density),
              this->kappa };
   }
 

--- a/include/material/acoustic_properties.hpp
+++ b/include/material/acoustic_properties.hpp
@@ -45,8 +45,7 @@ public:
              const type_real &Qkappa, const type_real &Qmu,
              const type_real &compaction_grad)
       : density(density), cp(cp), Qkappa(Qkappa), Qmu(Qmu),
-        compaction_grad(compaction_grad), lambdaplus2mu(density * cp * cp),
-        lambda(lambdaplus2mu), kappa(lambda) {
+        compaction_grad(compaction_grad), kappa(density * cp * cp) {
     if (this->Qkappa <= 0.0 || this->Qmu <= 0.0) {
       std::runtime_error(
           "negative or null values of Q attenuation factor not allowed; set "
@@ -99,8 +98,7 @@ public:
    */
   inline specfem::point::properties<dimension, medium_tag, property_tag, false>
   get_properties() const {
-    return { static_cast<type_real>(1.0) /
-                 static_cast<type_real>(lambdaplus2mu),
+    return { static_cast<type_real>(1.0) / static_cast<type_real>(kappa),
              static_cast<type_real>(1.0) / static_cast<type_real>(density),
              this->kappa };
   }
@@ -114,7 +112,6 @@ public:
             << "      cp : " << this->cp << "\n"
             << "      kappa : " << this->kappa << "\n"
             << "      Qkappa : " << this->Qkappa << "\n"
-            << "      lambda : " << this->lambda << "\n"
             << "      youngs modulus : 0.0 \n"
             << "      poisson ratio :  0.5 \n";
 
@@ -127,8 +124,6 @@ private:
   type_real Qkappa;          ///< Attenuation factor for bulk modulus
   type_real Qmu;             ///< Attenuation factor for shear modulus
   type_real compaction_grad; ///< Compaction gradient
-  type_real lambdaplus2mu;   ///< Lame parameter
-  type_real lambda;          ///< Lame parameter
   type_real kappa;           ///< Bulk modulus
 };
 

--- a/include/point/properties.hpp
+++ b/include/point/properties.hpp
@@ -197,28 +197,24 @@ struct properties<specfem::dimension::type::dim2,
       typename simd::datatype; ///< Value type to store properties
   ///@}
 
-  value_type lambdaplus2mu_inverse; ///< @f$ \frac{1}{\lambda + 2\mu} @f$
-  value_type rho_inverse;           ///< @f$ \frac{1}{\rho} @f$
-  value_type kappa;                 ///< Bulk modulus @f$ \kappa @f$
+  value_type kappa_inverse; ///< @f$ \frac{1}{\lambda + 2\mu} @f$
+  value_type rho_inverse;   ///< @f$ \frac{1}{\rho} @f$
+  value_type kappa;         ///< Bulk modulus @f$ \kappa @f$
 
   value_type rho_vpinverse; ///< @f$ \frac{1}{\rho v_p} @f$
 
 private:
   KOKKOS_FUNCTION
-  properties(const value_type &lambdaplus2mu_inverse,
-             const value_type &rho_inverse, const value_type &kappa,
-             std::false_type)
-      : lambdaplus2mu_inverse(lambdaplus2mu_inverse), rho_inverse(rho_inverse),
-        kappa(kappa), rho_vpinverse(sqrt(rho_inverse * lambdaplus2mu_inverse)) {
-  }
+  properties(const value_type &kappa_inverse, const value_type &rho_inverse,
+             const value_type &kappa, std::false_type)
+      : kappa_inverse(kappa_inverse), rho_inverse(rho_inverse), kappa(kappa),
+        rho_vpinverse(sqrt(rho_inverse * kappa_inverse)) {}
 
   KOKKOS_FUNCTION
-  properties(const value_type &lambdaplus2mu_inverse,
-             const value_type &rho_inverse, const value_type &kappa,
-             std::true_type)
-      : lambdaplus2mu_inverse(lambdaplus2mu_inverse), rho_inverse(rho_inverse),
-        kappa(kappa),
-        rho_vpinverse(Kokkos::sqrt(rho_inverse * lambdaplus2mu_inverse)) {}
+  properties(const value_type &kappa_inverse, const value_type &rho_inverse,
+             const value_type &kappa, std::true_type)
+      : kappa_inverse(kappa_inverse), rho_inverse(rho_inverse), kappa(kappa),
+        rho_vpinverse(Kokkos::sqrt(rho_inverse * kappa_inverse)) {}
 
 public:
   /**
@@ -237,14 +233,14 @@ public:
   /**
    * @brief Construct a new properties object
    *
-   * @param lambdaplus2mu_inverse @f$ \frac{1}{\lambda + 2\mu} @f$
+   * @param kappa_inverse @f$ \frac{1}{\lambda + 2\mu} @f$
    * @param rho_inverse @f$ \frac{1}{\rho} @f$
    * @param kappa Bulk modulus @f$ \kappa @f$
    */
   KOKKOS_FUNCTION
-  properties(const value_type &lambdaplus2mu_inverse,
-             const value_type &rho_inverse, const value_type &kappa)
-      : properties(lambdaplus2mu_inverse, rho_inverse, kappa,
+  properties(const value_type &kappa_inverse, const value_type &rho_inverse,
+             const value_type &kappa)
+      : properties(kappa_inverse, rho_inverse, kappa,
                    std::integral_constant<bool, UseSIMD>{}) {}
   ///@}
 };

--- a/include/point/properties.hpp
+++ b/include/point/properties.hpp
@@ -205,15 +205,15 @@ struct properties<specfem::dimension::type::dim2,
 
 private:
   KOKKOS_FUNCTION
-  properties(const value_type &kappa_inverse, const value_type &rho_inverse,
-             const value_type &kappa, std::false_type)
-      : kappa_inverse(kappa_inverse), rho_inverse(rho_inverse), kappa(kappa),
+  properties(const value_type &rho_inverse, const value_type &kappa,
+             std::false_type)
+      : kappa_inverse(1.0 / kappa), rho_inverse(rho_inverse), kappa(kappa),
         rho_vpinverse(sqrt(rho_inverse * kappa_inverse)) {}
 
   KOKKOS_FUNCTION
-  properties(const value_type &kappa_inverse, const value_type &rho_inverse,
-             const value_type &kappa, std::true_type)
-      : kappa_inverse(kappa_inverse), rho_inverse(rho_inverse), kappa(kappa),
+  properties(const value_type &rho_inverse, const value_type &kappa,
+             std::true_type)
+      : kappa_inverse(1.0 / kappa), rho_inverse(rho_inverse), kappa(kappa),
         rho_vpinverse(Kokkos::sqrt(rho_inverse * kappa_inverse)) {}
 
 public:
@@ -233,14 +233,12 @@ public:
   /**
    * @brief Construct a new properties object
    *
-   * @param kappa_inverse @f$ \frac{1}{\lambda + 2\mu} @f$
    * @param rho_inverse @f$ \frac{1}{\rho} @f$
    * @param kappa Bulk modulus @f$ \kappa @f$
    */
   KOKKOS_FUNCTION
-  properties(const value_type &kappa_inverse, const value_type &rho_inverse,
-             const value_type &kappa)
-      : properties(kappa_inverse, rho_inverse, kappa,
+  properties(const value_type &rho_inverse, const value_type &kappa)
+      : properties(rho_inverse, kappa,
                    std::integral_constant<bool, UseSIMD>{}) {}
   ///@}
 };


### PR DESCRIPTION
# Description

Rename lambdaplus2mu to kappa for acoustic.

# Issue Number

Closes #340 

# Checklist

Please make sure to check developer documentation on specfem docs. 

[] I ran the code through pre-commit to check style
[] My code passes all the integration tests
[] I have added sufficient unittests to test my changes
[] I have added/updated documentation for the changes I am proposing
[] I have updated CMakeLists to ensure my code builds
[] My code builds across all platforms 
