### PR TITLE
Issue 398 - Implement dynamic testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ examples/*/Par_File
 autotuning/
 profiles
 .cache/
+test*.cpp
+test*.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,12 +197,15 @@ add_library(
         src/IO/sources.cpp
         src/IO/receivers.cpp
         src/IO/mesh.cpp
+        # Fortran 2D part
         src/IO/mesh/impl/fortran/dim2/read_boundaries.cpp
         src/IO/mesh/impl/fortran/dim2/read_elements.cpp
         src/IO/mesh/impl/fortran/dim2/read_material_properties.cpp
         src/IO/mesh/impl/fortran/dim2/read_mesh_database.cpp
         src/IO/mesh/impl/fortran/dim2/read_interfaces.cpp
         src/IO/mesh/impl/fortran/dim2/read_parameters.cpp
+        # Fortran 3D part
+        src/IO/mesh/impl/fortran/dim3/read_parameters.cpp
 )
 
 if (NOT HDF5_CXX_BUILD)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,13 +2,26 @@
   "version": 6,
   "configurePresets": [
     {
+      "name": "release",
+      "displayName": "Default Release -- SIMD enabled",
+      "binaryDir": "build/release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "BUILD_TESTS": "ON",
+        "ENABLE_SIMD": "ON",
+        "Kokkos_ARCH_NATIVE": "ON",
+        "Kokkos_ENABLE_AGGRESSIVE_VECTORIZATION": "ON",
+        "Kokkos_ENABLE_ATOMICS_BYPASS": "ON"
+      }
+    },
+    {
       "name": "debug",
-      "displayName": "Debug (Serial)",
+      "displayName": "Default Debug -- SIMD enabled",
       "binaryDir": "build/debug",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "BUILD_TESTS": "ON",
-        "ENABLE_SIMD": "OFF",
+        "ENABLE_SIMD": "ON",
         "Kokkos_ARCH_NATIVE": "ON",
         "Kokkos_ENABLE_AGGRESSIVE_VECTORIZATION": "ON",
         "Kokkos_ENABLE_ATOMICS_BYPASS": "ON"
@@ -17,10 +30,14 @@
   ],
   "buildPresets": [
     {
+      "name": "release",
+      "configurePreset": "release",
+      "targets": ["all"]
+    },
+    {
       "name": "debug",
       "configurePreset": "debug",
-      "targets": ["all"],
-      "jobs": 8
+      "targets": ["all"]
     }
   ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,26 @@
+{
+  "version": 6,
+  "configurePresets": [
+    {
+      "name": "debug",
+      "displayName": "Debug (Serial)",
+      "binaryDir": "build/debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "BUILD_TESTS": "ON",
+        "ENABLE_SIMD": "OFF",
+        "Kokkos_ARCH_NATIVE": "ON",
+        "Kokkos_ENABLE_AGGRESSIVE_VECTORIZATION": "ON",
+        "Kokkos_ENABLE_ATOMICS_BYPASS": "ON"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "debug",
+      "configurePreset": "debug",
+      "targets": ["all"],
+      "jobs": 8
+    }
+  ]
+}

--- a/examples/dim3/homogeneous_halfspace/README.md
+++ b/examples/dim3/homogeneous_halfspace/README.md
@@ -1,0 +1,15 @@
+# Example of a homogeneous half-space in 3D
+
+## Meshing
+
+```bash
+mkdir -p OUTPUT_FILES/DATABASES_MPI
+xmeshfem3D -p DATA/meshfem3D_files/Mesh_Par_file
+xgenerate_databases -p Par_File
+```
+
+Then we can run specfem with the following command:
+
+```bash
+specfem3d -p specfem_config.yaml
+```

--- a/examples/dim3/homogeneous_halfspace/specfem_config.yaml
+++ b/examples/dim3/homogeneous_halfspace/specfem_config.yaml
@@ -45,6 +45,7 @@ parameters:
   ## databases
   databases:
     mesh-database: "OUTPUT_FILES/DATABASES_MPI/proc000000_external_mesh.bin"
+    mesh-parameters: "OUTPUT_FILES/DATABASES_MPI/mesh_parameters.bin"
 
   ## sources
   sources: "/Users/lsawade/SPECFEMPP/examples/homogeneous-medium-flat-topography/source.yaml"

--- a/examples/dim3/homogeneous_halfspace/specfem_config.yaml
+++ b/examples/dim3/homogeneous_halfspace/specfem_config.yaml
@@ -1,0 +1,50 @@
+parameters:
+
+  header:
+    ## Header information is used for logging. It is good practice to give your simulations explicit names
+    title: Isotropic Elastic simulation # name for your simulation
+    # A detailed description for your simulation
+    description: |
+      Material systems : Elastic domain (1)
+      Interfaces : None
+      Sources : Force source (1)
+      Boundary conditions : Neumann BCs on all edges
+
+  simulation-setup:
+    ## quadrature setup
+    quadrature:
+      quadrature-type: GLL4
+
+    ## Solver setup
+    solver:
+      time-marching:
+        time-scheme:
+          type: Newmark
+          dt: 1.1e-3
+          nstep: 1600
+
+    simulation-mode:
+      forward:
+        writer:
+          seismogram:
+            format: "ascii"
+            directory: "/Users/lsawade/SPECFEMPP/examples/homogeneous-medium-flat-topography/OUTPUT_FILES/results"
+
+  receivers:
+    stations: "/Users/lsawade/SPECFEMPP/examples/homogeneous-medium-flat-topography/OUTPUT_FILES/STATIONS"
+    angle: 0.0
+    seismogram-type:
+      - velocity
+    nstep_between_samples: 1
+
+  ## Runtime setup
+  run-setup:
+    number-of-processors: 1
+    number-of-runs: 1
+
+  ## databases
+  databases:
+    mesh-database: "OUTPUT_FILES/DATABASES_MPI/proc000000_external_mesh.bin"
+
+  ## sources
+  sources: "/Users/lsawade/SPECFEMPP/examples/homogeneous-medium-flat-topography/source.yaml"

--- a/fortran/meshfem3d/generate_databases/CMakeLists.txt
+++ b/fortran/meshfem3d/generate_databases/CMakeLists.txt
@@ -43,6 +43,7 @@ set(MESHFEM3D_GENERATE_DATABASES_MODULE
   read_parameters.f90
   read_partition_files.f90
   save_arrays_solver.F90
+  save_parameters.f90
   setup_color_perm.f90
   setup_mesh_adjacency.f90
   setup_mesh.f90

--- a/fortran/meshfem3d/generate_databases/create_regions_mesh.f90
+++ b/fortran/meshfem3d/generate_databases/create_regions_mesh.f90
@@ -354,6 +354,7 @@
     write(IMAIN,*) '  ...saving mesh databases'
     call flush_IMAIN()
   endif
+  call save_parameters()
   call save_arrays_solver_mesh()
 
   ! user output
@@ -1697,7 +1698,7 @@ contains
     num_phase_ispec_acoustic = max(nspec_inner_acoustic,nspec_outer_acoustic)
     if (num_phase_ispec_acoustic < 0) stop 'error acoustic simulation: num_phase_ispec_acoustic is < zero'
 
-    allocate( phase_ispec_inner_acoustic(num_phase_ispec_acoustic,2),stat=ier)
+    allocate(phase_ispec_inner_acoustic(num_phase_ispec_acoustic,2),stat=ier)
     if (ier /= 0) call exit_MPI_without_rank('error allocating array 828')
     if (ier /= 0) stop 'error allocating array phase_ispec_inner_acoustic'
     phase_ispec_inner_acoustic(:,:) = 0

--- a/fortran/meshfem3d/generate_databases/save_arrays_solver.F90
+++ b/fortran/meshfem3d/generate_databases/save_arrays_solver.F90
@@ -127,6 +127,7 @@ module save_arrays_module
   use wavefield_discontinuity_generate_databases, only: &
                               save_arrays_solver_mesh_wavefield_discontinuity
 
+
   implicit none
 
   ! local parameters

--- a/fortran/meshfem3d/generate_databases/save_parameters.f90
+++ b/fortran/meshfem3d/generate_databases/save_parameters.f90
@@ -5,7 +5,7 @@ subroutine save_parameters()
   use shared_parameters, only: LOCAL_PATH, MAX_STRING_LEN
 
   use generate_databases_par, only: &
-    IOUT, myrank, &
+    IOUT, myrank, sizeprocs, &
     NDIM, NSPEC_AB, NGLOB_AB, &
     NGLLX, NGLLY, NGLLZ, nfaces_surface, num_neighbors_all, NGLLSQUARE, &
     nspec2D_xmin, nspec2D_xmin, nspec2D_ymin, nspec2D_ymin, &
@@ -69,6 +69,7 @@ subroutine save_parameters()
       WRITE(IOUT) NGLLY
       WRITE(IOUT) NGLLZ
       WRITE(IOUT) NGLLSQUARE
+      WRITE(IOUT) sizeprocs
 
       ! Write test parameter
       itest = 9997

--- a/fortran/meshfem3d/generate_databases/save_parameters.f90
+++ b/fortran/meshfem3d/generate_databases/save_parameters.f90
@@ -58,7 +58,6 @@ subroutine save_parameters()
       WRITE(IOUT) APPROXIMATE_OCEAN_LOAD
       WRITE(IOUT) USE_MESH_COLORING_GPU
 
-
       ! Write test parameter
       itest = 9998
       WRITE(IOUT) itest
@@ -79,25 +78,25 @@ subroutine save_parameters()
       WRITE(IOUT) NSPEC_PORO ! nspec_poro == nspec, if POROELASTIC_SIMULATION
       WRITE(IOUT) NGLOB_AB ! nglob
       WRITE(IOUT) NGLOB_OCEAN
-      WRITE(IOUT) NSPEC2D_BOTTOM
-      WRITE(IOUT) NSPEC2D_TOP
-      WRITE(IOUT) nspec_irregular
 
       ! Write test parameter
       WRITE(IOUT) itest
       itest = 9996
 
-      WRITE(IOUT) num_neighbors_all
-      WRITE(IOUT) nfaces_surface
+      WRITE(IOUT) NSPEC2D_BOTTOM
+      WRITE(IOUT) NSPEC2D_TOP
       WRITE(IOUT) nspec2D_xmin
-      WRITE(IOUT) nspec2D_xmin
+      WRITE(IOUT) nspec2D_xmax
       WRITE(IOUT) nspec2D_ymin
-      WRITE(IOUT) nspec2D_ymin
+      WRITE(IOUT) nspec2D_ymax
+      WRITE(IOUT) nspec_irregular
 
       ! Write test parameter
       WRITE(IOUT) itest
       itest = 9995
 
+      WRITE(IOUT) num_neighbors_all
+      WRITE(IOUT) nfaces_surface
       WRITE(IOUT) num_abs_boundary_faces
       WRITE(IOUT) num_free_surface_faces
       WRITE(IOUT) num_coupling_ac_el_faces

--- a/fortran/meshfem3d/generate_databases/save_parameters.f90
+++ b/fortran/meshfem3d/generate_databases/save_parameters.f90
@@ -71,8 +71,8 @@ subroutine save_parameters()
       WRITE(IOUT) NGLLSQUARE
 
       ! Write test parameter
-      WRITE(IOUT) itest
       itest = 9997
+      WRITE(IOUT) itest
 
       WRITE(IOUT) NSPEC_AB ! nspec
       WRITE(IOUT) NSPEC_PORO ! nspec_poro == nspec, if POROELASTIC_SIMULATION
@@ -80,8 +80,8 @@ subroutine save_parameters()
       WRITE(IOUT) NGLOB_OCEAN
 
       ! Write test parameter
-      WRITE(IOUT) itest
       itest = 9996
+      WRITE(IOUT) itest
 
       WRITE(IOUT) NSPEC2D_BOTTOM
       WRITE(IOUT) NSPEC2D_TOP
@@ -92,8 +92,8 @@ subroutine save_parameters()
       WRITE(IOUT) nspec_irregular
 
       ! Write test parameter
-      WRITE(IOUT) itest
       itest = 9995
+      WRITE(IOUT) itest
 
       WRITE(IOUT) num_neighbors_all
       WRITE(IOUT) nfaces_surface
@@ -107,8 +107,8 @@ subroutine save_parameters()
       WRITE(IOUT) max_nibool_interfaces_ext_mesh
 
       ! Write test parameter
-      WRITE(IOUT) itest
       itest = 9994
+      WRITE(IOUT) itest
 
       WRITE(IOUT) nspec_inner_acoustic
       WRITE(IOUT) nspec_outer_acoustic
@@ -118,8 +118,8 @@ subroutine save_parameters()
       WRITE(IOUT) nspec_outer_poroelastic
 
       ! Write test parameter
-      WRITE(IOUT) itest
       itest = 9993
+      WRITE(IOUT) itest
 
       WRITE(IOUT) num_phase_ispec_acoustic
       WRITE(IOUT) num_phase_ispec_elastic
@@ -130,8 +130,8 @@ subroutine save_parameters()
       WRITE(IOUT) num_colors_outer_elastic
 
       ! Write test parameter
-      WRITE(IOUT) itest
       itest = 9992
+      WRITE(IOUT) itest
   endif
 
 end subroutine save_parameters

--- a/fortran/meshfem3d/generate_databases/save_parameters.f90
+++ b/fortran/meshfem3d/generate_databases/save_parameters.f90
@@ -1,0 +1,138 @@
+subroutine save_parameters()
+
+! stores a header file of parameters needed by the solver
+
+  use shared_parameters, only: LOCAL_PATH, MAX_STRING_LEN
+
+  use generate_databases_par, only: &
+    IOUT, myrank, &
+    NDIM, NSPEC_AB, NGLOB_AB, &
+    NGLLX, NGLLY, NGLLZ, nfaces_surface, num_neighbors_all, NGLLSQUARE, &
+    nspec2D_xmin, nspec2D_xmin, nspec2D_ymin, nspec2D_ymin, &
+    NSPEC2D_BOTTOM, NSPEC2D_TOP, &
+    ACOUSTIC_SIMULATION, ELASTIC_SIMULATION, POROELASTIC_SIMULATION, &
+    ANISOTROPY, &
+    STACEY_ABSORBING_CONDITIONS, PML_CONDITIONS, APPROXIMATE_OCEAN_LOAD, &
+    USE_MESH_COLORING_GPU, &
+    num_interfaces_ext_mesh, max_nibool_interfaces_ext_mesh
+
+  use create_regions_mesh_ext_par, only: NSPEC_PORO, &
+    NGLOB_OCEAN, nspec_irregular, &
+    num_abs_boundary_faces, num_free_surface_faces, &
+    num_coupling_ac_el_faces, num_coupling_ac_po_faces, &
+    num_coupling_el_po_faces, &
+    nspec_inner_acoustic, nspec_outer_acoustic, &
+    nspec_inner_elastic, nspec_outer_elastic, &
+    nspec_inner_poroelastic, nspec_outer_poroelastic, &
+    num_phase_ispec_acoustic, num_phase_ispec_elastic, &
+    num_phase_ispec_poroelastic, &
+    num_colors_inner_acoustic, num_colors_outer_acoustic, &
+    num_colors_inner_elastic, num_colors_outer_elastic
+
+
+
+  ! Error handling
+  integer :: ier
+
+  ! Test write
+  integer :: itest
+  ! name of the database file
+  character(len=MAX_STRING_LEN) :: filename
+  filename = LOCAL_PATH(1:len_trim(LOCAL_PATH)) // '/mesh_parameters.bin'
+
+  if (myrank == 0) then
+    open(unit=IOUT,file=trim(filename),status='unknown',action='write',form='unformatted',iostat=ier)
+    if (ier /= 0) stop 'error opening database mesh_parameters.bin'
+
+      ! Write test parameter
+      itest = 9999
+      WRITE(IOUT) itest
+
+      ! Booleans
+      WRITE(IOUT) ACOUSTIC_SIMULATION
+      WRITE(IOUT) ELASTIC_SIMULATION
+      WRITE(IOUT) POROELASTIC_SIMULATION
+      WRITE(IOUT) ANISOTROPY
+      WRITE(IOUT) STACEY_ABSORBING_CONDITIONS
+      WRITE(IOUT) PML_CONDITIONS
+      WRITE(IOUT) APPROXIMATE_OCEAN_LOAD
+      WRITE(IOUT) USE_MESH_COLORING_GPU
+
+
+      ! Write test parameter
+      itest = 9998
+      WRITE(IOUT) itest
+
+
+      ! Integers
+      WRITE(IOUT) NDIM
+      WRITE(IOUT) NGLLX
+      WRITE(IOUT) NGLLY
+      WRITE(IOUT) NGLLZ
+      WRITE(IOUT) NGLLSQUARE
+
+      ! Write test parameter
+      WRITE(IOUT) itest
+      itest = 9997
+
+      WRITE(IOUT) NSPEC_AB ! nspec
+      WRITE(IOUT) NSPEC_PORO ! nspec_poro == nspec, if POROELASTIC_SIMULATION
+      WRITE(IOUT) NGLOB_AB ! nglob
+      WRITE(IOUT) NGLOB_OCEAN
+      WRITE(IOUT) NSPEC2D_BOTTOM
+      WRITE(IOUT) NSPEC2D_TOP
+      WRITE(IOUT) nspec_irregular
+
+      ! Write test parameter
+      WRITE(IOUT) itest
+      itest = 9996
+
+      WRITE(IOUT) num_neighbors_all
+      WRITE(IOUT) nfaces_surface
+      WRITE(IOUT) nspec2D_xmin
+      WRITE(IOUT) nspec2D_xmin
+      WRITE(IOUT) nspec2D_ymin
+      WRITE(IOUT) nspec2D_ymin
+
+      ! Write test parameter
+      WRITE(IOUT) itest
+      itest = 9995
+
+      WRITE(IOUT) num_abs_boundary_faces
+      WRITE(IOUT) num_free_surface_faces
+      WRITE(IOUT) num_coupling_ac_el_faces
+      WRITE(IOUT) num_coupling_ac_po_faces
+      WRITE(IOUT) num_coupling_el_po_faces
+      WRITE(IOUT) num_coupling_po_el_faces
+      WRITE(IOUT) num_interfaces_ext_mesh
+      WRITE(IOUT) max_nibool_interfaces_ext_mesh
+
+      ! Write test parameter
+      WRITE(IOUT) itest
+      itest = 9994
+
+      WRITE(IOUT) nspec_inner_acoustic
+      WRITE(IOUT) nspec_outer_acoustic
+      WRITE(IOUT) nspec_inner_elastic
+      WRITE(IOUT) nspec_outer_elastic
+      WRITE(IOUT) nspec_inner_poroelastic
+      WRITE(IOUT) nspec_outer_poroelastic
+
+      ! Write test parameter
+      WRITE(IOUT) itest
+      itest = 9993
+
+      WRITE(IOUT) num_phase_ispec_acoustic
+      WRITE(IOUT) num_phase_ispec_elastic
+      WRITE(IOUT) num_phase_ispec_poroelastic
+      WRITE(IOUT) num_colors_inner_acoustic
+      WRITE(IOUT) num_colors_outer_acoustic
+      WRITE(IOUT) num_colors_inner_elastic
+      WRITE(IOUT) num_colors_outer_elastic
+
+      ! Write test parameter
+      WRITE(IOUT) itest
+      itest = 9992
+  endif
+
+end subroutine save_parameters

--- a/fortran/meshfem3d/generate_databases/setup_mesh.f90
+++ b/fortran/meshfem3d/generate_databases/setup_mesh.f90
@@ -30,7 +30,23 @@
 
 ! mesh creation for solver
 
-  use generate_databases_par
+  use generate_databases_par, only: NSPEC_AB, NGLLX, NGLLY, NGLLZ, NGNOD2D, &
+                                    ibool, xstore, ystore, zstore, &
+                                    ispec_is_surface_external_mesh, &
+                                    iglob_is_surface_external_mesh, &
+                                    neighbors_xadj, neighbors_adjncy, &
+                                    HUGEVAL, IMAIN, max_elevation, &
+                                    max_elevation_all, min_elevation, &
+                                    min_elevation_all, max_interface_size_ext_mesh, &
+                                    nspec2D_xmin, nspec2D_xmax, nspec2D_ymin, &
+                                    nspec2D_ymax, nspec2D_bottom, nspec2D_top, &
+                                    max_memory_size, max_memory_size_request, &
+                                    myrank, nelmnts_ext_mesh, nmat_ext_mesh,num_interfaces_ext_mesh, &
+                                    nnodes_ext_mesh, npointot, nspec2D_top_ext, &
+                                    nodes_ibelm_top, nodes_coords_ext_mesh
+
+
+
 
   implicit none
 

--- a/include/IO/interface.hpp
+++ b/include/IO/interface.hpp
@@ -25,7 +25,9 @@ specfem::mesh::mesh<specfem::dimension::type::dim2>
 read_2d_mesh(const std::string filename, const specfem::MPI::MPI *mpi);
 
 specfem::mesh::mesh<specfem::dimension::type::dim3>
-read_3d_mesh(const std::string filename, const specfem::MPI::MPI *mpi);
+read_3d_mesh(const std::string mesh_parameters_file,
+             const std::string mesh_databases_file,
+             const specfem::MPI::MPI *mpi);
 /**
  * @brief Read station file
  *

--- a/include/IO/mesh/impl/fortran/dim3/read_parameters.hpp
+++ b/include/IO/mesh/impl/fortran/dim3/read_parameters.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "IO/fortranio/interface.hpp"
+#include "mesh/parameters/parameters.hpp"
+#include "specfem_mpi/interface.hpp"
+
+namespace specfem {
+namespace IO {
+namespace mesh {
+namespace impl {
+namespace fortran {
+namespace dim3 {
+
+/*
+ * @brief Read paramters from 3D mesh database
+ *
+ * @param stream Input stream
+ * @param mpi MPI object
+ * @return specfem::mesh::parameters<specfem::dimension::type::dim2> Mesh
+ * parameters
+ */
+specfem::mesh::parameters<specfem::dimension::type::dim3>
+read_mesh_parameters(std::ifstream &stream, const specfem::MPI::MPI *mpi);
+
+} // namespace dim3
+} // namespace fortran
+} // namespace impl
+} // namespace mesh
+} // namespace IO
+} // namespace specfem

