### PR TITLE
Updated chunk vector view layouts

### DIFF
--- a/include/algorithms/divergence.hpp
+++ b/include/algorithms/divergence.hpp
@@ -100,11 +100,11 @@ KOKKOS_FORCEINLINE_FUNCTION void divergence(
         for (int l = 0; l < NGLL; ++l) {
           for (int icomp = 0; icomp < components; ++icomp) {
             temp1l[icomp] +=
-                f(ielement, iz, l, 0, icomp) * hprimewgll(ix, l) * jacobian;
+                f(ielement, iz, l, icomp, 0) * hprimewgll(ix, l) * jacobian;
           }
           for (int icomp = 0; icomp < components; ++icomp) {
             temp2l[icomp] +=
-                f(ielement, l, ix, 1, icomp) * hprimewgll(iz, l) * jacobian;
+                f(ielement, l, ix, icomp, 1) * hprimewgll(iz, l) * jacobian;
           }
         }
 

--- a/include/datatypes/chunk_element_view.hpp
+++ b/include/datatypes/chunk_element_view.hpp
@@ -118,7 +118,7 @@ struct VectorChunkViewType
     : public Kokkos::View<
           typename specfem::datatype::simd<T, UseSIMD>::datatype
               [NumberOfElements][NumberOfGLLPoints][NumberOfGLLPoints]
-              [NumberOfDimensions][Components],
+              [Components][NumberOfDimensions],
           MemorySpace, MemoryTraits> {
   /**
    * @name Typedefs
@@ -128,8 +128,8 @@ struct VectorChunkViewType
   using simd = specfem::datatype::simd<T, UseSIMD>; ///< SIMD data type
   using type = typename Kokkos::View<
       typename simd::datatype[NumberOfElements][NumberOfGLLPoints]
-                             [NumberOfGLLPoints][NumberOfDimensions]
-                             [Components],
+                             [NumberOfGLLPoints][Components]
+                             [NumberOfDimensions],
       MemorySpace, MemoryTraits>; ///< Underlying data type used to store values
   using value_type = typename type::value_type; ///< Value type used to store
                                                 ///< the elements of the array
@@ -192,7 +192,7 @@ struct VectorChunkViewType
   VectorChunkViewType(const ScratchMemorySpace &scratch_memory_space)
       : Kokkos::View<
             value_type[NumberOfElements][NumberOfGLLPoints][NumberOfGLLPoints]
-                      [NumberOfDimensions][Components],
+                      [Components][NumberOfDimensions],
             MemorySpace, MemoryTraits>(scratch_memory_space) {}
 };
 

--- a/include/kokkos_kernels/impl/compute_stiffness_interaction.tpp
+++ b/include/kokkos_kernels/impl/compute_stiffness_interaction.tpp
@@ -201,8 +201,9 @@ int specfem::kokkos_kernels::impl::compute_stiffness_interaction(
                   for (int icomponent = 0; icomponent < components;
                        ++icomponent) {
                     for (int idim = 0; idim < num_dimensions; ++idim) {
-                      stress_integrand.F(ielement, index.iz, index.ix, idim,
-                                         icomponent) = F(idim, icomponent);
+                      stress_integrand.F(ielement, index.iz, index.ix,
+                                         icomponent, idim) =
+                          F(idim, icomponent);
                     }
                   }
                 });


### PR DESCRIPTION
## Description

Updated `ChunkVectorViewType` layouts. Similar to #693 this issue updates the order of indexing for vector view types. 

- [x] Updates chunk vector view layouts
- [x] Update the storage layout for chunk stress integrands (F)

## Issue Number

Closes #693 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
