### PR TITLE
Issue-521: Rename medium::properties to medium::impl_material

### DIFF
--- a/include/medium/dim2/acoustic/isotropic/material.hpp
+++ b/include/medium/dim2/acoustic/isotropic/material.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "enumerations/medium.hpp"
-#include "medium/properties.hpp"
+#include "medium/impl/material.hpp"
 #include "point/properties.hpp"
 #include "specfem_setup.hpp"
 #include <exception>
@@ -13,17 +13,18 @@ namespace specfem {
 namespace medium {
 
 /**
- * @brief Template specialization for elastic isotropic material properties
+ * @brief Template specialization for acoustic isotropic material properties
  *
  */
 template <>
-class properties<specfem::element::medium_tag::elastic,
-                 specfem::element::property_tag::isotropic> {
+class impl_material<specfem::element::medium_tag::acoustic,
+                    specfem::element::property_tag::isotropic> {
+
 public:
   constexpr static auto dimension =
       specfem::dimension::type::dim2; ///< Dimension of the material
   constexpr static auto medium_tag =
-      specfem::element::medium_tag::elastic; ///< Medium tag
+      specfem::element::medium_tag::acoustic; ///< Medium tag
   constexpr static auto property_tag =
       specfem::element::property_tag::isotropic; ///< Property tag
 
@@ -32,40 +33,25 @@ public:
    */
   ///@{
   /**
-   * @brief Construct a new elastic isotropic material
+   * @brief Construct a new acoustic isotropic material
    *
    * @param density Density of the material
-   * @param cs Shear wave speed
    * @param cp Compressional wave speed
    * @param Qkappa Attenuation factor for bulk modulus
    * @param Qmu Attenuation factor for shear modulus
    * @param compaction_grad Compaction gradient
    */
-  properties(const type_real &density, const type_real &cs, const type_real &cp,
-             const type_real &Qkappa, const type_real &Qmu,
-             const type_real &compaction_grad)
-      : density(density), cs(cs), cp(cp), Qkappa(Qkappa), Qmu(Qmu),
-        compaction_grad(compaction_grad), lambdaplus2mu(density * cp * cp),
-        mu(density * cs * cs), lambda(lambdaplus2mu - 2.0 * mu),
-        kappa(lambda + mu), young(9.0 * kappa * mu / (3.0 * kappa + mu)),
-        poisson(0.5 * (cp * cp - 2.0 * cs * cs) / (cp * cp - cs * cs)) {
+  impl_material(const type_real &density, const type_real &cp,
+                const type_real &Qkappa, const type_real &Qmu,
+                const type_real &compaction_grad)
+      : density(density), cp(cp), Qkappa(Qkappa), Qmu(Qmu),
+        compaction_grad(compaction_grad), kappa(density * cp * cp) {
     if (this->Qkappa <= 0.0 || this->Qmu <= 0.0) {
       std::runtime_error(
           "negative or null values of Q attenuation factor not allowed; set "
           "them equal to 9999 to indicate no attenuation");
     }
-
-    if (this->poisson < -1.0 || this->poisson > 0.5)
-      std::runtime_error("Poisson's ratio out of range");
-  };
-
-  /**
-   * @brief Default constructor
-   *
-   */
-  properties() = default;
-
-  ///@}
+  }
 
   /**
    * @brief Check if 2 materials have the same properties
@@ -73,13 +59,12 @@ public:
    * @param other Material to compare with
    * @return true If the materials have the same properties
    */
-  bool operator==(const properties<specfem::element::medium_tag::elastic,
-                                   specfem::element::property_tag::isotropic>
+  bool operator==(const impl_material<specfem::element::medium_tag::acoustic,
+                                      specfem::element::property_tag::isotropic>
                       &other) const {
 
     return (std::abs(this->density - other.density) < 1e-6 &&
             std::abs(this->cp - other.cp) < 1e-6 &&
-            std::abs(this->cs - other.cs) < 1e-6 &&
             std::abs(this->Qkappa - other.Qkappa) < 1e-6 &&
             std::abs(this->Qmu - other.Qmu) < 1e-6 &&
             std::abs(this->compaction_grad - other.compaction_grad) < 1e-6);
@@ -91,55 +76,54 @@ public:
    * @param other Material to compare with
    * @return true If the materials have different properties
    */
-  bool operator!=(const properties<specfem::element::medium_tag::elastic,
-                                   specfem::element::property_tag::isotropic>
+  bool operator!=(const impl_material<specfem::element::medium_tag::acoustic,
+                                      specfem::element::property_tag::isotropic>
                       &other) const {
     return !(*this == other);
   }
 
   /**
-   * @brief Get the material properties
+   * @brief Default constructor
+   *
+   */
+  impl_material() = default;
+  ///@}
+
+  ~impl_material() = default;
+
+  /**
+   * @brief Get the properties of the material
    *
    * @return specfem::point::properties Material properties
    */
   inline specfem::point::properties<dimension, medium_tag, property_tag, false>
   get_properties() const {
-    return { this->lambdaplus2mu, this->mu, this->density };
+    return { static_cast<type_real>(1.0) / static_cast<type_real>(density),
+             this->kappa };
   }
 
   inline std::string print() const {
     std::ostringstream message;
 
-    message << "- Elastic Material : \n"
+    message << "- Acoustic Material : \n"
             << "    Properties:\n"
             << "      density : " << this->density << "\n"
-            << "      cs : " << this->cs << "\n"
             << "      cp : " << this->cp << "\n"
             << "      kappa : " << this->kappa << "\n"
-            << "      mu : " << this->mu << "\n"
             << "      Qkappa : " << this->Qkappa << "\n"
-            << "      Qmu : " << this->Qmu << "\n"
-            << "      lambda : " << this->lambda << "\n"
-            << "      mu : " << this->mu << "\n"
-            << "      youngs modulus : " << this->young << "\n"
-            << "      poisson ratio : " << this->poisson << "\n";
+            << "      youngs modulus : 0.0 \n"
+            << "      poisson ratio :  0.5 \n";
 
     return message.str();
   }
 
 private:
   type_real density;         ///< Density of the material
-  type_real cs;              ///< Shear wave speed
   type_real cp;              ///< Compressional wave speed
   type_real Qkappa;          ///< Attenuation factor for bulk modulus
   type_real Qmu;             ///< Attenuation factor for shear modulus
   type_real compaction_grad; ///< Compaction gradient
-  type_real lambdaplus2mu;   ///< Lame parameter
-  type_real mu;              ///< Lame parameter
-  type_real lambda;          ///< Lame parameter
   type_real kappa;           ///< Bulk modulus
-  type_real young;           ///< Young's modulus
-  type_real poisson;         ///< Poisson's ratio
 };
 
 } // namespace medium

--- a/include/medium/dim2/elastic/anisotropic/material.hpp
+++ b/include/medium/dim2/elastic/anisotropic/material.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "enumerations/specfem_enums.hpp"
-#include "medium/properties.hpp"
+#include "medium/impl/material.hpp"
 #include "point/properties.hpp"
 #include "specfem_setup.hpp"
 #include <exception>
@@ -17,8 +17,8 @@ namespace medium {
  *
  */
 template <>
-class properties<specfem::element::medium_tag::elastic,
-                 specfem::element::property_tag::anisotropic> {
+class impl_material<specfem::element::medium_tag::elastic,
+                    specfem::element::property_tag::anisotropic> {
 public:
   constexpr static auto dimension =
       specfem::dimension::type::dim2; ///< Dimension of the material
@@ -46,11 +46,12 @@ public:
    * @param Qkappa Attenuation factor for bulk modulus
    * @param Qmu Attenuation factor for shear modulus
    */
-  properties(const type_real &density, const type_real &c11,
-             const type_real &c13, const type_real &c15, const type_real &c33,
-             const type_real &c35, const type_real &c55, const type_real &c12,
-             const type_real &c23, const type_real &c25,
-             const type_real &Qkappa, const type_real &Qmu)
+  impl_material(const type_real &density, const type_real &c11,
+                const type_real &c13, const type_real &c15,
+                const type_real &c33, const type_real &c35,
+                const type_real &c55, const type_real &c12,
+                const type_real &c23, const type_real &c25,
+                const type_real &Qkappa, const type_real &Qmu)
       : density(density), c11(c11), c13(c13), c15(c15), c33(c33), c35(c35),
         c55(c55), c12(c12), c23(c23), c25(c25), Qkappa(Qkappa), Qmu(Qmu) {
 
@@ -67,7 +68,7 @@ public:
    * @brief Default constructor
    *
    */
-  properties() = default;
+  impl_material() = default;
 
   ///@}
 
@@ -77,9 +78,10 @@ public:
    * @param other Material to compare with
    * @return true If the materials have the same properties
    */
-  bool operator==(const properties<specfem::element::medium_tag::elastic,
-                                   specfem::element::property_tag::anisotropic>
-                      &other) const {
+  bool operator==(
+      const impl_material<specfem::element::medium_tag::elastic,
+                          specfem::element::property_tag::anisotropic> &other)
+      const {
     return (std::abs(this->density - other.density) < 1e-6 &&
             std::abs(this->c11 - other.c11) < 1e-6 &&
             std::abs(this->c13 - other.c13) < 1e-6 &&
@@ -100,9 +102,10 @@ public:
    * @param other Material to compare with
    * @return true If the materials have different properties
    */
-  bool operator!=(const properties<specfem::element::medium_tag::elastic,
-                                   specfem::element::property_tag::anisotropic>
-                      &other) const {
+  bool operator!=(
+      const impl_material<specfem::element::medium_tag::elastic,
+                          specfem::element::property_tag::anisotropic> &other)
+      const {
     return !(*this == other);
   }
 

--- a/include/medium/dim2/elastic/isotropic/material.hpp
+++ b/include/medium/dim2/elastic/isotropic/material.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "enumerations/medium.hpp"
-#include "medium/properties.hpp"
+#include "medium/impl/material.hpp"
 #include "point/properties.hpp"
 #include "specfem_setup.hpp"
 #include <exception>
@@ -13,18 +13,17 @@ namespace specfem {
 namespace medium {
 
 /**
- * @brief Template specialization for acoustic isotropic material properties
+ * @brief Template specialization for elastic isotropic material properties
  *
  */
 template <>
-class properties<specfem::element::medium_tag::acoustic,
-                 specfem::element::property_tag::isotropic> {
-
+class impl_material<specfem::element::medium_tag::elastic,
+                    specfem::element::property_tag::isotropic> {
 public:
   constexpr static auto dimension =
       specfem::dimension::type::dim2; ///< Dimension of the material
   constexpr static auto medium_tag =
-      specfem::element::medium_tag::acoustic; ///< Medium tag
+      specfem::element::medium_tag::elastic; ///< Medium tag
   constexpr static auto property_tag =
       specfem::element::property_tag::isotropic; ///< Property tag
 
@@ -33,25 +32,40 @@ public:
    */
   ///@{
   /**
-   * @brief Construct a new acoustic isotropic material
+   * @brief Construct a new elastic isotropic material
    *
    * @param density Density of the material
+   * @param cs Shear wave speed
    * @param cp Compressional wave speed
    * @param Qkappa Attenuation factor for bulk modulus
    * @param Qmu Attenuation factor for shear modulus
    * @param compaction_grad Compaction gradient
    */
-  properties(const type_real &density, const type_real &cp,
-             const type_real &Qkappa, const type_real &Qmu,
-             const type_real &compaction_grad)
-      : density(density), cp(cp), Qkappa(Qkappa), Qmu(Qmu),
-        compaction_grad(compaction_grad), kappa(density * cp * cp) {
+  impl_material(const type_real &density, const type_real &cs,
+                const type_real &cp, const type_real &Qkappa,
+                const type_real &Qmu, const type_real &compaction_grad)
+      : density(density), cs(cs), cp(cp), Qkappa(Qkappa), Qmu(Qmu),
+        compaction_grad(compaction_grad), lambdaplus2mu(density * cp * cp),
+        mu(density * cs * cs), lambda(lambdaplus2mu - 2.0 * mu),
+        kappa(lambda + mu), young(9.0 * kappa * mu / (3.0 * kappa + mu)),
+        poisson(0.5 * (cp * cp - 2.0 * cs * cs) / (cp * cp - cs * cs)) {
     if (this->Qkappa <= 0.0 || this->Qmu <= 0.0) {
       std::runtime_error(
           "negative or null values of Q attenuation factor not allowed; set "
           "them equal to 9999 to indicate no attenuation");
     }
-  }
+
+    if (this->poisson < -1.0 || this->poisson > 0.5)
+      std::runtime_error("Poisson's ratio out of range");
+  };
+
+  /**
+   * @brief Default constructor
+   *
+   */
+  impl_material() = default;
+
+  ///@}
 
   /**
    * @brief Check if 2 materials have the same properties
@@ -59,12 +73,13 @@ public:
    * @param other Material to compare with
    * @return true If the materials have the same properties
    */
-  bool operator==(const properties<specfem::element::medium_tag::acoustic,
-                                   specfem::element::property_tag::isotropic>
+  bool operator==(const impl_material<specfem::element::medium_tag::elastic,
+                                      specfem::element::property_tag::isotropic>
                       &other) const {
 
     return (std::abs(this->density - other.density) < 1e-6 &&
             std::abs(this->cp - other.cp) < 1e-6 &&
+            std::abs(this->cs - other.cs) < 1e-6 &&
             std::abs(this->Qkappa - other.Qkappa) < 1e-6 &&
             std::abs(this->Qmu - other.Qmu) < 1e-6 &&
             std::abs(this->compaction_grad - other.compaction_grad) < 1e-6);
@@ -76,54 +91,55 @@ public:
    * @param other Material to compare with
    * @return true If the materials have different properties
    */
-  bool operator!=(const properties<specfem::element::medium_tag::acoustic,
-                                   specfem::element::property_tag::isotropic>
+  bool operator!=(const impl_material<specfem::element::medium_tag::elastic,
+                                      specfem::element::property_tag::isotropic>
                       &other) const {
     return !(*this == other);
   }
 
   /**
-   * @brief Default constructor
-   *
-   */
-  properties() = default;
-  ///@}
-
-  ~properties() = default;
-
-  /**
-   * @brief Get the properties of the material
+   * @brief Get the material properties
    *
    * @return specfem::point::properties Material properties
    */
   inline specfem::point::properties<dimension, medium_tag, property_tag, false>
   get_properties() const {
-    return { static_cast<type_real>(1.0) / static_cast<type_real>(density),
-             this->kappa };
+    return { this->lambdaplus2mu, this->mu, this->density };
   }
 
   inline std::string print() const {
     std::ostringstream message;
 
-    message << "- Acoustic Material : \n"
+    message << "- Elastic Material : \n"
             << "    Properties:\n"
             << "      density : " << this->density << "\n"
+            << "      cs : " << this->cs << "\n"
             << "      cp : " << this->cp << "\n"
             << "      kappa : " << this->kappa << "\n"
+            << "      mu : " << this->mu << "\n"
             << "      Qkappa : " << this->Qkappa << "\n"
-            << "      youngs modulus : 0.0 \n"
-            << "      poisson ratio :  0.5 \n";
+            << "      Qmu : " << this->Qmu << "\n"
+            << "      lambda : " << this->lambda << "\n"
+            << "      mu : " << this->mu << "\n"
+            << "      youngs modulus : " << this->young << "\n"
+            << "      poisson ratio : " << this->poisson << "\n";
 
     return message.str();
   }
 
 private:
   type_real density;         ///< Density of the material
+  type_real cs;              ///< Shear wave speed
   type_real cp;              ///< Compressional wave speed
   type_real Qkappa;          ///< Attenuation factor for bulk modulus
   type_real Qmu;             ///< Attenuation factor for shear modulus
   type_real compaction_grad; ///< Compaction gradient
+  type_real lambdaplus2mu;   ///< Lame parameter
+  type_real mu;              ///< Lame parameter
+  type_real lambda;          ///< Lame parameter
   type_real kappa;           ///< Bulk modulus
+  type_real young;           ///< Young's modulus
+  type_real poisson;         ///< Poisson's ratio
 };
 
 } // namespace medium

--- a/include/medium/impl/material.hpp
+++ b/include/medium/impl/material.hpp
@@ -12,6 +12,6 @@ namespace medium {
  */
 template <specfem::element::medium_tag MediumTag,
           specfem::element::property_tag PropertyTag>
-class properties;
+class impl_material;
 } // namespace medium
 } // namespace specfem

--- a/include/medium/material.hpp
+++ b/include/medium/material.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
-#include "dim2/acoustic/isotropic/properties.hpp"
-#include "dim2/elastic/anisotropic/properties.hpp"
-#include "dim2/elastic/isotropic/properties.hpp"
+#include "dim2/acoustic/isotropic/material.hpp"
+#include "dim2/elastic/anisotropic/material.hpp"
+#include "dim2/elastic/isotropic/material.hpp"
 #include "enumerations/specfem_enums.hpp"
 #include "point/properties.hpp"
-#include "properties.hpp"
 #include "specfem_setup.hpp"
 #include <ostream>
 #include <tuple>
@@ -21,7 +20,7 @@ namespace medium {
  */
 template <specfem::element::medium_tag MediumTag,
           specfem::element::property_tag PropertyTag>
-class material : public specfem::medium::properties<MediumTag, PropertyTag> {
+class material : public specfem::medium::impl_material<MediumTag, PropertyTag> {
 public:
   constexpr static auto medium_tag = MediumTag;     ///< Medium tag
   constexpr static auto property_tag = PropertyTag; ///< Property tag
@@ -45,7 +44,7 @@ public:
    */
   template <typename... Args>
   material(Args &&...args)
-      : specfem::medium::properties<MediumTag, PropertyTag>(
+      : specfem::medium::impl_material<MediumTag, PropertyTag>(
             std::forward<Args>(args)...) {}
   ///@}
 


### PR DESCRIPTION
## Description

Rename medium::properties to medium::impl_material

## Issue Number

Closes #521 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
