### PR TITLE
Separate mesher and generate databases par file

### DIFF
--- a/examples/dim3/homogeneous_halfspace/DATA/meshfem3D_files/Mesh_Par_file
+++ b/examples/dim3/homogeneous_halfspace/DATA/meshfem3D_files/Mesh_Par_file
@@ -4,6 +4,9 @@
 #
 #-----------------------------------------------------------
 
+MESH_A_CHUNK_OF_THE_EARTH        = .false.
+CHUNK_MESH_PAR_FILE              = dummy.txt
+
 # coordinates of mesh block in latitude/longitude and depth in km
 LATITUDE_MIN                    = 0.0
 LATITUDE_MAX                    = 134000.0
@@ -18,6 +21,11 @@ INTERFACES_FILE                 = DATA/meshfem3D_files/interfaces.txt
 
 # file that contains the cavity
 CAVITY_FILE                     = no_cavity.dat
+
+# Number of nodes for 2D and 3D shape functions for hexahedra.
+# We use either 8-node mesh elements (bricks) or 27-node elements.
+# If you use our internal mesher, the only option is 8-node bricks (27-node elements are not supported).
+NGNOD                           = 8
 
 # number of elements at the surface along edges of the mesh at the surface
 # (must be 8 * multiple of NPROC below if mesh is not regular and contains mesh doublings)

--- a/examples/dim3/homogeneous_halfspace/DATA/meshfem3D_files/Mesh_Par_file
+++ b/examples/dim3/homogeneous_halfspace/DATA/meshfem3D_files/Mesh_Par_file
@@ -14,7 +14,7 @@ UTM_PROJECTION_ZONE             = 11
 SUPPRESS_UTM_PROJECTION         = .true.
 
 # file that contains the interfaces of the model / mesh
-INTERFACES_FILE                 = MESH_FILES/interfaces.txt
+INTERFACES_FILE                 = DATA/meshfem3D_files/interfaces.txt
 
 # file that contains the cavity
 CAVITY_FILE                     = no_cavity.dat

--- a/examples/dim3/homogeneous_halfspace/DATA/meshfem3D_files/Mesh_Par_file
+++ b/examples/dim3/homogeneous_halfspace/DATA/meshfem3D_files/Mesh_Par_file
@@ -14,7 +14,7 @@ UTM_PROJECTION_ZONE             = 11
 SUPPRESS_UTM_PROJECTION         = .true.
 
 # file that contains the interfaces of the model / mesh
-INTERFACES_FILE                 = interfaces3.txt
+INTERFACES_FILE                 = MESH_FILES/interfaces.txt
 
 # file that contains the cavity
 CAVITY_FILE                     = no_cavity.dat

--- a/examples/dim3/homogeneous_halfspace/DATA/meshfem3D_files/interfaces.txt
+++ b/examples/dim3/homogeneous_halfspace/DATA/meshfem3D_files/interfaces.txt
@@ -8,7 +8,7 @@
 #
 # interface number 1 (topography, top of the mesh)
  .true. 2 2 0.0 0.0 1000.0 1000.0
- MESH_FILES/interface1.txt
+ DATA/meshfem3D_files/interface1.txt
 #
 # for each layer, we give the number of spectral elements in the vertical direction
 #

--- a/examples/dim3/homogeneous_halfspace/DATA/meshfem3D_files/interfaces.txt
+++ b/examples/dim3/homogeneous_halfspace/DATA/meshfem3D_files/interfaces.txt
@@ -8,7 +8,7 @@
 #
 # interface number 1 (topography, top of the mesh)
  .true. 2 2 0.0 0.0 1000.0 1000.0
- interface1.txt
+ MESH_FILES/interface1.txt
 #
 # for each layer, we give the number of spectral elements in the vertical direction
 #

--- a/examples/dim3/homogeneous_halfspace/Par_File
+++ b/examples/dim3/homogeneous_halfspace/Par_File
@@ -51,8 +51,6 @@ RATIO_BY_WHICH_TO_INCREASE_IT   = 1.4
 #
 #-----------------------------------------------------------
 
-MESH_PAR_FILE = DATA/meshfem3D_files/Mesh_Par_file
-
 # Number of nodes for 2D and 3D shape functions for hexahedra.
 # We use either 8-node mesh elements (bricks) or 27-node elements.
 # If you use our internal mesher, the only option is 8-node bricks (27-node elements are not supported).

--- a/examples/dim3/homogeneous_halfspace/Par_File
+++ b/examples/dim3/homogeneous_halfspace/Par_File
@@ -272,6 +272,28 @@ USE_TRICK_FOR_BETTER_PRESSURE   = .false.
 
 #-----------------------------------------------------------
 #
+# Fault simulations
+#
+#-----------------------------------------------------------
+
+# Define if the simulation has kinematic or dynamic faults
+HAS_FINITE_FAULT_SOURCE         = .false.
+
+# File containing parameters of the fault
+FAULT_PAR_FILE                  = dummy.txt
+
+# STATIONS in the fault plane
+FAULT_STATIONS                  = dummy.txt
+
+# Specifications for heterogeneous stresses and friction for linear slip weakening friction parameters. To activate this feature set DATA/Par_file_faults name list&RUPTURE_SWITCHES, set TPV16=.TRUE..
+STRESS_FRICTION_FILE            = dummy.txt
+
+# Heterogeneous stresses and friction input for rate and state friction. To activate this feature, in DATA/Par_file_faults name list&RUPTURE_SWITCHES, set RSF_HETE=.TRUE..
+RSF_HETE_FILE                   = dummy.txt
+
+
+#-----------------------------------------------------------
+#
 # Energy calculation
 #
 #-----------------------------------------------------------

--- a/examples/dim3/homogeneous_halfspace/Par_File
+++ b/examples/dim3/homogeneous_halfspace/Par_File
@@ -196,7 +196,7 @@ USE_SOURCES_RECEIVERS_Z         = .false.
 # its norm is ignored and the norm of the force used is the factor force source times the source time function.
 USE_FORCE_POINT_SOURCE          = .false.
 
-SOURCE_FILENAME                    = CMTSOLUTION
+SOURCE_FILENAME                    = DATA/CMTSOLUTION
 
 # set to true to use a Ricker source time function instead of the source time functions set by default
 # to represent a (tilted) FORCESOLUTION force point source or a CMTSOLUTION moment-tensor source.

--- a/examples/dim3/homogeneous_halfspace/Par_File
+++ b/examples/dim3/homogeneous_halfspace/Par_File
@@ -51,6 +51,8 @@ RATIO_BY_WHICH_TO_INCREASE_IT   = 1.4
 #
 #-----------------------------------------------------------
 
+MESH_PAR_FILE = DATA/meshfem3D_files/Mesh_Par_file
+
 # Number of nodes for 2D and 3D shape functions for hexahedra.
 # We use either 8-node mesh elements (bricks) or 27-node elements.
 # If you use our internal mesher, the only option is 8-node bricks (27-node elements are not supported).
@@ -64,6 +66,9 @@ NGNOD                           = 8
 # 3D models available are:
 #   aniso,external,gll,salton_trough,tomo,SEP,coupled,...
 MODEL                           = default
+
+# path for external model files (if MODEL = coupled)
+COUPLED_MODEL_DIRECTORY         = DATA/coupled_model/
 
 # path for external tomographic models files
 TOMOGRAPHY_PATH                 = DATA/tomo_files/
