### PR TITLE
Fixed Intel CI after system update

### DIFF
--- a/.jenkins/gnu_compiler_checks.gvy
+++ b/.jenkins/gnu_compiler_checks.gvy
@@ -74,7 +74,7 @@ pipeline{
                                         module load boost/1.85.0
                                         module load ${GNU_COMPILER_MODULE}
                                         cd build_cpu_${GNU_COMPILER_NAME}_${CMAKE_HOST_NAME}_${SIMD_NAME}_${env.BUILD_TAG}/tests/unit-tests
-                                        srun -N 1 -t 00:20:00 ${HOST_RUN_FLAGS} --constraint=skylake bash -c 'export OMP_PROC_BIND=spread; export OMP_THREADS=places; ctest --verbose;'
+                                        srun -N 1 -t 00:20:00 ${HOST_RUN_FLAGS} --constraint="intel|cascade" bash -c 'export OMP_PROC_BIND=spread; export OMP_THREADS=places; ctest --verbose;'
                                     """
                                     echo ' Testing completed '
                                 }

--- a/.jenkins/intel_compiler_checks.gvy
+++ b/.jenkins/intel_compiler_checks.gvy
@@ -75,7 +75,7 @@ pipeline{
                                         module load boost/1.85.0
                                         module load ${INTEL_MODULE}
                                         cd build_cpu_${INTEL_COMPILER_NAME}_${CMAKE_HOST_NAME}_${SIMD_NAME}_${env.BUILD_TAG}/tests/unit-tests
-                                        srun -N 1 -t 00:20:00 ${HOST_RUN_FLAGS} --constraint=skylake bash -c 'export OMP_PROC_BIND=spread; export OMP_THREADS=places; ctest --verbose;'
+                                        srun -N 1 -t 00:20:00 ${HOST_RUN_FLAGS} --constraint="intel|cascade" bash -c 'export OMP_PROC_BIND=spread; export OMP_THREADS=places; ctest --verbose;'
                                     """
                                     echo ' Testing completed '
                                 }


### PR DESCRIPTION
## Description

Skylake nodes were removed from the SLURM queue in the last system downtime. Update intel CI slurm constraint to `intel|cascade`.

## Issue Number

If there is an issue created for these changes, link it here

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
