### PR TITLE
Issue 357 - Fix Boost installation to remove non-official dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,26 +105,26 @@ endif()
 
 
 # Try finding boost and if not found install.
-find_package(Boost 1.83.0 COMPONENTS program_options filesystem system)
+find_package(Boost 1.78.0 COMPONENTS program_options filesystem system)
 
 if (NOT ${Boost_FOUND})
     # Add boost lib sources
     set(BOOST_INCLUDE_LIBRARIES program_options filesystem system algorithm tokenizer)
     set(BOOST_ENABLE_CMAKE ON)
-    set(BOOST_ENABLE_MPI ON CACHE INTERNAL "Boost MPI Switch") # Assume outer variable
+    set(BOOST_ENABLE_MPI OFF CACHE INTERNAL "Boost MPI Switch") # Assume outer variable
     set(BOOST_ENABLE_PYTHON OFF CACHE INTERNAL "Boost Python Switch") # Assume outer variable
     set(BOOST_BUILD_TESTING OFF CACHE BOOL INTERNAL "Boost Test Switch") # Disable testing for boost
     # The test flag is not really working... added it for completeness
 
     # Download and extract the boost library from GitHub
-    set(BOOST_VERSION 1.83.0)
+    set(BOOST_VERSION 1.87.0)
     message(STATUS "Downloading and extracting boost (${BOOST_VERSION}) library sources. This will take <1 min.")
     include(FetchContent)
 
     # Fetch boost from the Github release zip file to reduce download time
     FetchContent_Declare(
         Boost
-        URL https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}.7z # downloading a zip release speeds up the download
+        URL https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}-cmake.7z # downloading a zip release speeds up the download
         USES_TERMINAL_DOWNLOAD True
         GIT_PROGRESS TRUE
         DOWNLOAD_NO_EXTRACT FALSE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,11 +105,13 @@ endif()
 
 
 # Try finding boost and if not found install.
-find_package(Boost 1.73.0 COMPONENTS program_options filesystem system algorithm tokenizer)
+find_package(Boost 1.73.0 COMPONENTS program_options filesystem system)
+
 
 if (NOT ${Boost_FOUND})
     # Add boost lib sources
     set(BOOST_INCLUDE_LIBRARIES program_options filesystem system algorithm tokenizer)
+    set(BOOST_LIBS Boost::program_options Boost::filesystem Boost::system Boost::algorithm Boost::tokenizer)
     set(BOOST_ENABLE_CMAKE ON)
     set(BOOST_ENABLE_MPI OFF CACHE INTERNAL "Boost MPI Switch") # Assume outer variable
     set(BOOST_ENABLE_PYTHON OFF CACHE INTERNAL "Boost Python Switch") # Assume outer variable
@@ -134,6 +136,7 @@ if (NOT ${Boost_FOUND})
 
 else()
     # Check which boost LIBRARY_DIRS to use
+    set(BOOST_LIBS Boost::boost Boost::program_options Boost::filesystem Boost::system)
     message(STATUS "Boost libs/ and incs/:")
     message(STATUS "    LIB:   ${Boost_LIBRARY_DIRS}")
     message(STATUS "    INC:   ${Boost_INCLUDE_DIRS}")
@@ -214,9 +217,7 @@ if (NOT HDF5_CXX_BUILD)
         mesh
         source_class
         receiver_class
-        Boost::filesystem
-        Boost::algorithm
-        Boost::tokenizer
+        ${BOOST_LIBS}
         Kokkos::kokkos)
 else()
     target_link_libraries(
@@ -224,9 +225,7 @@ else()
         mesh
         source_class
         receiver_class
-        Boost::filesystem
-        Boost::algorithm
-        Boost::tokenizer
+
         Kokkos::kokkos
         ${HDF5_LIBRARIES}
     )