@@ -174,8 +179,6 @@ NTSTEP_BETWEEN_OUTPUT_INFO      = 500
 #
 #-----------------------------------------------------------
 
-CMTSOLUTION                    = CMTSOLUTION
-
 # sources and receivers Z coordinates given directly (i.e. as their true position) instead of as their depth
 USE_SOURCES_RECEIVERS_Z         = .false.
 
@@ -192,6 +195,8 @@ USE_SOURCES_RECEIVERS_Z         = .false.
 # The direction vector is made unitary internally in the code and thus only its direction matters here;
 # its norm is ignored and the norm of the force used is the factor force source times the source time function.
 USE_FORCE_POINT_SOURCE          = .false.
+
+SOURCE_FILENAME                    = CMTSOLUTION
 
 # set to true to use a Ricker source time function instead of the source time functions set by default
 # to represent a (tilted) FORCESOLUTION force point source or a CMTSOLUTION moment-tensor source.

--- a/fortran/meshfem3d/CMakeLists.txt
+++ b/fortran/meshfem3d/CMakeLists.txt
@@ -8,6 +8,9 @@ project(MESHFEM3D LANGUAGES Fortran C)
 set(CMAKE_Fortran_STANDARD 95)
 set(CMAKE_Fortran_STANDARD_REQUIRED ON)
 
+unset(WITH_MPI)
+unset(WITH_SCOTCH)
+
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/fortran/meshfem3d/modules)
 include_directories("${CMAKE_BINARY_DIR}/fortran/meshfem3d/modules")
 

