### PR TITLE
Issue 783 - Add option to write wavefield every N timesteps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -611,6 +611,7 @@ add_library(
         periodic_tasks
         src/periodic_tasks/plot_wavefield.cpp
         src/periodic_tasks/check_signal.cpp
+        src/utilities/string.cpp
 )
 
 if (NOT VTK_CXX_BUILD)
@@ -653,6 +654,9 @@ add_library(
         src/parameter_parser/writer/plot_wavefield.cpp
         src/parameter_parser/writer/kernel.cpp
         src/parameter_parser/writer/property.cpp
+        src/periodic_tasks/wavefield_reader.cpp
+        src/periodic_tasks/wavefield_writer.cpp
+        src/utilities/string.cpp
 )
 
 target_link_libraries(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,6 +411,7 @@ target_link_libraries(
 
 add_library(
         reader
+        src/utilities/strings.cpp
         src/io/wavefield/reader.cpp
         src/io/property/reader.cpp
 )
@@ -594,6 +595,7 @@ target_link_libraries(
 
 add_library(
         writer
+        src/utilities/strings.cpp
         src/io/seismogram/writer.cpp
         src/io/wavefield/writer.cpp
         src/io/kernel/writer.cpp
@@ -611,7 +613,14 @@ add_library(
         periodic_tasks
         src/periodic_tasks/plot_wavefield.cpp
         src/periodic_tasks/check_signal.cpp
-        src/utilities/string.cpp
+        src/periodic_tasks/wavefield_reader.cpp
+        src/periodic_tasks/wavefield_writer.cpp
+)
+
+target_link_libraries(
+        periodic_tasks
+        reader
+        writer
 )
 
 if (NOT VTK_CXX_BUILD)
@@ -654,9 +663,6 @@ add_library(
         src/parameter_parser/writer/plot_wavefield.cpp
         src/parameter_parser/writer/kernel.cpp
         src/parameter_parser/writer/property.cpp
-        src/periodic_tasks/wavefield_reader.cpp
-        src/periodic_tasks/wavefield_writer.cpp
-        src/utilities/string.cpp
 )
 
 target_link_libraries(
@@ -665,6 +671,7 @@ target_link_libraries(
         timescheme
         receiver_class
         yaml-cpp
+        periodic_tasks
         writer
         reader
         kokkos_kernels

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,10 +410,15 @@ target_link_libraries(
         )
 
 add_library(
-        reader
+        utilities
         src/utilities/strings.cpp
-        src/io/wavefield/reader.cpp
+)
+
+add_library(
+        reader
         src/io/property/reader.cpp
+        src/io/wavefield/reader.cpp
+        src/periodic_tasks/wavefield_reader.cpp
 )
 
 target_link_libraries(
@@ -421,6 +426,7 @@ target_link_libraries(
         compute
         io
         read_seismogram
+        utilities
 )
 
 add_library(
@@ -595,11 +601,11 @@ target_link_libraries(
 
 add_library(
         writer
-        src/utilities/strings.cpp
         src/io/seismogram/writer.cpp
-        src/io/wavefield/writer.cpp
         src/io/kernel/writer.cpp
         src/io/property/writer.cpp
+        src/io/wavefield/writer.cpp
+        src/periodic_tasks/wavefield_writer.cpp
 )
 
 target_link_libraries(
@@ -607,14 +613,13 @@ target_link_libraries(
         compute
         receiver_class
         io
+        utilities
 )
 
 add_library(
         periodic_tasks
         src/periodic_tasks/plot_wavefield.cpp
         src/periodic_tasks/check_signal.cpp
-        src/periodic_tasks/wavefield_reader.cpp
-        src/periodic_tasks/wavefield_writer.cpp
 )
 
 target_link_libraries(

--- a/examples/Tromp_2005/Snakefile
+++ b/examples/Tromp_2005/Snakefile
@@ -35,7 +35,7 @@ rule forward_simulation:
             network_name=["AA"],
             component=["BXX", "BXZ"],
         ),
-        forward_wavefield="OUTPUT_FILES/ForwardWavefield.h5",
+        forward_wavefield="OUTPUT_FILES/ForwardWavefield002004.h5",
     resources:
         nodes=1,
         tasks=1,

--- a/include/io/wavefield/reader.hpp
+++ b/include/io/wavefield/reader.hpp
@@ -29,8 +29,12 @@ public:
    */
   void read(specfem::compute::assembly &assembly) override;
 
+  void set_istep(int istep) { this->istep = istep; }
+
 private:
   std::string output_folder; ///< Path to output folder
+  int istep = -1; ///< Current time step for file name, if value is -1, the time
+                  ///< step will be be included in the output file name.
 };
 
 } // namespace io

--- a/include/io/wavefield/reader.tpp
+++ b/include/io/wavefield/reader.tpp
@@ -3,6 +3,7 @@
 #include "io/ASCII/ASCII.hpp"
 #include "io/HDF5/HDF5.hpp"
 #include "io/wavefield/reader.hpp"
+#include "utilities/string.hpp"
 
 template <typename IOLibrary>
 specfem::io::wavefield_reader<IOLibrary>::wavefield_reader(
@@ -15,7 +16,13 @@ void specfem::io::wavefield_reader<IOLibrary>::read(
   auto &buffer = assembly.fields.buffer;
   auto &boundary_values = assembly.boundary_values;
 
-  typename IOLibrary::File file(output_folder + "/ForwardWavefield");
+  std::string dst = this->output_folder + "/ForwardWavefield";
+
+  if (this->istep != -1) {
+    dst += specfem::utilities::to_zero_lead(istep, 6);
+  }
+
+  typename IOLibrary::File file(dst);
 
   typename IOLibrary::Group elastic_psv = file.openGroup("/ElasticSV");
 

--- a/include/io/wavefield/reader.tpp
+++ b/include/io/wavefield/reader.tpp
@@ -3,7 +3,7 @@
 #include "io/ASCII/ASCII.hpp"
 #include "io/HDF5/HDF5.hpp"
 #include "io/wavefield/reader.hpp"
-#include "utilities/string.hpp"
+#include "utilities/strings.hpp"
 
 template <typename IOLibrary>
 specfem::io::wavefield_reader<IOLibrary>::wavefield_reader(

--- a/include/io/wavefield/writer.hpp
+++ b/include/io/wavefield/writer.hpp
@@ -38,8 +38,12 @@ public:
    */
   void write(specfem::compute::assembly &assembly) override;
 
+  void set_istep(int istep) { this->istep = istep; }
+
 private:
   std::string output_folder; ///< Path to output folder
+  int istep = -1; ///< Current time step for file name, if value is -1, the time
+                  ///< step will be be included in the output file name.
 };
 } // namespace io
 } // namespace specfem

--- a/include/io/wavefield/writer.tpp
+++ b/include/io/wavefield/writer.tpp
@@ -3,7 +3,7 @@
 #include "io/wavefield/writer.hpp"
 #include "compute/interface.hpp"
 #include "enumerations/interface.hpp"
-#include "utilities/string.hpp"
+#include "utilities/strings.hpp"
 
 template <typename OutputLibrary>
 specfem::io::wavefield_writer<OutputLibrary>::wavefield_writer(

--- a/include/io/wavefield/writer.tpp
+++ b/include/io/wavefield/writer.tpp
@@ -3,6 +3,7 @@
 #include "io/wavefield/writer.hpp"
 #include "compute/interface.hpp"
 #include "enumerations/interface.hpp"
+#include "utilities/string.hpp"
 
 template <typename OutputLibrary>
 specfem::io::wavefield_writer<OutputLibrary>::wavefield_writer(
@@ -18,7 +19,13 @@ void specfem::io::wavefield_writer<OutputLibrary>::write(
   forward.copy_to_host();
   boundary_values.copy_to_host();
 
-  typename OutputLibrary::File file(output_folder + "/ForwardWavefield");
+  std::string dst = this->output_folder + "/ForwardWavefield";
+
+  if (this->istep != -1) {
+    dst += specfem::utilities::to_zero_lead(istep, 6);
+  }
+
+  typename OutputLibrary::File file(dst);
 
   typename OutputLibrary::Group elastic_psv = file.createGroup("/ElasticSV");
   const auto &elastic_psv_field =
@@ -71,6 +78,6 @@ void specfem::io::wavefield_writer<OutputLibrary>::write(
                      boundary_values.stacey.poroelastic.h_values)
       .write();
 
-  std::cout << "Wavefield written to " << output_folder + "/ForwardWavefield"
+  std::cout << "Wavefield written to " << dst
             << std::endl;
 }

--- a/include/io/writer.hpp
+++ b/include/io/writer.hpp
@@ -21,6 +21,7 @@ public:
    *
    */
   virtual void write(specfem::compute::assembly &assembly) {};
+  virtual void write(specfem::compute::assembly &assembly, int istep) {};
 };
 
 } // namespace io

--- a/include/io/writer.hpp
+++ b/include/io/writer.hpp
@@ -21,7 +21,6 @@ public:
    *
    */
   virtual void write(specfem::compute::assembly &assembly) {};
-  virtual void write(specfem::compute::assembly &assembly, int istep) {};
 };
 
 } // namespace io

--- a/include/parameter_parser/setup.hpp
+++ b/include/parameter_parser/setup.hpp
@@ -180,7 +180,8 @@ public:
     }
   }
 
-  std::shared_ptr<specfem::io::writer> instantiate_wavefield_writer() const {
+  std::shared_ptr<specfem::periodic_tasks::periodic_task>
+  instantiate_wavefield_writer() const {
     if (this->wavefield) {
       return this->wavefield->instantiate_wavefield_writer();
     } else {
@@ -188,7 +189,8 @@ public:
     }
   }
 
-  std::shared_ptr<specfem::io::reader> instantiate_wavefield_reader() const {
+  std::shared_ptr<specfem::periodic_tasks::periodic_task>
+  instantiate_wavefield_reader() const {
     if (this->wavefield) {
       return this->wavefield->instantiate_wavefield_reader();
     } else {

--- a/include/parameter_parser/writer/wavefield.hpp
+++ b/include/parameter_parser/writer/wavefield.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "enumerations/simulation.hpp"
-#include "io/reader.hpp"
-#include "io/writer.hpp"
+#include "periodic_tasks/periodic_task.hpp"
 #include "yaml-cpp/yaml.h"
 
 namespace specfem {
@@ -31,16 +30,16 @@ public:
    * nsteps_between_samples_by_memory will be used instead.
    * @param time_interval_by_memory automatically determine the number of
    * timesteps between wavefield by the memory value provided, e.g. 100MB, 20GB.
-   * @param write_last_step Whether or not to write the final time step.
+   * @param include_last_step Whether or not to write the final time step.
    */
   wavefield(const std::string output_format, const std::string output_folder,
             const specfem::simulation::type type, const int time_interval,
             const std::string time_interval_by_memory,
-            const bool write_last_step)
+            const bool include_last_step)
       : output_format(output_format), output_folder(output_folder),
         simulation_type(type), time_interval(time_interval),
         time_interval_by_memory(time_interval_by_memory),
-        write_last_step(write_last_step) {}
+        include_last_step(include_last_step) {}
 
   /**
    * @brief Construct a new wavefield configuration object from YAML node
@@ -57,7 +56,8 @@ public:
    * @return std::shared_ptr<specfem::io::writer> Pointer to an instantiated
    * writer object
    */
-  std::shared_ptr<specfem::io::writer> instantiate_wavefield_writer() const;
+  std::shared_ptr<specfem::periodic_tasks::periodic_task>
+  instantiate_wavefield_writer() const;
 
   /**
    * @brief Instantiate a wavefield reader object
@@ -65,7 +65,8 @@ public:
    * @return std::shared_ptr<specfem::io::reader> Pointer to an instantiated
    * reader object
    */
-  std::shared_ptr<specfem::io::reader> instantiate_wavefield_reader() const;
+  std::shared_ptr<specfem::periodic_tasks::periodic_task>
+  instantiate_wavefield_reader() const;
 
   inline specfem::simulation::type get_simulation_type() const {
     return this->simulation_type;
@@ -81,7 +82,7 @@ private:
                                        ///< of timesteps between wavefield by
                                        ///< the memory value provided, e.g.
                                        ///< 100MB, 20GB.
-  bool write_last_step; ///< Whether or not to write the final time step
+  bool include_last_step; ///< Whether or not to write the final time step
 };
 } // namespace runtime_configuration
 } // namespace specfem

--- a/include/parameter_parser/writer/wavefield.hpp
+++ b/include/parameter_parser/writer/wavefield.hpp
@@ -26,11 +26,21 @@ public:
    * @param output_format Output wavefield file format
    * @param output_folder Path to folder location where wavefield will be stored
    * @param type Type of simulation (forward or adjoint)
+   * @param time_interval number of timesteps between wavefield if it is 0, do
+   * not write wavefield periodically, if it is -1, the second parameter
+   * nsteps_between_samples_by_memory will be used instead.
+   * @param time_interval_by_memory automatically determine the number of
+   * timesteps between wavefield by the memory value provided, e.g. 100MB, 20GB.
+   * @param write_final_step Whether or not to write the final time step.
    */
   wavefield(const std::string output_format, const std::string output_folder,
-            const specfem::simulation::type type)
+            const specfem::simulation::type type, const int time_interval,
+            const std::string time_interval_by_memory,
+            const bool write_final_step)
       : output_format(output_format), output_folder(output_folder),
-        simulation_type(type) {}
+        simulation_type(type), time_interval(time_interval),
+        time_interval_by_memory(time_interval_by_memory),
+        write_final_step(write_final_step) {}
 
   /**
    * @brief Construct a new wavefield configuration object from YAML node
@@ -65,6 +75,13 @@ private:
   std::string output_format;                 ///< format of output file
   std::string output_folder;                 ///< Path to output folder
   specfem::simulation::type simulation_type; ///< Type of simulation
+  int time_interval;                         ///< Number of timesteps between
+                                             ///< wavefield
+  std::string time_interval_by_memory; ///< Automatically determine the number
+                                       ///< of timesteps between wavefield by
+                                       ///< the memory value provided, e.g.
+                                       ///< 100MB, 20GB.
+  bool write_final_step; ///< Whether or not to write the final time step
 };
 } // namespace runtime_configuration
 } // namespace specfem

--- a/include/parameter_parser/writer/wavefield.hpp
+++ b/include/parameter_parser/writer/wavefield.hpp
@@ -31,16 +31,16 @@ public:
    * nsteps_between_samples_by_memory will be used instead.
    * @param time_interval_by_memory automatically determine the number of
    * timesteps between wavefield by the memory value provided, e.g. 100MB, 20GB.
-   * @param write_final_step Whether or not to write the final time step.
+   * @param write_last_step Whether or not to write the final time step.
    */
   wavefield(const std::string output_format, const std::string output_folder,
             const specfem::simulation::type type, const int time_interval,
             const std::string time_interval_by_memory,
-            const bool write_final_step)
+            const bool write_last_step)
       : output_format(output_format), output_folder(output_folder),
         simulation_type(type), time_interval(time_interval),
         time_interval_by_memory(time_interval_by_memory),
-        write_final_step(write_final_step) {}
+        write_last_step(write_last_step) {}
 
   /**
    * @brief Construct a new wavefield configuration object from YAML node
@@ -81,7 +81,7 @@ private:
                                        ///< of timesteps between wavefield by
                                        ///< the memory value provided, e.g.
                                        ///< 100MB, 20GB.
-  bool write_final_step; ///< Whether or not to write the final time step
+  bool write_last_step; ///< Whether or not to write the final time step
 };
 } // namespace runtime_configuration
 } // namespace specfem

--- a/include/periodic_tasks/check_signal.hpp
+++ b/include/periodic_tasks/check_signal.hpp
@@ -19,7 +19,7 @@ class check_signal : public periodic_task {
    * @brief Check for keyboard interrupt and more, when running from Python
    *
    */
-  void run(const int istep) override;
+  void run(specfem::compute::assembly &assembly, const int istep) override;
 };
 
 } // namespace periodic_tasks

--- a/include/periodic_tasks/check_signal.hpp
+++ b/include/periodic_tasks/check_signal.hpp
@@ -19,7 +19,7 @@ class check_signal : public periodic_task {
    * @brief Check for keyboard interrupt and more, when running from Python
    *
    */
-  void run() override;
+  void run(const int istep) override;
 };
 
 } // namespace periodic_tasks

--- a/include/periodic_tasks/periodic_task.hpp
+++ b/include/periodic_tasks/periodic_task.hpp
@@ -22,7 +22,7 @@ public:
    * @brief Method to plot the data
    *
    */
-  virtual void run([[maybe_unused]] const int istep) {};
+  virtual void run(const int istep) {};
 
   /**
    * @brief Returns true if the data should be plotted at the current

--- a/include/periodic_tasks/periodic_task.hpp
+++ b/include/periodic_tasks/periodic_task.hpp
@@ -1,6 +1,12 @@
 #pragma once
 
 namespace specfem {
+namespace compute {
+struct assembly;
+} // namespace compute
+} // namespace specfem
+
+namespace specfem {
 namespace periodic_tasks {
 /**
  * @brief Base writer class
@@ -22,7 +28,7 @@ public:
    * @brief Method to plot the data
    *
    */
-  virtual void run(const int istep) {};
+  virtual void run(specfem::compute::assembly &assembly, const int istep) {};
 
   /**
    * @brief Returns true if the data should be plotted at the current

--- a/include/periodic_tasks/periodic_task.hpp
+++ b/include/periodic_tasks/periodic_task.hpp
@@ -12,14 +12,17 @@ public:
    * @brief Construct a new plotter object
    *
    * @param time_interval Time interval between subsequent plots
+   * @param include_last_step Whether or not to include the last step regardless
+   * of the time interval
    */
-  periodic_task(const int time_interval) : time_interval(time_interval) {};
+  periodic_task(const int time_interval, const bool include_last_step = true)
+      : time_interval(time_interval), include_last_step(include_last_step) {};
 
   /**
    * @brief Method to plot the data
    *
    */
-  virtual void run() {};
+  virtual void run([[maybe_unused]] const int istep) {};
 
   /**
    * @brief Returns true if the data should be plotted at the current
@@ -29,16 +32,20 @@ public:
    * @return true if the data should be plotted at the current timestep
    */
   bool should_run(const int istep) {
-    if (istep % time_interval == 0) {
-      this->m_istep = istep;
+    if (include_last_step && istep == -1) {
       return true;
     }
+
+    if (istep % time_interval == 0) {
+      return true;
+    }
+
     return false;
   }
 
 protected:
   int time_interval;
-  int m_istep;
+  bool include_last_step;
 };
 
 } // namespace periodic_tasks

