### PR TITLE
Make the directory structure for 3D mesher flexible

### DIFF
--- a/examples/dim3/homogeneous_halfspace/DATA/meshfem3D_files/Mesh_Par_file
+++ b/examples/dim3/homogeneous_halfspace/DATA/meshfem3D_files/Mesh_Par_file
@@ -14,7 +14,7 @@ UTM_PROJECTION_ZONE             = 11
 SUPPRESS_UTM_PROJECTION         = .true.
 
 # file that contains the interfaces of the model / mesh
-INTERFACES_FILE                 = MESH_FILES/interfaces.txt
+INTERFACES_FILE                 = DATA/meshfem3D_files/interfaces.txt
 
 # file that contains the cavity
 CAVITY_FILE                     = no_cavity.dat

--- a/examples/dim3/homogeneous_halfspace/DATA/meshfem3D_files/Mesh_Par_file
+++ b/examples/dim3/homogeneous_halfspace/DATA/meshfem3D_files/Mesh_Par_file
@@ -14,7 +14,7 @@ UTM_PROJECTION_ZONE             = 11
 SUPPRESS_UTM_PROJECTION         = .true.
 
 # file that contains the interfaces of the model / mesh
-INTERFACES_FILE                 = interfaces3.txt
+INTERFACES_FILE                 = MESH_FILES/interfaces.txt
 
 # file that contains the cavity
 CAVITY_FILE                     = no_cavity.dat

--- a/examples/dim3/homogeneous_halfspace/DATA/meshfem3D_files/interfaces.txt
+++ b/examples/dim3/homogeneous_halfspace/DATA/meshfem3D_files/interfaces.txt
@@ -8,7 +8,7 @@
 #
 # interface number 1 (topography, top of the mesh)
  .true. 2 2 0.0 0.0 1000.0 1000.0
- MESH_FILES/interface1.txt
+ DATA/meshfem3D_files/interface1.txt
 #
 # for each layer, we give the number of spectral elements in the vertical direction
 #

--- a/examples/dim3/homogeneous_halfspace/DATA/meshfem3D_files/interfaces.txt
+++ b/examples/dim3/homogeneous_halfspace/DATA/meshfem3D_files/interfaces.txt
@@ -8,7 +8,7 @@
 #
 # interface number 1 (topography, top of the mesh)
  .true. 2 2 0.0 0.0 1000.0 1000.0
- interface1.txt
+ MESH_FILES/interface1.txt
 #
 # for each layer, we give the number of spectral elements in the vertical direction
 #

--- a/examples/dim3/homogeneous_halfspace/Par_File
+++ b/examples/dim3/homogeneous_halfspace/Par_File
@@ -272,6 +272,28 @@ USE_TRICK_FOR_BETTER_PRESSURE   = .false.
 
 #-----------------------------------------------------------
 #
+# Fault simulations
+#
+#-----------------------------------------------------------
+
+# Define if the simulation has kinematic or dynamic faults
+HAS_FINITE_FAULT_SOURCE         = .false.
+
+# File containing parameters of the fault
+FAULT_PAR_FILE                  = dummy.txt
+
+# STATIONS in the fault plane
+FAULT_STATIONS                  = dummy.txt
+
+# Specifications for heterogeneous stresses and friction for linear slip weakening friction parameters. To activate this feature set DATA/Par_file_faults name list&RUPTURE_SWITCHES, set TPV16=.TRUE..
+STRESS_FRICTION_FILE            = dummy.txt
+
+# Heterogeneous stresses and friction input for rate and state friction. To activate this feature, in DATA/Par_file_faults name list&RUPTURE_SWITCHES, set RSF_HETE=.TRUE..
+RSF_HETE_FILE                   = dummy.txt
+
+
+#-----------------------------------------------------------
+#
 # Energy calculation
 #
 #-----------------------------------------------------------

--- a/examples/dim3/homogeneous_halfspace/Par_File
+++ b/examples/dim3/homogeneous_halfspace/Par_File
@@ -196,7 +196,7 @@ USE_SOURCES_RECEIVERS_Z         = .false.
 # its norm is ignored and the norm of the force used is the factor force source times the source time function.
 USE_FORCE_POINT_SOURCE          = .false.
 
