### PR TITLE
Issue 574 - Fixing the execution from Python + VTK_CXX_BUILD=OFF works now even if VTK is found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,24 +85,33 @@ FetchContent_MakeAvailable(yaml)
 
 include_directories(BEFORE SYSTEM ${yaml_BINARY_DIR} ${yaml_SOURCE_DIR}/include)
 
-find_package(VTK COMPONENTS
-  CommonColor
-  CommonCore
-  FiltersSources
-  InteractionStyle
-  RenderingContextOpenGL2
-  RenderingCore
-  RenderingFreeType
-  RenderingGL2PSOpenGL2
-  RenderingOpenGL2
-)
 
+if (VTK_CXX_BUILD)
 
-if (NOT VTK_FOUND)
-  message(STATUS "VTK not found: ${VTK_NOT_FOUND_MESSAGE}")
-  set(VTK_CXX_BUILD OFF)
+    find_package(VTK COMPONENTS
+        CommonColor
+        CommonCore
+        FiltersSources
+        InteractionStyle
+        RenderingContextOpenGL2
+        RenderingCore
+        RenderingFreeType
+        RenderingGL2PSOpenGL2
+        RenderingOpenGL2
+    )
+
+    if (VTK_FOUND)
+        message(STATUS "VTK libs/ and incs/:")
+        message(STATUS "    LIB:   ${VTK_LIBRARY_DIRS}")
+        message(STATUS "    INC:   ${VTK_INCLUDE_DIRS}")
+        message(STATUS "    LIBSO: ${VTK_LIBRARIES}")
+    else(NOT VTK_FOUND)
+        message(STATUS "VTK not found. Building without VTK.")
+        set(VTK_CXX_BUILD OFF)
+    endif()
 else ()
