### PR TITLE
[Draft] Demonstration of the new macro implementation

### DIFF
--- a/include/compute/element_types/element_types.hpp
+++ b/include/compute/element_types/element_types.hpp
@@ -135,21 +135,17 @@ private:
 #undef MEDIUM_TAG_VARIABLES
 
 #define MATERIAL_SYSTEMS_VARIABLE_NAMES(DIMENSION_TAG, MEDIUM_TAG,             \
-                                        PROPERTY_TAG)                          \
-  IndexViewType CREATE_VARIABLE_NAME(elements, GET_NAME(DIMENSION_TAG),        \
-                                     GET_NAME(MEDIUM_TAG),                     \
-                                     GET_NAME(PROPERTY_TAG));                  \
-  IndexViewType::HostMirror CREATE_VARIABLE_NAME(                              \
-      h_elements, GET_NAME(DIMENSION_TAG), GET_NAME(MEDIUM_TAG),               \
-      GET_NAME(PROPERTY_TAG));
+                                        PROPERTY_TAG, POSTFIX)                 \
+  IndexViewType elements_##POSTFIX;                                            \
+  IndexViewType::HostMirror h_elements_##POSTFIX;
 
-  CALL_MACRO_FOR_ALL_MATERIAL_SYSTEMS(MATERIAL_SYSTEMS_VARIABLE_NAMES,
-                                      WHERE(DIMENSION_TAG_DIM2)
-                                          WHERE(MEDIUM_TAG_ELASTIC_SV,
-                                                MEDIUM_TAG_ELASTIC_SH,
-                                                MEDIUM_TAG_ACOUSTIC)
-                                              WHERE(PROPERTY_TAG_ISOTROPIC,
-                                                    PROPERTY_TAG_ANISOTROPIC))
+  CALL_MACRO_FOR_ALL_MATERIAL_SYSTEMS2(MATERIAL_SYSTEMS_VARIABLE_NAMES,
+                                       WHERE(DIMENSION_TAG_DIM2)
+                                           WHERE(MEDIUM_TAG_ELASTIC_SV,
+                                                 MEDIUM_TAG_ELASTIC_SH,
+                                                 MEDIUM_TAG_ACOUSTIC)
+                                               WHERE(PROPERTY_TAG_ISOTROPIC,
+                                                     PROPERTY_TAG_ANISOTROPIC))
 
 #undef MATERIAL_SYSTEMS_VARIABLE_NAMES
 

--- a/include/compute/impl/value_containers.hpp
+++ b/include/compute/impl/value_containers.hpp
@@ -27,18 +27,17 @@ struct value_containers {
                                                       ///< property index
                                                       ///< mapping
 
-#define GENERATE_CONTAINER_NAME(DIMENSION_TAG, MEDIUM_TAG, PROPERTY_TAG)       \
-  containers_type<GET_TAG(MEDIUM_TAG), GET_TAG(PROPERTY_TAG)>                  \
-      CREATE_VARIABLE_NAME(value, GET_NAME(DIMENSION_TAG),                     \
-                           GET_NAME(MEDIUM_TAG), GET_NAME(PROPERTY_TAG));
+#define GENERATE_CONTAINER_NAME(DIMENSION_TAG, MEDIUM_TAG, PROPERTY_TAG,       \
+                                POSTFIX)                                       \
+  containers_type<MEDIUM_TAG, PROPERTY_TAG> value_##POSTFIX;
 
-  CALL_MACRO_FOR_ALL_MATERIAL_SYSTEMS(GENERATE_CONTAINER_NAME,
-                                      WHERE(DIMENSION_TAG_DIM2)
-                                          WHERE(MEDIUM_TAG_ELASTIC_SV,
-                                                MEDIUM_TAG_ELASTIC_SH,
-                                                MEDIUM_TAG_ACOUSTIC)
-                                              WHERE(PROPERTY_TAG_ISOTROPIC,
-                                                    PROPERTY_TAG_ANISOTROPIC));
+  CALL_MACRO_FOR_ALL_MATERIAL_SYSTEMS2(GENERATE_CONTAINER_NAME,
+                                       WHERE(DIMENSION_TAG_DIM2)
+                                           WHERE(MEDIUM_TAG_ELASTIC_SV,
+                                                 MEDIUM_TAG_ELASTIC_SH,
+                                                 MEDIUM_TAG_ACOUSTIC)
+                                               WHERE(PROPERTY_TAG_ISOTROPIC,
+                                                     PROPERTY_TAG_ANISOTROPIC));
 
 #undef GENERATE_CONTAINER_NAME
 