-SOURCE_FILENAME                    = CMTSOLUTION
+SOURCE_FILENAME                    = DATA/CMTSOLUTION
 
 # set to true to use a Ricker source time function instead of the source time functions set by default
 # to represent a (tilted) FORCESOLUTION force point source or a CMTSOLUTION moment-tensor source.

--- a/examples/dim3/homogeneous_halfspace/Par_File
+++ b/examples/dim3/homogeneous_halfspace/Par_File
@@ -51,6 +51,8 @@ RATIO_BY_WHICH_TO_INCREASE_IT   = 1.4
 #
 #-----------------------------------------------------------
 
+MESH_PAR_FILE = DATA/meshfem3D_files/Mesh_Par_file
+
 # Number of nodes for 2D and 3D shape functions for hexahedra.
 # We use either 8-node mesh elements (bricks) or 27-node elements.
 # If you use our internal mesher, the only option is 8-node bricks (27-node elements are not supported).
@@ -64,6 +66,9 @@ NGNOD                           = 8
 # 3D models available are:
 #   aniso,external,gll,salton_trough,tomo,SEP,coupled,...
 MODEL                           = default
+
+# path for external model files (if MODEL = coupled)
+COUPLED_MODEL_DIRECTORY         = DATA/coupled_model/
 
 # path for external tomographic models files
 TOMOGRAPHY_PATH                 = DATA/tomo_files/
@@ -174,8 +179,6 @@ NTSTEP_BETWEEN_OUTPUT_INFO      = 500
 #
 #-----------------------------------------------------------
 
-CMTSOLUTION                    = CMTSOLUTION
-
 # sources and receivers Z coordinates given directly (i.e. as their true position) instead of as their depth
 USE_SOURCES_RECEIVERS_Z         = .false.
 
@@ -192,6 +195,8 @@ USE_SOURCES_RECEIVERS_Z         = .false.
 # The direction vector is made unitary internally in the code and thus only its direction matters here;
 # its norm is ignored and the norm of the force used is the factor force source times the source time function.
 USE_FORCE_POINT_SOURCE          = .false.
+
+SOURCE_FILENAME                    = CMTSOLUTION
 
 # set to true to use a Ricker source time function instead of the source time functions set by default
 # to represent a (tilted) FORCESOLUTION force point source or a CMTSOLUTION moment-tensor source.

--- a/fortran/meshfem3d/CMakeLists.txt
+++ b/fortran/meshfem3d/CMakeLists.txt
@@ -8,6 +8,9 @@ project(MESHFEM3D LANGUAGES Fortran C)
 set(CMAKE_Fortran_STANDARD 95)
 set(CMAKE_Fortran_STANDARD_REQUIRED ON)
 
+unset(WITH_MPI)
+unset(WITH_SCOTCH)
+
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/fortran/meshfem3d/modules)
 include_directories("${CMAKE_BINARY_DIR}/fortran/meshfem3d/modules")
 

--- a/fortran/meshfem3d/generate_databases/fault_generate_databases.f90
+++ b/fortran/meshfem3d/generate_databases/fault_generate_databases.f90
@@ -99,7 +99,8 @@ contains
 
   subroutine fault_read_input(prname)
 
-  use constants, only: MAX_STRING_LEN, IN_DATA_FILES,myrank,IIN_PAR,IIN_BIN
+  use constants, only: MAX_STRING_LEN,myrank,IIN_PAR,IIN_BIN
+  use shared_input_parameters, only: FAULT_PAR_FILE
 
   implicit none
   character(len=MAX_STRING_LEN), intent(in) :: prname
@@ -108,7 +109,7 @@ contains
 
   ! read fault input file
   nb = 0
