### PR TITLE
Issue 461 -- Implement Parameter Reader 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,12 +197,15 @@ add_library(
         src/IO/sources.cpp
         src/IO/receivers.cpp
         src/IO/mesh.cpp
+        # Fortran 2D part
         src/IO/mesh/impl/fortran/dim2/read_boundaries.cpp
         src/IO/mesh/impl/fortran/dim2/read_elements.cpp
         src/IO/mesh/impl/fortran/dim2/read_material_properties.cpp
         src/IO/mesh/impl/fortran/dim2/read_mesh_database.cpp
         src/IO/mesh/impl/fortran/dim2/read_interfaces.cpp
         src/IO/mesh/impl/fortran/dim2/read_parameters.cpp
+        # Fortran 3D part
+        src/IO/mesh/impl/fortran/dim3/read_parameters.cpp
 )
 
 if (NOT HDF5_CXX_BUILD)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,26 @@
+{
+  "version": 6,
+  "configurePresets": [
+    {
+      "name": "debug",
+      "displayName": "Debug (Serial)",
+      "binaryDir": "build/debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "BUILD_TESTS": "ON",
+        "ENABLE_SIMD": "OFF",
+        "Kokkos_ARCH_NATIVE": "ON",
+        "Kokkos_ENABLE_AGGRESSIVE_VECTORIZATION": "ON",
+        "Kokkos_ENABLE_ATOMICS_BYPASS": "ON"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "debug",
+      "configurePreset": "debug",
+      "targets": ["all"],
+      "jobs": 8
+    }
+  ]
+}

--- a/examples/dim3/homogeneous_halfspace/specfem_config.yaml
+++ b/examples/dim3/homogeneous_halfspace/specfem_config.yaml
@@ -45,6 +45,7 @@ parameters:
   ## databases
   databases:
     mesh-database: "OUTPUT_FILES/DATABASES_MPI/proc000000_external_mesh.bin"
+    mesh-parameters: "OUTPUT_FILES/DATABASES_MPI/mesh_parameters.bin"
 
   ## sources
   sources: "/Users/lsawade/SPECFEMPP/examples/homogeneous-medium-flat-topography/source.yaml"

--- a/fortran/meshfem3d/generate_databases/save_parameters.f90
+++ b/fortran/meshfem3d/generate_databases/save_parameters.f90
@@ -58,7 +58,6 @@ subroutine save_parameters()
       WRITE(IOUT) APPROXIMATE_OCEAN_LOAD
       WRITE(IOUT) USE_MESH_COLORING_GPU
 
-
       ! Write test parameter
       itest = 9998
       WRITE(IOUT) itest
@@ -79,25 +78,25 @@ subroutine save_parameters()
       WRITE(IOUT) NSPEC_PORO ! nspec_poro == nspec, if POROELASTIC_SIMULATION
       WRITE(IOUT) NGLOB_AB ! nglob
       WRITE(IOUT) NGLOB_OCEAN
-      WRITE(IOUT) NSPEC2D_BOTTOM
-      WRITE(IOUT) NSPEC2D_TOP
-      WRITE(IOUT) nspec_irregular
 
       ! Write test parameter
       WRITE(IOUT) itest
       itest = 9996
 
-      WRITE(IOUT) num_neighbors_all
-      WRITE(IOUT) nfaces_surface
+      WRITE(IOUT) NSPEC2D_BOTTOM
+      WRITE(IOUT) NSPEC2D_TOP
       WRITE(IOUT) nspec2D_xmin
-      WRITE(IOUT) nspec2D_xmin
+      WRITE(IOUT) nspec2D_xmax
       WRITE(IOUT) nspec2D_ymin
-      WRITE(IOUT) nspec2D_ymin
+      WRITE(IOUT) nspec2D_ymax
+      WRITE(IOUT) nspec_irregular
 
       ! Write test parameter
       WRITE(IOUT) itest
       itest = 9995
 
+      WRITE(IOUT) num_neighbors_all
+      WRITE(IOUT) nfaces_surface
       WRITE(IOUT) num_abs_boundary_faces
       WRITE(IOUT) num_free_surface_faces
       WRITE(IOUT) num_coupling_ac_el_faces

--- a/fortran/meshfem3d/generate_databases/save_parameters.f90
+++ b/fortran/meshfem3d/generate_databases/save_parameters.f90
@@ -71,8 +71,8 @@ subroutine save_parameters()
       WRITE(IOUT) NGLLSQUARE
 
       ! Write test parameter
-      WRITE(IOUT) itest
       itest = 9997
+      WRITE(IOUT) itest
 
       WRITE(IOUT) NSPEC_AB ! nspec
       WRITE(IOUT) NSPEC_PORO ! nspec_poro == nspec, if POROELASTIC_SIMULATION
@@ -80,8 +80,8 @@ subroutine save_parameters()
       WRITE(IOUT) NGLOB_OCEAN
 
       ! Write test parameter
-      WRITE(IOUT) itest
       itest = 9996
+      WRITE(IOUT) itest
 
       WRITE(IOUT) NSPEC2D_BOTTOM
       WRITE(IOUT) NSPEC2D_TOP
@@ -92,8 +92,8 @@ subroutine save_parameters()
       WRITE(IOUT) nspec_irregular
 
       ! Write test parameter
-      WRITE(IOUT) itest
       itest = 9995
+      WRITE(IOUT) itest
 
       WRITE(IOUT) num_neighbors_all
       WRITE(IOUT) nfaces_surface
@@ -107,8 +107,8 @@ subroutine save_parameters()
       WRITE(IOUT) max_nibool_interfaces_ext_mesh
 
       ! Write test parameter
-      WRITE(IOUT) itest
       itest = 9994
+      WRITE(IOUT) itest
 
       WRITE(IOUT) nspec_inner_acoustic
       WRITE(IOUT) nspec_outer_acoustic