--- a/include/enumerations/material_definitions.hpp
+++ b/include/enumerations/material_definitions.hpp
@@ -282,6 +282,20 @@ constexpr auto element_types() {
    BOOST_PP_TUPLE_ELEM(1, (BOOST_PP_SEQ_ENUM(elem))),                          \
    BOOST_PP_TUPLE_ELEM(2, (BOOST_PP_SEQ_ENUM(elem))))
 
+#define ARGUMENTS_FOR_ONE_MATERIAL_SYSTEM(elem)                                \
+  (GET_TAG(BOOST_PP_TUPLE_ELEM(0, (BOOST_PP_SEQ_ENUM(elem)))),                 \
+   GET_TAG(BOOST_PP_TUPLE_ELEM(1, (BOOST_PP_SEQ_ENUM(elem)))),                 \
+   GET_TAG(BOOST_PP_TUPLE_ELEM(2, (BOOST_PP_SEQ_ENUM(elem)))),                 \
+   CREATE_VARIABLE_NAME(                                                       \
+       GET_NAME(BOOST_PP_TUPLE_ELEM(0, (BOOST_PP_SEQ_ENUM(elem)))),            \
+       GET_NAME(BOOST_PP_TUPLE_ELEM(1, (BOOST_PP_SEQ_ENUM(elem)))),            \
+       GET_NAME(BOOST_PP_TUPLE_ELEM(2, (BOOST_PP_SEQ_ENUM(elem))))))
+
+#define CALL_FOR_ONE_MATERIAL_SYSTEM2(s, MACRO, elem)                          \
+  BOOST_PP_EXPAND(BOOST_PP_IF(MAT_SYS_IN_SEQUENCE((BOOST_PP_SEQ_ENUM(elem))),  \
+                              MACRO, EMPTY_MACRO)                              \
+                      ARGUMENTS_FOR_ONE_MATERIAL_SYSTEM(elem))
+
 #define CALL_FOR_ONE_ELEMENT_TYPE(s, MACRO, elem)                              \
   BOOST_PP_IF(ELEM_IN_SEQUENCE((BOOST_PP_SEQ_ENUM(elem))), MACRO, EMPTY_MACRO) \
   (BOOST_PP_TUPLE_ELEM(0, (BOOST_PP_SEQ_ENUM(elem))),                          \
@@ -346,6 +360,9 @@ constexpr auto element_types() {
   BOOST_PP_SEQ_FOR_EACH(CALL_FOR_ONE_MATERIAL_SYSTEM, MACRO,                   \
                         BOOST_PP_SEQ_FOR_EACH_PRODUCT(CREATE_SEQ, seq))
 
+#define CALL_MACRO_FOR_ALL_MATERIAL_SYSTEMS2(MACRO, seq)                       \
+  BOOST_PP_SEQ_FOR_EACH(CALL_FOR_ONE_MATERIAL_SYSTEM2, MACRO,                  \
+                        BOOST_PP_SEQ_FOR_EACH_PRODUCT(CREATE_SEQ, seq))
 /**
  * @brief Call a macro for all element types
  *


### PR DESCRIPTION
## Description

A working example of the new macro syntax. Currently the macro is named `CALL_MACRO_FOR_ALL_MATERIAL_SYSTEMS2` for the code to compile and will eventually replace `CALL_MACRO_FOR_ALL_MATERIAL_SYSTEMS` when the branch is done.

## Issue Number

Demonstrates the changes that will be made in #655

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