--- a/fortran/meshfem3d/generate_databases/CMakeLists.txt
+++ b/fortran/meshfem3d/generate_databases/CMakeLists.txt
@@ -19,6 +19,7 @@ set(MESHFEM3D_GENERATE_DATABASES_MODULE
   finalize_databases.f90
   # generate_databases_par.F90
   generate_databases.f90
+  command_line_arguments.f90
   get_absorbing_boundary.F90
   get_coupling_surfaces.f90
   get_model.F90

--- a/fortran/meshfem3d/generate_databases/command_line_arguments.f90
+++ b/fortran/meshfem3d/generate_databases/command_line_arguments.f90
@@ -1,0 +1,74 @@
+
+subroutine print_help_message()
+
+    implicit none
+
+    write(*,*) ' '
+    write(*,*) 'Usage: meshfem3D [options]'
+    write(*,*) ' '
+    write(*,*) 'Options:'
+    write(*,*) ' '
+    write(*,*) '  -h, --help'
+    write(*,*) '     Print this help message'
+    write(*,*) ' '
+    write(*,*) '  -p, --Par_File'
+    write(*,*) '     Specify the generate database parameter file to use'
+    write(*,*) ' '
+
+end subroutine print_help_message
+
+subroutine parse_command_line_arguments()
+
+  use constants, only: MAX_STRING_LEN, one
+  use shared_input_parameters, only: Par_file
+
+  implicit none
+
+  integer :: i = 1, n_args
+
+  character(len=MAX_STRING_LEN) :: arg
+
+  ! get the number of command line arguments
+  n_args = command_argument_count()
+
+  if (n_args == 0) then
+    ! print help message
+    call print_help_message()
+    ! stop the code
+    stop
+  endif
+
+  ! loop over the command line arguments
+  do while(.TRUE.)
+    ! get the i-th command line argument
+    call get_command_argument(i, arg)
+
+    select case (arg)
+      case ('-h', '--help')
+        ! print help message
+        call print_help_message()
+        ! stop the code gracefully
+        call finalize_mpi()
+        call EXIT(0)
+      case ('-p', '--Par_File')
+        if (i == n_args) then
+          ! print error message
+          print *, 'Error: missing command line argument for option '//trim(arg)
+          stop
+        endif
+        ! get the next command line argument
+        call get_command_argument(i+1, Par_file )
+        ! skip the next command line argument
+        i = i + 1
+      case default
+        ! print error message
+        print *, 'Error: unknown command line argument '//trim(arg)
+        stop
+    end select
+
+    if (i == n_args) exit
+    ! increment the counter
+    i = i + 1
+  end do
+
+end subroutine parse_command_line_arguments

--- a/fortran/meshfem3d/generate_databases/fault_generate_databases.f90
+++ b/fortran/meshfem3d/generate_databases/fault_generate_databases.f90
@@ -99,7 +99,8 @@ contains
 
   subroutine fault_read_input(prname)
 
-  use constants, only: MAX_STRING_LEN, IN_DATA_FILES,myrank,IIN_PAR,IIN_BIN
+  use constants, only: MAX_STRING_LEN,myrank,IIN_PAR,IIN_BIN
+  use shared_input_parameters, only: FAULT_PAR_FILE
 
   implicit none
   character(len=MAX_STRING_LEN), intent(in) :: prname
@@ -108,7 +109,7 @@ contains
 
   ! read fault input file
   nb = 0
-  open(unit=IIN_PAR,file=IN_DATA_FILES(1:len_trim(IN_DATA_FILES))//'Par_file_faults',status='old',action='read',iostat=ier)
+  open(unit=IIN_PAR,file=FAULT_PAR_FILE,status='old',action='read',iostat=ier)
   if (ier == 0) then
     read(IIN_PAR,*) nb
     if (myrank == 0) then

--- a/fortran/meshfem3d/generate_databases/generate_databases.f90
+++ b/fortran/meshfem3d/generate_databases/generate_databases.f90
@@ -52,6 +52,8 @@
   ! timing
   double precision, external :: wtime
 
+  call parse_command_line_arguments()
+
   ! MPI initialization
   call init_mpi()
 

--- a/fortran/meshfem3d/generate_databases/generate_databases_par.F90
+++ b/fortran/meshfem3d/generate_databases/generate_databases_par.F90
@@ -158,6 +158,8 @@
   logical,dimension(:),allocatable :: ispec_is_surface_external_mesh,iglob_is_surface_external_mesh
   integer :: nfaces_surface,nfaces_surface_glob_ext_mesh
 
+  logical :: MESH_A_CHUNK_OF_THE_EARTH
+
   ! adjacency arrays
   integer,dimension(:),allocatable :: neighbors_xadj   ! adjacency indexing
   integer,dimension(:),allocatable :: neighbors_adjncy ! adjacency

--- a/fortran/meshfem3d/generate_databases/get_absorbing_boundary.F90
+++ b/fortran/meshfem3d/generate_databases/get_absorbing_boundary.F90
@@ -44,7 +44,8 @@
 
   ! injection technique
   use constants, only: INJECTION_TECHNIQUE_IS_DSM
-  use shared_parameters, only: COUPLE_WITH_INJECTION_TECHNIQUE,MESH_A_CHUNK_OF_THE_EARTH,INJECTION_TECHNIQUE_TYPE
+  use shared_parameters, only: COUPLE_WITH_INJECTION_TECHNIQUE,INJECTION_TECHNIQUE_TYPE
+    use generate_databases_par, only: MESH_A_CHUNK_OF_THE_EARTH
 
   ! common normals
   use constants, only: NGLLSQUARE

--- a/fortran/meshfem3d/generate_databases/get_model.F90
+++ b/fortran/meshfem3d/generate_databases/get_model.F90
@@ -42,7 +42,8 @@
 
   ! injection technique
   use constants, only: INJECTION_TECHNIQUE_IS_FK,INJECTION_TECHNIQUE_IS_DSM,INJECTION_TECHNIQUE_IS_AXISEM
-  use shared_parameters, only: COUPLE_WITH_INJECTION_TECHNIQUE,MESH_A_CHUNK_OF_THE_EARTH,INJECTION_TECHNIQUE_TYPE
+  use shared_parameters, only: COUPLE_WITH_INJECTION_TECHNIQUE,INJECTION_TECHNIQUE_TYPE
+    use generate_databases_par, only: MESH_A_CHUNK_OF_THE_EARTH
 
   implicit none
 

--- a/fortran/meshfem3d/generate_databases/model_coupled.f90
+++ b/fortran/meshfem3d/generate_databases/model_coupled.f90
@@ -64,7 +64,8 @@
 
   use constants
 
-  use shared_parameters, only: COUPLE_WITH_INJECTION_TECHNIQUE,MESH_A_CHUNK_OF_THE_EARTH
+  use shared_parameters, only: COUPLE_WITH_INJECTION_TECHNIQUE
+  use generate_databases_par, only: MESH_A_CHUNK_OF_THE_EARTH
 
   implicit none
 
@@ -185,7 +186,8 @@
 
   use constants, only: CUSTOM_REAL
 
-  use shared_parameters, only: COUPLE_WITH_INJECTION_TECHNIQUE,MESH_A_CHUNK_OF_THE_EARTH
+  use shared_parameters, only: COUPLE_WITH_INJECTION_TECHNIQUE
+  use generate_databases_par, only: MESH_A_CHUNK_OF_THE_EARTH
 
   implicit none
 

--- a/fortran/meshfem3d/generate_databases/model_coupled.f90
+++ b/fortran/meshfem3d/generate_databases/model_coupled.f90
@@ -84,7 +84,8 @@
 
   subroutine read_model_for_coupling_or_chunk()
 
-  use constants, only: IMAIN,IN_DATA_FILES,myrank
+  use constants, only: IMAIN,myrank
+  use shared_input_parameters, only: COUPLED_MODEL_DIRECTORY
 
   use model_coupled_par !! VM VM custom subroutine for coupling with DSM
 
@@ -103,7 +104,7 @@
     call flush_IMAIN()
   endif
 
-  filename = IN_DATA_FILES(1:len_trim(IN_DATA_FILES))//'/coeff_poly_deg12'
+  filename = COUPLED_MODEL_DIRECTORY(1:len_trim(COUPLED_MODEL_DIRECTORY))//'/coeff_poly_deg12'
   open(27,file=trim(filename),iostat=ier)
   if (ier /= 0) then
     print *,'Error opening file: ',filename
@@ -123,7 +124,7 @@
 
   !write(*,*) " Reading 1D model "
 
-  filename = IN_DATA_FILES(1:len_trim(IN_DATA_FILES))//'/model_1D.in'
+  filename = COUPLED_MODEL_DIRECTORY(1:len_trim(COUPLED_MODEL_DIRECTORY))//'/model_1D.in'
   open(27,file=trim(filename),iostat=ier)
   if (ier /= 0) then
     print *,'Error opening file: ',filename

--- a/fortran/meshfem3d/generate_databases/model_external_values.F90
+++ b/fortran/meshfem3d/generate_databases/model_external_values.F90
@@ -67,7 +67,8 @@
 
   use constants
 
-  use shared_parameters, only: COUPLE_WITH_INJECTION_TECHNIQUE,MESH_A_CHUNK_OF_THE_EARTH
+  use shared_parameters, only: COUPLE_WITH_INJECTION_TECHNIQUE
+  use generate_databases_par, only: MESH_A_CHUNK_OF_THE_EARTH
 
   implicit none
 

--- a/fortran/meshfem3d/generate_databases/read_partition_files.f90
+++ b/fortran/meshfem3d/generate_databases/read_partition_files.f90
@@ -39,6 +39,7 @@
   integer :: num_cpml
   integer :: num_moho
   integer :: i,j,inode,imat,ispec,ie,dummy_node,dummy_elmnt,ier
+  integer :: ngnod_mesh
 
   ! read databases about external mesh simulation
   call create_name_database(prname,myrank,LOCAL_PATH)
@@ -51,6 +52,11 @@
     print *,'please make sure file exists'
     call exit_mpi(myrank,'Error opening database file')
   endif
+
+  read(IIN) MESH_A_CHUNK_OF_THE_EARTH
+  read(IIN) ngnod_mesh
+
+  if (ngnod_mesh /= NGNOD) stop 'Error: wrong number of nodes in database file'
 
   ! global nodes
   read(IIN) nnodes_ext_mesh

--- a/fortran/meshfem3d/generate_databases/save_arrays_solver.F90
+++ b/fortran/meshfem3d/generate_databases/save_arrays_solver.F90
@@ -86,7 +86,8 @@ module save_arrays_module
   use shared_parameters, only: ACOUSTIC_SIMULATION, ELASTIC_SIMULATION, POROELASTIC_SIMULATION, &
     APPROXIMATE_OCEAN_LOAD, SAVE_MESH_FILES, ANISOTROPY
 
-  use shared_parameters, only: COUPLE_WITH_INJECTION_TECHNIQUE,MESH_A_CHUNK_OF_THE_EARTH
+  use shared_parameters, only: COUPLE_WITH_INJECTION_TECHNIQUE
+  use generate_databases_par, only: MESH_A_CHUNK_OF_THE_EARTH
 
   ! global indices
   use generate_databases_par, only: nspec => NSPEC_AB, ibool
@@ -873,7 +874,8 @@ module save_arrays_module
 
   use constants, only: myrank,NGLLSQUARE,IMAIN,IOUT
 
-  use shared_parameters, only: COUPLE_WITH_INJECTION_TECHNIQUE,MESH_A_CHUNK_OF_THE_EARTH
+  use shared_parameters, only: COUPLE_WITH_INJECTION_TECHNIQUE
+  use generate_databases_par, only: MESH_A_CHUNK_OF_THE_EARTH
 
   ! global indices
   use generate_databases_par, only: ibool

--- a/fortran/meshfem3d/meshfem3D/CMakeLists.txt
+++ b/fortran/meshfem3d/meshfem3D/CMakeLists.txt
@@ -31,6 +31,7 @@ set(MESHFEM3D_MESH_MODULE
     get_MPI_cutplanes_xi.f90
     meshfem3D.F90
     get_wavefield_discontinuity.f90
+    command_line_arguments.f90
     read_mesh_parameter_file.f90
     read_value_mesh_parameters.f90
     save_databases.F90

--- a/fortran/meshfem3d/meshfem3D/chunk_earth_mesh_mod.f90
+++ b/fortran/meshfem3d/meshfem3D/chunk_earth_mesh_mod.f90
@@ -56,15 +56,19 @@ contains
 
     subroutine mesh_chunk_earth()
 
+      use meshfem_par, only: CHUNK_MESH_PAR_FILE
+
+      implicit none
+
       !! SB SB COMMENT THIS IERR (variable alreafy exist in module)
       !! this makes gfortran complins because the one in the ;odule header is unsed
       !! integer :: ierr
       !! SB SB
       character(len=MAX_STRING_LEN) :: keyw
 
-      open(27, file='DATA/meshfem3D_files/Mesh_Chunk_Par_file', action='read', iostat=ierr)
+      open(27, file=trim(CHUNK_MESH_PAR_FILE), action='read', iostat=ierr)
       if (ierr /= 0 ) then
-         write(*,*) " ERROR : file DATA/meshfem3D_files/Mesh_Chunk_Par_file not found "
+         write(*,*) " ERROR : file ", trim(CHUNK_MESH_PAR_FILE), " not found "
          stop
       endif
 
@@ -115,6 +119,10 @@ contains
 
     subroutine read_metric_params()
 
+      use meshfem_par, only: CHUNK_MESH_PAR_FILE
+
+      implicit none
+
       character(len=MAX_STRING_LEN) :: keyw
       integer :: ilayer, nx, ny, k, ntmp
       double precision :: dz
@@ -122,7 +130,7 @@ contains
       double precision :: vp, vs, rho, Q_Kappa, Q_mu, Aniso
       double precision :: x0, x1, y0, y1, z0, z1
 
-      open(27, file='DATA/meshfem3D_files/Mesh_Chunk_Par_file', action='read')
+      open(27, file=trim(CHUNK_MESH_PAR_FILE), action='read')
       do
           read(27,'(a)',end=99) line
 

--- a/fortran/meshfem3d/meshfem3D/command_line_arguments.f90
+++ b/fortran/meshfem3d/meshfem3D/command_line_arguments.f90
@@ -1,0 +1,74 @@
+
+subroutine print_help_message()
+
+    implicit none
+
+    write(*,*) ' '
+    write(*,*) 'Usage: meshfem3D [options]'
+    write(*,*) ' '
+    write(*,*) 'Options:'
+    write(*,*) ' '
+    write(*,*) '  -h, --help'
+    write(*,*) '     Print this help message'
+    write(*,*) ' '
+    write(*,*) '  -p, --Par_File'
+    write(*,*) '     Specify the mesher parameter file to use'
+    write(*,*) ' '
+
+end subroutine print_help_message
+
+subroutine parse_command_line_arguments()
+
+  use constants, only: MAX_STRING_LEN, one
+  use shared_input_parameters, only: MESH_PAR_FILE
+
+  implicit none
+
+  integer :: i = 1, n_args
+
+  character(len=MAX_STRING_LEN) :: arg
+
+  ! get the number of command line arguments
+  n_args = command_argument_count()
+
+  if (n_args == 0) then
+    ! print help message
+    call print_help_message()
+    ! stop the code
+    stop
+  endif
+
+  ! loop over the command line arguments
+  do while(.TRUE.)
+    ! get the i-th command line argument
+    call get_command_argument(i, arg)
+
+    select case (arg)
+      case ('-h', '--help')
+        ! print help message
+        call print_help_message()
+        ! stop the code gracefully
+        call finalize_mpi()
+        call EXIT(0)
+      case ('-p', '--Par_File')
+        if (i == n_args) then
+          ! print error message
+          print *, 'Error: missing command line argument for option '//trim(arg)
+          stop
+        endif
+        ! get the next command line argument
+        call get_command_argument(i+1, MESH_PAR_FILE )
+        ! skip the next command line argument
+        i = i + 1
+      case default
+        ! print error message
+        print *, 'Error: unknown command line argument '//trim(arg)
+        stop
+    end select
+
+    if (i == n_args) exit
+    ! increment the counter
+    i = i + 1
+  end do
+
+end subroutine parse_command_line_arguments

--- a/fortran/meshfem3d/meshfem3D/create_interfaces_mesh.f90
+++ b/fortran/meshfem3d/meshfem3D/create_interfaces_mesh.f90
@@ -36,7 +36,7 @@
     number_of_layers,ner_layer,iproc_xi_current,iproc_eta_current,NPROC_XI,NPROC_ETA, &
     xgrid,ygrid,zgrid
 
-  use constants, only: IMAIN,IIN,MF_IN_DATA_FILES,DONT_IGNORE_JUNK,IUTM2LONGLAT,MAX_STRING_LEN,HUGEVAL
+  use constants, only: IMAIN,IIN,DONT_IGNORE_JUNK,IUTM2LONGLAT,MAX_STRING_LEN,HUGEVAL
 
   implicit none
 
@@ -95,13 +95,16 @@
 
   ! user output
   if (myrank == 0) then
-    write(IMAIN,*) 'Reading interface data from file ',trim(MF_IN_DATA_FILES)//trim(INTERFACES_FILE)
+    write(IMAIN,*) 'Reading interface data from file ',trim(INTERFACES_FILE)
     write(IMAIN,*)
     call flush_IMAIN()
   endif
 
-  open(unit=IIN,file=trim(MF_IN_DATA_FILES)//trim(INTERFACES_FILE),status='old',iostat=ier)
-  if (ier /= 0) stop 'Error opening interfaces file'
+  open(unit=IIN,file=trim(INTERFACES_FILE),status='old',iostat=ier)
+  if (ier /= 0) then
+    print *,'Error opening interface file: ',trim(INTERFACES_FILE)
+    stop 'Error opening interface file'
+  endif
 
   ! allocates interface arrays
   allocate(interface_bottom(max_npx_interface,max_npy_interface),stat=ier)
@@ -203,9 +206,9 @@
     endif
 
     ! loop on all the points describing this interface
-    open(unit=45,file=trim(MF_IN_DATA_FILES)//trim(interface_top_file),status='old',iostat=ier)
+    open(unit=45,file=trim(interface_top_file),status='old',iostat=ier)
     if (ier /= 0) then
-      print *,'Error opening file: ',trim(MF_IN_DATA_FILES)//trim(interface_top_file)
+      print *,'Error opening file: ',trim(interface_top_file)
       stop 'Error opening interface file'
     endif
 
@@ -232,7 +235,7 @@
     ! checks number of points npoints_interface_top = npx_interface_top * npy_interface
     if (icount /= npx_interface_top * npy_interface_top) then
       print *,'Error number of interface points ',icount,' should be ',npx_interface_top * npy_interface_top
-      print *,'Please check interface definition in file: ',trim(MF_IN_DATA_FILES)//trim(interface_top_file)
+      print *,'Please check interface definition in file: ',trim(interface_top_file)
       stop 'Error invalid number of interface file points'
     endif
 
@@ -460,7 +463,7 @@
     number_of_interfaces,max_npx_interface,max_npy_interface, &
     number_of_layers,ner_layer
 
-  use constants, only: IMAIN,IIN,MF_IN_DATA_FILES,DONT_IGNORE_JUNK,MAX_STRING_LEN,myrank
+  use constants, only: IMAIN,IIN,DONT_IGNORE_JUNK,MAX_STRING_LEN,myrank
 
   implicit none
 
@@ -478,14 +481,14 @@
   ! user output
   if (myrank == 0) then
     write(IMAIN,*)
-    write(IMAIN,*) 'Reading interface data from file ',trim(MF_IN_DATA_FILES)//trim(INTERFACES_FILE)
+    write(IMAIN,*) 'Reading interface data from file ',trim(INTERFACES_FILE)
     call flush_IMAIN()
   endif
 
   ! opens interfaces file
-  open(unit=IIN,file=trim(MF_IN_DATA_FILES)//trim(INTERFACES_FILE),status='old',iostat=ier)
+  open(unit=IIN,file=trim(INTERFACES_FILE),status='old',iostat=ier)
   if (ier /= 0) then
-    print *,'Error opening interface file: ',trim(MF_IN_DATA_FILES)//trim(INTERFACES_FILE)
+    print *,'Error opening interface file: ',trim(INTERFACES_FILE)
     stop 'Error opening interface file'
   endif
 

--- a/fortran/meshfem3d/meshfem3D/determine_cavity.f90
+++ b/fortran/meshfem3d/meshfem3D/determine_cavity.f90
@@ -28,7 +28,7 @@
 
   subroutine cmm_determine_cavity(nglob)
 
-  use constants, only: MF_IN_DATA_FILES,MAX_STRING_LEN,IMAIN,HUGEVAL,TINYVAL,NDIM,myrank
+  use constants, only: MAX_STRING_LEN,IMAIN,HUGEVAL,TINYVAL,NDIM,myrank
   use constants_meshfem, only: NGLLX_M,NGLLY_M,NGLLZ_M
 
   use create_meshfem_par, only: nodes_coords,ispec_material_id,iboun,iMPIcut_xi,iMPIcut_eta
@@ -75,7 +75,7 @@
   ncavity = 0
 
   ! read cavity file
-  filename = trim(MF_IN_DATA_FILES)//trim(CAVITY_FILE)
+  filename = trim(CAVITY_FILE)
   open(111,file=filename,action='read',status='old',iostat=ier)
   if (ier /= 0) then
     cavity_file_exists = .false.

--- a/fortran/meshfem3d/meshfem3D/meshfem3D.F90
+++ b/fortran/meshfem3d/meshfem3D/meshfem3D.F90
@@ -98,7 +98,7 @@
   endif
 
   if (myrank == 0) then
-    write(IMAIN,*) 'Reading parameters from ',IN_DATA_FILES(1:len_trim(IN_DATA_FILES))//'Par_file'
+    write(IMAIN,*) 'Reading parameters from ',trim(Par_file)
     write(IMAIN,*)
     call flush_IMAIN()
   endif

--- a/fortran/meshfem3d/meshfem3D/meshfem3D.F90
+++ b/fortran/meshfem3d/meshfem3D/meshfem3D.F90
@@ -104,8 +104,15 @@
   endif
 
   ! read the parameter file (DATA/Par_file)
-  BROADCAST_AFTER_READ = .true.
-  call read_parameter_file(BROADCAST_AFTER_READ)
+  ! BROADCAST_AFTER_READ = .true.
+  ! call read_parameter_file(BROADCAST_AFTER_READ)
+
+  ! open parameter file Mesh_Par_file
+  call open_parameter_file_mesh(MESH_PAR_FILE)
+
+  call read_value_logical_mesh(IIN,IGNORE_JUNK,MESH_A_CHUNK_OF_THE_EARTH, 'MESH_A_CHUNK_OF_THE_EARTH', ier)
+
+  call close_parameter_file_mesh()
 
   ! make sure everybody is synchronized
   call synchronize_all()

--- a/fortran/meshfem3d/meshfem3D/meshfem3D.F90
+++ b/fortran/meshfem3d/meshfem3D/meshfem3D.F90
@@ -60,6 +60,8 @@
   double precision :: time_start,tCPU
   character(len=3) :: str_unit
 
+  call parse_command_line_arguments()
+
   ! MPI initialization
   call init_mpi()
 

--- a/fortran/meshfem3d/meshfem3D/meshfem3D_par.f90
+++ b/fortran/meshfem3d/meshfem3D/meshfem3D_par.f90
@@ -86,6 +86,9 @@ module meshfem_par
   ! for Cubit postprocessing
   logical :: SAVE_MESH_AS_CUBIT = .false.
 
+  logical :: MESH_A_CHUNK_OF_THE_EARTH
+  character(len=MAX_STRING_LEN) :: CHUNK_MESH_PAR_FILE
+
   ! CPML
   double precision :: THICKNESS_OF_X_PML,THICKNESS_OF_Y_PML,THICKNESS_OF_Z_PML
   logical, dimension(:), allocatable :: is_CPML

--- a/fortran/meshfem3d/meshfem3D/read_mesh_parameter_file.f90
+++ b/fortran/meshfem3d/meshfem3D/read_mesh_parameter_file.f90
@@ -37,13 +37,14 @@
     USE_REGULAR_MESH,NDOUBLINGS,ner_doublings, &
     THICKNESS_OF_X_PML,THICKNESS_OF_Y_PML,THICKNESS_OF_Z_PML, &
     myrank,sizeprocs,NUMBER_OF_MATERIAL_PROPERTIES, &
-    SAVE_MESH_AS_CUBIT
+    SAVE_MESH_AS_CUBIT, MESH_A_CHUNK_OF_THE_EARTH, CHUNK_MESH_PAR_FILE
 
   use constants, only: IIN,MAX_STRING_LEN,IMAIN, &
     IDOMAIN_ACOUSTIC,IDOMAIN_ELASTIC,IDOMAIN_POROELASTIC, &
     ILONGLAT2UTM,IGNORE_JUNK,DONT_IGNORE_JUNK
 
-  use shared_input_parameters, only: MESH_PAR_FILE
+  use shared_input_parameters, only: NGNOD, MESH_PAR_FILE
+  use shared_parameters, only: NGNOD2D
 
   implicit none
 
@@ -83,6 +84,9 @@
     call flush_IMAIN()
   endif
 
+  call read_value_logical_mesh(IIN,IGNORE_JUNK,MESH_A_CHUNK_OF_THE_EARTH, 'MESH_A_CHUNK_OF_THE_EARTH', ier)
+  call read_value_string_mesh(IIN,IGNORE_JUNK,CHUNK_MESH_PAR_FILE, 'CHUNK_MESH_PAR_FILE', ier)
+
   call read_value_dble_precision_mesh(IIN,IGNORE_JUNK,LATITUDE_MIN, 'LATITUDE_MIN', ier)
   if (ier /= 0) stop 'Error reading Mesh parameter LATITUDE_MIN'
   call read_value_dble_precision_mesh(IIN,IGNORE_JUNK,LATITUDE_MAX, 'LATITUDE_MAX', ier)
@@ -101,6 +105,15 @@
   if (ier /= 0) stop 'Error reading Mesh parameter INTERFACES_FILE'
   call read_value_string_mesh(IIN,IGNORE_JUNK,CAVITY_FILE, 'CAVITY_FILE', ier)
   if (ier /= 0) stop 'Error reading Mesh parameter CAVITY_FILE'
+
+  call read_value_integer_mesh(IIN,IGNORE_JUNK,NGNOD, 'NGNOD', ier)
+  if (NGNOD == 8) then
+    NGNOD2D = 4
+  else if (NGNOD == 27) then
+    NGNOD2D = 9
+  else if (NGNOD /= 8 .and. NGNOD /= 27) then
+    stop 'Error elements should have 8 or 27 control nodes, please modify NGNOD in Par_file and recompile solver'
+  endif
 
   call read_value_integer_mesh(IIN,IGNORE_JUNK,NEX_XI, 'NEX_XI', ier)
   if (ier /= 0) stop 'Error reading Mesh parameter NEX_XI'

--- a/fortran/meshfem3d/meshfem3D/read_mesh_parameter_file.f90
+++ b/fortran/meshfem3d/meshfem3D/read_mesh_parameter_file.f90
@@ -39,9 +39,11 @@
     myrank,sizeprocs,NUMBER_OF_MATERIAL_PROPERTIES, &
     SAVE_MESH_AS_CUBIT
 
-  use constants, only: IIN,MF_IN_DATA_FILES,MAX_STRING_LEN,IMAIN, &
+  use constants, only: IIN,MAX_STRING_LEN,IMAIN, &
     IDOMAIN_ACOUSTIC,IDOMAIN_ELASTIC,IDOMAIN_POROELASTIC, &
     ILONGLAT2UTM,IGNORE_JUNK,DONT_IGNORE_JUNK
+
+  use shared_input_parameters, only: MESH_PAR_FILE
 
   implicit none
 
@@ -63,11 +65,9 @@
   logical :: found
   character(len=MAX_STRING_LEN) :: filename
 
-  ! Mesh Parameter file
-  filename = MF_IN_DATA_FILES(1:len_trim(MF_IN_DATA_FILES)) // 'Mesh_Par_file'
 
   if (myrank == 0) then
-    write(IMAIN,*) 'Reading mesh parameters from file ',trim(filename)
+    write(IMAIN,*) 'Reading mesh parameters from file ',trim(MESH_PAR_FILE)
     call flush_IMAIN()
   endif
 
@@ -75,7 +75,7 @@
   !       must match the order of appearance in the Mesh_Par_file
   !
   ! open parameter file Mesh_Par_file
-  call open_parameter_file_mesh(filename)
+  call open_parameter_file_mesh(MESH_PAR_FILE)
 
   ! user output
   if (myrank == 0) then

--- a/fortran/meshfem3d/meshfem3D/save_databases.F90
+++ b/fortran/meshfem3d/meshfem3D/save_databases.F90
@@ -44,7 +44,7 @@
     NSPEC2DMAX_XMIN_XMAX,NSPEC2DMAX_YMIN_YMAX,NSPEC2D_BOTTOM,NSPEC2D_TOP, &
     NMATERIALS,material_properties,material_properties_undef, &
     nspec_CPML,is_CPML,CPML_to_spec,CPML_regions, &
-    SAVE_MESH_AS_CUBIT
+    SAVE_MESH_AS_CUBIT, MESH_A_CHUNK_OF_THE_EARTH
 
   !! setting up wavefield discontinuity interface
   use shared_parameters, only: IS_WAVEFIELD_DISCONTINUITY
@@ -152,6 +152,9 @@
     print *,'Error opening Database file: ',prname(1:len_trim(prname))//'Database'
     stop 'error opening Database file'
   endif
+
+  write(IIN_database) MESH_A_CHUNK_OF_THE_EARTH
+  write(IIN_database) NGNOD
 
   ! global nodes
   write(IIN_database) nglob

--- a/fortran/meshfem3d/setup/constants.h
+++ b/fortran/meshfem3d/setup/constants.h
@@ -117,8 +117,6 @@
 !!-----------------------------------------------------------
 
 ! paths for inputs and outputs files
-  character(len=*), parameter :: IN_DATA_FILES = './DATA/'
-  character(len=*), parameter :: MF_IN_DATA_FILES = './DATA/meshfem3D_files/'
   character(len=*), parameter :: OUTPUT_FILES_BASE = './OUTPUT_FILES/'
 
 !!-----------------------------------------------------------

--- a/fortran/meshfem3d/setup/constants.h.in
+++ b/fortran/meshfem3d/setup/constants.h.in
@@ -117,8 +117,6 @@
 !!-----------------------------------------------------------
 
 ! paths for inputs and outputs files
-  character(len=*), parameter :: IN_DATA_FILES = './DATA/'
-  character(len=*), parameter :: MF_IN_DATA_FILES = './DATA/meshfem3D_files/'
   character(len=*), parameter :: OUTPUT_FILES_BASE = './OUTPUT_FILES/'
 
 !!-----------------------------------------------------------

--- a/fortran/meshfem3d/shared/CMakeLists.txt
+++ b/fortran/meshfem3d/shared/CMakeLists.txt
@@ -35,7 +35,7 @@ set(MESHFEM3D_SHARED_MODULE
   merge_sort.f90
   netlib_specfun_erf.f90
   prepare_assemble_MPI.f90
-  command_line_arguments.f90
+  # command_line_arguments.f90
   read_parameter_file.F90
   read_topo_bathy_file.f90
   read_value_parameters.f90

--- a/fortran/meshfem3d/shared/CMakeLists.txt
+++ b/fortran/meshfem3d/shared/CMakeLists.txt
@@ -126,4 +126,5 @@ target_link_libraries(meshfem3D_shared PRIVATE
   meshfem3D::shared_module
   meshfem3D::constants
   meshfem3D::shared_hdf5_module
+  meshfem3D::param_reader
 )

--- a/fortran/meshfem3d/shared/count_number_of_sources.f90
+++ b/fortran/meshfem3d/shared/count_number_of_sources.f90
@@ -53,14 +53,14 @@
   ! initializes
   NSOURCES = 0
 
-  if (HAS_FINITE_FAULT_SOURCE) return
-
-  open(unit=IIN_PAR,file=trim(FAULT_PAR_FILE),status='old',iostat=ier)
-  if (ier /= 0) then
-    print *,'Error opening fault file: ',trim(FAULT_PAR_FILE)
-    stop 'Error opening fault file'
+  if (HAS_FINITE_FAULT_SOURCE) then
+    open(unit=IIN_PAR,file=trim(FAULT_PAR_FILE),status='old',iostat=ier)
+    if (ier /= 0) then
+      print *,'Error opening fault file: ',trim(FAULT_PAR_FILE)
+      stop 'Error opening fault file'
+    endif
+    close(IIN_PAR)
   endif
-  close(IIN_PAR)
 
   ! checks if anything to do, finite fault simulations ignore CMT and force sources
   if (HAS_FINITE_FAULT_SOURCE) return

--- a/fortran/meshfem3d/shared/count_number_of_sources.f90
+++ b/fortran/meshfem3d/shared/count_number_of_sources.f90
@@ -30,12 +30,12 @@
 ! determines number of sources depending on number of lines in source file
 ! (only executed by main process)
 
-  use constants, only: IIN,IIN_PAR,MAX_STRING_LEN,IN_DATA_FILES, &
+  use constants, only: IIN,IIN_PAR,MAX_STRING_LEN, &
     NLINES_PER_FORCESOLUTION_SOURCE,NLINES_PER_CMTSOLUTION_SOURCE, &
     mygroup
 
   use shared_parameters, only: USE_FORCE_POINT_SOURCE,USE_EXTERNAL_SOURCE_FILE, &
-    HAS_FINITE_FAULT_SOURCE,NUMBER_OF_SIMULTANEOUS_RUNS
+    HAS_FINITE_FAULT_SOURCE,NUMBER_OF_SIMULTANEOUS_RUNS, FAULT_PAR_FILE
 
   use shared_parameters, only: IS_WAVEFIELD_DISCONTINUITY
 
@@ -47,32 +47,20 @@
   ! local variables
   integer :: icounter,ier
   integer :: nlines_per_source
-  character(len=MAX_STRING_LEN) :: fault_filename
   character(len=MAX_STRING_LEN) :: path_to_add
   character(len=MAX_STRING_LEN) :: dummystring
 
   ! initializes
   NSOURCES = 0
 
-  ! checks if finite fault source defined
-  fault_filename = IN_DATA_FILES(1:len_trim(IN_DATA_FILES))//'Par_file_faults'
-  ! see if we are running several independent runs in parallel
-  ! if so, add the right directory for that run
-  ! (group numbers start at zero, but directory names start at run0001, thus we add one)
-  ! a negative value for "mygroup" is a convention that indicates that groups (i.e. sub-communicators, one per run) are off
-  if (NUMBER_OF_SIMULTANEOUS_RUNS > 1 .and. mygroup >= 0) then
-    write(path_to_add,"('run',i4.4,'/')") mygroup + 1
-    fault_filename = path_to_add(1:len_trim(path_to_add))//fault_filename(1:len_trim(fault_filename))
-  endif
+  if (HAS_FINITE_FAULT_SOURCE) return
 
-  open(unit=IIN_PAR,file=trim(fault_filename),status='old',iostat=ier)
-  if (ier == 0) then
-    HAS_FINITE_FAULT_SOURCE = .true.
-    !write(IMAIN,*) 'provides finite faults'
-    close(IIN_PAR)
-  else
-    HAS_FINITE_FAULT_SOURCE = .false.
+  open(unit=IIN_PAR,file=trim(FAULT_PAR_FILE),status='old',iostat=ier)
+  if (ier /= 0) then
+    print *,'Error opening fault file: ',trim(FAULT_PAR_FILE)
+    stop 'Error opening fault file'
   endif
+  close(IIN_PAR)
 
   ! checks if anything to do, finite fault simulations ignore CMT and force sources
   if (HAS_FINITE_FAULT_SOURCE) return

--- a/fortran/meshfem3d/shared/read_parameter_file.F90
+++ b/fortran/meshfem3d/shared/read_parameter_file.F90
@@ -222,10 +222,10 @@
       write(*,*)
     endif
 
-    call read_value_string(RST_HETE_FILE, 'RST_HETE_FILE', ier)
+    call read_value_string(RSF_HETE_FILE, 'RSF_HETE_FILE', ier)
     if (ier /= 0) then
       some_parameters_missing_from_Par_file = .true.
-      write(*,'(a)') 'RST_HETE_FILE                   = dummy.txt'
+      write(*,'(a)') 'RSF_HETE_FILE                   = dummy.txt'
       write(*,*)
     endif
 

--- a/fortran/meshfem3d/shared/read_parameter_file.F90
+++ b/fortran/meshfem3d/shared/read_parameter_file.F90
@@ -159,12 +159,6 @@
     !-------------------------------------------------------
     ! Mesh
     !-------------------------------------------------------
-    call read_value_string(MESH_PAR_FILE, 'MESH_PAR_FILE', ier)
-    if (ier /= 0) then
-      some_parameters_missing_from_Par_file = .true.
-      write(*,'(a)') 'MESH_PAR_FILE                   = ./DATA/meshfem3D_files/Mesh_Par_file'
-      write(*,*)
-    endif
 
     call read_value_integer(NGNOD, 'NGNOD', ier)
     if (ier /= 0) then
@@ -710,13 +704,6 @@
       write(*,*)
     endif
 
-    call read_value_logical(MESH_A_CHUNK_OF_THE_EARTH,'MESH_A_CHUNK_OF_THE_EARTH',ier)
-    if (ier /= 0) then
-      some_parameters_missing_from_Par_file = .true.
-      write(*,'(a)') 'MESH_A_CHUNK_OF_THE_EARTH       = .false.'
-      write(*,*)
-    endif
-
     call read_value_string(TRACTION_PATH, 'TRACTION_PATH', ier)
     if (ier /= 0) then
       some_parameters_missing_from_Par_file = .true.
@@ -747,13 +734,6 @@
       if (INJECTION_TECHNIQUE_TYPE /= INJECTION_TECHNIQUE_IS_DSM .and. &
          INJECTION_TECHNIQUE_TYPE /= INJECTION_TECHNIQUE_IS_AXISEM .and. &
          INJECTION_TECHNIQUE_TYPE /= INJECTION_TECHNIQUE_IS_FK) stop 'Error incorrect value of INJECTION_TECHNIQUE_TYPE read'
-
-      if ( (INJECTION_TECHNIQUE_TYPE == INJECTION_TECHNIQUE_IS_DSM ) .and. (.not. MESH_A_CHUNK_OF_THE_EARTH) ) &
-        stop 'Error, coupling with DSM only works with a Earth chunk mesh'
-
-      if (INJECTION_TECHNIQUE_TYPE == INJECTION_TECHNIQUE_IS_FK .and. MESH_A_CHUNK_OF_THE_EARTH) &
-        stop 'Error: coupling with F-K is for models with a flat surface (Earth flattening), &
-                       &thus turn MESH_A_CHUNK_OF_THE_EARTH off'
 
       if ((INJECTION_TECHNIQUE_TYPE /= INJECTION_TECHNIQUE_IS_AXISEM) .and. RECIPROCITY_AND_KH_INTEGRAL) &
         stop 'Error: the use of RECIPROCITY_AND_KH_INTEGRAL is only available for coupling with AxiSEM for now'
@@ -1448,7 +1428,6 @@
   ! coupling
   call bcast_all_singlel(COUPLE_WITH_INJECTION_TECHNIQUE)
   call bcast_all_singlei(INJECTION_TECHNIQUE_TYPE)
-  call bcast_all_singlel(MESH_A_CHUNK_OF_THE_EARTH)
   call bcast_all_string(TRACTION_PATH)
   call bcast_all_string(FKMODEL_FILE)
   call bcast_all_singlel(RECIPROCITY_AND_KH_INTEGRAL)

--- a/fortran/meshfem3d/shared/read_parameter_file.F90
+++ b/fortran/meshfem3d/shared/read_parameter_file.F90
@@ -44,8 +44,6 @@
   ! to avoid an I/O bottleneck in the case of very large runs
   if (myrank == 0) then
 
-    call parse_command_line_arguments()
-
     ! opens file Par_file
     call open_parameter_file(ier)
 
@@ -179,6 +177,41 @@
     if (ier /= 0) then
       some_parameters_missing_from_Par_file = .true.
       write(*,'(a)') 'TOMOGRAPHY_PATH                 = ./DATA/tomo_files/'
+      write(*,*)
+    endif
+
+    call read_value_logical(HAS_FINITE_FAULT_SOURCE, 'HAS_FINITE_FAULT_SOURCE', ier)
+    if (ier /= 0) then
+      some_parameters_missing_from_Par_file = .true.
+      write(*,'(a)') 'HAS_FINITE_FAULT_SOURCE         = .false.'
+      write(*,*)
+    endif
+
+    call read_value_string(FAULT_PAR_FILE, 'FAULT_PAR_FILE', ier)
+    if (ier /= 0) then
+      some_parameters_missing_from_Par_file = .true.
+      write(*,'(a)') 'FAULT_PAR_FILE                  = dummy.txt'
+      write(*,*)
+    endif
+
+    call read_value_string(FAULT_STATIONS, 'FAULT_STATIONS', ier)
+    if (ier /= 0) then
+      some_parameters_missing_from_Par_file = .true.
+      write(*,'(a)') 'FAULT_STATIONS                  = dummy.txt'
+      write(*,*)
+    endif
+
+    call read_value_string(STRESS_FRICTION_FILE, 'STRESS_FRICTION_FILE', ier)
+    if (ier /= 0) then
+      some_parameters_missing_from_Par_file = .true.
+      write(*,'(a)') 'STRESS_FRICTION_FILE            = dummy.txt'
+      write(*,*)
+    endif
+
+    call read_value_string(RST_HETE_FILE, 'RST_HETE_FILE', ier)
+    if (ier /= 0) then
+      some_parameters_missing_from_Par_file = .true.
+      write(*,'(a)') 'RST_HETE_FILE                   = dummy.txt'
       write(*,*)
     endif
 

--- a/fortran/meshfem3d/shared/read_value_parameters.f90
+++ b/fortran/meshfem3d/shared/read_value_parameters.f90
@@ -101,7 +101,8 @@
 
   subroutine open_parameter_file_from_main_only(ier)
 
-  use constants, only: MAX_STRING_LEN,IN_DATA_FILES
+  use constants, only: MAX_STRING_LEN
+  use shared_input_parameters, only: Par_file
 
   implicit none
 
@@ -109,45 +110,10 @@
   character(len=MAX_STRING_LEN) :: filename_main,filename_run0001
   logical :: exists_main_Par_file,exists_run0001_Par_file
 
-  filename_main = IN_DATA_FILES(1:len_trim(IN_DATA_FILES))//'Par_file'
-
-  ! also see if we are running several independent runs in parallel
-  ! to do so, add the right directory for that run for the main process only here
-  filename_run0001 = 'run0001/'//filename_main(1:len_trim(filename_main))
-
-  call param_open(filename_main, len(filename_main), ier)
-  if (ier == 0) then
-    exists_main_Par_file = .true.
-    call close_parameter_file()
-  else
-    exists_main_Par_file    = .false.
-  endif
-
-  call param_open(filename_run0001, len(filename_run0001), ier)
-  if (ier == 0) then
-    exists_run0001_Par_file = .true.
-    call close_parameter_file()
-  else
-    exists_run0001_Par_file = .false.
-  endif
-
-  if (exists_main_Par_file .and. exists_run0001_Par_file) then
-    print *
-    print *,'Cannot have both DATA/Par_file and run0001/DATA/Par_file present, please remove one of them.'
-    stop 'Error: two different copies of the Par_file'
-  endif
-
-  call param_open(filename_main, len(filename_main), ier)
+  call param_open(Par_file, len(Par_file), ier)
   if (ier /= 0) then
-    ! checks second option with Par_file in run0001/DATA/
-    call param_open(filename_run0001, len(filename_run0001), ier)
-    if (ier /= 0) then
-      print *
-      print *,'Opening file failed, please check your file path and run-directory.'
-      print *,'checked first: ',trim(filename_main)
-      print *,'     and then: ',trim(filename_run0001)
-      stop 'Error opening Par_file'
-    endif
+    print *, 'Error opening Par_file: ',trim(Par_file)
+    stop
   endif
 
   end subroutine open_parameter_file_from_main_only
@@ -156,7 +122,7 @@
 
   subroutine open_parameter_file(ier)
 
-  use constants, only: MAX_STRING_LEN,IN_DATA_FILES
+  use constants, only: MAX_STRING_LEN
   use shared_input_parameters, only: Par_file
 
   implicit none

--- a/fortran/meshfem3d/shared/serial.f90
+++ b/fortran/meshfem3d/shared/serial.f90
@@ -632,7 +632,9 @@
   ! we need to make sure that NUMBER_OF_SIMULTANEOUS_RUNS is read, thus read the parameter file
   myrank = 0
   BROADCAST_AFTER_READ = .false.
-  call read_parameter_file(BROADCAST_AFTER_READ)
+  ! call read_parameter_file(BROADCAST_AFTER_READ)
+
+  NUMBER_OF_SIMULTANEOUS_RUNS = 1
 
   if (NUMBER_OF_SIMULTANEOUS_RUNS <= 0) stop 'NUMBER_OF_SIMULTANEOUS_RUNS <= 0 makes no sense'
 

--- a/fortran/meshfem3d/shared/shared_par.F90
+++ b/fortran/meshfem3d/shared/shared_par.F90
@@ -100,6 +100,7 @@ end module constants
   integer :: NGNOD
 
   character(len=MAX_STRING_LEN) :: MODEL
+  character(len=MAX_STRING_LEN) :: COUPLED_MODEL_DIRECTORY
   character(len=MAX_STRING_LEN) :: SEP_MODEL_DIRECTORY
 
   ! physical parameters
@@ -109,6 +110,7 @@ end module constants
   character(len=MAX_STRING_LEN) :: TOMOGRAPHY_PATH
 
   character(len=MAX_STRING_LEN) :: Par_file
+  character(len=MAX_STRING_LEN) :: MESH_PAR_FILE
 
   ! fault parameters
   logical :: HAS_FINITE_FAULT_SOURCE
@@ -172,6 +174,7 @@ end module constants
 
   ! sources
   logical :: USE_FORCE_POINT_SOURCE
+  character(len=MAX_STRING_LEN) :: SOURCE_FILENAME
   logical :: USE_RICKER_TIME_FUNCTION,PRINT_SOURCE_TIME_FUNCTION
 
   ! external source time function

--- a/fortran/meshfem3d/shared/shared_par.F90
+++ b/fortran/meshfem3d/shared/shared_par.F90
@@ -215,7 +215,6 @@ end module constants
   integer :: INJECTION_TECHNIQUE_TYPE
   character(len=MAX_STRING_LEN) :: TRACTION_PATH,TRACTION_PATH_new
   character(len=MAX_STRING_LEN) :: FKMODEL_FILE
-  logical :: MESH_A_CHUNK_OF_THE_EARTH
   logical :: RECIPROCITY_AND_KH_INTEGRAL
 
   ! prescribed wavefield discontinuity on an interface

--- a/fortran/meshfem3d/shared/shared_par.F90
+++ b/fortran/meshfem3d/shared/shared_par.F90
@@ -117,7 +117,7 @@ end module constants
   character(len=MAX_STRING_LEN) :: FAULT_PAR_FILE
   character(len=MAX_STRING_LEN) :: FAULT_STATIONS
   character(len=MAX_STRING_LEN) :: STRESS_FRICTION_FILE
-  character(len=MAX_STRING_LEN) :: RST_HETE_FILE
+  character(len=MAX_STRING_LEN) :: RSF_HETE_FILE
 
   ! attenuation
   ! reference frequency of seismic model

--- a/fortran/meshfem3d/shared/shared_par.F90
+++ b/fortran/meshfem3d/shared/shared_par.F90
@@ -110,6 +110,13 @@ end module constants
 
   character(len=MAX_STRING_LEN) :: Par_file
 
+  ! fault parameters
+  logical :: HAS_FINITE_FAULT_SOURCE
+  character(len=MAX_STRING_LEN) :: FAULT_PAR_FILE
+  character(len=MAX_STRING_LEN) :: FAULT_STATIONS
+  character(len=MAX_STRING_LEN) :: STRESS_FRICTION_FILE
+  character(len=MAX_STRING_LEN) :: RST_HETE_FILE
+
   ! attenuation
   ! reference frequency of seismic model
   double precision :: ATTENUATION_f0_REFERENCE
@@ -166,7 +173,6 @@ end module constants
   ! sources
   logical :: USE_FORCE_POINT_SOURCE
   logical :: USE_RICKER_TIME_FUNCTION,PRINT_SOURCE_TIME_FUNCTION
-  logical :: HAS_FINITE_FAULT_SOURCE
 
   ! external source time function
   logical :: USE_EXTERNAL_SOURCE_FILE


### PR DESCRIPTION
# Description

- Separates mesher par file to mesher par file, which is significantly smaller than the solver par file 
- Generate databases uses the original solver Par_file

# Issue Number

Closes #424 

# Checklist

Please make sure to check developer documentation on specfem docs. 

- [ ] I ran the code through pre-commit to check style
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms 
