### PR TITLE
Add elastic shear wave enumerations

### DIFF
--- a/include/enumerations/material_definitions.hpp
+++ b/include/enumerations/material_definitions.hpp
@@ -16,9 +16,11 @@ namespace element {
 #define DIMENSION_TAG_DIM2 (0, specfem::dimension::type::dim2, dim2)
 
 #define MEDIUM_TAG_ELASTIC_SV                                                  \
-  (0, specfem::element::medium_tag::elastic_sv, elastic)
+  (0, specfem::element::medium_tag::elastic_sv, elastic_sv)
+#define MEDIUM_TAG_ELASTIC_SH                                                  \
+  (1, specfem::element::medium_tag::elastic_sh, elastic_sh)
 #define MEDIUM_TAG_ACOUSTIC                                                    \
-  (1, specfem::element::medium_tag::acoustic, acoustic)
+  (2, specfem::element::medium_tag::acoustic, acoustic)
 
 #define PROPERTY_TAG_ISOTROPIC                                                 \
   (0, specfem::element::property_tag::isotropic, isotropic)
@@ -50,6 +52,7 @@ namespace element {
  */
 #define MEDIUM_TYPES                                                           \
   ((DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_SV))(                               \
+      (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_SH))(                            \
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_ACOUSTIC))
 
 #define MAKE_ARRAY_ELEM(s, data, elem)                                         \
@@ -88,6 +91,8 @@ constexpr auto medium_types() {
 #define MATERIAL_SYSTEMS                                                       \
   ((DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_SV, PROPERTY_TAG_ISOTROPIC))(       \
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_SV, PROPERTY_TAG_ANISOTROPIC))(  \
+      (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_SH, PROPERTY_TAG_ISOTROPIC))(    \
+      (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_SH, PROPERTY_TAG_ANISOTROPIC))(  \
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_ACOUSTIC, PROPERTY_TAG_ISOTROPIC))
 
 #define MAKE_ARRAY_ELEM(s, data, elem)                                         \
@@ -127,6 +132,9 @@ constexpr auto material_systems() {
   ((DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_SV, PROPERTY_TAG_ISOTROPIC,         \
     BOUNDARY_TAG_NONE))((DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_SV,            \
                          PROPERTY_TAG_ISOTROPIC, BOUNDARY_TAG_STACEY))(        \
+      (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_SH, PROPERTY_TAG_ISOTROPIC,      \
+       BOUNDARY_TAG_NONE))((DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_SH,         \
+                            PROPERTY_TAG_ISOTROPIC, BOUNDARY_TAG_STACEY))(     \
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_ACOUSTIC, PROPERTY_TAG_ISOTROPIC,        \
        BOUNDARY_TAG_NONE))((DIMENSION_TAG_DIM2, MEDIUM_TAG_ACOUSTIC,           \
                             PROPERTY_TAG_ISOTROPIC,                            \
@@ -137,6 +145,9 @@ constexpr auto material_systems() {
                               BOUNDARY_TAG_COMPOSITE_STACEY_DIRICHLET))(       \
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_SV, PROPERTY_TAG_ANISOTROPIC,    \
        BOUNDARY_TAG_NONE))((DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_SV,         \
+                            PROPERTY_TAG_ANISOTROPIC, BOUNDARY_TAG_STACEY))(   \
+      (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_SH, PROPERTY_TAG_ANISOTROPIC,    \
+       BOUNDARY_TAG_NONE))((DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_SH,         \
                             PROPERTY_TAG_ANISOTROPIC, BOUNDARY_TAG_STACEY))
 
 #define MAKE_ARRAY_ELEM(s, data, elem)                                         \
@@ -287,7 +298,7 @@ constexpr auto element_types() {
  * \ foo<GET_TAG(DIMENTION_TAG), GET_TAG(MEDIUM_TAG)>();
  *
  *   CALL_MACRO_FOR_ALL_MEDIUM_TAGS(CALL_FOO, WHERE(DIMENSION_TAG_DIM2)
- * WHERE(MEDIUM_TAG_ELASTIC_SV, MEDIUM_TAG_ACOUSTIC))
+ * WHERE(MEDIUM_TAG_ELASTIC_SV, MEDIUM_TAG_ELASTIC_SH))
  * @endcode
  *
  *
@@ -313,8 +324,8 @@ constexpr auto element_types() {
  * \ foo<GET_TAG(DIMENTION_TAG), GET_TAG(MEDIUM_TAG), GET_TAG(PROPERTY_TAG)>();
  *
  *   CALL_MACRO_FOR_ALL_MATERIAL_SYSTEMS(CALL_FOO, WHERE(DIMENSION_TAG_DIM2)
- * WHERE(MEDIUM_TAG_ELASTIC_SV) WHERE(PROPERTY_TAG_ISOTROPIC,
- * PROPERTY_TAG_ANISOTROPIC))
+ * WHERE(MEDIUM_TAG_ELASTIC_SV, MEDIUM_TAG_ELASTIC_SH)
+ * WHERE(PROPERTY_TAG_ISOTROPIC, PROPERTY_TAG_ANISOTROPIC))
  * @endcode
  *
  *
