### PR TITLE
Global index mapping reordering 

### DIFF
--- a/include/algorithms/divergence.hpp
+++ b/include/algorithms/divergence.hpp
@@ -41,7 +41,7 @@ namespace algorithms {
 template <typename MemberType, typename IteratorType, typename VectorFieldType,
           typename QuadratureType, typename CallableType,
           std::enable_if_t<(VectorFieldType::isChunkViewType), int> = 0>
-KOKKOS_FORCEINLINE_FUNCTION void divergence(
+NOINLINE KOKKOS_FUNCTION void divergence(
     const MemberType &team, const IteratorType &iterator,
     const specfem::compute::partial_derivatives &partial_derivatives,
     const Kokkos::View<type_real *,

--- a/include/algorithms/gradient.hpp
+++ b/include/algorithms/gradient.hpp
@@ -38,7 +38,7 @@ namespace algorithms {
 template <typename MemberType, typename IteratorType, typename ViewType,
           typename QuadratureType, typename CallbackFunctor,
           std::enable_if_t<ViewType::isChunkViewType, int> = 0>
-KOKKOS_FORCEINLINE_FUNCTION void
+NOINLINE KOKKOS_FUNCTION void
 gradient(const MemberType &team, const IteratorType &iterator,
          const specfem::compute::partial_derivatives &partial_derivatives,
          const QuadratureType &quadrature, const ViewType &f,

--- a/include/algorithms/gradient.hpp
+++ b/include/algorithms/gradient.hpp
@@ -147,7 +147,7 @@ gradient(const MemberType &team, const IteratorType &iterator,
 template <typename MemberType, typename IteratorType, typename ViewType,
           typename QuadratureType, typename CallbackFunctor,
           std::enable_if_t<ViewType::isChunkViewType, int> = 0>
-KOKKOS_FORCEINLINE_FUNCTION void
+NOINLINE KOKKOS_FUNCTION void
 gradient(const MemberType &team, const IteratorType &iterator,
          const specfem::compute::partial_derivatives &partial_derivatives,
          const QuadratureType &quadrature, const ViewType &f, const ViewType &g,

--- a/include/compute/fields/data_access.tpp
+++ b/include/compute/fields/data_access.tpp
@@ -1902,7 +1902,7 @@ template <
     typename ViewType,
     typename std::enable_if_t<
         ViewType::isChunkFieldType && !ViewType::simd::using_simd, int> = 0>
-KOKKOS_FORCEINLINE_FUNCTION void
+NOINLINE KOKKOS_FUNCTION void
 impl_load_on_device(const MemberType &team, const IteratorType &iterator,
                     const WavefieldType &field, ViewType &chunk_field) {
 
@@ -1980,7 +1980,7 @@ template <
     typename ViewType,
     typename std::enable_if_t<
         ViewType::isChunkFieldType && ViewType::simd::using_simd, int> = 0>
-KOKKOS_FORCEINLINE_FUNCTION void
+NOINLINE KOKKOS_FUNCTION void
 impl_load_on_device(const MemberType &team, const IteratorType &iterator,
                     const WavefieldType &field, ViewType &chunk_field) {
 

--- a/include/compute/fields/data_access.tpp
+++ b/include/compute/fields/data_access.tpp
@@ -1690,7 +1690,7 @@ template <
     typename WavefieldType, typename ViewType,
     typename std::enable_if_t<
         ViewType::isPointFieldType && !ViewType::simd::using_simd, int> = 0>
-KOKKOS_FORCEINLINE_FUNCTION void impl_atomic_add_on_device(
+NOINLINE KOKKOS_FUNCTION void impl_atomic_add_on_device(
     const specfem::point::index<ViewType::dimension> &index,
     const ViewType &point_field, const WavefieldType &field) {
 
@@ -1707,7 +1707,7 @@ template <
     typename WavefieldType, typename ViewType,
     typename std::enable_if_t<
         ViewType::isPointFieldType && ViewType::simd::using_simd, int> = 0>
-KOKKOS_FORCEINLINE_FUNCTION void impl_atomic_add_on_device(
+NOINLINE KOKKOS_FUNCTION void impl_atomic_add_on_device(
     const specfem::point::simd_index<ViewType::dimension> &index,
     const ViewType &point_field, const WavefieldType &field) {
 

--- a/include/compute/fields/impl/field_impl.tpp
+++ b/include/compute/fields/impl/field_impl.tpp
@@ -1,8 +1,8 @@
 #ifndef _COMPUTE_FIELDS_IMPL_FIELD_IMPL_TPP_
 #define _COMPUTE_FIELDS_IMPL_FIELD_IMPL_TPP_
 
-#include "compute/fields/impl/field_impl.hpp"
 #include "compute/element_types/element_types.hpp"
+#include "compute/fields/impl/field_impl.hpp"
 #include "kokkos_abstractions.h"
 #include <Kokkos_Core.hpp>
 
@@ -35,19 +35,38 @@ specfem::compute::impl::field_impl<DimensionType, MediumTag>::field_impl(
 
   // Count the total number of distinct global indices for the medium
   int count = 0;
+  using simd = specfem::datatype::simd<type_real, true>;
 
-  for (int ix = 0; ix < ngllx; ++ix) {
-    for (int iz = 0; iz < ngllz; ++iz) {
-      for (int ispec = 0; ispec < nspec; ++ispec) {
-        const auto medium = element_types.get_medium_tag(ispec);
-        if (medium == MediumTag) {
-          const int index = index_mapping(ispec, iz, ix); // get global index
-          // increase the count only if the global index is not already counted
-          /// static_cast<int>(medium::value) is the index of the medium in the
-          /// enum class
-          if (assembly_index_mapping(index) == -1) {
-            assembly_index_mapping(index) = count;
-            count++;
+#ifdef KOKKOS_ENABLE_CUDA
+  constexpr int chunk_size = 32 * simd::size();
+#endif
+
+#ifdef KOKKOS_ENABLE_OPENMP
+  constexpr int chunk_size = 1 * simd::size();
+#endif
+
+#ifdef KOKKOS_ENABLE_SERIAL
+  constexpr int chunk_size = 1 * simd::size();
+#endif
+
+  int nchunks = nspec / chunk_size;
+  int iloc = 0;
+  for (int ichunk = 0; ichunk < nchunks; ichunk++) {
+    for (int iz = 0; iz < ngllz; iz++) {
+      for (int ix = 0; ix < ngllx; ix++) {
+        for (int ielement = 0; ielement < chunk_size; ielement++) {
+          int ispec = ichunk * chunk_size + ielement;
+          const auto medium = element_types.get_medium_tag(ispec);
+          if (medium == MediumTag) {
+            const int index = index_mapping(ispec, iz, ix); // get global index
+            // increase the count only if the global index is not already
+            // counted
+            /// static_cast<int>(medium::value) is the index of the medium in
+            /// the enum class
+            if (assembly_index_mapping(index) == -1) {
+              assembly_index_mapping(index) = count;
+              count++;
+            }
           }
         }
       }

--- a/include/compute/fields/impl/field_impl.tpp
+++ b/include/compute/fields/impl/field_impl.tpp
@@ -39,13 +39,9 @@ specfem::compute::impl::field_impl<DimensionType, MediumTag>::field_impl(
 
 #ifdef KOKKOS_ENABLE_CUDA
   constexpr int chunk_size = 32 * simd::size();
-#endif
-
-#ifdef KOKKOS_ENABLE_OPENMP
-  constexpr int chunk_size = 1 * simd::size();
-#endif
-
-#ifdef KOKKOS_ENABLE_SERIAL
+#elif KOKKOS_ENABLE_OPENMP
+  constexpr int chunk_size = 1;
+#else
   constexpr int chunk_size = 1 * simd::size();
 #endif
 

--- a/include/compute/fields/impl/field_impl.tpp
+++ b/include/compute/fields/impl/field_impl.tpp
@@ -3,6 +3,7 @@
 
 #include "compute/element_types/element_types.hpp"
 #include "compute/fields/impl/field_impl.hpp"
+#include "parallel_configuration/chunk_config.hpp"
 #include "kokkos_abstractions.h"
 #include <Kokkos_Core.hpp>
 
@@ -37,14 +38,7 @@ specfem::compute::impl::field_impl<DimensionType, MediumTag>::field_impl(
   int count = 0;
   using simd = specfem::datatype::simd<type_real, true>;
 
-#ifdef KOKKOS_ENABLE_CUDA
-  constexpr int chunk_size = 32 * simd::size();
-#elif KOKKOS_ENABLE_OPENMP
-  constexpr int chunk_size = 1;
-#else
-  constexpr int chunk_size = 1 * simd::size();
-#endif
-
+  constexpr int chunk_size = specfem::parallel_config::storage_chunk_size;
   int nchunks = nspec / chunk_size;
   int iloc = 0;
   for (int ichunk = 0; ichunk < nchunks; ichunk++) {

--- a/include/parallel_configuration/chunk_config.hpp
+++ b/include/parallel_configuration/chunk_config.hpp
@@ -7,17 +7,20 @@
 namespace specfem {
 namespace parallel_config {
 
+namespace impl {
+constexpr int cuda_chunk_size = 32;
+constexpr int openmp_chunk_size = 1;
+constexpr int serial_chunk_size = 1;
+} // namespace impl
+
 #ifdef KOKKOS_ENABLE_CUDA
-constexpr int chunk_size = 32;
-constexpr int storage_chunk_size = chunk_size;
+constexpr int storage_chunk_size = impl::cuda_chunk_size;
 #elif KOKKOS_ENABLE_OPENMP
-constexpr int chunk_size = 1;
 constexpr int simd_size = specfem::datatypes::simd<type_real, true>::size();
-constexpr int storage_chunk_size = chunk_size * simd_size;
+constexpr int storage_chunk_size = impl::openmp_chunk_size * simd_size;
 #else
-constexpr int chunk_size = 1;
 constexpr int simd_size = specfem::datatypes::simd<type_real, true>::size();
-constexpr int storage_chunk_size = chunk_size * simd_size;
+constexpr int storage_chunk_size = impl::serial_chunk_size * simd_size;
 #endif
 
 /**
@@ -62,24 +65,24 @@ struct default_chunk_config;
 #ifdef KOKKOS_ENABLE_CUDA
 template <typename SIMD>
 struct default_chunk_config<specfem::dimension::type::dim2, SIMD, Kokkos::Cuda>
-    : chunk_config<specfem::dimension::type::dim2, chunk_size, chunk_size, 160,
-                   1, SIMD, Kokkos::Cuda> {};
+    : chunk_config<specfem::dimension::type::dim2, impl::cuda_chunk_size,
+                   impl::cuda_chunk_size, 160, 1, SIMD, Kokkos::Cuda> {};
 #endif
 
 #ifdef KOKKOS_ENABLE_OPENMP
 template <typename SIMD>
 struct default_chunk_config<specfem::dimension::type::dim2, SIMD,
                             Kokkos::OpenMP>
-    : chunk_config<specfem::dimension::type::dim2, 1, 1, 1, 1, SIMD,
-                   Kokkos::OpenMP> {};
+    : chunk_config<specfem::dimension::type::dim2, impl::openmp_chunk_size,
+                   impl::openmp_chunk_size, 1, 1, SIMD, Kokkos::OpenMP> {};
 #endif
 
 #ifdef KOKKOS_ENABLE_SERIAL
 template <typename SIMD>
 struct default_chunk_config<specfem::dimension::type::dim2, SIMD,
                             Kokkos::Serial>
-    : chunk_config<specfem::dimension::type::dim2, 1, 1, 1, 1, SIMD,
-                   Kokkos::Serial> {};
+    : chunk_config<specfem::dimension::type::dim2, impl::serial_chunk_size,
+                   impl::serial_chunk_size, 1, 1, SIMD, Kokkos::Serial> {};
 #endif
 } // namespace parallel_config
 } // namespace specfem

--- a/include/parallel_configuration/chunk_config.hpp
+++ b/include/parallel_configuration/chunk_config.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "constants.hpp"
+#include "datatypes/simd.hpp"
 #include "enumerations/dimension.hpp"
 #include <Kokkos_Core.hpp>
 
@@ -16,10 +17,10 @@ constexpr int serial_chunk_size = 1;
 #ifdef KOKKOS_ENABLE_CUDA
 constexpr int storage_chunk_size = impl::cuda_chunk_size;
 #elif KOKKOS_ENABLE_OPENMP
-constexpr int simd_size = specfem::datatypes::simd<type_real, true>::size();
+constexpr int simd_size = specfem::datatype::simd<type_real, true>::size();
 constexpr int storage_chunk_size = impl::openmp_chunk_size * simd_size;
 #else
-constexpr int simd_size = specfem::datatypes::simd<type_real, true>::size();
+constexpr int simd_size = specfem::datatype::simd<type_real, true>::size();
 constexpr int storage_chunk_size = impl::serial_chunk_size * simd_size;
 #endif
 

--- a/include/parallel_configuration/chunk_config.hpp
+++ b/include/parallel_configuration/chunk_config.hpp
@@ -6,6 +6,20 @@
 
 namespace specfem {
 namespace parallel_config {
+
+#ifdef KOKKOS_ENABLE_CUDA
+constexpr int chunk_size = 32;
+constexpr int storage_chunk_size = chunk_size;
+#elif KOKKOS_ENABLE_OPENMP
+constexpr int chunk_size = 1;
+constexpr int simd_size = specfem::datatypes::simd<type_real, true>::size();
+constexpr int storage_chunk_size = chunk_size * simd_size;
+#else
+constexpr int chunk_size = 1;
+constexpr int simd_size = specfem::datatypes::simd<type_real, true>::size();
+constexpr int storage_chunk_size = chunk_size * simd_size;
+#endif
+
 /**
  * @brief Parallel configuration for chunk policy.
  *
@@ -48,8 +62,8 @@ struct default_chunk_config;
 #ifdef KOKKOS_ENABLE_CUDA
 template <typename SIMD>
 struct default_chunk_config<specfem::dimension::type::dim2, SIMD, Kokkos::Cuda>
-    : chunk_config<specfem::dimension::type::dim2, 32, 32, 160, 1, SIMD,
-                   Kokkos::Cuda> {};
+    : chunk_config<specfem::dimension::type::dim2, chunk_size, chunk_size, 160,
+                   1, SIMD, Kokkos::Cuda> {};
 #endif
 
 #ifdef KOKKOS_ENABLE_OPENMP

--- a/src/compute/compute_mesh.cpp
+++ b/src/compute/compute_mesh.cpp
@@ -50,13 +50,32 @@ assign_numbering(specfem::kokkos::HostView4d<double> global_coordinates) {
 
   std::vector<qp> cart_cord(nspec * ngllxz);
 
-  for (int ispec = 0; ispec < nspec; ispec++) {
-    for (int iz = 0; iz < ngll; iz++) {
-      for (int ix = 0; ix < ngll; ix++) {
-        int iloc = ix * nspec * ngll + iz * nspec + ispec;
-        cart_cord[iloc].x = global_coordinates(ispec, iz, ix, 0);
-        cart_cord[iloc].z = global_coordinates(ispec, iz, ix, 1);
-        cart_cord[iloc].iloc = iloc;
+  using simd = specfem::datatype::simd<type_real, true>;
+
+#ifdef KOKKOS_ENABLE_CUDA
+  constexpr int chunk_size = 32 * simd::size();
+#endif
+
+#ifdef KOKKOS_ENABLE_OPENMP
+  constexpr int chunk_size = 1 * simd::size();
+#endif
+
+#ifdef KOKKOS_ENABLE_SERIAL
+  constexpr int chunk_size = 1 * simd::size();
+#endif
+
+  int nchunks = nspec / chunk_size;
+  int iloc = 0;
+  for (int ichunk = 0; ichunk < nchunks; ichunk++) {
+    for (int ix = 0; ix < ngll; ix++) {
+      for (int iz = 0; iz < ngll; iz++) {
+        for (int ielement = 0; ielement < chunk_size; ielement++) {
+          int ispec = ichunk * chunk_size + ielement;
+          cart_cord[iloc].x = global_coordinates(ispec, iz, ix, 0);
+          cart_cord[iloc].z = global_coordinates(ispec, iz, ix, 1);
+          cart_cord[iloc].iloc = iloc;
+          iloc++;
+        }
       }
     }
   }
@@ -101,40 +120,44 @@ assign_numbering(specfem::kokkos::HostView4d<double> global_coordinates) {
 
   // Assign numbering to corresponding ispec, iz, ix
   std::vector<int> iglob_counted(nglob, -1);
-  int iloc = 0;
+  iloc = 0;
   int inum = 0;
   type_real xmin = std::numeric_limits<type_real>::max();
   type_real xmax = std::numeric_limits<type_real>::min();
   type_real zmin = std::numeric_limits<type_real>::max();
   type_real zmax = std::numeric_limits<type_real>::min();
-  for (int ix = 0; ix < ngll; ix++) {
-    for (int iz = 0; iz < ngll; iz++) {
-      for (int ispec = 0; ispec < nspec; ispec++) {
-        if (iglob_counted[copy_cart_cord[iloc].iglob] == -1) {
 
-          const type_real x_cor = copy_cart_cord[iloc].x;
-          const type_real z_cor = copy_cart_cord[iloc].z;
-          if (xmin > x_cor)
-            xmin = x_cor;
-          if (zmin > z_cor)
-            zmin = z_cor;
-          if (xmax < x_cor)
-            xmax = x_cor;
-          if (zmax < z_cor)
-            zmax = z_cor;
+  for (int ichunk = 0; ichunk < nchunks; ichunk++) {
+    for (int ix = 0; ix < ngll; ix++) {
+      for (int iz = 0; iz < ngll; iz++) {
+        for (int ielement = 0; ielement < chunk_size; ielement++) {
+          int ispec = ichunk * chunk_size + ielement;
+          if (iglob_counted[copy_cart_cord[iloc].iglob] == -1) {
 
-          iglob_counted[copy_cart_cord[iloc].iglob] = inum;
-          points.h_index_mapping(ispec, iz, ix) = inum;
-          points.h_coord(0, ispec, iz, ix) = x_cor;
-          points.h_coord(1, ispec, iz, ix) = z_cor;
-          inum++;
-        } else {
-          points.h_index_mapping(ispec, iz, ix) =
-              iglob_counted[copy_cart_cord[iloc].iglob];
-          points.h_coord(0, ispec, iz, ix) = copy_cart_cord[iloc].x;
-          points.h_coord(1, ispec, iz, ix) = copy_cart_cord[iloc].z;
+            const type_real x_cor = copy_cart_cord[iloc].x;
+            const type_real z_cor = copy_cart_cord[iloc].z;
+            if (xmin > x_cor)
+              xmin = x_cor;
+            if (zmin > z_cor)
+              zmin = z_cor;
+            if (xmax < x_cor)
+              xmax = x_cor;
+            if (zmax < z_cor)
+              zmax = z_cor;
+
+            iglob_counted[copy_cart_cord[iloc].iglob] = inum;
+            points.h_index_mapping(ispec, iz, ix) = inum;
+            points.h_coord(0, ispec, iz, ix) = x_cor;
+            points.h_coord(1, ispec, iz, ix) = z_cor;
+            inum++;
+          } else {
+            points.h_index_mapping(ispec, iz, ix) =
+                iglob_counted[copy_cart_cord[iloc].iglob];
+            points.h_coord(0, ispec, iz, ix) = copy_cart_cord[iloc].x;
+            points.h_coord(1, ispec, iz, ix) = copy_cart_cord[iloc].z;
+          }
+          iloc++;
         }
-        iloc++;
       }
     }
   }

--- a/src/compute/compute_mesh.cpp
+++ b/src/compute/compute_mesh.cpp
@@ -3,6 +3,7 @@
 #include "enumerations/material_definitions.hpp"
 #include "jacobian/interface.hpp"
 #include "kokkos_abstractions.h"
+#include "parallel_configuration/chunk_config.hpp"
 #include "quadrature/interface.hpp"
 #include "specfem_setup.hpp"
 #include <Kokkos_Core.hpp>
@@ -52,13 +53,7 @@ assign_numbering(specfem::kokkos::HostView4d<double> global_coordinates) {
 
   using simd = specfem::datatype::simd<type_real, true>;
 
-#ifdef KOKKOS_ENABLE_CUDA
-  constexpr int chunk_size = 32 * simd::size();
-#elif KOKKOS_ENABLE_OPENMP
-  constexpr int chunk_size = 1;
-#else
-  constexpr int chunk_size = 1 * simd::size();
-#endif
+  constexpr int chunk_size = specfem::parallel_config::storage_chunk_size;
 
   int nchunks = nspec / chunk_size;
   int iloc = 0;

--- a/src/compute/compute_mesh.cpp
+++ b/src/compute/compute_mesh.cpp
@@ -67,8 +67,8 @@ assign_numbering(specfem::kokkos::HostView4d<double> global_coordinates) {
   int nchunks = nspec / chunk_size;
   int iloc = 0;
   for (int ichunk = 0; ichunk < nchunks; ichunk++) {
-    for (int ix = 0; ix < ngll; ix++) {
-      for (int iz = 0; iz < ngll; iz++) {
+    for (int iz = 0; iz < ngll; iz++) {
+      for (int ix = 0; ix < ngll; ix++) {
         for (int ielement = 0; ielement < chunk_size; ielement++) {
           int ispec = ichunk * chunk_size + ielement;
           cart_cord[iloc].x = global_coordinates(ispec, iz, ix, 0);
@@ -128,8 +128,8 @@ assign_numbering(specfem::kokkos::HostView4d<double> global_coordinates) {
   type_real zmax = std::numeric_limits<type_real>::min();
 
   for (int ichunk = 0; ichunk < nchunks; ichunk++) {
-    for (int ix = 0; ix < ngll; ix++) {
-      for (int iz = 0; iz < ngll; iz++) {
+    for (int iz = 0; iz < ngll; iz++) {
+      for (int ix = 0; ix < ngll; ix++) {
         for (int ielement = 0; ielement < chunk_size; ielement++) {
           int ispec = ichunk * chunk_size + ielement;
           if (iglob_counted[copy_cart_cord[iloc].iglob] == -1) {

--- a/src/compute/compute_mesh.cpp
+++ b/src/compute/compute_mesh.cpp
@@ -54,13 +54,9 @@ assign_numbering(specfem::kokkos::HostView4d<double> global_coordinates) {
 
 #ifdef KOKKOS_ENABLE_CUDA
   constexpr int chunk_size = 32 * simd::size();
-#endif
-
-#ifdef KOKKOS_ENABLE_OPENMP
-  constexpr int chunk_size = 1 * simd::size();
-#endif
-
-#ifdef KOKKOS_ENABLE_SERIAL
+#elif KOKKOS_ENABLE_OPENMP
+  constexpr int chunk_size = 1;
+#else
   constexpr int chunk_size = 1 * simd::size();
 #endif
 


### PR DESCRIPTION
## Description

This PR updates global index mapping i.e. `specfem::compute::points::index_mapping` to account for `chunk_size` used within the compute kernels. This serializes accesses to assembled fields resulting in better performance. 

**I will add performance curve here once the simulations finish running**

## Issue Number

closes #481 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [x] I ran the code through pre-commit to check style
- [ ] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [x] My code builds across all platforms