@@ -400,7 +399,7 @@ target_link_libraries(
         yaml-cpp
         point
         algorithms
-        Boost::filesystem
+        ${BOOST_LIBS}
 )
 
 add_library(
@@ -415,7 +414,7 @@ target_link_libraries(
         # utilities
         quadrature
         yaml-cpp
-        Boost::filesystem
+        ${BOOST_LIBS}
 )
 
 add_library(
@@ -618,7 +617,7 @@ target_link_libraries(
         kernels
         domain
         solver
-        Boost::filesystem
+        ${BOOST_LIBS}
 )
 
 add_executable(
@@ -645,7 +644,7 @@ target_link_libraries(
         coupled_interface
         kernels
         solver
-        Boost::program_options
+        ${BOOST_LIBS}
 )
 
 # Include tests
@@ -708,7 +707,7 @@ if (SPECFEMPP_ENABLE_PYTHON)
         coupled_interface
         kernels
         solver
-        Boost::program_options
+        ${BOOST_LIBS}
         pybind11::headers
     )
     target_compile_definitions(_core PRIVATE SPECFEMPP_ENABLE_PYTHON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ endif()
 
 
 # Try finding boost and if not found install.
-find_package(Boost 1.73.0 COMPONENTS program_options filesystem system)
+find_package(Boost 1.83.0 COMPONENTS program_options filesystem system)
 
 if (NOT ${Boost_FOUND})
     # Add boost lib sources

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ find_package(Boost 1.73.0 COMPONENTS program_options filesystem system)
 
 if (NOT ${Boost_FOUND})
     # Add boost lib sources
-    set(BOOST_INCLUDE_LIBRARIES program_options filesystem system algorithm)
+    set(BOOST_INCLUDE_LIBRARIES program_options filesystem system algorithm tokenizer)
     set(BOOST_ENABLE_CMAKE ON)
     set(BOOST_ENABLE_MPI ON CACHE INTERNAL "Boost MPI Switch") # Assume outer variable
     set(BOOST_ENABLE_PYTHON OFF CACHE INTERNAL "Boost Python Switch") # Assume outer variable
@@ -216,6 +216,7 @@ if (NOT HDF5_CXX_BUILD)
         receiver_class
         Boost::filesystem
         Boost::algorithm
+        Boost::tokenizer
         Kokkos::kokkos)
 else()
     target_link_libraries(
@@ -225,6 +226,7 @@ else()
         receiver_class
         Boost::filesystem
         Boost::algorithm
+        Boost::tokenizer
         Kokkos::kokkos
         ${HDF5_LIBRARIES}
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ if (NOT ${Boost_FOUND})
     # Fetch boost from the Github release zip file to reduce download time
     FetchContent_Declare(
         Boost
-        URL https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}-cmake.7z # downloading a zip release speeds up the download
+        URL https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}-cmake.tar.gz # downloading a zip release speeds up the download
         USES_TERMINAL_DOWNLOAD True
         GIT_PROGRESS TRUE
         DOWNLOAD_NO_EXTRACT FALSE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/archive)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+# For external modules that need to be built suppress build output
+set(FETCHCONTENT_QUIET TRUE)
 
 if (SPECFEMPP_ENABLE_PYTHON)
     message("-- Adding -fPIC flag for Python binding.")
@@ -54,40 +56,43 @@ else(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif()
 
 if (DEFINED Kokkos_ENABLE_CUDA)
-        if (Kokkos_ENABLE_CUDA)
-                # message("Setting CUDA variables")
-                set(Kokkos_ENABLE_CUDA_LAMBDA ON CACHE BOOL "Using CUDA Lambda by default")
-                set(Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE ON CACHE BOOL "Using CUDA Relocatable device by default")
-        endif()
+    if (Kokkos_ENABLE_CUDA)
+        # message("Setting CUDA variables")
+        set(Kokkos_ENABLE_CUDA_LAMBDA ON CACHE BOOL "Using CUDA Lambda by default")
+        set(Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE ON CACHE BOOL "Using CUDA Relocatable device by default")
+    endif()
 endif()
+
 
 # Install Kokkos as a dependency
 ## TODO: Add options for on utilizing in house builds
 include(FetchContent)
 FetchContent_Declare(
-kokkos
-URL https://github.com/kokkos/kokkos/archive/refs/tags/4.3.01.zip
+  kokkos
+  URL https://github.com/kokkos/kokkos/archive/refs/tags/4.3.01.zip
+  DOWNLOAD_EXTRACT_TIMESTAMP FALSE
 )
 FetchContent_MakeAvailable(kokkos)
 
 FetchContent_Declare(
         yaml
         URL https://github.com/jbeder/yaml-cpp/archive/refs/tags/0.8.0.tar.gz
+        DOWNLOAD_EXTRACT_TIMESTAMP FALSE
 )
 FetchContent_MakeAvailable(yaml)
 
 include_directories(BEFORE SYSTEM ${yaml_BINARY_DIR} ${yaml_SOURCE_DIR}/include)
 
 find_package(VTK COMPONENTS
-CommonColor
-CommonCore
-FiltersSources
-InteractionStyle
-RenderingContextOpenGL2
-RenderingCore
-RenderingFreeType
-RenderingGL2PSOpenGL2
-RenderingOpenGL2
+  CommonColor
+  CommonCore
+  FiltersSources
+  InteractionStyle
+  RenderingContextOpenGL2
+  RenderingCore
+  RenderingFreeType
+  RenderingGL2PSOpenGL2
+  RenderingOpenGL2
 )
 
 
@@ -103,24 +108,51 @@ endif()
 find_package(Boost 1.73.0 COMPONENTS program_options filesystem system)
 
 if (NOT ${Boost_FOUND})
-        add_subdirectory(boost-cmake)
-else ()
-        message(STATUS "    LIB:   ${Boost_LIBRARY_DIRS}")
-        message(STATUS "    INC:   ${Boost_INCLUDE_DIRS}")
-        message(STATUS "    LIBSO: ${Boost_LIBRARIES}")
+    # Add boost lib sources
+    set(BOOST_INCLUDE_LIBRARIES program_options filesystem system algorithm)
+    set(BOOST_ENABLE_CMAKE ON)
+    set(BOOST_ENABLE_MPI ON CACHE INTERNAL "Boost MPI Switch") # Assume outer variable
+    set(BOOST_ENABLE_PYTHON OFF CACHE INTERNAL "Boost Python Switch") # Assume outer variable
+    set(BOOST_BUILD_TESTING OFF CACHE BOOL INTERNAL "Boost Test Switch") # Disable testing for boost
+    # The test flag is not really working... added it for completeness
+
+    # Download and extract the boost library from GitHub
+    set(BOOST_VERSION 1.83.0)
+    message(STATUS "Downloading and extracting boost (${BOOST_VERSION}) library sources. This will take <1 min.")
+    include(FetchContent)
+
+    # Fetch boost from the Github release zip file to reduce download time
+    FetchContent_Declare(
+        Boost
+        URL https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}.7z # downloading a zip release speeds up the download
+        USES_TERMINAL_DOWNLOAD True
+        GIT_PROGRESS TRUE
+        DOWNLOAD_NO_EXTRACT FALSE
+        DOWNLOAD_EXTRACT_TIMESTAMP FALSE
+    )
+    FetchContent_MakeAvailable(Boost)
+
+else()
+    # Check which boost LIBRARY_DIRS to use
+    message(STATUS "Boost libs/ and incs/:")
+    message(STATUS "    LIB:   ${Boost_LIBRARY_DIRS}")
+    message(STATUS "    INC:   ${Boost_INCLUDE_DIRS}")
+    message(STATUS "    LIBSO: ${Boost_LIBRARIES}")
 endif()
 
 # Install HDF5 as a dependency if not found
 find_package(HDF5 COMPONENTS CXX)
 
 if (NOT ${HDF5_FOUND})
-        message("-- HDF5 not found. Building without HDF5.")
-        set(HDF5_CXX_BUILD OFF)
-else ()
-        message(STATUS "    LIB:   ${HDF5_LIBRARIES}")
-        message(STATUS "    INC:   ${HDF5_INCLUDE_DIRS}")
-        message(STATUS "    LIBSO: ${HDF5_CXX_LIBRARIES}")
+    message("-- HDF5 not found. Building without HDF5.")
+    set(HDF5_CXX_BUILD OFF)
+else()
+    message("HDF5 libs/ and incs/:.")
+    message(STATUS "    LIB:   ${HDF5_LIBRARIES}")
+    message(STATUS "    INC:   ${HDF5_INCLUDE_DIRS}")
+    message(STATUS "    LIBSO: ${HDF5_CXX_LIBRARIES}")
 endif()
+
 
 configure_file(constants.hpp.in constants.hpp)
 
@@ -131,13 +163,13 @@ add_subdirectory(fortran/meshfem2d)
 add_subdirectory(fortran/meshfem3d)
 
 if (ENABLE_SIMD)
-        message("-- Enabling SIMD")
-        add_definitions(-DENABLE_SIMD)
+    message("-- Enabling SIMD")
+    add_definitions(-DENABLE_SIMD)
 endif()
 
 if (ENABLE_PROFILING)
-        message("-- Enabling profiling")
-        add_definitions(-DENABLE_PROFILING)
+    message("-- Enabling profiling")
+    add_definitions(-DENABLE_PROFILING)
 endif()
 
 # Build specfem2d libraries
@@ -172,31 +204,32 @@ add_library(
 )
 
 if (NOT HDF5_CXX_BUILD)
-        target_compile_definitions(
-                IO
-                PUBLIC -DNO_HDF5
-        )
+    target_compile_definitions(
+        IO
+        PUBLIC -DNO_HDF5
+    )
 
-        target_link_libraries(
-                IO
-                Boost::boost
-                Kokkos::kokkos
-        )
+    target_link_libraries(
+        IO
+        mesh
+        source_class
+        receiver_class
+        Boost::filesystem
+        Boost::algorithm
+        Kokkos::kokkos)
 else()
-        target_link_libraries(
-                IO
-                ${HDF5_LIBRARIES}
-                Boost::boost
-                Kokkos::kokkos
-        )
+    target_link_libraries(
+        IO
+        mesh
+        source_class
+        receiver_class
+        Boost::filesystem
+        Boost::algorithm
+        Kokkos::kokkos
+        ${HDF5_LIBRARIES}
+    )
 endif()
 
-target_link_libraries(
-  IO
-  mesh
-  source_class
-  receiver_class
-)
 
 add_library(
         point
@@ -365,7 +398,7 @@ target_link_libraries(
         yaml-cpp
         point
         algorithms
-        Boost::boost
+        Boost::filesystem
 )
 
 add_library(
@@ -380,7 +413,7 @@ target_link_libraries(
         # utilities
         quadrature
         yaml-cpp
-        Boost::boost
+        Boost::filesystem
 )
 
 add_library(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ endif()
 
 
 # Try finding boost and if not found install.
-find_package(Boost 1.78.0 COMPONENTS program_options filesystem system)
+find_package(Boost 1.73.0 COMPONENTS program_options filesystem system algorithm tokenizer)
 
 if (NOT ${Boost_FOUND})
     # Add boost lib sources

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -7,6 +7,7 @@ include(FetchContent)
 FetchContent_Declare(
   googletest
   URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
+  DOWNLOAD_EXTRACT_TIMESTAMP FALSE
 )
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
# Description

The hash for the boost download changed, which is a dependency that is outside of this repo that could change anytime again. This pull request introduces a fast way to build  boost from the official repo's release zips, only building the required libraries.

It should fix previous build issues.

# Issue Number

Closes #357 

# Checklist

Please make sure to check developer documentation on specfem docs. 

- [x] I ran the code through pre-commit to check style
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms 