-  message(STATUS "    VTK:   ${VTK_LIBRARIES}")
+    set(VTK_FOUND OFF)
+    message(STATUS "Building without VTK.")
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -599,6 +599,7 @@ target_link_libraries(
 add_library(
         periodic_tasks
         src/periodic_tasks/plot_wavefield.cpp
+        src/periodic_tasks/check_signal.cpp
 )
 
 if (NOT VTK_CXX_BUILD)
@@ -763,6 +764,7 @@ if (SPECFEMPP_BINDING_PYTHON)
     target_link_libraries(
         _core PRIVATE
         execute
+        periodic_tasks
         ${BOOST_LIBS}
         pybind11::headers
     )

--- a/include/periodic_tasks/check_signal.hpp
+++ b/include/periodic_tasks/check_signal.hpp
@@ -6,36 +6,6 @@
 #include <iostream>
 #include <Kokkos_Core.hpp>
 
-/**
- * @brief Catch signals
- * 
- * This function is catching the keyboard interrupt signal and other interrupt 
- * signals to parse them as exceptions to Python without crashing or hanging
- * the program. This is to avoid the program to hang via 
- * @code
- * if (PyErr_CheckSignals() != 0) {
- *     throw pybind11::error_already_set();
- * }
- * @endcode
- * if releasing the GIL in execute() function.
- */
-
-// Global flag for signal state - must be volatile sig_atomic_t for thread safety
-volatile sig_atomic_t signal_received = 0;
-
-// Static function to handle signals
-static void signal_handler(int code) {
-    // Just set the flag and return
-    signal_received = code;
-    std::cout << "Signal " << code << " received (probably Ctrl-C)" << std::endl;
-}
-
-void catch_signals() {
-    // Register our handler for SIGINT (Ctrl-C)
-    signal(SIGINT, signal_handler);
-}
-
-
 namespace specfem {
 namespace periodic_tasks {
 /**
@@ -46,24 +16,10 @@ class check_signal : public periodic_task {
   using periodic_task::periodic_task; 
 
   /**
-   * @brief Plot the wavefield
+   * @brief Check for keyboard interrupt and more, when running from Python
    *
    */
-  void run() override {
-    // Catch signals
-    catch_signals();
-
-    // Check if a signal was received
-    if (signal_received) {
-      // Handle the signal (e.g., throw an exception)
-      std::string error_message = "Signal " + std::to_string(signal_received) +
-                                   " received. Exiting...";
-      // Reset the signal flag
-      signal_received = 0;
-      throw std::runtime_error(error_message);
-    }
-    
-  }
+  void run() override;  
 };
 
 } // namespace periodic_tasks

--- a/include/periodic_tasks/check_signal.hpp
+++ b/include/periodic_tasks/check_signal.hpp
@@ -3,6 +3,7 @@
 #include <stdexcept>
 #include <csignal>
 #include <string>
+#include <iostream>
 
 /**
  * @brief Catch signals
@@ -18,10 +19,11 @@
  * if releasing the GIL in execute() function.
  */
 void catch_signals() {
-  auto handler = [](int code) { throw std::runtime_error("SIGNAL " + std::to_string(code)); };
+  auto handler = [](int code) { 
+    std::string message =  "SIGNAL " + std::to_string(code);
+    throw std::runtime_error(message);
+  };
   signal(SIGINT, handler);
-  signal(SIGTERM, handler);
-  signal(SIGKILL, handler);
 }
 
 namespace specfem {

--- a/include/periodic_tasks/check_signal.hpp
+++ b/include/periodic_tasks/check_signal.hpp
@@ -40,6 +40,7 @@ class check_signal : public periodic_task {
    *
    */
   void run() override {
+    // Catch signals
     catch_signals();
   }
 };

--- a/include/periodic_tasks/check_signal.hpp
+++ b/include/periodic_tasks/check_signal.hpp
@@ -19,13 +19,22 @@
  * @endcode
  * if releasing the GIL in execute() function.
  */
-void catch_signals() {
-  auto handler = [](int code) { 
-    std::string message =  "SIGNAL " + std::to_string(code);
-    throw std::runtime_error(message);
-  };
-  signal(SIGINT, handler);
+
+// Global flag for signal state - must be volatile sig_atomic_t for thread safety
+volatile sig_atomic_t signal_received = 0;
+
+// Static function to handle signals
+static void signal_handler(int code) {
+    // Just set the flag and return
+    signal_received = code;
+    std::cout << "Signal " << code << " received (probably Ctrl-C)" << std::endl;
 }
+
+void catch_signals() {
+    // Register our handler for SIGINT (Ctrl-C)
+    signal(SIGINT, signal_handler);
+}
+
 
 namespace specfem {
 namespace periodic_tasks {
@@ -43,6 +52,17 @@ class check_signal : public periodic_task {
   void run() override {
     // Catch signals
     catch_signals();
+
+    // Check if a signal was received
+    if (signal_received) {
+      // Handle the signal (e.g., throw an exception)
+      std::string error_message = "Signal " + std::to_string(signal_received) +
+                                   " received. Exiting...";
+      // Reset the signal flag
+      signal_received = 0;
+      throw std::runtime_error(error_message);
+    }
+    
   }
 };
 

--- a/include/periodic_tasks/check_signal.hpp
+++ b/include/periodic_tasks/check_signal.hpp
@@ -1,7 +1,28 @@
 #pragma once
 #include "periodic_task.hpp"
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+#include <stdexcept>
+#include <csignal>
+#include <string>
+
+/**
+ * @brief Catch signals
+ * 
+ * This function is catching the keyboard interrupt signal and other interrupt 
+ * signals to parse them as exceptions to Python without crashing or hanging
+ * the program. This is to avoid the program to hang via 
+ * @code
+ * if (PyErr_CheckSignals() != 0) {
+ *     throw pybind11::error_already_set();
+ * }
+ * @endcode
+ * if releasing the GIL in execute() function.
+ */
+void catch_signals() {
+  auto handler = [](int code) { throw std::runtime_error("SIGNAL " + std::to_string(code)); };
+  signal(SIGINT, handler);
+  signal(SIGTERM, handler);
+  signal(SIGKILL, handler);
+}
 
 namespace specfem {
 namespace periodic_tasks {
@@ -17,9 +38,7 @@ class check_signal : public periodic_task {
    *
    */
   void run() override {
-    if (PyErr_CheckSignals() != 0) {
-      throw pybind11::error_already_set();
-    }
+    catch_signals();
   }
 };
 

--- a/include/periodic_tasks/check_signal.hpp
+++ b/include/periodic_tasks/check_signal.hpp
@@ -4,6 +4,7 @@
 #include <csignal>
 #include <string>
 #include <iostream>
+#include <Kokkos_Core.hpp>
 
 /**
  * @brief Catch signals
@@ -33,7 +34,7 @@ namespace periodic_tasks {
  *
  */
 class check_signal : public periodic_task {
-  using periodic_task::periodic_task;
+  using periodic_task::periodic_task; 
 
   /**
    * @brief Plot the wavefield

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,4 +53,4 @@ cmake.define.BUILD_TESTS = "ON"
 cmake.define.SPECFEMPP_USE_SKBUILD = "ON"
 cmake.define.SPECFEMPP_BINDING_PYTHON = "ON"
 build-dir = "./build"
-build.tool-args = ["-j8"]
+build.tool-args = ["-j4"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,4 +53,4 @@ cmake.define.BUILD_TESTS = "ON"
 cmake.define.SPECFEMPP_USE_SKBUILD = "ON"
 cmake.define.SPECFEMPP_BINDING_PYTHON = "ON"
 build-dir = "./build"
-build.tool-args = ["-j4"]
+build.tool-args = ["-j8"]

--- a/src/periodic_tasks/check_signal.cpp
+++ b/src/periodic_tasks/check_signal.cpp
@@ -1,0 +1,46 @@
+#include "periodic_tasks/check_signal.hpp"
+#include <signal.h>
+
+/**
+ * @brief Catch signals
+ * 
+ * This function is catching the keyboard interrupt signal and other interrupt 
+ * signals to parse them as exceptions to Python without crashing or hanging
+ * the program. This is to avoid the program to hang via 
+ * @code
+ * if (PyErr_CheckSignals() != 0) {
+ *     throw pybind11::error_already_set();
+ * }
+ * @endcode
+ * if releasing the GIL in execute() function.
+ */
+
+// Global flag for signal state - must be volatile sig_atomic_t for thread safety
+volatile sig_atomic_t signal_received = 0;
+
+// Static function to handle signals
+static void signal_handler(int code) {
+    // Just set the flag and return
+    signal_received = code;
+    std::cout << "Signal " << code << " received (probably Ctrl-C)" << std::endl;
+}
+
+void catch_signals() {
+    // Register our handler for SIGINT (Ctrl-C)
+    signal(SIGINT, signal_handler);
+}
+
+void specfem::periodic_tasks::check_signal::run() {
+    // Catch signals
+    catch_signals();
+
+    // Check if a signal was received
+    if (signal_received) {
+      // Handle the signal (e.g., throw an exception)
+      std::string error_message = "Signal " + std::to_string(signal_received) +
+                                   " received. Exiting...";
+      // Reset the signal flag
+      signal_received = 0;
+      throw std::runtime_error(error_message);
+    }
+}

--- a/src/python/core.cpp
+++ b/src/python/core.cpp
@@ -4,6 +4,7 @@
 #define STRINGIFY(x) #x
 #define MACRO_STRINGIFY(x) STRINGIFY(x)
 #include "periodic_tasks/check_signal.hpp"
+// #include <signal.h>
 
 namespace py = pybind11;
 
@@ -50,7 +51,6 @@ bool _execute(const std::string &parameter_string,
     return false;
   }
 
-  
   // This is the signal handler for catching signals for Python only 
   // so that jupyter notebooks aren't killed.
   const YAML::Node parameter_dict = YAML::Load(parameter_string);

--- a/src/python/core.cpp
+++ b/src/python/core.cpp
@@ -43,11 +43,16 @@ bool _initialize(py::list py_argv) {
   return true;
 }
 
+
 bool _execute(const std::string &parameter_string,
               const std::string &default_string) {
   if (_py_mpi == NULL) {
     return false;
   }
+
+  
+  // This is the signal handler for catching signals for Python only 
+  // so that jupyter notebooks aren't killed.
   const YAML::Node parameter_dict = YAML::Load(parameter_string);
   const YAML::Node default_dict = YAML::Load(default_string);
   std::vector<std::shared_ptr<specfem::periodic_tasks::periodic_task> > tasks;

--- a/src/python/core.cpp
+++ b/src/python/core.cpp
@@ -43,7 +43,6 @@ bool _initialize(py::list py_argv) {
   return true;
 }
 
-
 bool _execute(const std::string &parameter_string,
               const std::string &default_string) {
   if (_py_mpi == NULL) {
@@ -79,7 +78,7 @@ bool _finalize() {
 }
 
 PYBIND11_MODULE(_core, m) {
-    m.doc() = R"pbdoc(
+  m.doc() = R"pbdoc(
         SPECfem++ core module
         -----------------------
 
@@ -91,23 +90,23 @@ PYBIND11_MODULE(_core, m) {
            _run
     )pbdoc";
 
-    m.def("_initialize", &_initialize, R"pbdoc(
+  m.def("_initialize", &_initialize, R"pbdoc(
         Initialize SPECFEM++.
     )pbdoc");
 
-    m.def("_execute", &_execute, R"pbdoc(
+  m.def("_execute", &_execute, R"pbdoc(
         Execute the main SPECFEM++ workflow.
     )pbdoc");
 
-    m.def("_finalize", &_finalize, R"pbdoc(
+  m.def("_finalize", &_finalize, R"pbdoc(
         Finalize SPECFEM++.
     )pbdoc");
 
-    m.attr("_default_file_path") = __default_file__;
+  m.attr("_default_file_path") = __default_file__;
 
 #ifdef VERSION_INFO
-    m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);
+  m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);
 #else
-    m.attr("__version__") = "dev";
+  m.attr("__version__") = "dev";
 #endif
 }

--- a/src/python/core.cpp
+++ b/src/python/core.cpp
@@ -52,9 +52,12 @@ bool _execute(const std::string &parameter_string,
   const YAML::Node default_dict = YAML::Load(default_string);
   std::vector<std::shared_ptr<specfem::periodic_tasks::periodic_task> > tasks;
   const auto signal_task =
-      std::make_shared<specfem::periodic_tasks::check_signal>(10);
+  std::make_shared<specfem::periodic_tasks::check_signal>(10);
   tasks.push_back(signal_task);
-  execute(parameter_dict, default_dict, tasks, _py_mpi);
+  {
+    py::gil_scoped_release release;
+    execute(parameter_dict, default_dict, tasks, _py_mpi);
+  }
   return true;
 }
 

--- a/src/python/core.cpp
+++ b/src/python/core.cpp
@@ -54,7 +54,7 @@ bool _execute(const std::string &parameter_string,
   const YAML::Node default_dict = YAML::Load(default_string);
   std::vector<std::shared_ptr<specfem::periodic_tasks::periodic_task> > tasks;
   const auto signal_task =
-  std::make_shared<specfem::periodic_tasks::check_signal>(10);
+      std::make_shared<specfem::periodic_tasks::check_signal>(10);
   tasks.push_back(signal_task);
   // Releasing the GIL in a scoped section
   // is needed for long running tasks, such as a


### PR DESCRIPTION
## Description

This PR fixes the ability to interrupt the execution of the execute function from python and continue to work in the terminal. The issue at the end was that I was throwing an error in the signal_handler that is passed to the `signal(int signal, static void func(int i)` handling function from the `signal.h` C header. This caused the program to segfault. The solution is the following.

In our `periodic_tasks/check_signal.hpp` create an atomic flag:
```cpp
// Global flag for signal state - must be volatile sig_atomic_t for thread safety
volatile sig_atomic_t signal_received = 0;
```
and updated this flag through the handler:
```cpp
// Static function to handle signals
static void signal_handler(int code) {
    // Just set the flag and return
    signal_received = code;
    std::cout << "Signal " << code << " received (probably Ctrl-C)" << std::endl;
}
```
then call a super function that registers handler:
```cpp
void catch_signals() {
    // Register our handler for SIGINT (Ctrl-C)
    signal(SIGINT, signal_handler);
    
    // Currently only doing SIGINT
    //signal(SIGSEGV, signal_handler);
}
```
the periodic task function
is then:
```
void run() override {
    // Catch signals
    catch_signals();

    // Check if a signal was received
    if (signal_received) {
      // Handle the signal (e.g., throw an exception)
      std::string error_message = "Signal " + std::to_string(signal_received) +
                                   " received. Exiting...";
      // Reset the signal flag
      signal_received = 0;
      throw std::runtime_error(error_message);
    } 
  }
```

## Extra

Fixed the `VTK_CXX_BUILD=OFF` compilation which was disregarded if cmake found VTK.

## Issue Number

Closes #574 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [x] I ran the code through pre-commit to check style
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
