### PR TITLE
Updates to mesher parameters to run CUBIT

### DIFF
--- a/fortran/meshfem2d/read_parameter_file.F90
+++ b/fortran/meshfem2d/read_parameter_file.F90
@@ -304,6 +304,13 @@ subroutine read_parameter_file_only()
       write(*,*)
    endif
 
+   call read_value_logical_p(STACEY_ABSORBING_CONDITIONS, 'STACEY_ABSORBING_CONDITIONS')
+   if (err_occurred() /= 0) then
+      some_parameters_missing_from_Par_file = .true.
+      write(*,'(a)') 'STACEY_ABSORBING_CONDITIONS     = .true.'
+      write(*,*)
+   endif
+
    !--------------------------------------------------------------------
    !
    ! receivers
@@ -488,13 +495,6 @@ subroutine read_parameter_file_only()
          write(*,*)
       endif
 
-      call read_value_logical_p(STACEY_ABSORBING_CONDITIONS, 'STACEY_ABSORBING_CONDITIONS')
-      if (err_occurred() /= 0) then
-         some_parameters_missing_from_Par_file = .true.
-         write(*,'(a)') 'STACEY_ABSORBING_CONDITIONS     = .true.'
-         write(*,*)
-      endif
-
       ! read absorbing boundary parameters
       call read_value_logical_p(absorbbottom, 'absorbbottom')
       if (err_occurred() /= 0) then
@@ -603,8 +603,8 @@ subroutine check_parameters()
       call stop_the_code('Error invalid partitioning method')
    endif
 
-   if ( NGNOD /= 9) &
-      call stop_the_code('NGNOD should be 9!')
+   ! if ( NGNOD /= 9) &
+   !    call stop_the_code('NGNOD should be 9!')
 
    ! reads in material definitions
    if (nbmodels <= 0) &

--- a/src/io/mesh/impl/fortran/dim2/read_parameters.cpp
+++ b/src/io/mesh/impl/fortran/dim2/read_parameters.cpp
@@ -27,13 +27,13 @@ specfem::io::mesh::impl::fortran::dim2::read_mesh_parameters(
                                  &plot_lowerleft_corner_only);
 
   // ---------------------------------------------------------------------
-  if (ngnod != 9) {
-    std::ostringstream error_message;
-    error_message << "Number of control nodes per element must be 9, but is "
-                  << ngnod << "\n"
-                  << "Currently, there is a bug when NGNOD == 4 \n";
-    throw std::runtime_error(error_message.str());
-  }
+  // if (ngnod != 9) {
+  //   std::ostringstream error_message;
+  //   error_message << "Number of control nodes per element must be 9, but is "
+  //                 << ngnod << "\n"
+  //                 << "Currently, there is a bug when NGNOD == 4 \n";
+  //   throw std::runtime_error(error_message.str());
+  // }
 
   specfem::io::fortran_read_line(
       stream, &nelemabs, &nelem_acforcing, &nelem_acoustic_surface,


### PR DESCRIPTION
## Description

- [x] Updates the fortran mesher to mesh NGNOD=4
- [x] Fixes fortran mesher bug to read external absorbing boundary files
- [x] Updates SPECFEM++ mesh reader to NGNOD=4 meshes

## Issue Number

Closes #791 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