@@ -118,8 +118,8 @@ subroutine save_parameters()
       WRITE(IOUT) nspec_outer_poroelastic
 
       ! Write test parameter
-      WRITE(IOUT) itest
       itest = 9993
+      WRITE(IOUT) itest
 
       WRITE(IOUT) num_phase_ispec_acoustic
       WRITE(IOUT) num_phase_ispec_elastic
@@ -130,8 +130,8 @@ subroutine save_parameters()
       WRITE(IOUT) num_colors_outer_elastic
 
       ! Write test parameter
-      WRITE(IOUT) itest
       itest = 9992
+      WRITE(IOUT) itest
   endif
 
 end subroutine save_parameters

--- a/include/IO/interface.hpp
+++ b/include/IO/interface.hpp
@@ -25,7 +25,9 @@ specfem::mesh::mesh<specfem::dimension::type::dim2>
 read_2d_mesh(const std::string filename, const specfem::MPI::MPI *mpi);
 
 specfem::mesh::mesh<specfem::dimension::type::dim3>
-read_3d_mesh(const std::string filename, const specfem::MPI::MPI *mpi);
+read_3d_mesh(const std::string mesh_parameters_file,
+             const std::string mesh_databases_file,
+             const specfem::MPI::MPI *mpi);
 /**
  * @brief Read station file
  *

--- a/include/IO/mesh/impl/fortran/dim3/read_parameters.hpp
+++ b/include/IO/mesh/impl/fortran/dim3/read_parameters.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "IO/fortranio/interface.hpp"
+#include "mesh/parameters/parameters.hpp"
+#include "specfem_mpi/interface.hpp"
+
+namespace specfem {
+namespace IO {
+namespace mesh {
+namespace impl {
+namespace fortran {
+namespace dim3 {
+
+/*
+ * @brief Read paramters from 3D mesh database
+ *
+ * @param stream Input stream
+ * @param mpi MPI object
+ * @return specfem::mesh::parameters<specfem::dimension::type::dim2> Mesh
+ * parameters
+ */
+specfem::mesh::parameters<specfem::dimension::type::dim3>
+read_mesh_parameters(std::ifstream &stream, const specfem::MPI::MPI *mpi);
+
+} // namespace dim3
+} // namespace fortran
+} // namespace impl
+} // namespace mesh
+} // namespace IO
+} // namespace specfem