-  open(unit=IIN_PAR,file=IN_DATA_FILES(1:len_trim(IN_DATA_FILES))//'Par_file_faults',status='old',action='read',iostat=ier)
+  open(unit=IIN_PAR,file=FAULT_PAR_FILE,status='old',action='read',iostat=ier)
   if (ier == 0) then
     read(IIN_PAR,*) nb
     if (myrank == 0) then

--- a/fortran/meshfem3d/generate_databases/generate_databases.f90
+++ b/fortran/meshfem3d/generate_databases/generate_databases.f90
@@ -52,6 +52,8 @@
   ! timing
   double precision, external :: wtime
 
+  call parse_command_line_arguments()
+
   ! MPI initialization
   call init_mpi()
 

--- a/fortran/meshfem3d/generate_databases/model_coupled.f90
+++ b/fortran/meshfem3d/generate_databases/model_coupled.f90
@@ -84,7 +84,8 @@
 
   subroutine read_model_for_coupling_or_chunk()
 
-  use constants, only: IMAIN,IN_DATA_FILES,myrank
+  use constants, only: IMAIN,myrank
+  use shared_input_parameters, only: COUPLED_MODEL_DIRECTORY
 
   use model_coupled_par !! VM VM custom subroutine for coupling with DSM
 
@@ -103,7 +104,7 @@
     call flush_IMAIN()
   endif
 
-  filename = IN_DATA_FILES(1:len_trim(IN_DATA_FILES))//'/coeff_poly_deg12'
+  filename = COUPLED_MODEL_DIRECTORY(1:len_trim(COUPLED_MODEL_DIRECTORY))//'/coeff_poly_deg12'
   open(27,file=trim(filename),iostat=ier)
   if (ier /= 0) then
     print *,'Error opening file: ',filename
@@ -123,7 +124,7 @@
 
   !write(*,*) " Reading 1D model "
 
-  filename = IN_DATA_FILES(1:len_trim(IN_DATA_FILES))//'/model_1D.in'
+  filename = COUPLED_MODEL_DIRECTORY(1:len_trim(COUPLED_MODEL_DIRECTORY))//'/model_1D.in'
   open(27,file=trim(filename),iostat=ier)
   if (ier /= 0) then
     print *,'Error opening file: ',filename

--- a/fortran/meshfem3d/meshfem3D/create_interfaces_mesh.f90
+++ b/fortran/meshfem3d/meshfem3D/create_interfaces_mesh.f90
@@ -36,7 +36,7 @@
     number_of_layers,ner_layer,iproc_xi_current,iproc_eta_current,NPROC_XI,NPROC_ETA, &
     xgrid,ygrid,zgrid
 
-  use constants, only: IMAIN,IIN,MF_IN_DATA_FILES,DONT_IGNORE_JUNK,IUTM2LONGLAT,MAX_STRING_LEN,HUGEVAL
+  use constants, only: IMAIN,IIN,DONT_IGNORE_JUNK,IUTM2LONGLAT,MAX_STRING_LEN,HUGEVAL
 
   implicit none
 
@@ -95,13 +95,16 @@
 
   ! user output
   if (myrank == 0) then
-    write(IMAIN,*) 'Reading interface data from file ',trim(MF_IN_DATA_FILES)//trim(INTERFACES_FILE)
+    write(IMAIN,*) 'Reading interface data from file ',trim(INTERFACES_FILE)
     write(IMAIN,*)
     call flush_IMAIN()
   endif
 
-  open(unit=IIN,file=trim(MF_IN_DATA_FILES)//trim(INTERFACES_FILE),status='old',iostat=ier)
-  if (ier /= 0) stop 'Error opening interfaces file'
+  open(unit=IIN,file=trim(INTERFACES_FILE),status='old',iostat=ier)
+  if (ier /= 0) then
+    print *,'Error opening interface file: ',trim(INTERFACES_FILE)
+    stop 'Error opening interface file'
+  endif
 
   ! allocates interface arrays
   allocate(interface_bottom(max_npx_interface,max_npy_interface),stat=ier)
@@ -203,9 +206,9 @@
     endif
 
     ! loop on all the points describing this interface
-    open(unit=45,file=trim(MF_IN_DATA_FILES)//trim(interface_top_file),status='old',iostat=ier)
+    open(unit=45,file=trim(interface_top_file),status='old',iostat=ier)
     if (ier /= 0) then
-      print *,'Error opening file: ',trim(MF_IN_DATA_FILES)//trim(interface_top_file)
+      print *,'Error opening file: ',trim(interface_top_file)
       stop 'Error opening interface file'
     endif
 
@@ -232,7 +235,7 @@
     ! checks number of points npoints_interface_top = npx_interface_top * npy_interface
     if (icount /= npx_interface_top * npy_interface_top) then
       print *,'Error number of interface points ',icount,' should be ',npx_interface_top * npy_interface_top
-      print *,'Please check interface definition in file: ',trim(MF_IN_DATA_FILES)//trim(interface_top_file)
+      print *,'Please check interface definition in file: ',trim(interface_top_file)
       stop 'Error invalid number of interface file points'
     endif
 
@@ -460,7 +463,7 @@
     number_of_interfaces,max_npx_interface,max_npy_interface, &
     number_of_layers,ner_layer
 
-  use constants, only: IMAIN,IIN,MF_IN_DATA_FILES,DONT_IGNORE_JUNK,MAX_STRING_LEN,myrank
+  use constants, only: IMAIN,IIN,DONT_IGNORE_JUNK,MAX_STRING_LEN,myrank
 
   implicit none
 
@@ -478,14 +481,14 @@
   ! user output
   if (myrank == 0) then
     write(IMAIN,*)
-    write(IMAIN,*) 'Reading interface data from file ',trim(MF_IN_DATA_FILES)//trim(INTERFACES_FILE)
+    write(IMAIN,*) 'Reading interface data from file ',trim(INTERFACES_FILE)
     call flush_IMAIN()
   endif
 
   ! opens interfaces file
-  open(unit=IIN,file=trim(MF_IN_DATA_FILES)//trim(INTERFACES_FILE),status='old',iostat=ier)
+  open(unit=IIN,file=trim(INTERFACES_FILE),status='old',iostat=ier)
   if (ier /= 0) then
-    print *,'Error opening interface file: ',trim(MF_IN_DATA_FILES)//trim(INTERFACES_FILE)
+    print *,'Error opening interface file: ',trim(INTERFACES_FILE)
     stop 'Error opening interface file'
   endif
 

--- a/fortran/meshfem3d/meshfem3D/determine_cavity.f90
+++ b/fortran/meshfem3d/meshfem3D/determine_cavity.f90
@@ -28,7 +28,7 @@
 
   subroutine cmm_determine_cavity(nglob)
 
-  use constants, only: MF_IN_DATA_FILES,MAX_STRING_LEN,IMAIN,HUGEVAL,TINYVAL,NDIM,myrank
+  use constants, only: MAX_STRING_LEN,IMAIN,HUGEVAL,TINYVAL,NDIM,myrank
   use constants_meshfem, only: NGLLX_M,NGLLY_M,NGLLZ_M
 
   use create_meshfem_par, only: nodes_coords,ispec_material_id,iboun,iMPIcut_xi,iMPIcut_eta
@@ -75,7 +75,7 @@
   ncavity = 0
 
   ! read cavity file
-  filename = trim(MF_IN_DATA_FILES)//trim(CAVITY_FILE)
+  filename = trim(CAVITY_FILE)
   open(111,file=filename,action='read',status='old',iostat=ier)
   if (ier /= 0) then
     cavity_file_exists = .false.

--- a/fortran/meshfem3d/meshfem3D/meshfem3D.F90
+++ b/fortran/meshfem3d/meshfem3D/meshfem3D.F90
@@ -98,7 +98,7 @@
   endif
 
   if (myrank == 0) then
-    write(IMAIN,*) 'Reading parameters from ',IN_DATA_FILES(1:len_trim(IN_DATA_FILES))//'Par_file'
+    write(IMAIN,*) 'Reading parameters from ',trim(Par_file)
     write(IMAIN,*)
     call flush_IMAIN()
   endif

--- a/fortran/meshfem3d/meshfem3D/meshfem3D.F90
+++ b/fortran/meshfem3d/meshfem3D/meshfem3D.F90
@@ -60,6 +60,8 @@
   double precision :: time_start,tCPU
   character(len=3) :: str_unit
 
+  call parse_command_line_arguments()
+
   ! MPI initialization
   call init_mpi()
 

--- a/fortran/meshfem3d/meshfem3D/read_mesh_parameter_file.f90
+++ b/fortran/meshfem3d/meshfem3D/read_mesh_parameter_file.f90
@@ -39,9 +39,11 @@
     myrank,sizeprocs,NUMBER_OF_MATERIAL_PROPERTIES, &
     SAVE_MESH_AS_CUBIT
 
-  use constants, only: IIN,MF_IN_DATA_FILES,MAX_STRING_LEN,IMAIN, &
+  use constants, only: IIN,MAX_STRING_LEN,IMAIN, &
     IDOMAIN_ACOUSTIC,IDOMAIN_ELASTIC,IDOMAIN_POROELASTIC, &
     ILONGLAT2UTM,IGNORE_JUNK,DONT_IGNORE_JUNK
+
+  use shared_input_parameters, only: MESH_PAR_FILE
 
   implicit none
 
@@ -63,11 +65,9 @@
   logical :: found
   character(len=MAX_STRING_LEN) :: filename
 
-  ! Mesh Parameter file
-  filename = MF_IN_DATA_FILES(1:len_trim(MF_IN_DATA_FILES)) // 'Mesh_Par_file'
 
   if (myrank == 0) then
-    write(IMAIN,*) 'Reading mesh parameters from file ',trim(filename)
+    write(IMAIN,*) 'Reading mesh parameters from file ',trim(MESH_PAR_FILE)
     call flush_IMAIN()
   endif
 
@@ -75,7 +75,7 @@
   !       must match the order of appearance in the Mesh_Par_file
   !
   ! open parameter file Mesh_Par_file
-  call open_parameter_file_mesh(filename)
+  call open_parameter_file_mesh(MESH_PAR_FILE)
 
   ! user output
   if (myrank == 0) then

--- a/fortran/meshfem3d/setup/constants.h
+++ b/fortran/meshfem3d/setup/constants.h
@@ -117,8 +117,6 @@
 !!-----------------------------------------------------------
 
 ! paths for inputs and outputs files
-  character(len=*), parameter :: IN_DATA_FILES = './DATA/'
-  character(len=*), parameter :: MF_IN_DATA_FILES = './DATA/meshfem3D_files/'
   character(len=*), parameter :: OUTPUT_FILES_BASE = './OUTPUT_FILES/'
 
 !!-----------------------------------------------------------

--- a/fortran/meshfem3d/setup/constants.h.in
+++ b/fortran/meshfem3d/setup/constants.h.in
@@ -117,8 +117,6 @@
 !!-----------------------------------------------------------
 
 ! paths for inputs and outputs files
-  character(len=*), parameter :: IN_DATA_FILES = './DATA/'
-  character(len=*), parameter :: MF_IN_DATA_FILES = './DATA/meshfem3D_files/'
   character(len=*), parameter :: OUTPUT_FILES_BASE = './OUTPUT_FILES/'
 
 !!-----------------------------------------------------------

--- a/fortran/meshfem3d/shared/count_number_of_sources.f90
+++ b/fortran/meshfem3d/shared/count_number_of_sources.f90
@@ -53,14 +53,14 @@
   ! initializes
   NSOURCES = 0
 
-  if (HAS_FINITE_FAULT_SOURCE) return
-
-  open(unit=IIN_PAR,file=trim(FAULT_PAR_FILE),status='old',iostat=ier)
-  if (ier /= 0) then
-    print *,'Error opening fault file: ',trim(FAULT_PAR_FILE)
-    stop 'Error opening fault file'
+  if (HAS_FINITE_FAULT_SOURCE) then
+    open(unit=IIN_PAR,file=trim(FAULT_PAR_FILE),status='old',iostat=ier)
+    if (ier /= 0) then
+      print *,'Error opening fault file: ',trim(FAULT_PAR_FILE)
+      stop 'Error opening fault file'
+    endif
+    close(IIN_PAR)
   endif
-  close(IIN_PAR)
 
   ! checks if anything to do, finite fault simulations ignore CMT and force sources
   if (HAS_FINITE_FAULT_SOURCE) return

--- a/fortran/meshfem3d/shared/count_number_of_sources.f90
+++ b/fortran/meshfem3d/shared/count_number_of_sources.f90
@@ -30,12 +30,12 @@
 ! determines number of sources depending on number of lines in source file
 ! (only executed by main process)
 
-  use constants, only: IIN,IIN_PAR,MAX_STRING_LEN,IN_DATA_FILES, &
+  use constants, only: IIN,IIN_PAR,MAX_STRING_LEN, &
     NLINES_PER_FORCESOLUTION_SOURCE,NLINES_PER_CMTSOLUTION_SOURCE, &
     mygroup
 
   use shared_parameters, only: USE_FORCE_POINT_SOURCE,USE_EXTERNAL_SOURCE_FILE, &
-    HAS_FINITE_FAULT_SOURCE,NUMBER_OF_SIMULTANEOUS_RUNS
+    HAS_FINITE_FAULT_SOURCE,NUMBER_OF_SIMULTANEOUS_RUNS, FAULT_PAR_FILE
 
   use shared_parameters, only: IS_WAVEFIELD_DISCONTINUITY
 
@@ -47,32 +47,20 @@
   ! local variables
   integer :: icounter,ier
   integer :: nlines_per_source
-  character(len=MAX_STRING_LEN) :: fault_filename
   character(len=MAX_STRING_LEN) :: path_to_add
   character(len=MAX_STRING_LEN) :: dummystring
 
   ! initializes
   NSOURCES = 0
 
-  ! checks if finite fault source defined
-  fault_filename = IN_DATA_FILES(1:len_trim(IN_DATA_FILES))//'Par_file_faults'
-  ! see if we are running several independent runs in parallel
-  ! if so, add the right directory for that run
-  ! (group numbers start at zero, but directory names start at run0001, thus we add one)
-  ! a negative value for "mygroup" is a convention that indicates that groups (i.e. sub-communicators, one per run) are off
-  if (NUMBER_OF_SIMULTANEOUS_RUNS > 1 .and. mygroup >= 0) then
-    write(path_to_add,"('run',i4.4,'/')") mygroup + 1
-    fault_filename = path_to_add(1:len_trim(path_to_add))//fault_filename(1:len_trim(fault_filename))
-  endif
+  if (HAS_FINITE_FAULT_SOURCE) return
 
-  open(unit=IIN_PAR,file=trim(fault_filename),status='old',iostat=ier)
-  if (ier == 0) then
-    HAS_FINITE_FAULT_SOURCE = .true.
-    !write(IMAIN,*) 'provides finite faults'
-    close(IIN_PAR)
-  else
-    HAS_FINITE_FAULT_SOURCE = .false.
+  open(unit=IIN_PAR,file=trim(FAULT_PAR_FILE),status='old',iostat=ier)
+  if (ier /= 0) then
+    print *,'Error opening fault file: ',trim(FAULT_PAR_FILE)
+    stop 'Error opening fault file'
   endif
+  close(IIN_PAR)
 
   ! checks if anything to do, finite fault simulations ignore CMT and force sources
   if (HAS_FINITE_FAULT_SOURCE) return

--- a/fortran/meshfem3d/shared/read_parameter_file.F90
+++ b/fortran/meshfem3d/shared/read_parameter_file.F90
@@ -222,10 +222,10 @@
       write(*,*)
     endif
 
-    call read_value_string(RST_HETE_FILE, 'RST_HETE_FILE', ier)
+    call read_value_string(RSF_HETE_FILE, 'RSF_HETE_FILE', ier)
     if (ier /= 0) then
       some_parameters_missing_from_Par_file = .true.
-      write(*,'(a)') 'RST_HETE_FILE                   = dummy.txt'
+      write(*,'(a)') 'RSF_HETE_FILE                   = dummy.txt'
       write(*,*)
     endif
 

--- a/fortran/meshfem3d/shared/read_parameter_file.F90
+++ b/fortran/meshfem3d/shared/read_parameter_file.F90
@@ -44,8 +44,6 @@
   ! to avoid an I/O bottleneck in the case of very large runs
   if (myrank == 0) then
 
-    call parse_command_line_arguments()
-
     ! opens file Par_file
     call open_parameter_file(ier)
 
@@ -179,6 +177,41 @@
     if (ier /= 0) then
       some_parameters_missing_from_Par_file = .true.
       write(*,'(a)') 'TOMOGRAPHY_PATH                 = ./DATA/tomo_files/'
+      write(*,*)
+    endif
+
+    call read_value_logical(HAS_FINITE_FAULT_SOURCE, 'HAS_FINITE_FAULT_SOURCE', ier)
+    if (ier /= 0) then
+      some_parameters_missing_from_Par_file = .true.
+      write(*,'(a)') 'HAS_FINITE_FAULT_SOURCE         = .false.'
+      write(*,*)
+    endif
+
+    call read_value_string(FAULT_PAR_FILE, 'FAULT_PAR_FILE', ier)
+    if (ier /= 0) then
+      some_parameters_missing_from_Par_file = .true.
+      write(*,'(a)') 'FAULT_PAR_FILE                  = dummy.txt'
+      write(*,*)
+    endif
+
+    call read_value_string(FAULT_STATIONS, 'FAULT_STATIONS', ier)
+    if (ier /= 0) then
+      some_parameters_missing_from_Par_file = .true.
+      write(*,'(a)') 'FAULT_STATIONS                  = dummy.txt'
+      write(*,*)
+    endif
+
+    call read_value_string(STRESS_FRICTION_FILE, 'STRESS_FRICTION_FILE', ier)
+    if (ier /= 0) then
+      some_parameters_missing_from_Par_file = .true.
+      write(*,'(a)') 'STRESS_FRICTION_FILE            = dummy.txt'
+      write(*,*)
+    endif
+
+    call read_value_string(RST_HETE_FILE, 'RST_HETE_FILE', ier)
+    if (ier /= 0) then
+      some_parameters_missing_from_Par_file = .true.
+      write(*,'(a)') 'RST_HETE_FILE                   = dummy.txt'
       write(*,*)
     endif
 

--- a/fortran/meshfem3d/shared/read_value_parameters.f90
+++ b/fortran/meshfem3d/shared/read_value_parameters.f90
@@ -101,7 +101,8 @@
 
   subroutine open_parameter_file_from_main_only(ier)
 
-  use constants, only: MAX_STRING_LEN,IN_DATA_FILES
+  use constants, only: MAX_STRING_LEN
+  use shared_input_parameters, only: Par_file
 
   implicit none
 
@@ -109,45 +110,10 @@
   character(len=MAX_STRING_LEN) :: filename_main,filename_run0001
   logical :: exists_main_Par_file,exists_run0001_Par_file
 
-  filename_main = IN_DATA_FILES(1:len_trim(IN_DATA_FILES))//'Par_file'
-
-  ! also see if we are running several independent runs in parallel
-  ! to do so, add the right directory for that run for the main process only here
-  filename_run0001 = 'run0001/'//filename_main(1:len_trim(filename_main))
-
-  call param_open(filename_main, len(filename_main), ier)
-  if (ier == 0) then
-    exists_main_Par_file = .true.
-    call close_parameter_file()
-  else
-    exists_main_Par_file    = .false.
-  endif
-
-  call param_open(filename_run0001, len(filename_run0001), ier)
-  if (ier == 0) then
-    exists_run0001_Par_file = .true.
-    call close_parameter_file()
-  else
-    exists_run0001_Par_file = .false.
-  endif
-
-  if (exists_main_Par_file .and. exists_run0001_Par_file) then
-    print *
-    print *,'Cannot have both DATA/Par_file and run0001/DATA/Par_file present, please remove one of them.'
-    stop 'Error: two different copies of the Par_file'
-  endif
-
-  call param_open(filename_main, len(filename_main), ier)
+  call param_open(Par_file, len(Par_file), ier)
   if (ier /= 0) then
-    ! checks second option with Par_file in run0001/DATA/
-    call param_open(filename_run0001, len(filename_run0001), ier)
-    if (ier /= 0) then
-      print *
-      print *,'Opening file failed, please check your file path and run-directory.'
-      print *,'checked first: ',trim(filename_main)
-      print *,'     and then: ',trim(filename_run0001)
-      stop 'Error opening Par_file'
-    endif
+    print *, 'Error opening Par_file: ',trim(Par_file)
+    stop
   endif
 
   end subroutine open_parameter_file_from_main_only
@@ -156,7 +122,7 @@
 
   subroutine open_parameter_file(ier)
 
-  use constants, only: MAX_STRING_LEN,IN_DATA_FILES
+  use constants, only: MAX_STRING_LEN
   use shared_input_parameters, only: Par_file
 
   implicit none

--- a/fortran/meshfem3d/shared/shared_par.F90
+++ b/fortran/meshfem3d/shared/shared_par.F90
@@ -100,6 +100,7 @@ end module constants
   integer :: NGNOD
 
   character(len=MAX_STRING_LEN) :: MODEL
+  character(len=MAX_STRING_LEN) :: COUPLED_MODEL_DIRECTORY
   character(len=MAX_STRING_LEN) :: SEP_MODEL_DIRECTORY
 
   ! physical parameters
@@ -109,6 +110,7 @@ end module constants
   character(len=MAX_STRING_LEN) :: TOMOGRAPHY_PATH
 
   character(len=MAX_STRING_LEN) :: Par_file
+  character(len=MAX_STRING_LEN) :: MESH_PAR_FILE
 
   ! fault parameters
   logical :: HAS_FINITE_FAULT_SOURCE
@@ -172,6 +174,7 @@ end module constants
 
   ! sources
   logical :: USE_FORCE_POINT_SOURCE
+  character(len=MAX_STRING_LEN) :: SOURCE_FILENAME
   logical :: USE_RICKER_TIME_FUNCTION,PRINT_SOURCE_TIME_FUNCTION
 
   ! external source time function

--- a/fortran/meshfem3d/shared/shared_par.F90
+++ b/fortran/meshfem3d/shared/shared_par.F90
@@ -117,7 +117,7 @@ end module constants
   character(len=MAX_STRING_LEN) :: FAULT_PAR_FILE
   character(len=MAX_STRING_LEN) :: FAULT_STATIONS
   character(len=MAX_STRING_LEN) :: STRESS_FRICTION_FILE
-  character(len=MAX_STRING_LEN) :: RST_HETE_FILE
+  character(len=MAX_STRING_LEN) :: RSF_HETE_FILE
 
   ! attenuation
   ! reference frequency of seismic model

--- a/fortran/meshfem3d/shared/shared_par.F90
+++ b/fortran/meshfem3d/shared/shared_par.F90
@@ -110,6 +110,13 @@ end module constants
 
   character(len=MAX_STRING_LEN) :: Par_file
 
+  ! fault parameters
+  logical :: HAS_FINITE_FAULT_SOURCE
+  character(len=MAX_STRING_LEN) :: FAULT_PAR_FILE
+  character(len=MAX_STRING_LEN) :: FAULT_STATIONS
+  character(len=MAX_STRING_LEN) :: STRESS_FRICTION_FILE
+  character(len=MAX_STRING_LEN) :: RST_HETE_FILE
+
   ! attenuation
   ! reference frequency of seismic model
   double precision :: ATTENUATION_f0_REFERENCE
@@ -166,7 +173,6 @@ end module constants
   ! sources
   logical :: USE_FORCE_POINT_SOURCE
   logical :: USE_RICKER_TIME_FUNCTION,PRINT_SOURCE_TIME_FUNCTION
-  logical :: HAS_FINITE_FAULT_SOURCE
 
   ! external source time function
   logical :: USE_EXTERNAL_SOURCE_FILE


### PR DESCRIPTION
# Description

Removes the directory structure restrictions for `xmeshfem3D` and `xgenerate_databases` executibles. The file and directory paths are now added within the Par_file

# Issue Number

Closes #423 

# Checklist

Please make sure to check developer documentation on specfem docs. 

- [ ] I ran the code through pre-commit to check style
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms 
