### PR TITLE
Issue 482 - Fix cuda compilation + new presets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -704,7 +704,7 @@ target_link_libraries(
         coupled_interface
         kokkos_kernels
         solver
-        ${BOOST_LIBS}        ${BOOST_LIBS}
+        ${BOOST_LIBS}
         yaml-cpp
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -689,14 +689,25 @@ add_executable(
 target_link_libraries(
         specfem3d
         specfem_mpi
+        IO
         Kokkos::kokkos
         mesh
+        quadrature
+        compute
+        source_class
         parameter_reader
+        receiver_class
+        writer
         periodic_tasks
-        IO
-        ${BOOST_LIBS}
+        reader
+        medium
+        coupled_interface
+        kokkos_kernels
+        solver
+        ${BOOST_LIBS}        ${BOOST_LIBS}
         yaml-cpp
 )
+
 
 # Include tests
 if (BUILD_TESTS)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -15,6 +15,34 @@
       }
     },
     {
+      "name": "release-nosimd",
+      "displayName": "Release -- SIMD disabled",
+      "binaryDir": "build/release-nosimd",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "BUILD_TESTS": "ON",
+        "ENABLE_SIMD": "OFF",
+        "Kokkos_ARCH_NATIVE": "OFF",
+        "Kokkos_ENABLE_AGGRESSIVE_VECTORIZATION": "OFF",
+        "Kokkos_ENABLE_ATOMICS_BYPASS": "OFF"
+      }
+    },
+    {
+      "name": "release-cuda",
+      "displayName": "Release -- CUDA enabled",
+      "binaryDir": "build/release-cuda",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_BUILD_EXAMPLES": "ON",
+        "BUILD_TESTS": "ON",
+        "ENABLE_CUDA": "ON",
+        "Kokkos_ARCH_NATIVE": "ON",
+        "Kokkos_ENABLE_AGGRESSIVE_VECTORIZATION": "ON",
+        "Kokkos_ENABLE_ATOMICS_BYPASS": "ON",
+        "Kokkos_ARCH_AMPERE80":"ON"
+      }
+    },
+    {
       "name": "debug",
       "displayName": "Default Debug -- SIMD enabled",
       "binaryDir": "build/debug",
@@ -25,6 +53,35 @@
         "Kokkos_ARCH_NATIVE": "ON",
         "Kokkos_ENABLE_AGGRESSIVE_VECTORIZATION": "ON",
         "Kokkos_ENABLE_ATOMICS_BYPASS": "ON"
+      }
+    },
+    {
+      "name": "debug-cuda",
+      "displayName": "Debug -- CUDA enabled",
+      "binaryDir": "build/debug-cuda",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_BUILD_EXAMPLES": "ON",
+        "BUILD_TESTS": "ON",
+        "ENABLE_CUDA": "ON",
+        "ENABLE_SIMD": "ON",
+        "Kokkos_ARCH_NATIVE": "ON",
+        "Kokkos_ENABLE_AGGRESSIVE_VECTORIZATION": "ON",
+        "Kokkos_ENABLE_ATOMICS_BYPASS": "ON",
+        "Kokkos_ARCH_AMPERE80":"ON"
+      }
+    },
+    {
+      "name": "debug-nosimd",
+      "displayName": "Debug -- SIMD disabled",
+      "binaryDir": "build/debug-nosimd",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "BUILD_TESTS": "ON",
+        "ENABLE_SIMD": "OFF",
+        "Kokkos_ARCH_NATIVE": "OFF",
+        "Kokkos_ENABLE_AGGRESSIVE_VECTORIZATION": "OFF",
+        "Kokkos_ENABLE_ATOMICS_BYPASS": "OFF"
       }
     }
   ],
@@ -37,6 +94,26 @@
     {
       "name": "debug",
       "configurePreset": "debug",
+      "targets": ["all"]
+    },
+    {
+      "name": "release-cuda",
+      "configurePreset": "release-cuda",
+      "targets": ["all"]
+    },
+    {
+      "name": "debug-cuda",
+      "configurePreset": "debug-cuda",
+      "targets": ["all"]
+    },
+    {
+      "name": "release-nosimd",
+      "configurePreset": "release-nosimd",
+      "targets": ["all"]
+    },
+    {
+      "name": "debug-nosimd",
+      "configurePreset": "debug-nosimd",
       "targets": ["all"]
     }
   ]


### PR DESCRIPTION
## Description

I was not able to reproduce the NVIDIA compilation error or Della8.

Added more presets along the way

- release-cuda
- debug-cuda

```bash
cmake --preset release-cuda
cmake --build --preset cuda [-j]
```

Aimed at della compilation for A100s. 

## Issue Number

Closes #482

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