--- a/include/mesh/mesh.hpp
+++ b/include/mesh/mesh.hpp
@@ -104,6 +104,9 @@ template <> struct mesh<specfem::dimension::type::dim3> {
   constexpr static auto dimension =
       specfem::dimension::type::dim3; ///< Dimension
 
+  // Struct to store all the mesh parameter
+  specfem::mesh::parameters<dimension> parameters;
+
   // int npgeo; ///< Total number of spectral element control nodes
   // int nspec; ///< Total number of spectral elements
   // int nproc; ///< Total number of processors

--- a/include/mesh/mesh.hpp
+++ b/include/mesh/mesh.hpp
@@ -5,6 +5,7 @@
 #include "coupled_interfaces/coupled_interfaces.hpp"
 #include "elements/axial_elements.hpp"
 #include "elements/tangential_elements.hpp"
+#include "enumerations/dimension.hpp"
 #include "enumerations/interface.hpp"
 #include "materials/materials.hpp"
 #include "mesh/tags/tags.hpp"

--- a/include/mesh/parameters/parameters.hpp
+++ b/include/mesh/parameters/parameters.hpp
@@ -95,6 +95,13 @@ template <> struct parameters<specfem::dimension::type::dim3> {
   bool approximate_ocean_load; ///< Flag for approx. ocean load
   bool use_mesh_coloring;      ///< Flag for mesh coloring
 
+  // Integer Parameters: Dimensions and GLL layouts
+  int ndim;       ///< Number of dimensions
+  int ngllx;      ///< Number of GLL points in x
+  int nglly;      ///< Number of GLL points in y
+  int ngllz;      ///< Number of GLL points in z
+  int ngllsquare; ///< Number of GLL points in square
+
   // Integer Parameters: Elements/Nodes
   int nspec;           ///< Number of spectral elements (SEs)
   int nspec_poro;      ///< Number of poroelastic SEs
@@ -152,6 +159,8 @@ template <> struct parameters<specfem::dimension::type::dim3> {
    * @param pml_abc Flag for PML absorbing boundary c.
    * @param approximate_ocean_load Flag for approx. ocean load
    * @param use_mesh_coloring Flag for mesh coloring
+   *
+   *
    *
    * @param nspec Number of spectral elements (SEs)
    * @param nspec_poro Number of poroelastic SEs
@@ -246,7 +255,7 @@ template <> struct parameters<specfem::dimension::type::dim3> {
         num_colors_outer_acoustic(num_colors_outer_acoustic),
         num_colors_inner_elastic(num_colors_inner_elastic),
         num_colors_outer_elastic(num_colors_outer_elastic){};
-
+};
 } // namespace mesh
 } // namespace specfem
 

--- a/include/mesh/parameters/parameters.hpp
+++ b/include/mesh/parameters/parameters.hpp
@@ -76,6 +76,177 @@ template <> struct parameters<specfem::dimension::type::dim2> {
         nelem_on_the_axis(nelem_on_the_axis),
         plot_lowerleft_corner_only(plot_lowerleft_corner_only){};
 };
+
+/**
+ * @brief Template specialization for 3D mesh parameters
+ */
+template <> struct parameters<specfem::dimension::type::dim3> {
+  constexpr static auto dimension =
+      specfem::dimension::type::dim3; ///< Dimension
+                                      ///< type
+
+  // Flags
+  bool acoustic_simulation;    ///< Flag for acoustic simulation
+  bool elastic_simulation;     ///< Flag for elastic simulation
+  bool poroelastic_simulation; ///< Flag for poroelastic simulation
+  bool anisotropy;             ///< Flag for anisotropy
+  bool stacey_abc;             ///< Flag for Stacey absorbing boundary c.
+  bool pml_abc;                ///< Flag for PML absorbing boundary c.
+  bool approximate_ocean_load; ///< Flag for approx. ocean load
+  bool use_mesh_coloring;      ///< Flag for mesh coloring
+
+  // Integer Parameters: Elements/Nodes
+  int nspec;           ///< Number of spectral elements (SEs)
+  int nspec_poro;      ///< Number of poroelastic SEs
+  int nglob;           ///< Number of global nodes
+  int nglob_ocean;     ///< Number of global ocean nodes
+  int nspec2D_bottom;  ///< Number of 2D SEs at the bottom
+  int nspec2D_top;     ///< Number of 2D SEs at the top
+  int nspec2D_xmin;    ///< Number of 2D SEs at the left
+  int nspec2D_xmax;    ///< Number of 2D SEs at the right
+  int nspec2D_ymin;    ///< Number of 2D SEs at the front
+  int nspec2D_ymax;    ///< Number of 2D SEs at the back
+  int nspec_irregular; ///< Number of irregular SEs
+
+  // Integer Parameters: Mesh
+  int num_neighbors;                  ///< Number of neighbors
+  int nfaces_surface;                 ///< Number of faces on the surface
+  int num_abs_boundary_faces;         ///< Number of absorbing boundary faces
+  int num_free_surface_faces;         ///< Number of free surface faces
+  int num_coupling_ac_el_faces;       ///< Number of acoustic-elastic faces
+  int num_coupling_ac_po_faces;       ///< Number of acoustic-poroelastic faces
+  int num_coupling_el_po_faces;       ///< Number of elastic-poroelastic faces
+  int num_coupling_po_el_faces;       ///< Number of poroelastic-elastic faces
+  int num_interfaces_ext_mesh;        ///< Number of external mesh interfaces
+  int max_nibool_interfaces_ext_mesh; ///< Maximum number of interfaces
+
+  // Integer Parameters: Nspec Inner/Outer
+  int nspec_inner_acoustic;    ///< Number of inner acoustic SEs
+  int nspec_outer_acoustic;    ///< Number of outer acoustic SEs
+  int nspec_inner_elastic;     ///< Number of inner elastic SEs
+  int nspec_outer_elastic;     ///< Number of outer elastic SEs
+  int nspec_inner_poroelastic; ///< Number of inner poroelastic SEs
+  int nspec_outer_poroelastic; ///< Number of outer poroelastic SEs
+
+  // Integer Parameters: coloring
+  int num_phase_ispec_acoustic;
+  int num_phase_ispec_elastic;
+  int num_phase_ispec_poroelastic;
+  int num_colors_inner_acoustic;
+  int num_colors_outer_acoustic;
+  int num_colors_inner_elastic;
+  int num_colors_outer_elastic;
+
+  /**
+   * @brief Default constructor
+   *
+   */
+  parameters(){};
+
+  /** Constructor
+   * @param acoustic_simulation Flag for acoustic simulation
+   * @param elastic_simulation Flag for elastic simulation
+   * @param poroelastic_simulation Flag for poroelastic simulation
+   * @param anisotropy Flag for anisotropy
+   * @param stacey_abc Flag for Stacey absorbing boundary c.
+   * @param pml_abc Flag for PML absorbing boundary c.
+   * @param approximate_ocean_load Flag for approx. ocean load
+   * @param use_mesh_coloring Flag for mesh coloring
+   *
+   * @param nspec Number of spectral elements (SEs)
+   * @param nspec_poro Number of poroelastic SEs
+   * @param nglob Number of global nodes
+   * @param nglob_ocean Number of global ocean nodes
+   * @param nspec2D_bottom Number of 2D SEs at the bottom
+   * @param nspec2D_top Number of 2D SEs at the top
+   * @param nspec2D_xmin Number of 2D SEs at the left
+   * @param nspec2D_xmax Number of 2D SEs at the right
+   * @param nspec2D_ymin Number of 2D SEs at the front
+   * @param nspec2D_ymax Number of 2D SEs at the back
+   * @param nspec_irregular Number of irregular SEs
+   *
+   * @param num_neighbors Number of neighbors
+   * @param nfaces_surface Number of faces on the surface
+   * @param num_abs_boundary_faces Number of absorbing boundary faces
+   * @param num_free_surface_faces Number of free surface faces
+   * @param num_coupling_ac_el_faces Number of acoustic-elastic faces
+   * @param num_coupling_ac_po_faces Number of acoustic-poroelastic faces
+   * @param num_coupling_el_po_faces Number of elastic-poroelastic faces
+   * @param num_coupling_po_el_faces Number of poroelastic-elastic faces
+   * @param num_interfaces_ext_mesh Number of external mesh interfaces
+   * @param max_nibool_interfaces_ext_mesh Maximum number of interfaces
+   *
+   * @param nspec_inner_acoustic Number of inner acoustic SEs
+   * @param nspec_outer_acoustic Number of outer acoustic SEs
+   * @param nspec_inner_elastic Number of inner elastic SEs
+   * @param nspec_outer_elastic Number of outer elastic SEs
+   * @param nspec_inner_poroelastic Number of inner poroelastic SEs
+   * @param nspec_outer_poroelastic Number of outer poroelastic SEs
+   *
+   * @param num_phase_ispec_acoustic
+   * @param num_phase_ispec_elastic
+   * @param num_phase_ispec_poroelastic
+   * @param num_colors_inner_acoustic
+   * @param num_colors_outer_acoustic
+   * @param num_colors_inner_elastic
+   * @param num_colors_outer_elastic
+   *
+   */
+  parameters(
+      const bool acoustic_simulation, const bool elastic_simulation,
+      const bool poroelastic_simulation, const bool anisotropy,
+      const bool stacey_abc, const bool pml_abc,
+      const bool approximate_ocean_load, const bool use_mesh_coloring,
+      const int nspec, const int nspec_poro, const int nglob,
+      const int nglob_ocean, const int nspec2D_bottom, const int nspec2D_top,
+      const int nspec2D_xmin, const int nspec2D_xmax, const int nspec2D_ymin,
+      const int nspec2D_ymax, const int nspec_irregular,
+      const int num_neighbors, const int nfaces_surface,
+      const int num_abs_boundary_faces, const int num_free_surface_faces,
+      const int num_coupling_ac_el_faces, const int num_coupling_ac_po_faces,
+      const int num_coupling_el_po_faces, const int num_coupling_po_el_faces,
+      const int num_interfaces_ext_mesh,
+      const int max_nibool_interfaces_ext_mesh, const int nspec_inner_acoustic,
+      const int nspec_outer_acoustic, const int nspec_inner_elastic,
+      const int nspec_outer_elastic, const int nspec_inner_poroelastic,
+      const int nspec_outer_poroelastic, const int num_phase_ispec_acoustic,
+      const int num_phase_ispec_elastic, const int num_phase_ispec_poroelastic,
+      const int num_colors_inner_acoustic, const int num_colors_outer_acoustic,
+      const int num_colors_inner_elastic, const int num_colors_outer_elastic)
+      : acoustic_simulation(acoustic_simulation),
+        elastic_simulation(elastic_simulation),
+        poroelastic_simulation(poroelastic_simulation), anisotropy(anisotropy),
+        stacey_abc(stacey_abc), pml_abc(pml_abc),
+        approximate_ocean_load(approximate_ocean_load),
+        use_mesh_coloring(use_mesh_coloring), nspec(nspec),
+        nspec_poro(nspec_poro), nglob(nglob), nglob_ocean(nglob_ocean),
+        nspec2D_bottom(nspec2D_bottom), nspec2D_top(nspec2D_top),
+        nspec2D_xmin(nspec2D_xmin), nspec2D_xmax(nspec2D_xmax),
+        nspec2D_ymin(nspec2D_ymin), nspec2D_ymax(nspec2D_ymax),
+        nspec_irregular(nspec_irregular), num_neighbors(num_neighbors),
+        nfaces_surface(nfaces_surface),
+        num_abs_boundary_faces(num_abs_boundary_faces),
+        num_free_surface_faces(num_free_surface_faces),
+        num_coupling_ac_el_faces(num_coupling_ac_el_faces),
+        num_coupling_ac_po_faces(num_coupling_ac_po_faces),
+        num_coupling_el_po_faces(num_coupling_el_po_faces),
+        num_coupling_po_el_faces(num_coupling_po_el_faces),
+        num_interfaces_ext_mesh(num_interfaces_ext_mesh),
+        max_nibool_interfaces_ext_mesh(max_nibool_interfaces_ext_mesh),
+        nspec_inner_acoustic(nspec_inner_acoustic),
+        nspec_outer_acoustic(nspec_outer_acoustic),
+        nspec_inner_elastic(nspec_inner_elastic),
+        nspec_outer_elastic(nspec_outer_elastic),
+        nspec_inner_poroelastic(nspec_inner_poroelastic),
+        nspec_outer_poroelastic(nspec_outer_poroelastic),
+        num_phase_ispec_acoustic(num_phase_ispec_acoustic),
+        num_phase_ispec_elastic(num_phase_ispec_elastic),
+        num_phase_ispec_poroelastic(num_phase_ispec_poroelastic),
+        num_colors_inner_acoustic(num_colors_inner_acoustic),
+        num_colors_outer_acoustic(num_colors_outer_acoustic),
+        num_colors_inner_elastic(num_colors_inner_elastic),
+        num_colors_outer_elastic(num_colors_outer_elastic){};
+
 } // namespace mesh
 } // namespace specfem
 