--- a/include/periodic_tasks/plot_wavefield.hpp
+++ b/include/periodic_tasks/plot_wavefield.hpp
@@ -50,7 +50,7 @@ public:
    * @brief Plot the wavefield
    *
    */
-  void run(const int istep) override;
+  void run(specfem::compute::assembly &assembly, const int istep) override;
 
 private:
   const specfem::display::format output_format; ///< Output format of the plot

--- a/include/periodic_tasks/plot_wavefield.hpp
+++ b/include/periodic_tasks/plot_wavefield.hpp
@@ -50,7 +50,7 @@ public:
    * @brief Plot the wavefield
    *
    */
-  void run() override;
+  void run(const int istep) override;
 
 private:
   const specfem::display::format output_format; ///< Output format of the plot

--- a/include/periodic_tasks/wavefield_reader.hpp
+++ b/include/periodic_tasks/wavefield_reader.hpp
@@ -1,0 +1,34 @@
+#pragma once
+#include "io/wavefield/reader.hpp"
+#include "periodic_task.hpp"
+#include <Kokkos_Core.hpp>
+
+namespace specfem {
+namespace periodic_tasks {
+/**
+ * @brief Base plotter class
+ *
+ */
+template <typename IOLibrary>
+class wavefield_reader : public periodic_task,
+                         specfem::io::wavefield_reader<IOLibrary> {
+public:
+  wavefield_reader(const std::string output_folder, const int time_interval,
+                   const bool include_last_step)
+      : periodic_task(time_interval, include_last_step),
+        specfem::io::wavefield_reader<IOLibrary>(output_folder) {}
+
+  /**
+   * @brief Check for keyboard interrupt and more, when running from Python
+   *
+   */
+  void run(specfem::compute::assembly &assembly, const int istep) override {
+    std::cout << "Reading wavefield files:" << std::endl;
+    std::cout << "-------------------------------" << std::endl;
+    this->set_istep(istep);
+    this->read(assembly);
+  }
+};
+
+} // namespace periodic_tasks
+} // namespace specfem