--- a/include/mesh/mesh.hpp
+++ b/include/mesh/mesh.hpp
@@ -104,6 +104,9 @@ template <> struct mesh<specfem::dimension::type::dim3> {
   constexpr static auto dimension =
       specfem::dimension::type::dim3; ///< Dimension
 
+  // Struct to store all the mesh parameter
+  specfem::mesh::parameters<dimension> parameters;
+
   // int npgeo; ///< Total number of spectral element control nodes
   // int nspec; ///< Total number of spectral elements
   // int nproc; ///< Total number of processors

--- a/include/mesh/mesh.hpp
+++ b/include/mesh/mesh.hpp
@@ -108,6 +108,7 @@ template <> struct mesh<specfem::dimension::type::dim3> {
   // Struct to store all the mesh parameter
   specfem::mesh::parameters<dimension> parameters;
 
+  //
   // int npgeo; ///< Total number of spectral element control nodes
   // int nspec; ///< Total number of spectral elements
   // int nproc; ///< Total number of processors

--- a/include/mesh/mesh.hpp
+++ b/include/mesh/mesh.hpp
@@ -5,6 +5,7 @@
 #include "coupled_interfaces/coupled_interfaces.hpp"
 #include "elements/axial_elements.hpp"
 #include "elements/tangential_elements.hpp"
+#include "enumerations/dimension.hpp"
 #include "enumerations/interface.hpp"
 #include "materials/materials.hpp"
 #include "mesh/tags/tags.hpp"

--- a/include/mesh/parameters/parameters.hpp
+++ b/include/mesh/parameters/parameters.hpp
@@ -101,6 +101,7 @@ template <> struct parameters<specfem::dimension::type::dim3> {
   int nglly;      ///< Number of GLL points in y
   int ngllz;      ///< Number of GLL points in z
   int ngllsquare; ///< Number of GLL points in square
+  int nproc;      ///< Number of processors
 
   // Integer Parameters: Elements/Nodes
   int nspec;           ///< Number of spectral elements (SEs)

--- a/include/mesh/parameters/parameters.hpp
+++ b/include/mesh/parameters/parameters.hpp
@@ -95,6 +95,13 @@ template <> struct parameters<specfem::dimension::type::dim3> {
   bool approximate_ocean_load; ///< Flag for approx. ocean load
   bool use_mesh_coloring;      ///< Flag for mesh coloring
 
+  // Integer Parameters: Dimensions and GLL layouts
+  int ndim;       ///< Number of dimensions
+  int ngllx;      ///< Number of GLL points in x
+  int nglly;      ///< Number of GLL points in y
+  int ngllz;      ///< Number of GLL points in z
+  int ngllsquare; ///< Number of GLL points in square
+
   // Integer Parameters: Elements/Nodes
   int nspec;           ///< Number of spectral elements (SEs)
   int nspec_poro;      ///< Number of poroelastic SEs
@@ -152,6 +159,8 @@ template <> struct parameters<specfem::dimension::type::dim3> {
    * @param pml_abc Flag for PML absorbing boundary c.
    * @param approximate_ocean_load Flag for approx. ocean load
    * @param use_mesh_coloring Flag for mesh coloring
+   *
+   *
    *
    * @param nspec Number of spectral elements (SEs)
    * @param nspec_poro Number of poroelastic SEs
@@ -246,7 +255,7 @@ template <> struct parameters<specfem::dimension::type::dim3> {
         num_colors_outer_acoustic(num_colors_outer_acoustic),
         num_colors_inner_elastic(num_colors_inner_elastic),
         num_colors_outer_elastic(num_colors_outer_elastic){};
-
+};
 } // namespace mesh
 } // namespace specfem
 

--- a/include/mesh/parameters/parameters.hpp
+++ b/include/mesh/parameters/parameters.hpp
@@ -76,6 +76,177 @@ template <> struct parameters<specfem::dimension::type::dim2> {
         nelem_on_the_axis(nelem_on_the_axis),
         plot_lowerleft_corner_only(plot_lowerleft_corner_only){};
 };
+
+/**
+ * @brief Template specialization for 3D mesh parameters
+ */
+template <> struct parameters<specfem::dimension::type::dim3> {
+  constexpr static auto dimension =
+      specfem::dimension::type::dim3; ///< Dimension
+                                      ///< type
+
+  // Flags
+  bool acoustic_simulation;    ///< Flag for acoustic simulation
+  bool elastic_simulation;     ///< Flag for elastic simulation
+  bool poroelastic_simulation; ///< Flag for poroelastic simulation
+  bool anisotropy;             ///< Flag for anisotropy
+  bool stacey_abc;             ///< Flag for Stacey absorbing boundary c.
+  bool pml_abc;                ///< Flag for PML absorbing boundary c.
+  bool approximate_ocean_load; ///< Flag for approx. ocean load
+  bool use_mesh_coloring;      ///< Flag for mesh coloring
+
+  // Integer Parameters: Elements/Nodes
+  int nspec;           ///< Number of spectral elements (SEs)
+  int nspec_poro;      ///< Number of poroelastic SEs
+  int nglob;           ///< Number of global nodes
+  int nglob_ocean;     ///< Number of global ocean nodes
+  int nspec2D_bottom;  ///< Number of 2D SEs at the bottom
+  int nspec2D_top;     ///< Number of 2D SEs at the top
+  int nspec2D_xmin;    ///< Number of 2D SEs at the left
+  int nspec2D_xmax;    ///< Number of 2D SEs at the right
+  int nspec2D_ymin;    ///< Number of 2D SEs at the front
+  int nspec2D_ymax;    ///< Number of 2D SEs at the back
+  int nspec_irregular; ///< Number of irregular SEs
+
+  // Integer Parameters: Mesh
+  int num_neighbors;                  ///< Number of neighbors
+  int nfaces_surface;                 ///< Number of faces on the surface
+  int num_abs_boundary_faces;         ///< Number of absorbing boundary faces
+  int num_free_surface_faces;         ///< Number of free surface faces
+  int num_coupling_ac_el_faces;       ///< Number of acoustic-elastic faces
+  int num_coupling_ac_po_faces;       ///< Number of acoustic-poroelastic faces
+  int num_coupling_el_po_faces;       ///< Number of elastic-poroelastic faces
+  int num_coupling_po_el_faces;       ///< Number of poroelastic-elastic faces
+  int num_interfaces_ext_mesh;        ///< Number of external mesh interfaces
+  int max_nibool_interfaces_ext_mesh; ///< Maximum number of interfaces
+
+  // Integer Parameters: Nspec Inner/Outer
+  int nspec_inner_acoustic;    ///< Number of inner acoustic SEs
+  int nspec_outer_acoustic;    ///< Number of outer acoustic SEs
+  int nspec_inner_elastic;     ///< Number of inner elastic SEs
+  int nspec_outer_elastic;     ///< Number of outer elastic SEs
+  int nspec_inner_poroelastic; ///< Number of inner poroelastic SEs
+  int nspec_outer_poroelastic; ///< Number of outer poroelastic SEs
+
+  // Integer Parameters: coloring
+  int num_phase_ispec_acoustic;
+  int num_phase_ispec_elastic;
+  int num_phase_ispec_poroelastic;
+  int num_colors_inner_acoustic;
+  int num_colors_outer_acoustic;
+  int num_colors_inner_elastic;
+  int num_colors_outer_elastic;
+
+  /**
+   * @brief Default constructor
+   *
+   */
+  parameters(){};
+
+  /** Constructor
+   * @param acoustic_simulation Flag for acoustic simulation
+   * @param elastic_simulation Flag for elastic simulation
+   * @param poroelastic_simulation Flag for poroelastic simulation
+   * @param anisotropy Flag for anisotropy
+   * @param stacey_abc Flag for Stacey absorbing boundary c.
+   * @param pml_abc Flag for PML absorbing boundary c.
+   * @param approximate_ocean_load Flag for approx. ocean load
+   * @param use_mesh_coloring Flag for mesh coloring
+   *
+   * @param nspec Number of spectral elements (SEs)
+   * @param nspec_poro Number of poroelastic SEs
+   * @param nglob Number of global nodes
+   * @param nglob_ocean Number of global ocean nodes
+   * @param nspec2D_bottom Number of 2D SEs at the bottom
+   * @param nspec2D_top Number of 2D SEs at the top
+   * @param nspec2D_xmin Number of 2D SEs at the left
+   * @param nspec2D_xmax Number of 2D SEs at the right
+   * @param nspec2D_ymin Number of 2D SEs at the front
+   * @param nspec2D_ymax Number of 2D SEs at the back
+   * @param nspec_irregular Number of irregular SEs
+   *
+   * @param num_neighbors Number of neighbors
+   * @param nfaces_surface Number of faces on the surface
+   * @param num_abs_boundary_faces Number of absorbing boundary faces
+   * @param num_free_surface_faces Number of free surface faces
+   * @param num_coupling_ac_el_faces Number of acoustic-elastic faces
+   * @param num_coupling_ac_po_faces Number of acoustic-poroelastic faces
+   * @param num_coupling_el_po_faces Number of elastic-poroelastic faces
+   * @param num_coupling_po_el_faces Number of poroelastic-elastic faces
+   * @param num_interfaces_ext_mesh Number of external mesh interfaces
+   * @param max_nibool_interfaces_ext_mesh Maximum number of interfaces
+   *
+   * @param nspec_inner_acoustic Number of inner acoustic SEs
+   * @param nspec_outer_acoustic Number of outer acoustic SEs
+   * @param nspec_inner_elastic Number of inner elastic SEs
+   * @param nspec_outer_elastic Number of outer elastic SEs
+   * @param nspec_inner_poroelastic Number of inner poroelastic SEs
+   * @param nspec_outer_poroelastic Number of outer poroelastic SEs
+   *
+   * @param num_phase_ispec_acoustic
+   * @param num_phase_ispec_elastic
+   * @param num_phase_ispec_poroelastic
+   * @param num_colors_inner_acoustic
+   * @param num_colors_outer_acoustic
+   * @param num_colors_inner_elastic
+   * @param num_colors_outer_elastic
+   *
+   */
+  parameters(
+      const bool acoustic_simulation, const bool elastic_simulation,
+      const bool poroelastic_simulation, const bool anisotropy,
+      const bool stacey_abc, const bool pml_abc,
+      const bool approximate_ocean_load, const bool use_mesh_coloring,
+      const int nspec, const int nspec_poro, const int nglob,
+      const int nglob_ocean, const int nspec2D_bottom, const int nspec2D_top,
+      const int nspec2D_xmin, const int nspec2D_xmax, const int nspec2D_ymin,
+      const int nspec2D_ymax, const int nspec_irregular,
+      const int num_neighbors, const int nfaces_surface,
+      const int num_abs_boundary_faces, const int num_free_surface_faces,
+      const int num_coupling_ac_el_faces, const int num_coupling_ac_po_faces,
+      const int num_coupling_el_po_faces, const int num_coupling_po_el_faces,
+      const int num_interfaces_ext_mesh,
+      const int max_nibool_interfaces_ext_mesh, const int nspec_inner_acoustic,
+      const int nspec_outer_acoustic, const int nspec_inner_elastic,
+      const int nspec_outer_elastic, const int nspec_inner_poroelastic,
+      const int nspec_outer_poroelastic, const int num_phase_ispec_acoustic,
+      const int num_phase_ispec_elastic, const int num_phase_ispec_poroelastic,
+      const int num_colors_inner_acoustic, const int num_colors_outer_acoustic,
+      const int num_colors_inner_elastic, const int num_colors_outer_elastic)
+      : acoustic_simulation(acoustic_simulation),
+        elastic_simulation(elastic_simulation),
+        poroelastic_simulation(poroelastic_simulation), anisotropy(anisotropy),
+        stacey_abc(stacey_abc), pml_abc(pml_abc),
+        approximate_ocean_load(approximate_ocean_load),
+        use_mesh_coloring(use_mesh_coloring), nspec(nspec),
+        nspec_poro(nspec_poro), nglob(nglob), nglob_ocean(nglob_ocean),
+        nspec2D_bottom(nspec2D_bottom), nspec2D_top(nspec2D_top),
+        nspec2D_xmin(nspec2D_xmin), nspec2D_xmax(nspec2D_xmax),
+        nspec2D_ymin(nspec2D_ymin), nspec2D_ymax(nspec2D_ymax),
+        nspec_irregular(nspec_irregular), num_neighbors(num_neighbors),
+        nfaces_surface(nfaces_surface),
+        num_abs_boundary_faces(num_abs_boundary_faces),
+        num_free_surface_faces(num_free_surface_faces),
+        num_coupling_ac_el_faces(num_coupling_ac_el_faces),
+        num_coupling_ac_po_faces(num_coupling_ac_po_faces),
+        num_coupling_el_po_faces(num_coupling_el_po_faces),
+        num_coupling_po_el_faces(num_coupling_po_el_faces),
+        num_interfaces_ext_mesh(num_interfaces_ext_mesh),
+        max_nibool_interfaces_ext_mesh(max_nibool_interfaces_ext_mesh),
+        nspec_inner_acoustic(nspec_inner_acoustic),
+        nspec_outer_acoustic(nspec_outer_acoustic),
+        nspec_inner_elastic(nspec_inner_elastic),
+        nspec_outer_elastic(nspec_outer_elastic),
+        nspec_inner_poroelastic(nspec_inner_poroelastic),
+        nspec_outer_poroelastic(nspec_outer_poroelastic),
+        num_phase_ispec_acoustic(num_phase_ispec_acoustic),
+        num_phase_ispec_elastic(num_phase_ispec_elastic),
+        num_phase_ispec_poroelastic(num_phase_ispec_poroelastic),
+        num_colors_inner_acoustic(num_colors_inner_acoustic),
+        num_colors_outer_acoustic(num_colors_outer_acoustic),
+        num_colors_inner_elastic(num_colors_inner_elastic),
+        num_colors_outer_elastic(num_colors_outer_elastic){};
+
 } // namespace mesh
 } // namespace specfem
 

--- a/include/parameter_parser/database_configuration.hpp
+++ b/include/parameter_parser/database_configuration.hpp
@@ -23,6 +23,10 @@ public:
   database_configuration(std::string fortran_database)
       : fortran_database(fortran_database){};
 
+  database_configuration(std::string fortran_database,
+                         std::string mesh_parameters)
+      : fortran_database(fortran_database), mesh_parameters(mesh_parameters){};
+
   /**
    * @brief Construct a new run setup object
    *
@@ -32,8 +36,11 @@ public:
 
   std::string get_databases() const { return this->fortran_database; }
 
+  std::string get_mesh_parameters() const { return this->mesh_parameters; };
+
 private:
   std::string fortran_database; ///< location of fortran binary database
+  std::string mesh_parameters;  ///< location of mesh parameter file
 };
 
 } // namespace runtime_configuration

--- a/include/parameter_parser/setup.hpp
+++ b/include/parameter_parser/setup.hpp
@@ -103,6 +103,9 @@ public:
    * to mesh database and source yaml file
    */
   std::string get_databases() const { return databases->get_databases(); }
+  std::string get_mesh_parameters() const {
+    return databases->get_mesh_parameters();
+  }
 
   /**
    * @brief Get the sources YAML object

--- a/src/IO/mesh.cpp
+++ b/src/IO/mesh.cpp
@@ -8,6 +8,7 @@
 #include "IO/mesh/impl/fortran/dim2/read_material_properties.hpp"
 #include "IO/mesh/impl/fortran/dim2/read_mesh_database.hpp"
 #include "IO/mesh/impl/fortran/dim2/read_parameters.hpp"
+#include "IO/mesh/impl/fortran/dim3/read_parameters.hpp"
 #include "enumerations/interface.hpp"
 #include "kokkos_abstractions.h"
 #include "medium/material.hpp"
@@ -227,7 +228,8 @@ specfem::IO::read_2d_mesh(const std::string filename,
 }
 
 specfem::mesh::mesh<specfem::dimension::type::dim3>
-specfem::IO::read_3d_mesh(const std::string filename,
+specfem::IO::read_3d_mesh(const std::string mesh_parameters_file,
+                          const std::string mesh_databases_file,
                           const specfem::MPI::MPI *mpi) {
 
   // Declaring empty mesh objects
@@ -235,10 +237,10 @@ specfem::IO::read_3d_mesh(const std::string filename,
 
   // Open the database file
   std::ifstream stream;
-  stream.open(filename);
+  stream.open(mesh_parameters_file);
 
   if (!stream.is_open()) {
-    throw std::runtime_error("Could not open database file");
+    throw std::runtime_error("Could not open mesh parameter file");
   }
 
   try {
@@ -248,6 +250,18 @@ specfem::IO::read_3d_mesh(const std::string filename,
   } catch (std::runtime_error &e) {
     throw;
   }
+
+  // Mesh Parameters are populated, closing the parameters file.
+  stream.close();
+
+  // Open the database file
+  stream.open(mesh_databases_file);
+
+  if (!stream.is_open()) {
+    throw std::runtime_error("Could not open mesh database file");
+  }
+
+  stream.close();
 
   // // Mesh class to be populated from the database file.
   // try {

--- a/src/IO/mesh.cpp
+++ b/src/IO/mesh.cpp
@@ -240,15 +240,11 @@ specfem::IO::read_3d_mesh(const std::string filename,
   if (!stream.is_open()) {
     throw std::runtime_error("Could not open database file");
   }
-  int nspec, npgeo, nproc;
 
   try {
-    // std::tie(nspec, npgeo, nproc) =
-    //     specfem::IO::mesh::impl::fortran::dim2::read_mesh_database_header(stream,
-    //                                                                 mpi);
-    // mesh.nspec = nspec;
-    // mesh.npgeo = npgeo;
-    // mesh.nproc = nproc;
+    mesh.parameters =
+        specfem::IO::mesh::impl::fortran::dim3::read_mesh_parameters(stream,
+                                                                     mpi);
   } catch (std::runtime_error &e) {
     throw;
   }

--- a/src/IO/mesh/impl/fortran/dim3/read_parameters.cpp
+++ b/src/IO/mesh/impl/fortran/dim3/read_parameters.cpp
@@ -1,0 +1,51 @@
+#include "IO/mesh/impl/fortran/dim3/read_parameters.hpp"
+#include "IO/fortranio/interface.hpp"
+#include "enumerations/dimension.hpp"
+#include "mesh/parameters/parameters.hpp"
+#include "specfem_mpi/interface.hpp"
+
+specfem::mesh::parameters<specfem::dimension::type::dim3>
+specfem::IO::mesh::impl::fortran::dim3::read_mesh_parameters(
+    std::ifstream &stream, const specfem::MPI::MPI *mpi) {
+
+  // Initialize test parameter
+  int itest = -9999;
+
+  // Instantiate parameters object
+  specfem::mesh::parameters<specfem::dimension::type::dim3> mesh_parameters;
+
+  // Read testparamater
+  specfem::IO::fortran_read_line(stream, &itest);
+
+  // Throw error if test parameter is not correctly read
+  if (itest != 9999) {
+    std::ostringstream error_message;
+    error_message << "Error reading mesh parameters: " << itest
+                  << " // FILE:LINE " << __FILE__ << ":" << __LINE__ << "\n";
+    throw std::runtime_error(error_message.str());
+  }
+
+  // Read parameters
+  specfem::IO::fortran_read_line(
+      stream, &mesh_parameters.acoustic_simulation,
+      &mesh_parameters.elastic_simulation,
+      &mesh_parameters.poroelastic_simulation, &mesh_parameters.anisotropy,
+      &mesh_parameters.stacey_abc, &mesh_parameters.pml_abc,
+      &mesh_parameters.approximate_ocean_load,
+      &mesh_parameters.use_mesh_coloring);
+
+  // Read test parameter
+  specfem::IO::fortran_read_line(stream, &itest);
+
+  // Throw error if test parameter is not correctly read
+  if (itest != 9998) {
+    std::ostringstream error_message;
+    error_message << "Error reading mesh parameters: " << itest
+                  << " // FILE:LINE " << __FILE__ << ":" << __LINE__ << "\n";
+    throw std::runtime_error(error_message.str());
+  };
+
+  mpi->sync_all();
+
+  return mesh_parameters;
+}

--- a/src/IO/mesh/impl/fortran/dim3/read_parameters.cpp
+++ b/src/IO/mesh/impl/fortran/dim3/read_parameters.cpp
@@ -73,6 +73,7 @@ specfem::IO::mesh::impl::fortran::dim3::read_mesh_parameters(
   int ngly;
   int ngllz;
   int ngllsquare;
+  int nproc;
 
   // Read parameters
   specfem::IO::fortran_read_line(stream, &ndim);
@@ -80,6 +81,7 @@ specfem::IO::mesh::impl::fortran::dim3::read_mesh_parameters(
   specfem::IO::fortran_read_line(stream, &ngly);
   specfem::IO::fortran_read_line(stream, &ngllz);
   specfem::IO::fortran_read_line(stream, &ngllsquare);
+  specfem::IO::fortran_read_line(stream, &nproc);
 
 #ifndef NDEBUG
   // Print the read parameters
@@ -88,6 +90,7 @@ specfem::IO::mesh::impl::fortran::dim3::read_mesh_parameters(
   std::cout << "ngly:................." << ngly << std::endl;
   std::cout << "ngllz:................" << ngllz << std::endl;
   std::cout << "ngllsquare:..........." << ngllsquare << std::endl;
+  std::cout << "nproc:................" << nproc << std::endl;
 #endif
 
   // Read test parameter

--- a/src/IO/mesh/impl/fortran/dim3/read_parameters.cpp
+++ b/src/IO/mesh/impl/fortran/dim3/read_parameters.cpp
@@ -11,9 +11,6 @@ specfem::IO::mesh::impl::fortran::dim3::read_mesh_parameters(
   // Initialize test parameter
   int itest = -9999;
 
-  // Instantiate parameters object
-  specfem::mesh::parameters<specfem::dimension::type::dim3> mesh_parameters;
-
   // Read testparamater
   specfem::IO::fortran_read_line(stream, &itest);
 
@@ -25,14 +22,39 @@ specfem::IO::mesh::impl::fortran::dim3::read_mesh_parameters(
     throw std::runtime_error(error_message.str());
   }
 
+  // Initialize flags
+  bool acoustic_simulation;
+  bool elastic_simulation;
+  bool poroelastic_simulation;
+  bool anisotropy;
+  bool stacey_abc;
+  bool pml_abc;
+  bool approximate_ocean_load;
+  bool use_mesh_coloring;
+
   // Read parameters
-  specfem::IO::fortran_read_line(
-      stream, &mesh_parameters.acoustic_simulation,
-      &mesh_parameters.elastic_simulation,
-      &mesh_parameters.poroelastic_simulation, &mesh_parameters.anisotropy,
-      &mesh_parameters.stacey_abc, &mesh_parameters.pml_abc,
-      &mesh_parameters.approximate_ocean_load,
-      &mesh_parameters.use_mesh_coloring);
+  specfem::IO::fortran_read_line(stream, &acoustic_simulation);
+  specfem::IO::fortran_read_line(stream, &elastic_simulation);
+  specfem::IO::fortran_read_line(stream, &poroelastic_simulation);
+  specfem::IO::fortran_read_line(stream, &anisotropy);
+  specfem::IO::fortran_read_line(stream, &stacey_abc);
+  specfem::IO::fortran_read_line(stream, &pml_abc);
+  specfem::IO::fortran_read_line(stream, &approximate_ocean_load);
+  specfem::IO::fortran_read_line(stream, &use_mesh_coloring);
+
+#ifndef NDEBUG
+  // Print the read parameters
+  std::cout << "acoustic_simulation:...." << acoustic_simulation << std::endl;
+  std::cout << "elastic_simulation:....." << elastic_simulation << std::endl;
+  std::cout << "poroelastic_simulation:." << poroelastic_simulation
+            << std::endl;
+  std::cout << "anisotropy:............." << anisotropy << std::endl;
+  std::cout << "stacey_abc:............." << stacey_abc << std::endl;
+  std::cout << "pml_abc:................" << pml_abc << std::endl;
+  std::cout << "approximate_ocean_load:." << approximate_ocean_load
+            << std::endl;
+  std::cout << "use_mesh_coloring:......" << use_mesh_coloring << std::endl;
+#endif
 
   // Read test parameter
   specfem::IO::fortran_read_line(stream, &itest);
@@ -45,7 +67,284 @@ specfem::IO::mesh::impl::fortran::dim3::read_mesh_parameters(
     throw std::runtime_error(error_message.str());
   };
 
+  // Initialize first bout of integer parameters
+  int ndim;
+  int ngllx;
+  int ngly;
+  int ngllz;
+  int ngllsquare;
+
+  // Read parameters
+  specfem::IO::fortran_read_line(stream, &ndim);
+  specfem::IO::fortran_read_line(stream, &ngllx);
+  specfem::IO::fortran_read_line(stream, &ngly);
+  specfem::IO::fortran_read_line(stream, &ngllz);
+  specfem::IO::fortran_read_line(stream, &ngllsquare);
+
+#ifndef NDEBUG
+  // Print the read parameters
+  std::cout << "ndim:................." << ndim << std::endl;
+  std::cout << "ngllx:................" << ngllx << std::endl;
+  std::cout << "ngly:................." << ngly << std::endl;
+  std::cout << "ngllz:................" << ngllz << std::endl;
+  std::cout << "ngllsquare:..........." << ngllsquare << std::endl;
+#endif
+
+  // Read test parameter
+  specfem::IO::fortran_read_line(stream, &itest);
+
+  // Throw error if test parameter is not correctly read
+  if (itest != 9997) {
+    std::ostringstream error_message;
+    error_message << "Error reading mesh parameters: " << itest
+                  << " // FILE:LINE " << __FILE__ << ":" << __LINE__ << "\n";
+    throw std::runtime_error(error_message.str());
+  };
+
+  // Initialize second bout of integer parameters
+  int nspec;
+  int nspec_poro;
+  int nglob;
+  int nglob_ocean;
+
+  // Read parameters
+  specfem::IO::fortran_read_line(stream, &nspec);
+  specfem::IO::fortran_read_line(stream, &nspec_poro);
+  specfem::IO::fortran_read_line(stream, &nglob);
+  specfem::IO::fortran_read_line(stream, &nglob_ocean);
+
+#ifndef NDEBUG
+  // Print the read parameters
+  std::cout << "nspec:................." << nspec << std::endl;
+  std::cout << "nspec_poro:............" << nspec_poro << std::endl;
+  std::cout << "nglob:................." << nglob << std::endl;
+  std::cout << "nglob_ocean:............" << nglob_ocean << std::endl;
+#endif
+
+  // Read test parameter
+  specfem::IO::fortran_read_line(stream, &itest);
+
+  // Throw error if test parameter is not correctly read
+  if (itest != 9996) {
+    std::ostringstream error_message;
+    error_message << "Error reading mesh parameters: " << itest
+                  << " // FILE:LINE " << __FILE__ << ":" << __LINE__ << "\n";
+    throw std::runtime_error(error_message.str());
+  };
+
+  int nspec2D_bottom;
+  int nspec2D_top;
+  int nspec2D_xmin;
+  int nspec2D_xmax;
+  int nspec2D_ymin;
+  int nspec2D_ymax;
+  int nspec_irregular;
+
+  specfem::IO::fortran_read_line(stream, &nspec2D_bottom);
+  specfem::IO::fortran_read_line(stream, &nspec2D_top);
+  specfem::IO::fortran_read_line(stream, &nspec2D_xmin);
+  specfem::IO::fortran_read_line(stream, &nspec2D_xmax);
+  specfem::IO::fortran_read_line(stream, &nspec2D_ymin);
+  specfem::IO::fortran_read_line(stream, &nspec2D_ymax);
+  specfem::IO::fortran_read_line(stream, &nspec_irregular);
+
+#ifndef NDEBUG
+  std::cout << "nspec2D_bottom:........" << nspec2D_bottom << std::endl;
+  std::cout << "nspec2D_top:..........." << nspec2D_top << std::endl;
+  std::cout << "nspec2D_xmin:.........." << nspec2D_xmin << std::endl;
+  std::cout << "nspec2D_xmax:.........." << nspec2D_xmax << std::endl;
+  std::cout << "nspec2D_ymin:.........." << nspec2D_ymin << std::endl;
+  std::cout << "nspec2D_ymax:.........." << nspec2D_ymax << std::endl;
+  std::cout << "nspec_irregular:......." << nspec_irregular << std::endl;
+#endif
+
+  // Read test parameter
+  specfem::IO::fortran_read_line(stream, &itest);
+
+  // Throw error if test parameter is not correctly read
+  if (itest != 9995) {
+    std::ostringstream error_message;
+    error_message << "Error reading mesh parameters: " << itest
+                  << " // FILE:LINE " << __FILE__ << ":" << __LINE__ << "\n";
+    throw std::runtime_error(error_message.str());
+  };
+
+  int num_neighbors;
+  int nfaces_surface;
+  int num_abs_boundary_faces;
+  int num_free_surface_faces;
+  int num_coupling_ac_el_faces;
+  int num_coupling_ac_po_faces;
+  int num_coupling_el_po_faces;
+  int num_coupling_po_el_faces;
+  int num_interfaces_ext_mesh;
+  int max_nibool_interfaces_ext_mesh;
+
+  specfem::IO::fortran_read_line(stream, &num_neighbors);
+  specfem::IO::fortran_read_line(stream, &nfaces_surface);
+  specfem::IO::fortran_read_line(stream, &num_abs_boundary_faces);
+  specfem::IO::fortran_read_line(stream, &num_free_surface_faces);
+  specfem::IO::fortran_read_line(stream, &num_coupling_ac_el_faces);
+  specfem::IO::fortran_read_line(stream, &num_coupling_ac_po_faces);
+  specfem::IO::fortran_read_line(stream, &num_coupling_el_po_faces);
+  specfem::IO::fortran_read_line(stream, &num_coupling_po_el_faces);
+  specfem::IO::fortran_read_line(stream, &num_interfaces_ext_mesh);
+  specfem::IO::fortran_read_line(stream, &max_nibool_interfaces_ext_mesh);
+
+#ifndef NDEBUG
+  std::cout << "num_neighbors:.........." << num_neighbors << std::endl;
+  std::cout << "nfaces_surface:........." << nfaces_surface << std::endl;
+  std::cout << "num_abs_boundary_faces:." << num_abs_boundary_faces
+            << std::endl;
+  std::cout << "num_free_surface_faces:." << num_free_surface_faces
+            << std::endl;
+  std::cout << "num_coupling_ac_el_faces:" << num_coupling_ac_el_faces
+            << std::endl;
+  std::cout << "num_coupling_ac_po_faces:" << num_coupling_ac_po_faces
+            << std::endl;
+  std::cout << "num_coupling_el_po_faces:" << num_coupling_el_po_faces
+            << std::endl;
+  std::cout << "num_coupling_po_el_faces:" << num_coupling_po_el_faces
+            << std::endl;
+  std::cout << "num_interfaces_ext_mesh:." << num_interfaces_ext_mesh
+            << std::endl;
+  std::cout << "max_nibool_interfaces_ext_mesh:"
+            << max_nibool_interfaces_ext_mesh << std::endl;
+#endif
+
+  // Read test parameter
+  specfem::IO::fortran_read_line(stream, &itest);
+
+  // Throw error if test parameter is not correctly read
+  if (itest != 9994) {
+    std::ostringstream error_message;
+    error_message << "Error reading mesh parameters: " << itest
+                  << " // FILE:LINE " << __FILE__ << ":" << __LINE__ << "\n";
+    throw std::runtime_error(error_message.str());
+  };
+
+  int nspec_inner_acoustic;
+  int nspec_outer_acoustic;
+  int nspec_inner_elastic;
+  int nspec_outer_elastic;
+  int nspec_inner_poroelastic;
+  int nspec_outer_poroelastic;
+
+  specfem::IO::fortran_read_line(stream, &nspec_inner_acoustic);
+  specfem::IO::fortran_read_line(stream, &nspec_outer_acoustic);
+  specfem::IO::fortran_read_line(stream, &nspec_inner_elastic);
+  specfem::IO::fortran_read_line(stream, &nspec_outer_elastic);
+  specfem::IO::fortran_read_line(stream, &nspec_inner_poroelastic);
+  specfem::IO::fortran_read_line(stream, &nspec_outer_poroelastic);
+
+#ifndef NDEBUG
+  std::cout << "nspec_inner_acoustic:..." << nspec_inner_acoustic << std::endl;
+  std::cout << "nspec_outer_acoustic:..." << nspec_outer_acoustic << std::endl;
+  std::cout << "nspec_inner_elastic:...." << nspec_inner_elastic << std::endl;
+  std::cout << "nspec_outer_elastic:...." << nspec_outer_elastic << std::endl;
+  std::cout << "nspec_inner_poroelastic:." << nspec_inner_poroelastic
+            << std::endl;
+  std::cout << "nspec_outer_poroelastic:." << nspec_outer_poroelastic
+            << std::endl;
+#endif
+
+  // Read test parameter
+  specfem::IO::fortran_read_line(stream, &itest);
+
+  // Throw error if test parameter is not correctly read
+  if (itest != 9993) {
+    std::ostringstream error_message;
+    error_message << "Error reading mesh parameters: " << itest
+                  << " // FILE:LINE " << __FILE__ << ":" << __LINE__ << "\n";
+    throw std::runtime_error(error_message.str());
+  };
+
+  int num_phase_ispec_acoustic;
+  int num_phase_ispec_elastic;
+  int num_phase_ispec_poroelastic;
+  int num_colors_inner_acoustic;
+  int num_colors_outer_acoustic;
+  int num_colors_inner_elastic;
+  int num_colors_outer_elastic;
+
+  specfem::IO::fortran_read_line(stream, &num_phase_ispec_acoustic);
+  specfem::IO::fortran_read_line(stream, &num_phase_ispec_elastic);
+  specfem::IO::fortran_read_line(stream, &num_phase_ispec_poroelastic);
+  specfem::IO::fortran_read_line(stream, &num_colors_inner_acoustic);
+  specfem::IO::fortran_read_line(stream, &num_colors_outer_acoustic);
+  specfem::IO::fortran_read_line(stream, &num_colors_inner_elastic);
+  specfem::IO::fortran_read_line(stream, &num_colors_outer_elastic);
+
+#ifndef NDEBUG
+  std::cout << "num_phase_ispec_acoustic:" << num_phase_ispec_acoustic
+            << std::endl;
+  std::cout << "num_phase_ispec_elastic:." << num_phase_ispec_elastic
+            << std::endl;
+  std::cout << "num_phase_ispec_poroelastic:" << num_phase_ispec_poroelastic
+            << std::endl;
+  std::cout << "num_colors_inner_acoustic:" << num_colors_inner_acoustic
+            << std::endl;
+  std::cout << "num_colors_outer_acoustic:" << num_colors_outer_acoustic
+            << std::endl;
+  std::cout << "num_colors_inner_elastic:" << num_colors_inner_elastic
+            << std::endl;
+  std::cout << "num_colors_outer_elastic:" << num_colors_outer_elastic
+            << std::endl;
+#endif
+
+  // Read test parameter
+  specfem::IO::fortran_read_line(stream, &itest);
+
+  // Throw error if test parameter is not correctly read
+  if (itest != 9992) {
+    std::ostringstream error_message;
+    error_message << "Error reading mesh parameters: " << itest
+                  << " // FILE:LINE " << __FILE__ << ":" << __LINE__ << "\n";
+    throw std::runtime_error(error_message.str());
+  };
+
   mpi->sync_all();
 
-  return mesh_parameters;
+  return { acoustic_simulation,
+           elastic_simulation,
+           poroelastic_simulation,
+           anisotropy,
+           stacey_abc,
+           pml_abc,
+           approximate_ocean_load,
+           use_mesh_coloring,
+           nspec,
+           nspec_poro,
+           nglob,
+           nglob_ocean,
+           nspec2D_bottom,
+           nspec2D_top,
+           nspec2D_xmin,
+           nspec2D_xmax,
+           nspec2D_ymin,
+           nspec2D_ymax,
+           nspec_irregular,
+           num_neighbors,
+           nfaces_surface,
+           num_abs_boundary_faces,
+           num_free_surface_faces,
+           num_coupling_ac_el_faces,
+           num_coupling_ac_po_faces,
+           num_coupling_el_po_faces,
+           num_coupling_po_el_faces,
+           num_interfaces_ext_mesh,
+           max_nibool_interfaces_ext_mesh,
+           nspec_inner_acoustic,
+           nspec_outer_acoustic,
+           nspec_inner_elastic,
+           nspec_outer_elastic,
+           nspec_inner_poroelastic,
+           nspec_outer_poroelastic,
+           num_phase_ispec_acoustic,
+           num_phase_ispec_elastic,
+           num_phase_ispec_poroelastic,
+           num_colors_inner_acoustic,
+           num_colors_outer_acoustic,
+           num_colors_inner_elastic,
+           num_colors_outer_elastic };
 }

--- a/src/parameter_parser/database_configuration.cpp
+++ b/src/parameter_parser/database_configuration.cpp
@@ -1,12 +1,24 @@
 #include "parameter_parser/database_configuration.hpp"
+#include "specfem_mpi/interface.hpp"
 #include "yaml-cpp/yaml.h"
 #include <ostream>
 
 specfem::runtime_configuration::database_configuration::database_configuration(
-    const YAML::Node &Node) {
+    const YAML::Node &database_node) {
   try {
-    *this = specfem::runtime_configuration::database_configuration(
-        Node["mesh-database"].as<std::string>());
+    if (database_node.size() == 1) {
+      *this = specfem::runtime_configuration::database_configuration(
+          database_node["mesh-database"].as<std::string>());
+    } else if (database_node.size() == 2) {
+      *this = specfem::runtime_configuration::database_configuration(
+          database_node["mesh-database"].as<std::string>(),
+          database_node["mesh-parameters"].as<std::string>());
+
+    } else {
+      throw std::runtime_error(
+          "Error reading database configuration. Node size "
+          "is not 1 or 2");
+    }
 
   } catch (YAML::ParserException &e) {
 

--- a/src/specfem3d.cpp
+++ b/src/specfem3d.cpp
@@ -57,11 +57,13 @@ void execute(
   auto start_time = std::chrono::system_clock::now();
   specfem::runtime_configuration::setup setup(parameter_dict, default_dict);
   const auto database_filename = setup.get_databases();
+  const auto mesh_parameters_filename = setup.get_mesh_parameters();
 
   // Read mesh from the mesh database file
   mpi->cout("Reading the mesh...");
   mpi->cout("===================");
-  const auto mesh = specfem::IO::read_3d_mesh(database_filename, mpi);
+  const auto mesh = specfem::IO::read_3d_mesh(mesh_parameters_filename,
+                                              database_filename, mpi);
   mpi->cout("Done.");
   auto span = start_time - std::chrono::system_clock::now();
   mpi->cout("Time to read mesh: " + std::to_string(span.count()) + " seconds");

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -18,6 +18,12 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests/unit-tests)
 
 include_directories(.)
 
+set(TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+# Some of the writing test need to write somewhere and we don't want that
+# to be in the source directory
+set(TEST_OUTPUT_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+
 enable_testing()
 
 add_library(
@@ -58,6 +64,7 @@ add_executable(
   gll_tests
   gll/gll_tests.cpp
 )
+
 target_link_libraries(
   gll_tests
   gtest_main
@@ -203,6 +210,7 @@ add_executable(
   assembly/sources/sources.cpp
 )
 
+target_compile_definitions(assembly_tests PRIVATE TEST_OUTPUT_DIR=${TEST_OUTPUT_DIR})
 
 target_link_libraries(
   assembly_tests
@@ -423,22 +431,22 @@ target_link_libraries(
 # Link to gtest only if MPI is enabled
 if (NOT MPI_PARALLEL)
   include(GoogleTest)
-  gtest_discover_tests(gll_tests)
-  gtest_discover_tests(lagrange_tests)
-  gtest_discover_tests(fortranio_test)
-  gtest_discover_tests(IO_tests)
-  gtest_discover_tests(mesh_tests)
-  gtest_discover_tests(compute_partial_derivatives_tests)
-  # gtest_discover_tests(compute_elastic_tests)
-  # # gtest_discover_tests(compute_acoustic_tests)
-  # gtest_discover_tests(compute_coupled_interfaces_tests)
-  gtest_discover_tests(compute_tests)
-  gtest_discover_tests(assembly_tests)
-  gtest_discover_tests(policies)
-  gtest_discover_tests(locate_point)
-  gtest_discover_tests(interpolate_function)
-  gtest_discover_tests(rmass_inverse_tests)
-  gtest_discover_tests(displacement_newmark_tests)
+  gtest_discover_tests(gll_tests WORKING_DIRECTORY ${TEST_DIR})
+  gtest_discover_tests(lagrange_tests WORKING_DIRECTORY ${TEST_DIR})
+  gtest_discover_tests(fortranio_test WORKING_DIRECTORY ${TEST_DIR})
+  gtest_discover_tests(IO_tests WORKING_DIRECTORY ${TEST_DIR})
+  gtest_discover_tests(mesh_tests WORKING_DIRECTORY ${TEST_DIR})
+  gtest_discover_tests(compute_partial_derivatives_tests WORKING_DIRECTORY ${TEST_DIR})
+  # gtest_discover_tests(compute_elastic_tests WORKING_DIRECTORY ${TEST_DIR})
+  # # gtest_discover_tests(compute_acoustic_tests WORKING_DIRECTORY ${TEST_DIR})
+  # gtest_discover_tests(compute_coupled_interfaces_tests WORKING_DIRECTORY ${TEST_DIR})
+  gtest_discover_tests(compute_tests WORKING_DIRECTORY ${TEST_DIR})
+  gtest_discover_tests(assembly_tests WORKING_DIRECTORY ${TEST_DIR})
+  gtest_discover_tests(policies WORKING_DIRECTORY ${TEST_DIR})
+  gtest_discover_tests(locate_point WORKING_DIRECTORY ${TEST_DIR})
+  gtest_discover_tests(interpolate_function WORKING_DIRECTORY ${TEST_DIR})
+  gtest_discover_tests(rmass_inverse_tests WORKING_DIRECTORY ${TEST_DIR})
+  gtest_discover_tests(displacement_newmark_tests WORKING_DIRECTORY ${TEST_DIR})
   # gtest_discover_tests(seismogram_elastic_tests)
   # gtest_discover_tests(seismogram_acoustic_tests)
 endif(NOT MPI_PARALLEL)

--- a/tests/unit-tests/IO/sources/test_read_sources.cpp
+++ b/tests/unit-tests/IO/sources/test_read_sources.cpp
@@ -12,8 +12,7 @@ TEST(IO_TESTS, read_sources) {
    *  This test checks whether a moment tensor source is read correctly
    */
 
-  std::string sources_file =
-      "../../../tests/unit-tests/IO/sources/data/single_moment_tensor.yml";
+  std::string sources_file = "IO/sources/data/single_moment_tensor.yml";
 
   YAML::Node databases;
   databases["sources"] = sources_file;

--- a/tests/unit-tests/algorithms/interpolate_function.cpp
+++ b/tests/unit-tests/algorithms/interpolate_function.cpp
@@ -16,8 +16,7 @@ inline type_real function1(const type_real x, const type_real z) {
 
 TEST(ALGORITHMS, interpolate_function) {
 
-  std::string database_file =
-      "../../../tests/unit-tests/algorithms/serial/database.bin";
+  std::string database_file = "algorithms/serial/database.bin";
 
   // Read Mesh database
   specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();

--- a/tests/unit-tests/algorithms/locate.cpp
+++ b/tests/unit-tests/algorithms/locate.cpp
@@ -9,8 +9,7 @@
 
 TEST(ALGORITHMS, locate_point) {
 
-  std::string database_file =
-      "../../../tests/unit-tests/algorithms/serial/database.bin";
+  std::string database_file = "algorithms/serial/database.bin";
 
   // Read Mesh database
   specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();

--- a/tests/unit-tests/assembly/compute_wavefield/compute_wavefield.cpp
+++ b/tests/unit-tests/assembly/compute_wavefield/compute_wavefield.cpp
@@ -100,7 +100,7 @@ void test_compute_wavefield(specfem::compute::assembly &assembly) {
 TEST_F(ASSEMBLY, compute_wavefield) {
   for (auto parameters : *this) {
     const auto Test = std::get<0>(parameters);
-    specfem::compute::assembly assembly = std::get<4>(parameters);
+    specfem::compute::assembly assembly = std::get<5>(parameters);
 
     try {
       test_compute_wavefield(assembly);

--- a/tests/unit-tests/assembly/kernels/kernels.cpp
+++ b/tests/unit-tests/assembly/kernels/kernels.cpp
@@ -516,7 +516,7 @@ void test_kernels(specfem::compute::assembly &assembly) {
 TEST_F(ASSEMBLY, kernels_device_functions) {
   for (auto parameters : *this) {
     const auto Test = std::get<0>(parameters);
-    specfem::compute::assembly assembly = std::get<4>(parameters);
+    specfem::compute::assembly assembly = std::get<5>(parameters);
 
     try {
       test_kernels(assembly);

--- a/tests/unit-tests/assembly/sources/sources.cpp
+++ b/tests/unit-tests/assembly/sources/sources.cpp
@@ -304,7 +304,7 @@ TEST_F(ASSEMBLY, sources) {
   for (auto parameters : *this) {
     const auto Test = std::get<0>(parameters);
     auto sources = std::get<2>(parameters);
-    specfem::compute::assembly assembly = std::get<4>(parameters);
+    specfem::compute::assembly assembly = std::get<5>(parameters);
 
     try {
       test_assembly_source_construction(sources, assembly);

--- a/tests/unit-tests/assembly/test_config.yaml
+++ b/tests/unit-tests/assembly/test_config.yaml
@@ -6,9 +6,10 @@ Tests:
     config:
       nproc : 1
     databases:
-      mesh : "../../../tests/unit-tests/data/mesh/simple_mesh_flat_topography/database.bin"
-      sources : "../../../tests/unit-tests/data/mesh/simple_mesh_flat_topography/sources.yaml"
-      stations : "../../../tests/unit-tests/data/mesh/simple_mesh_flat_topography/STATIONS"
+      mesh : "data/mesh/simple_mesh_flat_topography/database.bin"
+      sources : "data/mesh/simple_mesh_flat_topography/sources.yaml"
+      stations : "data/mesh/simple_mesh_flat_topography/STATIONS"
+    suffix: "flat_topo"
   # Test 2:
   - name : "Test 2: Simple mesh with curved topography"
     description: >
@@ -16,9 +17,10 @@ Tests:
     config:
       nproc : 1
     databases:
-      mesh : "../../../tests/unit-tests/data/mesh/simple_mesh_curved_topography/database.bin"
-      sources : "../../../tests/unit-tests/data/mesh/simple_mesh_curved_topography/sources.yaml"
-      stations : "../../../tests/unit-tests/data/mesh/simple_mesh_curved_topography/STATIONS"
+      mesh : "data/mesh/simple_mesh_curved_topography/database.bin"
+      sources : "data/mesh/simple_mesh_curved_topography/sources.yaml"
+      stations : "data/mesh/simple_mesh_curved_topography/STATIONS"
+    suffix: "curved_topo"
   # Test 3:
   - name : "Test 3: Simple mesh with flat ocean bottom"
     description: >
@@ -26,9 +28,10 @@ Tests:
     config:
       nproc : 1
     databases:
-      mesh : "../../../tests/unit-tests/data/mesh/fluid_solid_mesh_flat_ocean_bottom/database.bin"
-      sources : "../../../tests/unit-tests/data/mesh/fluid_solid_mesh_flat_ocean_bottom/sources.yaml"
-      stations : "../../../tests/unit-tests/data/mesh/fluid_solid_mesh_flat_ocean_bottom/STATIONS"
+      mesh : "data/mesh/fluid_solid_mesh_flat_ocean_bottom/database.bin"
+      sources : "data/mesh/fluid_solid_mesh_flat_ocean_bottom/sources.yaml"
+      stations : "data/mesh/fluid_solid_mesh_flat_ocean_bottom/STATIONS"
+    suffix: "flat_ocean_bottom"
   # Test 4:
   - name : "Test 4: Simple mesh with curved ocean bottom"
     description: >
@@ -36,9 +39,10 @@ Tests:
     config:
       nproc : 1
     databases:
-      mesh : "../../../tests/unit-tests/data/mesh/fluid_solid_mesh_curved_ocean_bottom/database.bin"
-      sources : "../../../tests/unit-tests/data/mesh/fluid_solid_mesh_curved_ocean_bottom/sources.yaml"
-      stations : "../../../tests/unit-tests/data/mesh/fluid_solid_mesh_curved_ocean_bottom/STATIONS"
+      mesh : "data/mesh/fluid_solid_mesh_curved_ocean_bottom/database.bin"
+      sources : "data/mesh/fluid_solid_mesh_curved_ocean_bottom/sources.yaml"
+      stations : "data/mesh/fluid_solid_mesh_curved_ocean_bottom/STATIONS"
+    suffix: "curved_ocean_bottom"
   # Test 5:
   - name : "Test 5: Gmesh Example"
     description: >
@@ -46,6 +50,7 @@ Tests:
     config:
       nproc : 1
     databases:
-      mesh : "../../../tests/unit-tests/data/mesh/Gmesh_Example_Stacey/database.bin"
-      sources : "../../../tests/unit-tests/data/mesh/Gmesh_Example_Stacey/sources.yaml"
-      stations : "../../../tests/unit-tests/data/mesh/Gmesh_Example_Stacey/STATIONS"
+      mesh : "data/mesh/Gmesh_Example_Stacey/database.bin"
+      sources : "data/mesh/Gmesh_Example_Stacey/sources.yaml"
+      stations : "data/mesh/Gmesh_Example_Stacey/STATIONS"
+    suffix: "gmesh_example"

--- a/tests/unit-tests/assembly/test_fixture/test_fixture.cpp
+++ b/tests/unit-tests/assembly/test_fixture/test_fixture.cpp
@@ -18,8 +18,7 @@ void parse_test_config(const YAML::Node &yaml,
 
 ASSEMBLY::ASSEMBLY() {
 
-  std::string config_filename =
-      "../../../tests/unit-tests/assembly/test_config.yaml";
+  std::string config_filename = "assembly/test_config.yaml";
   parse_test_config(YAML::LoadFile(config_filename), Tests);
 
   specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
@@ -35,6 +34,7 @@ ASSEMBLY::ASSEMBLY() {
     const auto mesh = specfem::IO::read_2d_mesh(database_file, mpi);
 
     this->Meshes.push_back(mesh);
+    this->suffixes.push_back(Test.suffix);
 
     std::cout << sources_file << std::endl;
 

--- a/tests/unit-tests/assembly/test_fixture/test_fixture.hpp
+++ b/tests/unit-tests/assembly/test_fixture/test_fixture.hpp
@@ -45,6 +45,7 @@ public:
   Test(const YAML::Node &Node) {
     name = Node["name"].as<std::string>();
     description = Node["description"].as<std::string>();
+    suffix = Node["suffix"].as<std::string>();
     YAML::Node databases = Node["databases"];
     try {
       database = test_configuration::database(databases);
@@ -59,8 +60,11 @@ public:
     return database.get_databases();
   }
 
+  std::string get_suffix() { return suffix; }
+
   std::string name;
   std::string description;
+  std::string suffix;
   test_configuration::database database;
 };
 } // namespace test_configuration
@@ -77,22 +81,23 @@ protected:
         specfem::mesh::mesh<specfem::dimension::type::dim2> *p_mesh,
         std::vector<std::shared_ptr<specfem::sources::source> > *p_sources,
         std::vector<std::shared_ptr<specfem::receivers::receiver> > *p_stations,
-        specfem::compute::assembly *p_assembly)
+        std::string *p_suffixes, specfem::compute::assembly *p_assembly)
         : p_Test(p_Test), p_mesh(p_mesh), p_sources(p_sources),
-          p_stations(p_stations), p_assembly(p_assembly) {}
+          p_stations(p_stations), p_suffixes(p_suffixes),
+          p_assembly(p_assembly) {}
 
     std::tuple<test_configuration::Test,
                specfem::mesh::mesh<specfem::dimension::type::dim2>,
                std::vector<std::shared_ptr<specfem::sources::source> >,
                std::vector<std::shared_ptr<specfem::receivers::receiver> >,
-               specfem::compute::assembly>
+               std::string, specfem::compute::assembly>
     operator*() {
       std::cout << "-------------------------------------------------------\n"
                 << "\033[0;32m[RUNNING]\033[0m " << p_Test->name << "\n"
                 << "-------------------------------------------------------\n\n"
                 << std::endl;
       return std::make_tuple(*p_Test, *p_mesh, *p_sources, *p_stations,
-                             *p_assembly);
+                             *p_suffixes, *p_assembly);
     }
 
     Iterator &operator++() {
@@ -100,6 +105,7 @@ protected:
       ++p_mesh;
       ++p_sources;
       ++p_stations;
+      ++p_suffixes;
       ++p_assembly;
       return *this;
     }
@@ -113,6 +119,7 @@ protected:
     specfem::mesh::mesh<specfem::dimension::type::dim2> *p_mesh;
     std::vector<std::shared_ptr<specfem::sources::source> > *p_sources;
     std::vector<std::shared_ptr<specfem::receivers::receiver> > *p_stations;
+    std::string *p_suffixes;
     specfem::compute::assembly *p_assembly;
   };
 
@@ -120,13 +127,13 @@ protected:
 
   Iterator begin() {
     return Iterator(&Tests[0], &Meshes[0], &Sources[0], &Stations[0],
-                    &assemblies[0]);
+                    &suffixes[0], &assemblies[0]);
   }
 
   Iterator end() {
     return Iterator(&Tests[Tests.size()], &Meshes[Meshes.size()],
                     &Sources[Sources.size()], &Stations[Stations.size()],
-                    &assemblies[assemblies.size()]);
+                    &suffixes[suffixes.size()], &assemblies[assemblies.size()]);
   }
 
   std::vector<test_configuration::Test> Tests;
@@ -134,5 +141,6 @@ protected:
   std::vector<std::vector<std::shared_ptr<specfem::sources::source> > > Sources;
   std::vector<std::vector<std::shared_ptr<specfem::receivers::receiver> > >
       Stations;
+  std::vector<std::string> suffixes;
   std::vector<specfem::compute::assembly> assemblies;
 };

--- a/tests/unit-tests/compute/coupled_interfaces/coupled_interfaces_tests.cpp
+++ b/tests/unit-tests/compute/coupled_interfaces/coupled_interfaces_tests.cpp
@@ -163,8 +163,7 @@ TEST(COMPUTE_TESTS, coupled_interfaces_tests) {
 
   specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
 
-  std::string config_filename =
-      "../../../tests/unit-tests/compute/coupled_interfaces/test_config.yaml";
+  std::string config_filename = "compute/coupled_interfaces/test_config.yaml";
 
   std::vector<test_config::Test> tests;
   parse_test_config(YAML::LoadFile(config_filename), tests);

--- a/tests/unit-tests/compute/coupled_interfaces/test_config.yaml
+++ b/tests/unit-tests/compute/coupled_interfaces/test_config.yaml
@@ -6,10 +6,10 @@ Tests:
       nproc: 1
     databases:
       mesh:
-        database: "../../../tests/unit-tests/compute/coupled_interfaces/serial/test1/mesh/database.bin"
+        database: "compute/coupled_interfaces/serial/test1/mesh/database.bin"
       elastic_acoustic:
-        elastic_ispec: "../../../tests/unit-tests/compute/coupled_interfaces/serial/test1/elastic_acoustic/elastic_ispec.bin"
-        acoustic_ispec: "../../../tests/unit-tests/compute/coupled_interfaces/serial/test1/elastic_acoustic/acoustic_ispec.bin"
+        elastic_ispec: "compute/coupled_interfaces/serial/test1/elastic_acoustic/elastic_ispec.bin"
+        acoustic_ispec: "compute/coupled_interfaces/serial/test1/elastic_acoustic/acoustic_ispec.bin"
       elastic_poroelastic:
         elastic_ispec: "NULL"
         poroelastic_ispec: "NULL"

--- a/tests/unit-tests/compute/index/compute_tests.cpp
+++ b/tests/unit-tests/compute/index/compute_tests.cpp
@@ -71,8 +71,7 @@ TEST(COMPUTE_TESTS, compute_ibool) {
 
   specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
 
-  std::string config_filename =
-      "../../../tests/unit-tests/compute/index/test_config.yml";
+  std::string config_filename = "compute/index/test_config.yml";
   test_config test_config = get_test_config(config_filename, mpi);
 
   // Set up GLL quadrature points

--- a/tests/unit-tests/compute/index/test_config.yml
+++ b/tests/unit-tests/compute/index/test_config.yml
@@ -3,5 +3,5 @@ SerialTest:
     nproc : 1
   database:
     - processor : 0
-      database_file : "../../../tests/unit-tests/compute/index/serial/Database00000.bin"
-      ibool_file : "../../../tests/unit-tests/compute/index/serial/ibool_00000.bin"
+      database_file : "compute/index/serial/Database00000.bin"
+      ibool_file : "compute/index/serial/ibool_00000.bin"

--- a/tests/unit-tests/compute/partial_derivatives/compute_partial_derivatives_tests.cpp
+++ b/tests/unit-tests/compute/partial_derivatives/compute_partial_derivatives_tests.cpp
@@ -66,8 +66,7 @@ TEST(COMPUTE_TESTS, compute_partial_derivatives) {
 
   specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
 
-  std::string config_filename =
-      "../../../tests/unit-tests/compute/partial_derivatives/test_config.yml";
+  std::string config_filename = "compute/partial_derivatives/test_config.yml";
   test_config test_config = get_test_config(config_filename, mpi);
 
   // Set up GLL quadrature points

--- a/tests/unit-tests/compute/partial_derivatives/test_config.yml
+++ b/tests/unit-tests/compute/partial_derivatives/test_config.yml
@@ -3,9 +3,9 @@ SerialTest:
     nproc : 1
   database:
     - processor : 0
-      database_file : "../../../tests/unit-tests/compute/partial_derivatives/serial/Database00000.bin"
-      xix_file: "../../../tests/unit-tests/compute/partial_derivatives/serial/xix_00000.bin"
-      xiz_file: "../../../tests/unit-tests/compute/partial_derivatives/serial/xiz_00000.bin"
-      gammax_file: "../../../tests/unit-tests/compute/partial_derivatives/serial/gammax_00000.bin"
-      gammaz_file: "../../../tests/unit-tests/compute/partial_derivatives/serial/gammaz_00000.bin"
-      jacobian_file: "../../../tests/unit-tests/compute/partial_derivatives/serial/jacobian_00000.bin"
+      database_file : "compute/partial_derivatives/serial/Database00000.bin"
+      xix_file: "compute/partial_derivatives/serial/xix_00000.bin"
+      xiz_file: "compute/partial_derivatives/serial/xiz_00000.bin"
+      gammax_file: "compute/partial_derivatives/serial/gammax_00000.bin"
+      gammaz_file: "compute/partial_derivatives/serial/gammaz_00000.bin"
+      jacobian_file: "compute/partial_derivatives/serial/jacobian_00000.bin"

--- a/tests/unit-tests/displacement_tests/Newmark/acoustic/newmark_tests.cpp
+++ b/tests/unit-tests/displacement_tests/Newmark/acoustic/newmark_tests.cpp
@@ -44,7 +44,7 @@ test_config parse_test_config(std::string test_configuration_file,
 // ------------------------------------- //
 
 TEST(DISPLACEMENT_TESTS, newmark_scheme_tests) {
-  std::string config_filename = "../../../tests/unit-tests/displacement_tests/"
+  std::string config_filename = "displacement_tests/"
                                 "Newmark/acoustic/test_config.yaml";
 
   specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();

--- a/tests/unit-tests/displacement_tests/Newmark/acoustic/serial/specfem_config.yaml
+++ b/tests/unit-tests/displacement_tests/Newmark/acoustic/serial/specfem_config.yaml
@@ -42,9 +42,9 @@ parameters:
 
   ## databases
   databases:
-    mesh-database: "../../../tests/unit-tests/displacement_tests/Newmark/acoustic/serial/Database00000.bin"
+    mesh-database: "displacement_tests/Newmark/acoustic/serial/Database00000.bin"
 
-  sources: "../../../tests/unit-tests/displacement_tests/Newmark/acoustic/serial/sources.yaml"
+  sources: "displacement_tests/Newmark/acoustic/serial/sources.yaml"
 
   # seismogram output
   seismogram:

--- a/tests/unit-tests/displacement_tests/Newmark/acoustic/test_config.yaml
+++ b/tests/unit-tests/displacement_tests/Newmark/acoustic/test_config.yaml
@@ -1,5 +1,5 @@
 Tests:
 
   serial:
-    specfem_config: "../../../tests/unit-tests/displacement_tests/Newmark/acoustic/serial/specfem_config.yaml"
-    solutions_file: "../../../tests/unit-tests/displacement_tests/Newmark/acoustic/serial/potential_acoustic_00000.bin"
+    specfem_config: "displacement_tests/Newmark/acoustic/serial/specfem_config.yaml"
+    solutions_file: "displacement_tests/Newmark/acoustic/serial/potential_acoustic_00000.bin"

--- a/tests/unit-tests/displacement_tests/Newmark/elastic/newmark_tests.cpp
+++ b/tests/unit-tests/displacement_tests/Newmark/elastic/newmark_tests.cpp
@@ -44,7 +44,7 @@ test_config parse_test_config(std::string test_configuration_file,
 // ------------------------------------- //
 
 TEST(DISPLACEMENT_TESTS, newmark_scheme_tests) {
-  std::string config_filename = "../../../tests/unit-tests/displacement_tests/"
+  std::string config_filename = "displacement_tests/"
                                 "Newmark/elastic/test_config.yaml";
 
   specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();

--- a/tests/unit-tests/displacement_tests/Newmark/elastic/serial/specfem_config.yaml
+++ b/tests/unit-tests/displacement_tests/Newmark/elastic/serial/specfem_config.yaml
@@ -42,9 +42,9 @@ parameters:
 
   ## databases
   databases:
-    mesh-database: "../../../tests/unit-tests/displacement_tests/Newmark/elastic/serial/Database00000.bin"
+    mesh-database: "displacement_tests/Newmark/elastic/serial/Database00000.bin"
 
-  sources: "../../../tests/unit-tests/displacement_tests/Newmark/elastic/serial/sources.yaml"
+  sources: "displacement_tests/Newmark/elastic/serial/sources.yaml"
 
   seismogram:
     seismogram-format: ascii

--- a/tests/unit-tests/displacement_tests/Newmark/elastic/test_config.yaml
+++ b/tests/unit-tests/displacement_tests/Newmark/elastic/test_config.yaml
@@ -1,5 +1,5 @@
 Tests:
 
   serial:
-    specfem_config: "../../../tests/unit-tests/displacement_tests/Newmark/elastic/serial/specfem_config.yaml"
-    solutions_file: "../../../tests/unit-tests/displacement_tests/Newmark/elastic/serial/displs_00000.bin"
+    specfem_config: "displacement_tests/Newmark/elastic/serial/specfem_config.yaml"
+    solutions_file: "displacement_tests/Newmark/elastic/serial/displs_00000.bin"

--- a/tests/unit-tests/displacement_tests/Newmark/newmark_tests.cpp
+++ b/tests/unit-tests/displacement_tests/Newmark/newmark_tests.cpp
@@ -150,7 +150,7 @@ specfem::testing::array2d<type_real, Kokkos::LayoutLeft> compact_array(
 }
 
 TEST(DISPLACEMENT_TESTS, newmark_scheme_tests) {
-  std::string config_filename = "../../../tests/unit-tests/displacement_tests/"
+  std::string config_filename = "displacement_tests/"
                                 "Newmark/test_config.yaml";
 
   specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();

--- a/tests/unit-tests/displacement_tests/Newmark/serial/test1/specfem_config.yaml
+++ b/tests/unit-tests/displacement_tests/Newmark/serial/test1/specfem_config.yaml
@@ -33,7 +33,7 @@ parameters:
             directory: "."
 
   receivers:
-    stations: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test1/STATIONS"
+    stations: "displacement_tests/Newmark/serial/test1/STATIONS"
     angle: 0.0
     seismogram-type:
       - displacement
@@ -49,6 +49,6 @@ parameters:
 
   ## databases
   databases:
-    mesh-database: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test1/database.bin"
+    mesh-database: "displacement_tests/Newmark/serial/test1/database.bin"
 
-  sources: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test1/sources.yaml"
+  sources: "displacement_tests/Newmark/serial/test1/sources.yaml"

--- a/tests/unit-tests/displacement_tests/Newmark/serial/test2/specfem_config.yaml
+++ b/tests/unit-tests/displacement_tests/Newmark/serial/test2/specfem_config.yaml
@@ -33,7 +33,7 @@ parameters:
             output-folder: "."
 
   receivers:
-    stations: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test2/STATIONS"
+    stations: "displacement_tests/Newmark/serial/test2/STATIONS"
     angle: 0.0
     seismogram-type:
       - displacement
@@ -49,7 +49,7 @@ parameters:
 
   ## databases
   databases:
-    mesh-database: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test2/database.bin"
+    mesh-database: "displacement_tests/Newmark/serial/test2/database.bin"
 
 
-  sources: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test2/sources.yaml"
+  sources: "displacement_tests/Newmark/serial/test2/sources.yaml"

--- a/tests/unit-tests/displacement_tests/Newmark/serial/test3/specfem_config.yaml
+++ b/tests/unit-tests/displacement_tests/Newmark/serial/test3/specfem_config.yaml
@@ -37,7 +37,7 @@ parameters:
             directory: "."
 
   receivers:
-    stations: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test3/STATIONS"
+    stations: "displacement_tests/Newmark/serial/test3/STATIONS"
     angle: 0.0
     seismogram-type:
       - displacement
@@ -50,6 +50,6 @@ parameters:
 
   ## databases
   databases:
-    mesh-database: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test3/database.bin"
+    mesh-database: "displacement_tests/Newmark/serial/test3/database.bin"
 
-  sources: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test3/sources.yaml"
+  sources: "displacement_tests/Newmark/serial/test3/sources.yaml"

--- a/tests/unit-tests/displacement_tests/Newmark/serial/test4/specfem_config.yaml
+++ b/tests/unit-tests/displacement_tests/Newmark/serial/test4/specfem_config.yaml
@@ -37,7 +37,7 @@ parameters:
             output-folder: "."
 
   receivers:
-    stations: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test4/STATIONS"
+    stations: "displacement_tests/Newmark/serial/test4/STATIONS"
     angle: 0.0
     seismogram-type:
       - displacement
@@ -50,8 +50,8 @@ parameters:
 
   ## databases
   databases:
-    mesh-database: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test4/database.bin"
-    sources: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test4/sources.yaml"
+    mesh-database: "displacement_tests/Newmark/serial/test4/database.bin"
+    sources: "displacement_tests/Newmark/serial/test4/sources.yaml"
 
   seismogram:
     seismogram-format: ascii

--- a/tests/unit-tests/displacement_tests/Newmark/serial/test5/specfem_config.yaml
+++ b/tests/unit-tests/displacement_tests/Newmark/serial/test5/specfem_config.yaml
@@ -33,7 +33,7 @@ parameters:
             output-folder: "."
 
   receivers:
-    stations: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test5/STATIONS"
+    stations: "displacement_tests/Newmark/serial/test5/STATIONS"
     angle: 0.0
     seismogram-type:
       - displacement
@@ -46,6 +46,6 @@ parameters:
 
   ## databases
   databases:
-    mesh-database: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test5/database.bin"
+    mesh-database: "displacement_tests/Newmark/serial/test5/database.bin"
 
-  sources: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test5/sources.yaml"
+  sources: "displacement_tests/Newmark/serial/test5/sources.yaml"

--- a/tests/unit-tests/displacement_tests/Newmark/serial/test6/specfem_config.yaml
+++ b/tests/unit-tests/displacement_tests/Newmark/serial/test6/specfem_config.yaml
@@ -33,7 +33,7 @@ parameters:
             output-folder: "."
 
   receivers:
-    stations: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test6/STATIONS"
+    stations: "displacement_tests/Newmark/serial/test6/STATIONS"
     angle: 0.0
     seismogram-type:
       - displacement
@@ -46,6 +46,6 @@ parameters:
 
   ## databases
   databases:
-    mesh-database: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test6/database.bin"
+    mesh-database: "displacement_tests/Newmark/serial/test6/database.bin"
 
-  sources: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test6/sources.yaml"
+  sources: "displacement_tests/Newmark/serial/test6/sources.yaml"

--- a/tests/unit-tests/displacement_tests/Newmark/serial/test7/specfem_config.yaml
+++ b/tests/unit-tests/displacement_tests/Newmark/serial/test7/specfem_config.yaml
@@ -32,7 +32,7 @@ parameters:
             output-folder: "."
 
   receivers:
-    stations: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test7/STATIONS"
+    stations: "displacement_tests/Newmark/serial/test7/STATIONS"
     angle: 0.0
     seismogram-type:
       - displacement
@@ -45,6 +45,6 @@ parameters:
 
   ## databases
   databases:
-    mesh-database: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test7/database.bin"
+    mesh-database: "displacement_tests/Newmark/serial/test7/database.bin"
 
-  sources: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test7/sources.yaml"
+  sources: "displacement_tests/Newmark/serial/test7/sources.yaml"

--- a/tests/unit-tests/displacement_tests/Newmark/serial/test8/specfem_config.yaml
+++ b/tests/unit-tests/displacement_tests/Newmark/serial/test8/specfem_config.yaml
@@ -32,7 +32,7 @@ parameters:
             output-folder: "."
 
   receivers:
-    stations: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test8/STATIONS"
+    stations: "displacement_tests/Newmark/serial/test8/STATIONS"
     angle: 0.0
     seismogram-type:
       - displacement
@@ -45,6 +45,6 @@ parameters:
 
   ## databases
   databases:
-    mesh-database: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test8/database.bin"
+    mesh-database: "displacement_tests/Newmark/serial/test8/database.bin"
 
-  sources: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test8/source.yaml"
+  sources: "displacement_tests/Newmark/serial/test8/source.yaml"

--- a/tests/unit-tests/displacement_tests/Newmark/serial/test9/specfem_config.yaml
+++ b/tests/unit-tests/displacement_tests/Newmark/serial/test9/specfem_config.yaml
@@ -33,7 +33,7 @@ parameters:
             directory: "."
 
   receivers:
-    stations: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test9/STATIONS"
+    stations: "displacement_tests/Newmark/serial/test9/STATIONS"
     angle: 0.0
     seismogram-type:
       - displacement
@@ -49,6 +49,6 @@ parameters:
 
   ## databases
   databases:
-    mesh-database: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test9/database.bin"
+    mesh-database: "displacement_tests/Newmark/serial/test9/database.bin"
 
-  sources: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test9/sources.yaml"
+  sources: "displacement_tests/Newmark/serial/test9/sources.yaml"

--- a/tests/unit-tests/displacement_tests/Newmark/test_config.yaml
+++ b/tests/unit-tests/displacement_tests/Newmark/test_config.yaml
@@ -5,8 +5,8 @@ Tests:
     config:
       nproc : 1
     databases:
-      specfem_config: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test1/specfem_config.yaml"
-      traces: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test1/traces"
+      specfem_config: "displacement_tests/Newmark/serial/test1/specfem_config.yaml"
+      traces: "displacement_tests/Newmark/serial/test1/traces"
 
   - name : "SerialTest2 : Homogeneous acoustic domain"
     description: >
@@ -14,8 +14,8 @@ Tests:
     config:
       nproc : 1
     databases:
-      specfem_config: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test2/specfem_config.yaml"
-      traces: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test2/traces"
+      specfem_config: "displacement_tests/Newmark/serial/test2/specfem_config.yaml"
+      traces: "displacement_tests/Newmark/serial/test2/traces"
 
   - name : "SerialTest3 : Acoustic-Elastic coupled domain (Test 1/2)"
     description: >
@@ -23,8 +23,8 @@ Tests:
     config:
       nproc : 1
     databases:
-      specfem_config: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test3/specfem_config.yaml"
-      traces: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test3/traces"
+      specfem_config: "displacement_tests/Newmark/serial/test3/specfem_config.yaml"
+      traces: "displacement_tests/Newmark/serial/test3/traces"
 
   # - name : "SerialTest4 : Acoustic-Elastic coupled domain (Test 2/2)"
   #   description: >
@@ -32,8 +32,8 @@ Tests:
   #   config:
   #     nproc : 1
   #   databases:
-  #     specfem_config: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test4/specfem_config.yaml"
-  #     traces: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test4/traces"
+  #     specfem_config: "displacement_tests/Newmark/serial/test4/specfem_config.yaml"
+  #     traces: "displacement_tests/Newmark/serial/test4/traces"
 
 
   - name : "SerialTest5 : Homogeneous acoustic domain (dirichlet BC)"
@@ -42,8 +42,8 @@ Tests:
     config:
       nproc : 1
     databases:
-      specfem_config: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test5/specfem_config.yaml"
-      traces: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test5/traces"
+      specfem_config: "displacement_tests/Newmark/serial/test5/specfem_config.yaml"
+      traces: "displacement_tests/Newmark/serial/test5/traces"
 
   - name : "SerialTest6 : Homogeneous acoustic domain (stacey BC)"
     description: >
@@ -51,8 +51,8 @@ Tests:
     config:
       nproc : 1
     databases:
-      specfem_config: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test6/specfem_config.yaml"
-      traces: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test6/traces"
+      specfem_config: "displacement_tests/Newmark/serial/test6/specfem_config.yaml"
+      traces: "displacement_tests/Newmark/serial/test6/traces"
 
   - name : "SerialTest7 : Homogeneous elastic domain (stacey BC)"
     description: >
@@ -60,8 +60,8 @@ Tests:
     config:
       nproc : 1
     databases:
-      specfem_config: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test7/specfem_config.yaml"
-      traces: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test7/traces"
+      specfem_config: "displacement_tests/Newmark/serial/test7/specfem_config.yaml"
+      traces: "displacement_tests/Newmark/serial/test7/traces"
 
   - name : "SerialTest8 : Homogeneous acoustic domain (composite stacey dirichlet BC)"
     description: >
@@ -69,8 +69,8 @@ Tests:
     config:
       nproc : 1
     databases:
-      specfem_config: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test8/specfem_config.yaml"
-      traces: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test8/traces"
+      specfem_config: "displacement_tests/Newmark/serial/test8/specfem_config.yaml"
+      traces: "displacement_tests/Newmark/serial/test8/traces"
 
 
   - name : "SerialTest9 : Homogeneous elastic anisotropic domain"
@@ -79,5 +79,5 @@ Tests:
     config:
       nproc : 1
     databases:
-      specfem_config: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test9/specfem_config.yaml"
-      traces: "../../../tests/unit-tests/displacement_tests/Newmark/serial/test9/traces"
+      specfem_config: "displacement_tests/Newmark/serial/test9/specfem_config.yaml"
+      traces: "displacement_tests/Newmark/serial/test9/traces"

--- a/tests/unit-tests/domain/acoustic/rmass_inverse_tests.cpp
+++ b/tests/unit-tests/domain/acoustic/rmass_inverse_tests.cpp
@@ -42,8 +42,7 @@ test_config parse_test_config(std::string test_configuration_file,
 // ------------------------------------- //
 
 TEST(DOMAIN_TESTS, rmass_inverse_elastic_test) {
-  std::string config_filename =
-      "../../../tests/unit-tests/domain/acoustic/test_config.yaml";
+  std::string config_filename = "domain/acoustic/test_config.yaml";
 
   specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
 

--- a/tests/unit-tests/domain/acoustic/test_config.yaml
+++ b/tests/unit-tests/domain/acoustic/test_config.yaml
@@ -1,5 +1,5 @@
 Tests:
 
   serial:
-    specfem_config: "../../../tests/unit-tests/domain/acoustic/serial/specfem_config.yaml"
-    solutions_file: "../../../tests/unit-tests/domain/acoustic/serial/rmass_inverse_acoustic_00000.bin"
+    specfem_config: "domain/acoustic/serial/specfem_config.yaml"
+    solutions_file: "domain/acoustic/serial/rmass_inverse_acoustic_00000.bin"

--- a/tests/unit-tests/domain/elastic/rmass_inverse_tests.cpp
+++ b/tests/unit-tests/domain/elastic/rmass_inverse_tests.cpp
@@ -42,8 +42,7 @@ test_config parse_test_config(std::string test_configuration_file,
 // ------------------------------------- //
 
 TEST(DOMAIN_TESTS, rmass_inverse_elastic_test) {
-  std::string config_filename =
-      "../../../tests/unit-tests/domain/elastic/test_config.yaml";
+  std::string config_filename = "domain/elastic/test_config.yaml";
 
   specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
 

--- a/tests/unit-tests/domain/elastic/test_config.yaml
+++ b/tests/unit-tests/domain/elastic/test_config.yaml
@@ -1,5 +1,5 @@
 Tests:
 
   serial:
-    specfem_config: "../../../tests/unit-tests/domain/elastic/serial/specfem_config.yaml"
-    solutions_file: "../../../tests/unit-tests/domain/elastic/serial/rmass_inverse_elastic_00000.bin"
+    specfem_config: "domain/elastic/serial/specfem_config.yaml"
+    solutions_file: "domain/elastic/serial/rmass_inverse_elastic_00000.bin"

--- a/tests/unit-tests/domain/rmass_inverse_tests.cpp
+++ b/tests/unit-tests/domain/rmass_inverse_tests.cpp
@@ -91,8 +91,7 @@ std::vector<test_config::Test> parse_test_config(std::string test_config_file,
 }
 
 TEST(DOMAIN_TESTS, rmass_inverse) {
-  std::string config_filename =
-      "../../../tests/unit-tests/domain/test_config.yaml";
+  std::string config_filename = "domain/test_config.yaml";
 
   specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
 

--- a/tests/unit-tests/domain/serial/test1/specfem_config.yaml
+++ b/tests/unit-tests/domain/serial/test1/specfem_config.yaml
@@ -40,6 +40,6 @@ parameters:
     number-of-runs: 1
 
   databases:
-    mesh-database: "../../../tests/unit-tests/domain/serial/test1/database.bin"
+    mesh-database: "domain/serial/test1/database.bin"
 
-  sources: "../../../tests/unit-tests/domain/serial/test1/source.yaml"
+  sources: "domain/serial/test1/source.yaml"

--- a/tests/unit-tests/domain/serial/test2/specfem_config.yaml
+++ b/tests/unit-tests/domain/serial/test2/specfem_config.yaml
@@ -40,6 +40,6 @@ parameters:
     number-of-runs: 1
 
   databases:
-    mesh-database: "../../../tests/unit-tests/domain/serial/test2/database.bin"
+    mesh-database: "domain/serial/test2/database.bin"
 
-  sources: "../../../tests/unit-tests/domain/serial/test2/source.yaml"
+  sources: "domain/serial/test2/source.yaml"

--- a/tests/unit-tests/domain/serial/test3/specfem_config.yaml
+++ b/tests/unit-tests/domain/serial/test3/specfem_config.yaml
@@ -40,5 +40,5 @@ parameters:
     number-of-runs: 1
 
   databases:
-    mesh-database: "../../../tests/unit-tests/domain/serial/test3/database.bin"
-    sources: "../../../tests/unit-tests/domain/serial/test3/source.yaml"
+    mesh-database: "domain/serial/test3/database.bin"
+    sources: "domain/serial/test3/source.yaml"

--- a/tests/unit-tests/domain/serial/test4/specfem_config.yaml
+++ b/tests/unit-tests/domain/serial/test4/specfem_config.yaml
@@ -40,6 +40,6 @@ parameters:
     number-of-runs: 1
 
   databases:
-    mesh-database: "../../../tests/unit-tests/domain/serial/test4/database.bin"
+    mesh-database: "domain/serial/test4/database.bin"
 
-  sources: "../../../tests/unit-tests/domain/serial/test4/source.yaml"
+  sources: "domain/serial/test4/source.yaml"

--- a/tests/unit-tests/domain/test_config.yaml
+++ b/tests/unit-tests/domain/test_config.yaml
@@ -5,9 +5,9 @@ Tests:
     config:
       nproc : 1
     databases:
-      specfem_config: "../../../tests/unit-tests/domain/serial/test1/specfem_config.yaml"
-      index_mapping: "../../../tests/unit-tests/domain/serial/test1/index_mapping.bin"
-      elastic_mass_matrix: "../../../tests/unit-tests/domain/serial/test1/rmass_inverse_elastic.bin"
+      specfem_config: "domain/serial/test1/specfem_config.yaml"
+      index_mapping: "domain/serial/test1/index_mapping.bin"
+      elastic_mass_matrix: "domain/serial/test1/rmass_inverse_elastic.bin"
 
   - name : "SerialTest2 : Homogeneous acoustic domain"
     description: >
@@ -15,9 +15,9 @@ Tests:
     config:
       nproc : 1
     databases:
-      specfem_config: "../../../tests/unit-tests/domain/serial/test2/specfem_config.yaml"
-      index_mapping: "../../../tests/unit-tests/domain/serial/test2/index_mapping.bin"
-      acoustic_mass_matrix: "../../../tests/unit-tests/domain/serial/test2/rmass_inverse_acoustic.bin"
+      specfem_config: "domain/serial/test2/specfem_config.yaml"
+      index_mapping: "domain/serial/test2/index_mapping.bin"
+      acoustic_mass_matrix: "domain/serial/test2/rmass_inverse_acoustic.bin"
 
   # - name : "SerialTest3 : Homogeneous acoustic domain (stacey BC)"
   #   description: >
@@ -25,9 +25,9 @@ Tests:
   #   config:
   #     nproc : 1
   #   databases:
-  #     specfem_config: "../../../tests/unit-tests/domain/serial/test3/specfem_config.yaml"
-  #     index_mapping: "../../../tests/unit-tests/domain/serial/test3/index_mapping.bin"
-  #     acoustic_mass_matrix: "../../../tests/unit-tests/domain/serial/test3/rmass_inverse_acoustic.bin"
+  #     specfem_config: "domain/serial/test3/specfem_config.yaml"
+  #     index_mapping: "domain/serial/test3/index_mapping.bin"
+  #     acoustic_mass_matrix: "domain/serial/test3/rmass_inverse_acoustic.bin"
 
   # - name : "SerialTest4 : Homogeneous elastic domain (stacey BC)"
   #   description: >
@@ -35,6 +35,6 @@ Tests:
   #   config:
   #     nproc : 1
   #   databases:
-  #     specfem_config: "../../../tests/unit-tests/domain/serial/test4/specfem_config.yaml"
-  #     index_mapping: "../../../tests/unit-tests/domain/serial/test4/index_mapping.bin"
-  #     elastic_mass_matrix: "../../../tests/unit-tests/domain/serial/test4/rmass_inverse_elastic.bin"
+  #     specfem_config: "domain/serial/test4/specfem_config.yaml"
+  #     index_mapping: "domain/serial/test4/index_mapping.bin"
+  #     elastic_mass_matrix: "domain/serial/test4/rmass_inverse_elastic.bin"

--- a/tests/unit-tests/fortran_io/fortranio_tests.cpp
+++ b/tests/unit-tests/fortran_io/fortranio_tests.cpp
@@ -10,7 +10,7 @@
 
 TEST(iotests, fortran_io) {
 
-  std::string filename = "../../../tests/unit-tests/fortran_io/input.bin";
+  std::string filename = "fortran_io/input.bin";
   std::ifstream stream;
 
   int ival;

--- a/tests/unit-tests/mesh/test_config.yaml
+++ b/tests/unit-tests/mesh/test_config.yaml
@@ -6,9 +6,9 @@ Tests:
     config:
       nproc : 1
     databases:
-      mesh : "../../../tests/unit-tests/data/mesh/simple_mesh_flat_topography/database.bin"
-      sources : "../../../tests/unit-tests/data/mesh/simple_mesh_flat_topography/sources.yaml"
-      stations : "../../../tests/unit-tests/data/mesh/simple_mesh_flat_topography/STATIONS"
+      mesh : "data/mesh/simple_mesh_flat_topography/database.bin"
+      sources : "data/mesh/simple_mesh_flat_topography/sources.yaml"
+      stations : "data/mesh/simple_mesh_flat_topography/STATIONS"
   # Test 2:
   - name : "Test 2: Simple mesh with curved topography"
     description: >
@@ -16,9 +16,9 @@ Tests:
     config:
       nproc : 1
     databases:
-      mesh : "../../../tests/unit-tests/data/mesh/simple_mesh_curved_topography/database.bin"
-      sources : "../../../tests/unit-tests/data/mesh/simple_mesh_curved_topography/sources.yaml"
-      stations : "../../../tests/unit-tests/data/mesh/simple_mesh_curved_topography/STATIONS"
+      mesh : "data/mesh/simple_mesh_curved_topography/database.bin"
+      sources : "data/mesh/simple_mesh_curved_topography/sources.yaml"
+      stations : "data/mesh/simple_mesh_curved_topography/STATIONS"
   # Test 3:
   - name : "Test 3: Simple mesh with flat ocean bottom"
     description: >
@@ -26,9 +26,9 @@ Tests:
     config:
       nproc : 1
     databases:
-      mesh : "../../../tests/unit-tests/data/mesh/fluid_solid_mesh_flat_ocean_bottom/database.bin"
-      sources : "../../../tests/unit-tests/data/mesh/fluid_solid_mesh_flat_ocean_bottom/sources.yaml"
-      stations : "../../../tests/unit-tests/data/mesh/fluid_solid_mesh_flat_ocean_bottom/STATIONS"
+      mesh : "data/mesh/fluid_solid_mesh_flat_ocean_bottom/database.bin"
+      sources : "data/mesh/fluid_solid_mesh_flat_ocean_bottom/sources.yaml"
+      stations : "data/mesh/fluid_solid_mesh_flat_ocean_bottom/STATIONS"
   # Test 4:
   - name : "Test 4: Simple mesh with curved ocean bottom"
     description: >
@@ -36,9 +36,9 @@ Tests:
     config:
       nproc : 1
     databases:
-      mesh : "../../../tests/unit-tests/data/mesh/fluid_solid_mesh_curved_ocean_bottom/database.bin"
-      sources : "../../../tests/unit-tests/data/mesh/fluid_solid_mesh_curved_ocean_bottom/sources.yaml"
-      stations : "../../../tests/unit-tests/data/mesh/fluid_solid_mesh_curved_ocean_bottom/STATIONS"
+      mesh : "data/mesh/fluid_solid_mesh_curved_ocean_bottom/database.bin"
+      sources : "data/mesh/fluid_solid_mesh_curved_ocean_bottom/sources.yaml"
+      stations : "data/mesh/fluid_solid_mesh_curved_ocean_bottom/STATIONS"
 
   # Test 5:
   - name : "Test 5: Gmesh Example"
@@ -47,9 +47,9 @@ Tests:
     config:
       nproc : 1
     databases:
-      mesh : "../../../tests/unit-tests/data/mesh/Gmesh_Example_Stacey/database.bin"
-      sources : "../../../tests/unit-tests/data/mesh/Gmesh_Example_Stacey/sources.yaml"
-      stations : "../../../tests/unit-tests/data/mesh/Gmesh_Example_Stacey/STATIONS"
+      mesh : "data/mesh/Gmesh_Example_Stacey/database.bin"
+      sources : "data/mesh/Gmesh_Example_Stacey/sources.yaml"
+      stations : "data/mesh/Gmesh_Example_Stacey/STATIONS"
 
 
 # Test 6:
@@ -59,6 +59,6 @@ Tests:
     config:
       nproc : 1
     databases:
-      mesh : "../../../tests/unit-tests/data/mesh/homogeneous_elastic_anisotropic/database.bin"
-      sources : "../../../tests/unit-tests/data/mesh/homogeneous_elastic_anisotropic/sources.yaml"
-      stations : "../../../tests/unit-tests/data/mesh/homogeneous_elastic_anisotropic/STATIONS"
+      mesh : "data/mesh/homogeneous_elastic_anisotropic/database.bin"
+      sources : "data/mesh/homogeneous_elastic_anisotropic/sources.yaml"
+      stations : "data/mesh/homogeneous_elastic_anisotropic/STATIONS"

--- a/tests/unit-tests/mesh/test_fixture/test_fixture.cpp
+++ b/tests/unit-tests/mesh/test_fixture/test_fixture.cpp
@@ -17,8 +17,7 @@ void parse_test_config(const YAML::Node &yaml,
 
 MESH::MESH() {
 
-  std::string config_filename =
-      "../../../tests/unit-tests/mesh/test_config.yaml";
+  std::string config_filename = "mesh/test_config.yaml";
   parse_test_config(YAML::LoadFile(config_filename), Tests);
 
   specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();

--- a/tests/unit-tests/policies/policies.cpp
+++ b/tests/unit-tests/policies/policies.cpp
@@ -250,8 +250,7 @@ protected:
 
   POLICIES() {
 
-    std::string config_filename =
-        "../../../tests/unit-tests/policies/test_config.yaml";
+    std::string config_filename = "policies/test_config.yaml";
     parse_test_config(YAML::LoadFile(config_filename), Tests);
 
     for (auto &Test : Tests) {
@@ -385,7 +384,7 @@ TEST_F(POLICIES, ChunkElementPolicy) {
 // TEST(POLICIES, RangePolicy) {
 //   specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
 //   std::string config_filename =
-//       "../../../tests/unit-tests/policies/test_config.yaml";
+//       "policies/test_config.yaml";
 //   std::vector<test_configuration::Test> Tests;
 //   parse_test_config(YAML::LoadFile(config_filename), Tests);
 

--- a/tests/unit-tests/seismogram/acoustic/seismogram_tests.cpp
+++ b/tests/unit-tests/seismogram/acoustic/seismogram_tests.cpp
@@ -73,8 +73,7 @@ void read_field(
 }
 
 TEST(SEISMOGRAM_TESTS, acoustic_seismograms_test) {
-  std::string config_filename =
-      "../../../tests/unit-tests/seismogram/acoustic/test_config.yaml";
+  std::string config_filename = "seismogram/acoustic/test_config.yaml";
 
   specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
 

--- a/tests/unit-tests/seismogram/acoustic/serial/specfem_config.yaml
+++ b/tests/unit-tests/seismogram/acoustic/serial/specfem_config.yaml
@@ -30,7 +30,7 @@ parameters:
             output-folder: "."
 
   receivers:
-    stations: "../../../tests/unit-tests/seismogram/acoustic/serial/STATIONS"
+    stations: "seismogram/acoustic/serial/STATIONS"
     angle: 0.0
     seismogram-type:
       - displacement
@@ -45,5 +45,5 @@ parameters:
 
   ## databases
   databases:
-    mesh-database: "../../../tests/unit-tests/seismogram/acoustic/serial/database.bin"
+    mesh-database: "seismogram/acoustic/serial/database.bin"
     sources: "dummy-source.yaml"

--- a/tests/unit-tests/seismogram/acoustic/test_config.yaml
+++ b/tests/unit-tests/seismogram/acoustic/test_config.yaml
@@ -1,7 +1,7 @@
 Tests:
 
   serial:
-    specfem_config: "../../../tests/unit-tests/seismogram/acoustic/serial/specfem_config.yaml"
-    displacement_field: "../../../tests/unit-tests/seismogram/acoustic/serial/potential_acoustic_00000.bin"
-    velocity_field: "../../../tests/unit-tests/seismogram/acoustic/serial/potential_acoustic_dot_00000.bin"
-    acceleration_field: "../../../tests/unit-tests/seismogram/acoustic/serial/potential_acoustic_dot_dot_00000.bin"
+    specfem_config: "seismogram/acoustic/serial/specfem_config.yaml"
+    displacement_field: "seismogram/acoustic/serial/potential_acoustic_00000.bin"
+    velocity_field: "seismogram/acoustic/serial/potential_acoustic_dot_00000.bin"
+    acceleration_field: "seismogram/acoustic/serial/potential_acoustic_dot_dot_00000.bin"

--- a/tests/unit-tests/seismogram/elastic/seismogram_tests.cpp
+++ b/tests/unit-tests/seismogram/elastic/seismogram_tests.cpp
@@ -73,8 +73,7 @@ void read_field(
 }
 
 TEST(SEISMOGRAM_TESTS, elastic_seismograms_test) {
-  std::string config_filename =
-      "../../../tests/unit-tests/seismogram/elastic/test_config.yaml";
+  std::string config_filename = "seismogram/elastic/test_config.yaml";
 
   specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
 

--- a/tests/unit-tests/seismogram/elastic/serial/specfem_config.yaml
+++ b/tests/unit-tests/seismogram/elastic/serial/specfem_config.yaml
@@ -30,7 +30,7 @@ parameters:
             output-folder: "."
 
   receivers:
-    stations: "../../../tests/unit-tests/seismogram/elastic/serial/STATIONS"
+    stations: "seismogram/elastic/serial/STATIONS"
     angle: 0.0
     seismogram-type:
       - displacement
@@ -45,6 +45,6 @@ parameters:
 
   ## databases
   databases:
-    mesh-database: "../../../tests/unit-tests/seismogram/elastic/serial/database.bin"
+    mesh-database: "seismogram/elastic/serial/database.bin"
 
   sources: "dummy-source.yaml"

--- a/tests/unit-tests/seismogram/elastic/test_config.yaml
+++ b/tests/unit-tests/seismogram/elastic/test_config.yaml
@@ -1,7 +1,7 @@
 Tests:
 
   serial:
-    specfem_config: "../../../tests/unit-tests/seismogram/elastic/serial/specfem_config.yaml"
-    displacement_field: "../../../tests/unit-tests/seismogram/elastic/serial/displs_00000.bin"
-    velocity_field: "../../../tests/unit-tests/seismogram/elastic/serial/veloc_00000.bin"
-    acceleration_field: "../../../tests/unit-tests/seismogram/elastic/serial/accel_00000.bin"
+    specfem_config: "seismogram/elastic/serial/specfem_config.yaml"
+    displacement_field: "seismogram/elastic/serial/displs_00000.bin"
+    velocity_field: "seismogram/elastic/serial/veloc_00000.bin"
+    acceleration_field: "seismogram/elastic/serial/accel_00000.bin"

--- a/tests/unit-tests/source/source_location_tests.cpp
+++ b/tests/unit-tests/source/source_location_tests.cpp
@@ -143,8 +143,7 @@ test_config parse_test_config(std::string config_filename) {
  *
  */
 TEST(SOURCE_LOCATION_TESTS, compute_source_locations) {
-  std::string config_filename =
-      "../../../tests/unit-tests/source/test_config.yml";
+  std::string config_filename = "source/test_config.yml";
 
   //  alias the mpi environment pointer
   specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();

--- a/tests/unit-tests/source/test_config.yml
+++ b/tests/unit-tests/source/test_config.yml
@@ -1,3 +1,3 @@
-database_file: "../../../tests/unit-tests/source/serial/database.bin"
-sources_file: "../../../tests/unit-tests/source/serial/sources.yml"
-solutions_file: "../../../tests/unit-tests/source/serial/source_locations.yml"
+database_file: "source/serial/database.bin"
+sources_file: "source/serial/sources.yml"
+solutions_file: "source/serial/source_locations.yml"


### PR DESCRIPTION
# Description

- This mainly implements a couple of compilation presets using `CMakePresets.json`. Currently supported presets are `debug` and `release`, which both are the serial+SIMD presets. I will add more as I continue working on the 3D mesh reader.
- To make the presets work, the tests needed some work. That means all test now expect to be run from `./tests/unit-test` as defined using a `WORKING_DIRECTORY` in the `gtest_discover` section in the `tests/unit-tests/CMakeLists.txt`
   - All file locations that are used in the tests have thus been updated removing the `../../../tests/unit-tests/` prefix
   - To make sure that IO tests write in the output binary directory a compiler definition `TEST_OUTPUT_DIR` has been added. It is mainly the property reader and writer that are using this mechanism.
   - written files are being removed at the end of the testing cycle.

There are a few intermediate commits for the fortran reading that are insignificant. 

# Issue Number

closes #398 
closes #450 

# Checklist

Please make sure to check developer documentation on specfem docs. 

- [x] I ran the code through pre-commit to check style
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms 