--- a/include/parameter_parser/database_configuration.hpp
+++ b/include/parameter_parser/database_configuration.hpp
@@ -23,6 +23,10 @@ public:
   database_configuration(std::string fortran_database)
       : fortran_database(fortran_database){};
 
+  database_configuration(std::string fortran_database,
+                         std::string mesh_parameters)
+      : fortran_database(fortran_database), mesh_parameters(mesh_parameters){};
+
   /**
    * @brief Construct a new run setup object
    *
@@ -32,8 +36,11 @@ public:
 
   std::string get_databases() const { return this->fortran_database; }
 
+  std::string get_mesh_parameters() const { return this->mesh_parameters; };
+
 private:
   std::string fortran_database; ///< location of fortran binary database
+  std::string mesh_parameters;  ///< location of mesh parameter file
 };
 
 } // namespace runtime_configuration

--- a/include/parameter_parser/setup.hpp
+++ b/include/parameter_parser/setup.hpp
@@ -103,6 +103,9 @@ public:
    * to mesh database and source yaml file
    */
   std::string get_databases() const { return databases->get_databases(); }
+  std::string get_mesh_parameters() const {
+    return databases->get_mesh_parameters();
+  }
 
   /**
    * @brief Get the sources YAML object

--- a/src/IO/mesh.cpp
+++ b/src/IO/mesh.cpp
@@ -8,6 +8,7 @@
 #include "IO/mesh/impl/fortran/dim2/read_material_properties.hpp"
 #include "IO/mesh/impl/fortran/dim2/read_mesh_database.hpp"
 #include "IO/mesh/impl/fortran/dim2/read_parameters.hpp"
+#include "IO/mesh/impl/fortran/dim3/read_parameters.hpp"
 #include "enumerations/interface.hpp"
 #include "kokkos_abstractions.h"
 #include "medium/material.hpp"
@@ -227,7 +228,8 @@ specfem::IO::read_2d_mesh(const std::string filename,
 }
 
 specfem::mesh::mesh<specfem::dimension::type::dim3>
-specfem::IO::read_3d_mesh(const std::string filename,
+specfem::IO::read_3d_mesh(const std::string mesh_parameters_file,
+                          const std::string mesh_databases_file,
                           const specfem::MPI::MPI *mpi) {
 
   // Declaring empty mesh objects
@@ -235,10 +237,10 @@ specfem::IO::read_3d_mesh(const std::string filename,
 
   // Open the database file
   std::ifstream stream;
-  stream.open(filename);
+  stream.open(mesh_parameters_file);
 
   if (!stream.is_open()) {
-    throw std::runtime_error("Could not open database file");
+    throw std::runtime_error("Could not open mesh parameter file");
   }
 
   try {
@@ -248,6 +250,18 @@ specfem::IO::read_3d_mesh(const std::string filename,
   } catch (std::runtime_error &e) {
     throw;
   }
+
+  // Mesh Parameters are populated, closing the parameters file.
+  stream.close();
+
+  // Open the database file
+  stream.open(mesh_databases_file);
+
+  if (!stream.is_open()) {
+    throw std::runtime_error("Could not open mesh database file");
+  }
+
+  stream.close();
 
   // // Mesh class to be populated from the database file.
   // try {

--- a/src/IO/mesh.cpp
+++ b/src/IO/mesh.cpp
@@ -240,15 +240,11 @@ specfem::IO::read_3d_mesh(const std::string filename,
   if (!stream.is_open()) {
     throw std::runtime_error("Could not open database file");
   }
-  int nspec, npgeo, nproc;
 
   try {
-    // std::tie(nspec, npgeo, nproc) =
-    //     specfem::IO::mesh::impl::fortran::dim2::read_mesh_database_header(stream,
-    //                                                                 mpi);
-    // mesh.nspec = nspec;
-    // mesh.npgeo = npgeo;
-    // mesh.nproc = nproc;
+    mesh.parameters =
+        specfem::IO::mesh::impl::fortran::dim3::read_mesh_parameters(stream,
+                                                                     mpi);
   } catch (std::runtime_error &e) {
     throw;
   }

--- a/src/IO/mesh/impl/fortran/dim3/read_parameters.cpp
+++ b/src/IO/mesh/impl/fortran/dim3/read_parameters.cpp
@@ -1,0 +1,51 @@
+#include "IO/mesh/impl/fortran/dim3/read_parameters.hpp"
+#include "IO/fortranio/interface.hpp"
+#include "enumerations/dimension.hpp"
+#include "mesh/parameters/parameters.hpp"
+#include "specfem_mpi/interface.hpp"
+
+specfem::mesh::parameters<specfem::dimension::type::dim3>
+specfem::IO::mesh::impl::fortran::dim3::read_mesh_parameters(
+    std::ifstream &stream, const specfem::MPI::MPI *mpi) {
+
+  // Initialize test parameter
+  int itest = -9999;
+
+  // Instantiate parameters object
+  specfem::mesh::parameters<specfem::dimension::type::dim3> mesh_parameters;
+
+  // Read testparamater
+  specfem::IO::fortran_read_line(stream, &itest);
+
+  // Throw error if test parameter is not correctly read
+  if (itest != 9999) {
+    std::ostringstream error_message;
+    error_message << "Error reading mesh parameters: " << itest
+                  << " // FILE:LINE " << __FILE__ << ":" << __LINE__ << "\n";
+    throw std::runtime_error(error_message.str());
+  }
+
+  // Read parameters
+  specfem::IO::fortran_read_line(
+      stream, &mesh_parameters.acoustic_simulation,
+      &mesh_parameters.elastic_simulation,
+      &mesh_parameters.poroelastic_simulation, &mesh_parameters.anisotropy,
+      &mesh_parameters.stacey_abc, &mesh_parameters.pml_abc,
+      &mesh_parameters.approximate_ocean_load,
+      &mesh_parameters.use_mesh_coloring);
+
+  // Read test parameter
+  specfem::IO::fortran_read_line(stream, &itest);
+
+  // Throw error if test parameter is not correctly read
+  if (itest != 9998) {
+    std::ostringstream error_message;
+    error_message << "Error reading mesh parameters: " << itest
+                  << " // FILE:LINE " << __FILE__ << ":" << __LINE__ << "\n";
+    throw std::runtime_error(error_message.str());
+  };
+
+  mpi->sync_all();
+
+  return mesh_parameters;
+}

--- a/src/IO/mesh/impl/fortran/dim3/read_parameters.cpp
+++ b/src/IO/mesh/impl/fortran/dim3/read_parameters.cpp
@@ -11,9 +11,6 @@ specfem::IO::mesh::impl::fortran::dim3::read_mesh_parameters(
   // Initialize test parameter
   int itest = -9999;
 
-  // Instantiate parameters object
-  specfem::mesh::parameters<specfem::dimension::type::dim3> mesh_parameters;
-
   // Read testparamater
   specfem::IO::fortran_read_line(stream, &itest);
 
@@ -25,14 +22,39 @@ specfem::IO::mesh::impl::fortran::dim3::read_mesh_parameters(
     throw std::runtime_error(error_message.str());
   }
 
+  // Initialize flags
+  bool acoustic_simulation;
+  bool elastic_simulation;
+  bool poroelastic_simulation;
+  bool anisotropy;
+  bool stacey_abc;
+  bool pml_abc;
+  bool approximate_ocean_load;
+  bool use_mesh_coloring;
+
   // Read parameters
-  specfem::IO::fortran_read_line(
-      stream, &mesh_parameters.acoustic_simulation,
-      &mesh_parameters.elastic_simulation,
-      &mesh_parameters.poroelastic_simulation, &mesh_parameters.anisotropy,
-      &mesh_parameters.stacey_abc, &mesh_parameters.pml_abc,
-      &mesh_parameters.approximate_ocean_load,
-      &mesh_parameters.use_mesh_coloring);
+  specfem::IO::fortran_read_line(stream, &acoustic_simulation);
+  specfem::IO::fortran_read_line(stream, &elastic_simulation);
+  specfem::IO::fortran_read_line(stream, &poroelastic_simulation);
+  specfem::IO::fortran_read_line(stream, &anisotropy);
+  specfem::IO::fortran_read_line(stream, &stacey_abc);
+  specfem::IO::fortran_read_line(stream, &pml_abc);
+  specfem::IO::fortran_read_line(stream, &approximate_ocean_load);
+  specfem::IO::fortran_read_line(stream, &use_mesh_coloring);
+
+#ifndef NDEBUG
+  // Print the read parameters
+  std::cout << "acoustic_simulation:...." << acoustic_simulation << std::endl;
+  std::cout << "elastic_simulation:....." << elastic_simulation << std::endl;
+  std::cout << "poroelastic_simulation:." << poroelastic_simulation
+            << std::endl;
+  std::cout << "anisotropy:............." << anisotropy << std::endl;
+  std::cout << "stacey_abc:............." << stacey_abc << std::endl;
+  std::cout << "pml_abc:................" << pml_abc << std::endl;
+  std::cout << "approximate_ocean_load:." << approximate_ocean_load
+            << std::endl;
+  std::cout << "use_mesh_coloring:......" << use_mesh_coloring << std::endl;
+#endif
 
   // Read test parameter
   specfem::IO::fortran_read_line(stream, &itest);
@@ -45,7 +67,284 @@ specfem::IO::mesh::impl::fortran::dim3::read_mesh_parameters(
     throw std::runtime_error(error_message.str());
   };
 
+  // Initialize first bout of integer parameters
+  int ndim;
+  int ngllx;
+  int ngly;
+  int ngllz;
+  int ngllsquare;
+
+  // Read parameters
+  specfem::IO::fortran_read_line(stream, &ndim);
+  specfem::IO::fortran_read_line(stream, &ngllx);
+  specfem::IO::fortran_read_line(stream, &ngly);
+  specfem::IO::fortran_read_line(stream, &ngllz);
+  specfem::IO::fortran_read_line(stream, &ngllsquare);
+
+#ifndef NDEBUG
+  // Print the read parameters
+  std::cout << "ndim:................." << ndim << std::endl;
+  std::cout << "ngllx:................" << ngllx << std::endl;
+  std::cout << "ngly:................." << ngly << std::endl;
+  std::cout << "ngllz:................" << ngllz << std::endl;
+  std::cout << "ngllsquare:..........." << ngllsquare << std::endl;
+#endif
+
+  // Read test parameter
+  specfem::IO::fortran_read_line(stream, &itest);
+
+  // Throw error if test parameter is not correctly read
+  if (itest != 9997) {
+    std::ostringstream error_message;
+    error_message << "Error reading mesh parameters: " << itest
+                  << " // FILE:LINE " << __FILE__ << ":" << __LINE__ << "\n";
+    throw std::runtime_error(error_message.str());
+  };
+
+  // Initialize second bout of integer parameters
+  int nspec;
+  int nspec_poro;
+  int nglob;
+  int nglob_ocean;
+
+  // Read parameters
+  specfem::IO::fortran_read_line(stream, &nspec);
+  specfem::IO::fortran_read_line(stream, &nspec_poro);
+  specfem::IO::fortran_read_line(stream, &nglob);
+  specfem::IO::fortran_read_line(stream, &nglob_ocean);
+
+#ifndef NDEBUG
+  // Print the read parameters
+  std::cout << "nspec:................." << nspec << std::endl;
+  std::cout << "nspec_poro:............" << nspec_poro << std::endl;
+  std::cout << "nglob:................." << nglob << std::endl;
+  std::cout << "nglob_ocean:............" << nglob_ocean << std::endl;
+#endif
+
+  // Read test parameter
+  specfem::IO::fortran_read_line(stream, &itest);
+
+  // Throw error if test parameter is not correctly read
+  if (itest != 9996) {
+    std::ostringstream error_message;
+    error_message << "Error reading mesh parameters: " << itest
+                  << " // FILE:LINE " << __FILE__ << ":" << __LINE__ << "\n";
+    throw std::runtime_error(error_message.str());
+  };
+
+  int nspec2D_bottom;
+  int nspec2D_top;
+  int nspec2D_xmin;
+  int nspec2D_xmax;
+  int nspec2D_ymin;
+  int nspec2D_ymax;
+  int nspec_irregular;
+
+  specfem::IO::fortran_read_line(stream, &nspec2D_bottom);
+  specfem::IO::fortran_read_line(stream, &nspec2D_top);
+  specfem::IO::fortran_read_line(stream, &nspec2D_xmin);
+  specfem::IO::fortran_read_line(stream, &nspec2D_xmax);
+  specfem::IO::fortran_read_line(stream, &nspec2D_ymin);
+  specfem::IO::fortran_read_line(stream, &nspec2D_ymax);
+  specfem::IO::fortran_read_line(stream, &nspec_irregular);
+
+#ifndef NDEBUG
+  std::cout << "nspec2D_bottom:........" << nspec2D_bottom << std::endl;
+  std::cout << "nspec2D_top:..........." << nspec2D_top << std::endl;
+  std::cout << "nspec2D_xmin:.........." << nspec2D_xmin << std::endl;
+  std::cout << "nspec2D_xmax:.........." << nspec2D_xmax << std::endl;
+  std::cout << "nspec2D_ymin:.........." << nspec2D_ymin << std::endl;
+  std::cout << "nspec2D_ymax:.........." << nspec2D_ymax << std::endl;
+  std::cout << "nspec_irregular:......." << nspec_irregular << std::endl;
+#endif
+
+  // Read test parameter
+  specfem::IO::fortran_read_line(stream, &itest);
+
+  // Throw error if test parameter is not correctly read
+  if (itest != 9995) {
+    std::ostringstream error_message;
+    error_message << "Error reading mesh parameters: " << itest
+                  << " // FILE:LINE " << __FILE__ << ":" << __LINE__ << "\n";
+    throw std::runtime_error(error_message.str());
+  };
+
+  int num_neighbors;
+  int nfaces_surface;
+  int num_abs_boundary_faces;
+  int num_free_surface_faces;
+  int num_coupling_ac_el_faces;
+  int num_coupling_ac_po_faces;
+  int num_coupling_el_po_faces;
+  int num_coupling_po_el_faces;
+  int num_interfaces_ext_mesh;
+  int max_nibool_interfaces_ext_mesh;
+
+  specfem::IO::fortran_read_line(stream, &num_neighbors);
+  specfem::IO::fortran_read_line(stream, &nfaces_surface);
+  specfem::IO::fortran_read_line(stream, &num_abs_boundary_faces);
+  specfem::IO::fortran_read_line(stream, &num_free_surface_faces);
+  specfem::IO::fortran_read_line(stream, &num_coupling_ac_el_faces);
+  specfem::IO::fortran_read_line(stream, &num_coupling_ac_po_faces);
+  specfem::IO::fortran_read_line(stream, &num_coupling_el_po_faces);
+  specfem::IO::fortran_read_line(stream, &num_coupling_po_el_faces);
+  specfem::IO::fortran_read_line(stream, &num_interfaces_ext_mesh);
+  specfem::IO::fortran_read_line(stream, &max_nibool_interfaces_ext_mesh);
+
+#ifndef NDEBUG
+  std::cout << "num_neighbors:.........." << num_neighbors << std::endl;
+  std::cout << "nfaces_surface:........." << nfaces_surface << std::endl;
+  std::cout << "num_abs_boundary_faces:." << num_abs_boundary_faces
+            << std::endl;
+  std::cout << "num_free_surface_faces:." << num_free_surface_faces
+            << std::endl;
+  std::cout << "num_coupling_ac_el_faces:" << num_coupling_ac_el_faces
+            << std::endl;
+  std::cout << "num_coupling_ac_po_faces:" << num_coupling_ac_po_faces
+            << std::endl;
+  std::cout << "num_coupling_el_po_faces:" << num_coupling_el_po_faces
+            << std::endl;
+  std::cout << "num_coupling_po_el_faces:" << num_coupling_po_el_faces
+            << std::endl;
+  std::cout << "num_interfaces_ext_mesh:." << num_interfaces_ext_mesh
+            << std::endl;
+  std::cout << "max_nibool_interfaces_ext_mesh:"
+            << max_nibool_interfaces_ext_mesh << std::endl;
+#endif
+
+  // Read test parameter
+  specfem::IO::fortran_read_line(stream, &itest);
+
+  // Throw error if test parameter is not correctly read
+  if (itest != 9994) {
+    std::ostringstream error_message;
+    error_message << "Error reading mesh parameters: " << itest
+                  << " // FILE:LINE " << __FILE__ << ":" << __LINE__ << "\n";
+    throw std::runtime_error(error_message.str());
+  };
+
+  int nspec_inner_acoustic;
+  int nspec_outer_acoustic;
+  int nspec_inner_elastic;
+  int nspec_outer_elastic;
+  int nspec_inner_poroelastic;
+  int nspec_outer_poroelastic;
+
+  specfem::IO::fortran_read_line(stream, &nspec_inner_acoustic);
+  specfem::IO::fortran_read_line(stream, &nspec_outer_acoustic);
+  specfem::IO::fortran_read_line(stream, &nspec_inner_elastic);
+  specfem::IO::fortran_read_line(stream, &nspec_outer_elastic);
+  specfem::IO::fortran_read_line(stream, &nspec_inner_poroelastic);
+  specfem::IO::fortran_read_line(stream, &nspec_outer_poroelastic);
+
+#ifndef NDEBUG
+  std::cout << "nspec_inner_acoustic:..." << nspec_inner_acoustic << std::endl;
+  std::cout << "nspec_outer_acoustic:..." << nspec_outer_acoustic << std::endl;
+  std::cout << "nspec_inner_elastic:...." << nspec_inner_elastic << std::endl;
+  std::cout << "nspec_outer_elastic:...." << nspec_outer_elastic << std::endl;
+  std::cout << "nspec_inner_poroelastic:." << nspec_inner_poroelastic
+            << std::endl;
+  std::cout << "nspec_outer_poroelastic:." << nspec_outer_poroelastic
+            << std::endl;
+#endif
+
+  // Read test parameter
+  specfem::IO::fortran_read_line(stream, &itest);
+
+  // Throw error if test parameter is not correctly read
+  if (itest != 9993) {
+    std::ostringstream error_message;
+    error_message << "Error reading mesh parameters: " << itest
+                  << " // FILE:LINE " << __FILE__ << ":" << __LINE__ << "\n";
+    throw std::runtime_error(error_message.str());
+  };
+
+  int num_phase_ispec_acoustic;
+  int num_phase_ispec_elastic;
+  int num_phase_ispec_poroelastic;
+  int num_colors_inner_acoustic;
+  int num_colors_outer_acoustic;
+  int num_colors_inner_elastic;
+  int num_colors_outer_elastic;
+
+  specfem::IO::fortran_read_line(stream, &num_phase_ispec_acoustic);
+  specfem::IO::fortran_read_line(stream, &num_phase_ispec_elastic);
+  specfem::IO::fortran_read_line(stream, &num_phase_ispec_poroelastic);
+  specfem::IO::fortran_read_line(stream, &num_colors_inner_acoustic);
+  specfem::IO::fortran_read_line(stream, &num_colors_outer_acoustic);
+  specfem::IO::fortran_read_line(stream, &num_colors_inner_elastic);
+  specfem::IO::fortran_read_line(stream, &num_colors_outer_elastic);
+
+#ifndef NDEBUG
+  std::cout << "num_phase_ispec_acoustic:" << num_phase_ispec_acoustic
+            << std::endl;
+  std::cout << "num_phase_ispec_elastic:." << num_phase_ispec_elastic
+            << std::endl;
+  std::cout << "num_phase_ispec_poroelastic:" << num_phase_ispec_poroelastic
+            << std::endl;
+  std::cout << "num_colors_inner_acoustic:" << num_colors_inner_acoustic
+            << std::endl;
+  std::cout << "num_colors_outer_acoustic:" << num_colors_outer_acoustic
+            << std::endl;
+  std::cout << "num_colors_inner_elastic:" << num_colors_inner_elastic
+            << std::endl;
+  std::cout << "num_colors_outer_elastic:" << num_colors_outer_elastic
+            << std::endl;
+#endif
+
+  // Read test parameter
+  specfem::IO::fortran_read_line(stream, &itest);
+
+  // Throw error if test parameter is not correctly read
+  if (itest != 9992) {
+    std::ostringstream error_message;
+    error_message << "Error reading mesh parameters: " << itest
+                  << " // FILE:LINE " << __FILE__ << ":" << __LINE__ << "\n";
+    throw std::runtime_error(error_message.str());
+  };
+
   mpi->sync_all();
 
-  return mesh_parameters;
+  return { acoustic_simulation,
+           elastic_simulation,
+           poroelastic_simulation,
+           anisotropy,
+           stacey_abc,
+           pml_abc,
+           approximate_ocean_load,
+           use_mesh_coloring,
+           nspec,
+           nspec_poro,
+           nglob,
+           nglob_ocean,
+           nspec2D_bottom,
+           nspec2D_top,
+           nspec2D_xmin,
+           nspec2D_xmax,
+           nspec2D_ymin,
+           nspec2D_ymax,
+           nspec_irregular,
+           num_neighbors,
+           nfaces_surface,
+           num_abs_boundary_faces,
+           num_free_surface_faces,
+           num_coupling_ac_el_faces,
+           num_coupling_ac_po_faces,
+           num_coupling_el_po_faces,
+           num_coupling_po_el_faces,
+           num_interfaces_ext_mesh,
+           max_nibool_interfaces_ext_mesh,
+           nspec_inner_acoustic,
+           nspec_outer_acoustic,
+           nspec_inner_elastic,
+           nspec_outer_elastic,
+           nspec_inner_poroelastic,
+           nspec_outer_poroelastic,
+           num_phase_ispec_acoustic,
+           num_phase_ispec_elastic,
+           num_phase_ispec_poroelastic,
+           num_colors_inner_acoustic,
+           num_colors_outer_acoustic,
+           num_colors_inner_elastic,
+           num_colors_outer_elastic };
 }

--- a/src/parameter_parser/database_configuration.cpp
+++ b/src/parameter_parser/database_configuration.cpp
@@ -1,12 +1,24 @@
 #include "parameter_parser/database_configuration.hpp"
+#include "specfem_mpi/interface.hpp"
 #include "yaml-cpp/yaml.h"
 #include <ostream>
 
 specfem::runtime_configuration::database_configuration::database_configuration(
-    const YAML::Node &Node) {
+    const YAML::Node &database_node) {
   try {
-    *this = specfem::runtime_configuration::database_configuration(
-        Node["mesh-database"].as<std::string>());
+    if (database_node.size() == 1) {
+      *this = specfem::runtime_configuration::database_configuration(
+          database_node["mesh-database"].as<std::string>());
+    } else if (database_node.size() == 2) {
+      *this = specfem::runtime_configuration::database_configuration(
+          database_node["mesh-database"].as<std::string>(),
+          database_node["mesh-parameters"].as<std::string>());
+
+    } else {
+      throw std::runtime_error(
+          "Error reading database configuration. Node size "
+          "is not 1 or 2");
+    }
 
   } catch (YAML::ParserException &e) {
 

--- a/src/specfem3d.cpp
+++ b/src/specfem3d.cpp
@@ -57,11 +57,13 @@ void execute(
   auto start_time = std::chrono::system_clock::now();
   specfem::runtime_configuration::setup setup(parameter_dict, default_dict);
   const auto database_filename = setup.get_databases();
+  const auto mesh_parameters_filename = setup.get_mesh_parameters();
 
   // Read mesh from the mesh database file
   mpi->cout("Reading the mesh...");
   mpi->cout("===================");
-  const auto mesh = specfem::IO::read_3d_mesh(database_filename, mpi);
+  const auto mesh = specfem::IO::read_3d_mesh(mesh_parameters_filename,
+                                              database_filename, mpi);
   mpi->cout("Done.");
   auto span = start_time - std::chrono::system_clock::now();
   mpi->cout("Time to read mesh: " + std::to_string(span.count()) + " seconds");


### PR DESCRIPTION
# Description

Implements the reader for the `mesh_parameters.bin` file

I also implemented a first CMake preset that we can add on to (#450). I will probably add the remaining presets in the next PR. As a result you now can

You can now configure a serial debug version using

```bash
cmake --preset debug && cmake --build --preset debug
```

This will build in the `build/debug` directory, so to access `specfem2d`, you have to

```bash
export PATH="path/to/SPECFEMPP/build/debug/bin/":$PATH
```

**IMPORTANT**: This of course breaks the tests since the tests are built with relative directory locations. We need to add working directories for the tests in `./tests/CMakeLists.txt`.

# Issue Number

Closes #461, partially addresses #450 .

# Checklist

Please make sure to check developer documentation on specfem docs. 

- [x] I ran the code through pre-commit to check style
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms 