--- a/include/periodic_tasks/wavefield_writer.hpp
+++ b/include/periodic_tasks/wavefield_writer.hpp
@@ -1,0 +1,34 @@
+#pragma once
+#include "io/wavefield/writer.hpp"
+#include "periodic_task.hpp"
+#include <Kokkos_Core.hpp>
+
+namespace specfem {
+namespace periodic_tasks {
+/**
+ * @brief Base plotter class
+ *
+ */
+template <typename OutputLibrary>
+class wavefield_writer : public periodic_task,
+                         specfem::io::wavefield_writer<OutputLibrary> {
+public:
+  wavefield_writer(const std::string output_folder, const int time_interval,
+                   const bool include_last_step)
+      : periodic_task(time_interval, include_last_step),
+        specfem::io::wavefield_writer<OutputLibrary>(output_folder) {}
+
+  /**
+   * @brief Check for keyboard interrupt and more, when running from Python
+   *
+   */
+  void run(specfem::compute::assembly &assembly, const int istep) override {
+    std::cout << "Writing wavefield files:" << std::endl;
+    std::cout << "-------------------------------" << std::endl;
+    this->set_istep(istep);
+    this->write(assembly);
+  }
+};
+
+} // namespace periodic_tasks
+} // namespace specfem

--- a/include/solver/time_marching.tpp
+++ b/include/solver/time_marching.tpp
@@ -70,7 +70,7 @@ void specfem::solver::time_marching<specfem::simulation::type::forward,
     // Run periodic tasks such as plotting, etc.
     for (const auto &task : tasks) {
       if (task && task->should_run(istep)) {
-        task->run();
+        task->run(istep);
       }
     }
 