@@ -341,8 +352,9 @@ constexpr auto element_types() {
  * GET_TAG(PROPERTY_TAG), GET_TAG(BOUNDARY_TAG)>();
  *
  *   CALL_MACRO_FOR_ALL_ELEMENT_TYPES(CALL_FOO, WHERE(DIMENSION_TAG_DIM2)
- * WHERE(MEDIUM_TAG_ELASTIC_SV) WHERE(PROPERTY_TAG_ISOTROPIC,
- * PROPERTY_TAG_ANISOTROPIC) WHERE(BOUNDARY_TAG_NONE, BOUNDARY_TAG_STACEY))
+ * WHERE(MEDIUM_TAG_ELASTIC_SV, MEDIUM_TAG_ELASTIC_SH)
+ * WHERE(PROPERTY_TAG_ISOTROPIC, PROPERTY_TAG_ANISOTROPIC)
+ * WHERE(BOUNDARY_TAG_NONE, BOUNDARY_TAG_STACEY))
  * @endcode
  *
  *

--- a/include/enumerations/medium.hpp
+++ b/include/enumerations/medium.hpp
@@ -7,13 +7,13 @@
 namespace specfem {
 namespace element {
 
-constexpr int ntypes = 2; ///< Number of element types
+constexpr int ntypes = 3; ///< Number of element types
 
 /**
  * @brief Medium tag enumeration
  *
  */
-enum class medium_tag { elastic_sv, acoustic, poroelastic };
+enum class medium_tag { elastic_sv, elastic_sh, acoustic, poroelastic };
 
 /**
  * @brief Property tag enumeration
@@ -47,6 +47,16 @@ public:
   constexpr static int dimension() { return 2; }
 
   constexpr static int components() { return 2; }
+};
+
+template <>
+class attributes<specfem::dimension::type::dim2,
+                 specfem::element::medium_tag::elastic_sh> {
+
+public:
+  constexpr static int dimension() { return 2; }
+
+  constexpr static int components() { return 1; }
 };
 
 template <>

--- a/include/kokkos_kernels/domain_kernels.hpp
+++ b/include/kokkos_kernels/domain_kernels.hpp
@@ -25,7 +25,7 @@ public:
   constexpr static auto ngll = NGLL;
 
   domain_kernels(const specfem::compute::assembly &assembly)
-      : assembly(assembly), coupling_interfaces_elastic(assembly),
+      : assembly(assembly), coupling_interfaces_elastic_sv(assembly),
         coupling_interfaces_acoustic(assembly) {}
 
   template <specfem::element::medium_tag medium>

--- a/src/enumerations/medium.cpp
+++ b/src/enumerations/medium.cpp
@@ -12,6 +12,9 @@ specfem::element::to_string(const specfem::element::medium_tag &medium,
   case specfem::element::medium_tag::elastic_sv:
     medium_string = "elastic_sv";
     break;
+  case specfem::element::medium_tag::elastic_sh:
+    medium_string = "elastic_sh";
+    break;
   case specfem::element::medium_tag::acoustic:
     medium_string = "acoustic";
     break;
@@ -60,6 +63,9 @@ const std::string specfem::element::to_string(
   if ((medium == specfem::element::medium_tag::elastic_sv) &&
       (property_tag == specfem::element::property_tag::isotropic)) {
     return "elastic_sv isotropic";
+  } else if ((medium == specfem::element::medium_tag::elastic_sh) &&
+             (property_tag == specfem::element::property_tag::isotropic)) {
+    return "elastic_sh isotropic";
   } else if ((medium == specfem::element::medium_tag::acoustic) &&
              (property_tag == specfem::element::property_tag::isotropic)) {
     return "acoustic isotropic";
@@ -71,7 +77,9 @@ const std::string specfem::element::to_string(
 const std::string
 specfem::element::to_string(const specfem::element::medium_tag &medium) {
   if (medium == specfem::element::medium_tag::elastic_sv) {
-    return "elastic";
+    return "elastic_sv";
+  } else if (medium == specfem::element::medium_tag::elastic_sh) {
+    return "elastic_sh";
   } else if (medium == specfem::element::medium_tag::acoustic) {
     return "acoustic";
   } else {


### PR DESCRIPTION
## Description

Adds elastic_sh tag to medium_tag enumerations

- Updates medium.hpp and material_definitions.hpp to include elastic_sh enumeration
- Updates medium_tag specific methods within enumerations

## Issue Number

closes #495 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