@@ -99,6 +99,12 @@ void specfem::solver::time_marching<specfem::simulation::type::forward,
     }
   }
 
+  for (const auto &task : tasks) {
+    if (task && !task->should_run(nstep-1) && task->should_run(-1)) {
+      task->run(nstep-1);
+    }
+  }
+
   std::cout << std::endl;
 
   return;
@@ -122,6 +128,12 @@ void specfem::solver::time_marching<specfem::simulation::type::combined,
       4 * assembly.get_total_degrees_of_freedom();
 
   const int total_elements_to_be_updated = 2 * assembly.get_total_number_of_elements();
+
+  for (const auto &task : tasks) {
+    if (task && !task->should_run(nstep-1) && task->should_run(-1)) {
+      task->run(nstep-1);
+    }
+  }
 
   for (const auto [istep, dt] : time_scheme->iterate_backward()) {
     int dofs_updated = 0;
@@ -178,7 +190,7 @@ void specfem::solver::time_marching<specfem::simulation::type::combined,
 
     for (const auto &task : tasks) {
       if (task && task->should_run(istep)) {
-        task->run();
+        task->run(istep);
       }
     }
 

--- a/include/utilities/string.hpp
+++ b/include/utilities/string.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace specfem {
+namespace utilities {
+
+// Convert integer to string with zero leading
+std::string to_zero_lead(const int value, const int n_zero);
+
+} // namespace utilities
+} // namespace specfem

--- a/include/utilities/strings.hpp
+++ b/include/utilities/strings.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 namespace specfem {
 namespace utilities {
 

--- a/src/execute.cpp
+++ b/src/execute.cpp
@@ -108,9 +108,10 @@ void execute(
       nstep_between_samples, setup.get_simulation_type(),
       setup.instantiate_property_reader());
   time_scheme->link_assembly(assembly);
+  // --------------------------------------------------------------
 
   // --------------------------------------------------------------
-  //                Read or Write properties
+  //               Write properties
   // --------------------------------------------------------------
   const auto property_writer = setup.instantiate_property_writer();
   if (property_writer) {
@@ -120,23 +121,11 @@ void execute(
     property_writer->write(assembly);
     return;
   }
-
-  // const auto property_reader = setup.instantiate_property_reader();
-  // if (property_reader) {
-  //   mpi->cout("Reading model files:");
-  //   mpi->cout("-------------------------------");
-
-  //   property_reader->read(assembly);
-  // }
-
-  // --------------------------------------------------------------
-
   // --------------------------------------------------------------
 
   // --------------------------------------------------------------
   //                   Read wavefields
   // --------------------------------------------------------------
-
   const auto wavefield_reader = setup.instantiate_wavefield_reader();
   if (wavefield_reader) {
     mpi->cout("Reading wavefield files:");
@@ -149,11 +138,16 @@ void execute(
   // --------------------------------------------------------------
 
   // --------------------------------------------------------------
+  //                  Write Forward Wavefields
+  // --------------------------------------------------------------
+  const auto wavefield_writer = setup.instantiate_wavefield_writer();
+  // --------------------------------------------------------------
+
+  // --------------------------------------------------------------
   //                   Instantiate plotter
   // --------------------------------------------------------------
   const auto wavefield_plotter = setup.instantiate_wavefield_plotter(assembly);
   tasks.push_back(wavefield_plotter);
-
   // --------------------------------------------------------------
 
   // --------------------------------------------------------------
@@ -193,7 +187,6 @@ void execute(
   // --------------------------------------------------------------
   //                  Write Forward Wavefields
   // --------------------------------------------------------------
-  const auto wavefield_writer = setup.instantiate_wavefield_writer();
   if (wavefield_writer) {
     mpi->cout("Writing wavefield files:");
     mpi->cout("-------------------------------");

--- a/src/execute.cpp
+++ b/src/execute.cpp
@@ -127,13 +127,16 @@ void execute(
   //                   Read wavefields
   // --------------------------------------------------------------
   const auto wavefield_reader = setup.instantiate_wavefield_reader();
-  if (wavefield_reader) {
-    mpi->cout("Reading wavefield files:");
-    mpi->cout("-------------------------------");
+  // if (wavefield_reader) {
+  //   mpi->cout("Reading wavefield files:");
+  //   mpi->cout("-------------------------------");
 
-    wavefield_reader->read(assembly);
-    // Transfer the buffer field to device
-    assembly.fields.buffer.copy_to_device();
+  //   wavefield_reader->read(assembly);
+  //   // Transfer the buffer field to device
+  //   assembly.fields.buffer.copy_to_device();
+  // }
+  if (wavefield_reader) {
+    tasks.push_back(wavefield_reader);
   }
   // --------------------------------------------------------------
 
@@ -141,13 +144,18 @@ void execute(
   //                  Write Forward Wavefields
   // --------------------------------------------------------------
   const auto wavefield_writer = setup.instantiate_wavefield_writer();
+  if (wavefield_writer) {
+    tasks.push_back(wavefield_writer);
+  }
   // --------------------------------------------------------------
 
   // --------------------------------------------------------------
   //                   Instantiate plotter
   // --------------------------------------------------------------
   const auto wavefield_plotter = setup.instantiate_wavefield_plotter(assembly);
-  tasks.push_back(wavefield_plotter);
+  if (wavefield_plotter) {
+    tasks.push_back(wavefield_plotter);
+  }
   // --------------------------------------------------------------
 
   // --------------------------------------------------------------
@@ -184,16 +192,16 @@ void execute(
   }
   // --------------------------------------------------------------
 
-  // --------------------------------------------------------------
-  //                  Write Forward Wavefields
-  // --------------------------------------------------------------
-  if (wavefield_writer) {
-    mpi->cout("Writing wavefield files:");
-    mpi->cout("-------------------------------");
+  // // --------------------------------------------------------------
+  // //                  Write Forward Wavefields
+  // // --------------------------------------------------------------
+  // if (wavefield_writer) {
+  //   mpi->cout("Writing wavefield files:");
+  //   mpi->cout("-------------------------------");
 
-    wavefield_writer->write(assembly);
-  }
-  // --------------------------------------------------------------
+  //   wavefield_writer->write(assembly);
+  // }
+  // // --------------------------------------------------------------
 
   // --------------------------------------------------------------
   //                Write Kernels

--- a/src/parameter_parser/writer/wavefield.cpp
+++ b/src/parameter_parser/writer/wavefield.cpp
@@ -53,15 +53,15 @@ specfem::runtime_configuration::wavefield::wavefield(
     }
   }();
 
-  const bool write_final_step = [&]() -> bool {
-    if (Node["write_final_step"]) {
-      return Node["write_final_step"].as<bool>();
+  const bool write_last_step = [&]() -> bool {
+    if (Node["write_last_step"]) {
+      return Node["write_last_step"].as<bool>();
     } else {
       return true;
     }
   }();
 
-  if (time_interval == 0 && !write_final_step) {
+  if (time_interval == 0 && !write_last_step) {
     std::ostringstream message;
     message << "************************************************\n"
             << "Warning : Wavefield writer does not write any wavefield. \n"
@@ -71,7 +71,7 @@ specfem::runtime_configuration::wavefield::wavefield(
 
   *this = specfem::runtime_configuration::wavefield(
       output_format, output_folder, type, time_interval,
-      time_interval_by_memory, write_final_step);
+      time_interval_by_memory, write_last_step);
 
   return;
 }

--- a/src/parameter_parser/writer/wavefield.cpp
+++ b/src/parameter_parser/writer/wavefield.cpp
@@ -32,8 +32,46 @@ specfem::runtime_configuration::wavefield::wavefield(
     throw std::runtime_error(message.str());
   }
 
-  *this = specfem::runtime_configuration::wavefield(output_format,
-                                                    output_folder, type);
+  const int time_interval = [&]() -> int {
+    if (Node["time_interval"]) {
+      return Node["time_interval"].as<int>();
+    } else {
+      return 0;
+    }
+  }();
+
+  const std::string time_interval_by_memory = [&]() -> std::string {
+    if (Node["time_interval_by_memory"]) {
+      if (time_interval != 0) {
+        throw std::runtime_error(
+            "time_interval and time_interval_by_memory cannot be used "
+            "simultaneously");
+      }
+      return Node["time_interval_by_memory"].as<std::string>();
+    } else {
+      return "";
+    }
+  }();
+
+  const bool write_final_step = [&]() -> bool {
+    if (Node["write_final_step"]) {
+      return Node["write_final_step"].as<bool>();
+    } else {
+      return true;
+    }
+  }();
+
+  if (time_interval == 0 && !write_final_step) {
+    std::ostringstream message;
+    message << "************************************************\n"
+            << "Warning : Wavefield writer does not write any wavefield. \n"
+            << "************************************************\n";
+    std::cout << message.str();
+  }
+
+  *this = specfem::runtime_configuration::wavefield(
+      output_format, output_folder, type, time_interval,
+      time_interval_by_memory, write_final_step);
 
   return;
 }

--- a/src/parameter_parser/writer/wavefield.cpp
+++ b/src/parameter_parser/writer/wavefield.cpp
@@ -2,8 +2,6 @@
 #include "io/ASCII/ASCII.hpp"
 #include "io/HDF5/HDF5.hpp"
 #include "io/reader.hpp"
-#include "io/wavefield/reader.hpp"
-#include "io/wavefield/writer.hpp"
 #include "periodic_tasks/wavefield_reader.hpp"
 #include "periodic_tasks/wavefield_writer.hpp"
 #include <boost/filesystem.hpp>

--- a/src/periodic_tasks/check_signal.cpp
+++ b/src/periodic_tasks/check_signal.cpp
@@ -31,7 +31,8 @@ void catch_signals() {
   signal(SIGINT, signal_handler);
 }
 
-void specfem::periodic_tasks::check_signal::run(const int istep) {
+void specfem::periodic_tasks::check_signal::run(
+    specfem::compute::assembly &assembly, const int istep) {
   // Catch signals
   catch_signals();
 

--- a/src/periodic_tasks/check_signal.cpp
+++ b/src/periodic_tasks/check_signal.cpp
@@ -31,7 +31,7 @@ void catch_signals() {
   signal(SIGINT, signal_handler);
 }
 
-void specfem::periodic_tasks::check_signal::run() {
+void specfem::periodic_tasks::check_signal::run(const int istep) {
   // Catch signals
   catch_signals();
 

--- a/src/periodic_tasks/plot_wavefield.cpp
+++ b/src/periodic_tasks/plot_wavefield.cpp
@@ -219,7 +219,7 @@ vtkSmartPointer<vtkUnstructuredGrid> get_wavefield_on_vtk_grid(
 }
 } // namespace
 
-void specfem::periodic_tasks::plot_wavefield::run() {
+void specfem::periodic_tasks::plot_wavefield::run(const int istep) {
 
   auto colors = vtkSmartPointer<vtkNamedColors>::New();
 
@@ -307,16 +307,14 @@ void specfem::periodic_tasks::plot_wavefield::run() {
     // Save the plot
     if (this->output_format == specfem::display::format::PNG) {
       const auto filename =
-          this->output_folder /
-          ("wavefield" + to_zero_lead(this->m_istep, 6) + ".png");
+          this->output_folder / ("wavefield" + to_zero_lead(istep, 6) + ".png");
       auto writer = vtkSmartPointer<vtkPNGWriter>::New();
       writer->SetFileName(filename.string().c_str());
       writer->SetInputConnection(image_filter->GetOutputPort());
       writer->Write();
     } else if (this->output_format == specfem::display::format::JPG) {
       const auto filename =
-          this->output_folder /
-          ("wavefield" + std::to_string(this->m_istep) + ".jpg");
+          this->output_folder / ("wavefield" + std::to_string(istep) + ".jpg");
       auto writer = vtkSmartPointer<vtkJPEGWriter>::New();
       writer->SetFileName(filename.string().c_str());
       writer->SetInputConnection(image_filter->GetOutputPort());

--- a/src/periodic_tasks/plot_wavefield.cpp
+++ b/src/periodic_tasks/plot_wavefield.cpp
@@ -309,7 +309,8 @@ void specfem::periodic_tasks::plot_wavefield::run(
       writer->Write();
     } else if (this->output_format == specfem::display::format::JPG) {
       const auto filename =
-          this->output_folder / ("wavefield" + std::to_string(istep) + ".jpg");
+          this->output_folder /
+          ("wavefield" + specfem::utilities::to_zero_lead(istep, 6) + ".jpg");
       auto writer = vtkSmartPointer<vtkJPEGWriter>::New();
       writer->SetFileName(filename.string().c_str());
       writer->SetInputConnection(image_filter->GetOutputPort());

--- a/src/periodic_tasks/plot_wavefield.cpp
+++ b/src/periodic_tasks/plot_wavefield.cpp
@@ -2,6 +2,7 @@
 #include "periodic_tasks/plot_wavefield.hpp"
 #include "compute/assembly/assembly.hpp"
 #include "enumerations/display.hpp"
+#include "utilities/string.hpp"
 
 #ifdef NO_VTK
 
@@ -40,7 +41,8 @@
 
 #ifdef NO_VTK
 
-void specfem::periodic_tasks::plot_wavefield::run(const int istep) {
+void specfem::periodic_tasks::plot_wavefield::run(
+    specfem::compute::assembly &assembly, const int istep) {
   std::ostringstream message;
   message
       << "Display section is not enabled, since SPECFEM++ was built without "
@@ -52,15 +54,6 @@ void specfem::periodic_tasks::plot_wavefield::run(const int istep) {
 #else
 
 namespace {
-
-// Convert integer to string with zero leading
-std::string to_zero_lead(const int value, const int n_zero) {
-  auto old_str = std::to_string(value);
-  int n_zero_fix =
-      n_zero - std::min(n_zero, static_cast<int>(old_str.length()));
-  auto new_str = std::string(n_zero_fix, '0') + old_str;
-  return new_str;
-}
 
 // Sigmoid function centered at 0.0
 double sigmoid(double x) { return (1 / (1 + std::exp(-100 * x)) - 0.5) * 1.5; }
@@ -219,7 +212,8 @@ vtkSmartPointer<vtkUnstructuredGrid> get_wavefield_on_vtk_grid(
 }
 } // namespace
 
-void specfem::periodic_tasks::plot_wavefield::run(const int istep) {
+void specfem::periodic_tasks::plot_wavefield::run(
+    specfem::compute::assembly &assembly, const int istep) {
 
   auto colors = vtkSmartPointer<vtkNamedColors>::New();
 
@@ -307,7 +301,8 @@ void specfem::periodic_tasks::plot_wavefield::run(const int istep) {
     // Save the plot
     if (this->output_format == specfem::display::format::PNG) {
       const auto filename =
-          this->output_folder / ("wavefield" + to_zero_lead(istep, 6) + ".png");
+          this->output_folder /
+          ("wavefield" + specfem::utilities::to_zero_lead(istep, 6) + ".png");
       auto writer = vtkSmartPointer<vtkPNGWriter>::New();
       writer->SetFileName(filename.string().c_str());
       writer->SetInputConnection(image_filter->GetOutputPort());

--- a/src/periodic_tasks/plot_wavefield.cpp
+++ b/src/periodic_tasks/plot_wavefield.cpp
@@ -2,7 +2,7 @@
 #include "periodic_tasks/plot_wavefield.hpp"
 #include "compute/assembly/assembly.hpp"
 #include "enumerations/display.hpp"
-#include "utilities/string.hpp"
+#include "utilities/strings.hpp"
 
 #ifdef NO_VTK
 

--- a/src/periodic_tasks/plot_wavefield.cpp
+++ b/src/periodic_tasks/plot_wavefield.cpp
@@ -40,7 +40,7 @@
 
 #ifdef NO_VTK
 
-void specfem::periodic_tasks::plot_wavefield::run() {
+void specfem::periodic_tasks::plot_wavefield::run(const int istep) {
   std::ostringstream message;
   message
       << "Display section is not enabled, since SPECFEM++ was built without "

--- a/src/periodic_tasks/wavefield_reader.cpp
+++ b/src/periodic_tasks/wavefield_reader.cpp
@@ -1,11 +1,10 @@
-#include "io/wavefield/reader.hpp"
+#include "periodic_tasks/wavefield_reader.hpp"
 #include "io/ASCII/ASCII.hpp"
 #include "io/HDF5/HDF5.hpp"
-#include "io/wavefield/reader.tpp"
 
 // Explicit instantiation
-template class specfem::io::wavefield_reader<
+template class specfem::periodic_tasks::wavefield_reader<
     specfem::io::HDF5<specfem::io::read> >;
 
-template class specfem::io::wavefield_reader<
+template class specfem::periodic_tasks::wavefield_reader<
     specfem::io::ASCII<specfem::io::read> >;

--- a/src/periodic_tasks/wavefield_writer.cpp
+++ b/src/periodic_tasks/wavefield_writer.cpp
@@ -1,11 +1,10 @@
-#include "io/wavefield/writer.hpp"
+#include "periodic_tasks/wavefield_writer.hpp"
 #include "io/ASCII/ASCII.hpp"
 #include "io/HDF5/HDF5.hpp"
-#include "io/wavefield/writer.tpp"
 
 // Explicit instantiation
-template class specfem::io::wavefield_writer<
+template class specfem::periodic_tasks::wavefield_writer<
     specfem::io::HDF5<specfem::io::write> >;
 
-template class specfem::io::wavefield_writer<
+template class specfem::periodic_tasks::wavefield_writer<
     specfem::io::ASCII<specfem::io::write> >;

--- a/src/utilities/string.cpp
+++ b/src/utilities/string.cpp
@@ -1,0 +1,17 @@
+#include <algorithm>
+#include <string>
+
+namespace specfem {
+namespace utilities {
+
+// Convert integer to string with zero leading
+std::string to_zero_lead(const int value, const int n_zero) {
+  auto old_str = std::to_string(value);
+  int n_zero_fix =
+      n_zero - std::min(n_zero, static_cast<int>(old_str.length()));
+  auto new_str = std::string(n_zero_fix, '0') + old_str;
+  return new_str;
+}
+
+} // namespace utilities
+} // namespace specfem

--- a/src/utilities/strings.cpp
+++ b/src/utilities/strings.cpp
@@ -1,5 +1,5 @@
+#include "utilities/strings.hpp"
 #include <algorithm>
-#include <string>
 
 namespace specfem {
 namespace utilities {

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -335,7 +335,6 @@ target_link_libraries(
   algorithms
   io
   coupled_interface
-  periodic_tasks
   -lpthread -lm
 )
 


### PR DESCRIPTION
## Description

- Remove property `m_istep` from periodic_tasks
- Add `assembly` and `istep` to `periodic_task->run` parameters
- Add wavefield write configuration `time_interval`
- Add options `include_last_step` to periodic_tasks
- Add `utilities/string.hpp` for string utilities
- Change wavefield reader / writer to periodic_task

## Issue Number

Closes #783 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
