### PR TITLE
Issue 793 - Write wavefield data of different time steps into a single file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,7 +418,6 @@ add_library(
         reader
         src/io/property/reader.cpp
         src/io/wavefield/reader.cpp
-        src/periodic_tasks/wavefield_reader.cpp
 )
 
 target_link_libraries(
@@ -593,7 +592,6 @@ add_library(
         src/io/kernel/writer.cpp
         src/io/property/writer.cpp
         src/io/wavefield/writer.cpp
-        src/periodic_tasks/wavefield_writer.cpp
 )
 
 target_link_libraries(
@@ -608,6 +606,8 @@ add_library(
         periodic_tasks
         src/periodic_tasks/plot_wavefield.cpp
         src/periodic_tasks/check_signal.cpp
+        src/periodic_tasks/wavefield_writer.cpp
+        src/periodic_tasks/wavefield_reader.cpp
 )
 
 target_link_libraries(

--- a/examples/Tromp_2005/Snakefile
+++ b/examples/Tromp_2005/Snakefile
@@ -35,7 +35,7 @@ rule forward_simulation:
             network_name=["AA"],
             component=["BXX", "BXZ"],
         ),
-        forward_wavefield="OUTPUT_FILES/ForwardWavefield002004.h5",
+        forward_wavefield="OUTPUT_FILES/ForwardWavefield.h5",
     resources:
         nodes=1,
         tasks=1,

--- a/include/io/ASCII/impl/file.hpp
+++ b/include/io/ASCII/impl/file.hpp
@@ -95,6 +95,8 @@ public:
     return specfem::io::impl::ASCII::Group<OpType>(folder_path, name);
   }
 
+  void flush() {};
+
   ~File() {}
 
 private:

--- a/include/io/HDF5/impl/file.hpp
+++ b/include/io/HDF5/impl/file.hpp
@@ -45,6 +45,10 @@ public:
   specfem::io::impl::HDF5::Group<OpType> openGroup(const std::string &name) {
     throw std::runtime_error("SPECFEM++ was not compiled with HDF5 support");
   }
+
+  void flush() {
+    throw std::runtime_error("SPECFEM++ was not compiled with HDF5 support");
+  }
 };
 
 #else

--- a/include/io/HDF5/impl/file.hpp
+++ b/include/io/HDF5/impl/file.hpp
@@ -113,6 +113,8 @@ public:
     return specfem::io::impl::HDF5::Group<OpType>(file, name);
   }
 
+  void flush() { file->flush(H5F_SCOPE_GLOBAL); }
+
   ~File() { file->close(); }
 
 private:

--- a/include/io/HDF5/impl/file.hpp
+++ b/include/io/HDF5/impl/file.hpp
@@ -117,7 +117,7 @@ public:
     return specfem::io::impl::HDF5::Group<OpType>(file, name);
   }
 
-  void flush() { file->flush(H5F_SCOPE_GLOBAL); }
+  void flush() { file->flush(H5F_SCOPE_LOCAL); }
 
   ~File() { file->close(); }
 

--- a/include/io/reader.hpp
+++ b/include/io/reader.hpp
@@ -20,7 +20,7 @@ public:
    * @param assembly Assembly object
    *
    */
-  virtual void read(specfem::compute::assembly &assembly) = 0;
+  virtual void read(specfem::compute::assembly &assembly) {}
 };
 } // namespace io
 } // namespace specfem

--- a/include/io/reader.hpp
+++ b/include/io/reader.hpp
@@ -20,7 +20,7 @@ public:
    * @param assembly Assembly object
    *
    */
-  virtual void read(specfem::compute::assembly &assembly) {}
+  virtual void read(specfem::compute::assembly &assembly) = 0;
 };
 } // namespace io
 } // namespace specfem

--- a/include/io/wavefield/reader.hpp
+++ b/include/io/wavefield/reader.hpp
@@ -2,7 +2,6 @@
 
 #include "compute/interface.hpp"
 // #include "enumerations/interface.hpp"
-#include "io/reader.hpp"
 
 namespace specfem {
 namespace io {
@@ -11,7 +10,7 @@ namespace io {
  * @brief Reader to read wavefield data from disk
  *
  */
-template <typename IOLibrary> class wavefield_reader : public reader {
+template <typename IOLibrary> class wavefield_reader {
 
 public:
   /**
@@ -27,14 +26,10 @@ public:
    * @param assembly SPECFEM++ assembly
    *
    */
-  void read(specfem::compute::assembly &assembly) override;
-
-  void set_istep(int istep) { this->istep = istep; }
+  void read(specfem::compute::assembly &assembly, const int istep);
 
 private:
   std::string output_folder; ///< Path to output folder
-  int istep = -1; ///< Current time step for file name, if value is -1, the time
-                  ///< step will be be included in the output file name.
 };
 
 } // namespace io

--- a/include/io/wavefield/reader.tpp
+++ b/include/io/wavefield/reader.tpp
@@ -28,9 +28,9 @@ void specfem::io::wavefield_reader<IOLibrary>::read(
       (DIMENSION_TAG(DIM2),
        MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC)),
       {
-        typename OutputLibrary::Group group =
-            file.createGroup(std::string("/") + specfem::element::to_string(_medium_tag_));
-        const auto &field = forward.get_field<_medium_tag_>();
+        typename IOLibrary::Group group =
+            file.openGroup(std::string("/") + specfem::element::to_string(_medium_tag_));
+        const auto &field = buffer.get_field<_medium_tag_>();
 
         if (_medium_tag_ == specfem::element::medium_tag::acoustic) {
           group.openDataset("Potential", field.h_field).read();

--- a/include/io/wavefield/reader.tpp
+++ b/include/io/wavefield/reader.tpp
@@ -24,44 +24,25 @@ void specfem::io::wavefield_reader<IOLibrary>::read(
 
   typename IOLibrary::File file(dst);
 
-  typename IOLibrary::Group elastic_psv = file.openGroup("/ElasticSV");
+  FOR_EACH_IN_PRODUCT(
+      (DIMENSION_TAG(DIM2),
+       MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC)),
+      {
+        typename OutputLibrary::Group group =
+            file.createGroup(std::string("/") + specfem::element::to_string(_medium_tag_));
+        const auto &field = forward.get_field<_medium_tag_>();
 
-  const auto &elastic_psv_field =
-      buffer.get_field<specfem::element::medium_tag::elastic_psv>();
-
-  elastic_psv.openDataset("Displacement", elastic_psv_field.h_field).read();
-  elastic_psv.openDataset("Velocity", elastic_psv_field.h_field_dot).read();
-  elastic_psv.openDataset("Acceleration", elastic_psv_field.h_field_dot_dot)
-      .read();
-
-  typename IOLibrary::Group elastic_sh = file.openGroup("/ElasticSH");
-
-  const auto &elastic_sh_field =
-      buffer.get_field<specfem::element::medium_tag::elastic_sh>();
-
-  elastic_sh.openDataset("Displacement", elastic_sh_field.h_field).read();
-  elastic_sh.openDataset("Velocity", elastic_sh_field.h_field_dot).read();
-  elastic_sh.openDataset("Acceleration", elastic_sh_field.h_field_dot_dot)
-      .read();
-
-  typename IOLibrary::Group acoustic = file.openGroup("/Acoustic");
-  const auto &acoustic_field =
-      buffer.get_field<specfem::element::medium_tag::acoustic>();
-
-  acoustic.openDataset("Potential", acoustic_field.h_field).read();
-  acoustic.openDataset("PotentialDot", acoustic_field.h_field_dot).read();
-  acoustic.openDataset("PotentialDotDot", acoustic_field.h_field_dot_dot)
-      .read();
-
-  typename IOLibrary::Group poroelastic = file.openGroup("/Poroelastic");
-
-  const auto &poroelastic_field =
-      buffer.get_field<specfem::element::medium_tag::poroelastic>();
-
-  poroelastic.openDataset("Displacement", poroelastic_field.h_field).read();
-  poroelastic.openDataset("Velocity", poroelastic_field.h_field_dot).read();
-  poroelastic.openDataset("Acceleration", poroelastic_field.h_field_dot_dot)
-      .read();
+        if (_medium_tag_ == specfem::element::medium_tag::acoustic) {
+          group.openDataset("Potential", field.h_field).read();
+          group.openDataset("PotentialDot", field.h_field_dot).read();
+          group.openDataset("PotentialDotDot", field.h_field_dot_dot).read();
+        }
+        else {
+          group.openDataset("Displacement", field.h_field).read();
+          group.openDataset("Velocity", field.h_field_dot).read();
+          group.openDataset("Acceleration", field.h_field_dot_dot).read();
+        }
+      });
 
   typename IOLibrary::Group boundary = file.openGroup("/Boundary");
   typename IOLibrary::Group stacey = boundary.openGroup("/Stacey");

--- a/include/io/wavefield/writer.hpp
+++ b/include/io/wavefield/writer.hpp
@@ -2,7 +2,6 @@
 
 #include "compute/interface.hpp"
 #include "enumerations/interface.hpp"
-#include "io/writer.hpp"
 
 namespace specfem {
 namespace io {
@@ -12,7 +11,7 @@ namespace io {
  *
  * @tparam OutputLibrary Library to use for output (HDF5, ASCII, etc.)
  */
-template <typename OutputLibrary> class wavefield_writer : public writer {
+template <typename OutputLibrary> class wavefield_writer {
 
 public:
   /**
@@ -36,14 +35,13 @@ public:
    * @param assembly SPECFEM++ assembly
    *
    */
-  void write(specfem::compute::assembly &assembly) override;
+  void write(specfem::compute::assembly &assembly);
 
-  void set_istep(int istep) { this->istep = istep; }
+  void write(specfem::compute::assembly &assembly, const int istep);
 
 private:
   std::string output_folder; ///< Path to output folder
-  int istep = -1; ///< Current time step for file name, if value is -1, the time
-                  ///< step will be be included in the output file name.
+  typename OutputLibrary::File file;
 };
 } // namespace io
 } // namespace specfem

--- a/include/io/wavefield/writer.tpp
+++ b/include/io/wavefield/writer.tpp
@@ -1,54 +1,105 @@
 #pragma once
 
-#include "io/wavefield/writer.hpp"
 #include "compute/interface.hpp"
 #include "enumerations/interface.hpp"
+#include "io/wavefield/writer.hpp"
 #include "utilities/strings.hpp"
 
 template <typename OutputLibrary>
 specfem::io::wavefield_writer<OutputLibrary>::wavefield_writer(
     const std::string output_folder)
-    : output_folder(output_folder) {}
+    : output_folder(output_folder), file(typename OutputLibrary::File(
+                                        output_folder + "/ForwardWavefield")) {}
 
 template <typename OutputLibrary>
 void specfem::io::wavefield_writer<OutputLibrary>::write(
     specfem::compute::assembly &assembly) {
+
+  auto &forward = assembly.fields.forward;
+  auto &mesh = assembly.mesh;
+  auto &element_types = assembly.element_types;
+
+  using DomainView =
+      Kokkos::View<type_real *, Kokkos::LayoutLeft, Kokkos::HostSpace>;
+
+  const int ngllz = mesh.points.ngllz;
+  const int ngllx = mesh.points.ngllx;
+
+  typename OutputLibrary::Group base_group =
+      file.createGroup(std::string("/Coordinates"));
+
+  FOR_EACH_IN_PRODUCT(
+      (DIMENSION_TAG(DIM2),
+       MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC)),
+      {
+        const auto &field = forward.get_field<_medium_tag_>();
+
+        typename OutputLibrary::Group group = base_group.createGroup(
+            specfem::element::to_string(_medium_tag_));
+
+        const auto element_indices =
+            element_types.get_elements_on_host(_medium_tag_);
+        const int n_elements = element_indices.size();
+
+        DomainView x("xcoordinates", field.h_field.extent(0));
+        DomainView z("zcoordinates", field.h_field.extent(0));
+
+        for (int i = 0; i < n_elements; i++) {
+          const int ispec = element_indices(i);
+          for (int iz = 0; iz < ngllz; iz++) {
+            for (int ix = 0; ix < ngllx; ix++) {
+              const int iglob =
+                  forward.template get_iglob<false>(i, iz, ix, _medium_tag_);
+              x(iglob) = mesh.points.h_coord(0, ispec, iz, ix);
+              z(iglob) = mesh.points.h_coord(1, ispec, iz, ix);
+            }
+          }
+        }
+
+        group.createDataset("X", x).write();
+        group.createDataset("Z", z).write();
+      });
+
+  file.flush();
+
+  std::cout << "Coordinates written to " << output_folder + "/ForwardWavefield"
+            << std::endl;
+}
+
+template <typename OutputLibrary>
+void specfem::io::wavefield_writer<OutputLibrary>::write(
+    specfem::compute::assembly &assembly, const int istep) {
   auto &forward = assembly.fields.forward;
   auto &boundary_values = assembly.boundary_values;
 
   forward.copy_to_host();
   boundary_values.copy_to_host();
 
-  std::string dst = this->output_folder + "/ForwardWavefield";
-
-  if (this->istep != -1) {
-    dst += specfem::utilities::to_zero_lead(istep, 6);
-  }
-
-  typename OutputLibrary::File file(dst);
+  typename OutputLibrary::Group base_group = file.createGroup(
+      std::string("/Step") + specfem::utilities::to_zero_lead(istep, 6));
 
   FOR_EACH_IN_PRODUCT(
       (DIMENSION_TAG(DIM2),
        MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC)),
       {
-        typename OutputLibrary::Group group =
-            file.createGroup(std::string("/") + specfem::element::to_string(_medium_tag_));
         const auto &field = forward.get_field<_medium_tag_>();
+
+        typename OutputLibrary::Group group = base_group.createGroup(
+            specfem::element::to_string(_medium_tag_));
 
         if (_medium_tag_ == specfem::element::medium_tag::acoustic) {
           group.createDataset("Potential", field.h_field).write();
           group.createDataset("PotentialDot", field.h_field_dot).write();
           group.createDataset("PotentialDotDot", field.h_field_dot_dot).write();
-        }
-        else {
+        } else {
           group.createDataset("Displacement", field.h_field).write();
           group.createDataset("Velocity", field.h_field_dot).write();
           group.createDataset("Acceleration", field.h_field_dot_dot).write();
         }
       });
 
-  typename OutputLibrary::Group boundary = file.createGroup("/Boundary");
-  typename OutputLibrary::Group stacey = boundary.createGroup("/Stacey");
+  typename OutputLibrary::Group boundary = base_group.createGroup("Boundary");
+  typename OutputLibrary::Group stacey = boundary.createGroup("Stacey");
 
   stacey
       .createDataset("IndexMapping",
@@ -67,6 +118,8 @@ void specfem::io::wavefield_writer<OutputLibrary>::write(
                      boundary_values.stacey.poroelastic.h_values)
       .write();
 
-  std::cout << "Wavefield written to " << dst
+  file.flush();
+
+  std::cout << "Wavefield written to " << output_folder + "/ForwardWavefield"
             << std::endl;
 }

--- a/include/io/writer.hpp
+++ b/include/io/writer.hpp
@@ -20,7 +20,7 @@ public:
    * @param assembly Assembly object
    *
    */
-  virtual void write(specfem::compute::assembly &assembly) {};
+  virtual void write(specfem::compute::assembly &assembly) = 0;
 };
 
 } // namespace io

--- a/include/periodic_tasks/periodic_task.hpp
+++ b/include/periodic_tasks/periodic_task.hpp
@@ -25,10 +25,18 @@ public:
       : time_interval(time_interval), include_last_step(include_last_step) {};
 
   /**
-   * @brief Method to plot the data
+   * @brief Function to be called periodically.
    *
    */
   virtual void run(specfem::compute::assembly &assembly, const int istep) {};
+
+  /**
+   * @brief Functions to be called once at the beginning and once at the end of
+   * the simulation.
+   *
+   */
+  virtual void initialize(specfem::compute::assembly &assembly) {};
+  virtual void finalize(specfem::compute::assembly &assembly) {};
 
   /**
    * @brief Returns true if the data should be plotted at the current

--- a/include/periodic_tasks/wavefield_reader.hpp
+++ b/include/periodic_tasks/wavefield_reader.hpp
@@ -29,8 +29,7 @@ public:
   void run(specfem::compute::assembly &assembly, const int istep) override {
     std::cout << "Reading wavefield files:" << std::endl;
     std::cout << "-------------------------------" << std::endl;
-    reader.set_istep(istep);
-    reader.read(assembly);
+    reader.read(assembly, istep);
   }
 };
 

--- a/include/periodic_tasks/wavefield_reader.hpp
+++ b/include/periodic_tasks/wavefield_reader.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "io/operators.hpp"
 #include "io/wavefield/reader.hpp"
 #include "periodic_task.hpp"
 #include <Kokkos_Core.hpp>
@@ -9,14 +10,17 @@ namespace periodic_tasks {
  * @brief Base plotter class
  *
  */
-template <typename IOLibrary>
-class wavefield_reader : public periodic_task,
-                         specfem::io::wavefield_reader<IOLibrary> {
+template <template <typename OpType> class IOLibrary>
+class wavefield_reader : public periodic_task {
+private:
+  specfem::io::wavefield_reader<IOLibrary<specfem::io::read> > reader;
+
 public:
   wavefield_reader(const std::string output_folder, const int time_interval,
                    const bool include_last_step)
       : periodic_task(time_interval, include_last_step),
-        specfem::io::wavefield_reader<IOLibrary>(output_folder) {}
+        reader(specfem::io::wavefield_reader<IOLibrary<specfem::io::read> >(
+            output_folder)) {}
 
   /**
    * @brief Check for keyboard interrupt and more, when running from Python
@@ -25,8 +29,8 @@ public:
   void run(specfem::compute::assembly &assembly, const int istep) override {
     std::cout << "Reading wavefield files:" << std::endl;
     std::cout << "-------------------------------" << std::endl;
-    this->set_istep(istep);
-    this->read(assembly);
+    reader.set_istep(istep);
+    reader.read(assembly);
   }
 };
 

--- a/include/periodic_tasks/wavefield_writer.hpp
+++ b/include/periodic_tasks/wavefield_writer.hpp
@@ -14,15 +14,12 @@ template <template <typename OpType> class IOLibrary>
 class wavefield_writer : public periodic_task {
 private:
   specfem::io::wavefield_writer<IOLibrary<specfem::io::write> > writer;
-  specfem::io::wavefield_writer<IOLibrary<specfem::io::write> > appender;
 
 public:
   wavefield_writer(const std::string output_folder, const int time_interval,
                    const bool include_last_step)
       : periodic_task(time_interval, include_last_step),
         writer(specfem::io::wavefield_writer<IOLibrary<specfem::io::write> >(
-            output_folder)),
-        appender(specfem::io::wavefield_writer<IOLibrary<specfem::io::write> >(
             output_folder)) {}
 
   /**
@@ -32,7 +29,15 @@ public:
   void run(specfem::compute::assembly &assembly, const int istep) override {
     std::cout << "Writing wavefield files:" << std::endl;
     std::cout << "-------------------------------" << std::endl;
-    writer.set_istep(istep);
+    writer.write(assembly, istep);
+  }
+
+  /**
+   * @brief Write coordinates of wavefield data to disk.
+   */
+  void initialize(specfem::compute::assembly &assembly) override {
+    std::cout << "Writing coordinate files:" << std::endl;
+    std::cout << "-------------------------------" << std::endl;
     writer.write(assembly);
   }
 };

--- a/include/solver/time_marching.tpp
+++ b/include/solver/time_marching.tpp
@@ -25,6 +25,10 @@ void specfem::solver::time_marching<specfem::simulation::type::forward,
 
   const int total_elements_to_be_updated = assembly.get_total_number_of_elements();
 
+  for (const auto &task : tasks) {
+    task->initialize(assembly);
+  }
+
   for (const auto [istep, dt] : time_scheme->iterate_forward()) {
     int dofs_updated = 0;
     int elements_updated = 0;
@@ -105,6 +109,10 @@ void specfem::solver::time_marching<specfem::simulation::type::forward,
     }
   }
 
+  for (const auto &task : tasks) {
+    task->finalize(assembly);
+  }
+
   std::cout << std::endl;
 
   return;
@@ -128,6 +136,10 @@ void specfem::solver::time_marching<specfem::simulation::type::combined,
       4 * assembly.get_total_degrees_of_freedom();
 
   const int total_elements_to_be_updated = 2 * assembly.get_total_number_of_elements();
+
+  for (const auto &task : tasks) {
+    task->initialize(assembly);
+  }
 
   for (const auto &task : tasks) {
     if (task && !task->should_run(nstep) && task->should_run(-1)) {
@@ -218,6 +230,10 @@ void specfem::solver::time_marching<specfem::simulation::type::combined,
 
       throw std::runtime_error(message.str());
     }
+  }
+
+  for (const auto &task : tasks) {
+    task->finalize(assembly);
   }
 
   std::cout << std::endl;

--- a/include/utilities/strings.hpp
+++ b/include/utilities/strings.hpp
@@ -8,5 +8,8 @@ namespace utilities {
 // Convert integer to string with zero leading
 std::string to_zero_lead(const int value, const int n_zero);
 
+// Convert snake_case string to PascalCase
+std::string snake_to_pascal(const std::string &str);
+
 } // namespace utilities
 } // namespace specfem

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,8 @@ examples = [
   "jinja2==3.1.6",
   "PyYAML==6.0.2",
   "numpy==2.2.4",
-  "scipy==1.15.2"
+  "scipy==1.15.2",
+  "h5py==3.13.0",
 ]
 
 [tool.scikit-build]

--- a/src/parameter_parser/writer/wavefield.cpp
+++ b/src/parameter_parser/writer/wavefield.cpp
@@ -84,12 +84,12 @@ specfem::runtime_configuration::wavefield::instantiate_wavefield_writer()
       [&]() -> std::shared_ptr<specfem::periodic_tasks::periodic_task> {
     if (this->simulation_type == specfem::simulation::type::forward) {
       if (this->output_format == "HDF5") {
-        return std::make_shared<specfem::periodic_tasks::wavefield_writer<
-            specfem::io::HDF5<specfem::io::write> > >(
+        return std::make_shared<
+            specfem::periodic_tasks::wavefield_writer<specfem::io::HDF5> >(
             this->output_folder, this->time_interval, this->include_last_step);
       } else if (this->output_format == "ASCII") {
-        return std::make_shared<specfem::periodic_tasks::wavefield_writer<
-            specfem::io::ASCII<specfem::io::write> > >(
+        return std::make_shared<
+            specfem::periodic_tasks::wavefield_writer<specfem::io::ASCII> >(
             this->output_folder, this->time_interval, this->include_last_step);
       } else {
         throw std::runtime_error("Unknown wavefield format");
@@ -110,12 +110,12 @@ specfem::runtime_configuration::wavefield::instantiate_wavefield_reader()
       [&]() -> std::shared_ptr<specfem::periodic_tasks::periodic_task> {
     if (this->simulation_type == specfem::simulation::type::combined) {
       if (this->output_format == "HDF5") {
-        return std::make_shared<specfem::periodic_tasks::wavefield_reader<
-            specfem::io::HDF5<specfem::io::read> > >(
+        return std::make_shared<
+            specfem::periodic_tasks::wavefield_reader<specfem::io::HDF5> >(
             this->output_folder, this->time_interval, this->include_last_step);
       } else if (this->output_format == "ASCII") {
-        return std::make_shared<specfem::periodic_tasks::wavefield_reader<
-            specfem::io::ASCII<specfem::io::read> > >(
+        return std::make_shared<
+            specfem::periodic_tasks::wavefield_reader<specfem::io::ASCII> >(
             this->output_folder, this->time_interval, this->include_last_step);
       } else {
         throw std::runtime_error("Unknown wavefield format");

--- a/src/periodic_tasks/wavefield_reader.cpp
+++ b/src/periodic_tasks/wavefield_reader.cpp
@@ -3,8 +3,6 @@
 #include "io/HDF5/HDF5.hpp"
 
 // Explicit instantiation
-template class specfem::periodic_tasks::wavefield_reader<
-    specfem::io::HDF5<specfem::io::read> >;
+template class specfem::periodic_tasks::wavefield_reader<specfem::io::HDF5>;
 
-template class specfem::periodic_tasks::wavefield_reader<
-    specfem::io::ASCII<specfem::io::read> >;
+template class specfem::periodic_tasks::wavefield_reader<specfem::io::ASCII>;

--- a/src/periodic_tasks/wavefield_writer.cpp
+++ b/src/periodic_tasks/wavefield_writer.cpp
@@ -3,8 +3,6 @@
 #include "io/HDF5/HDF5.hpp"
 
 // Explicit instantiation
-template class specfem::periodic_tasks::wavefield_writer<
-    specfem::io::HDF5<specfem::io::write> >;
+template class specfem::periodic_tasks::wavefield_writer<specfem::io::HDF5>;
 
-template class specfem::periodic_tasks::wavefield_writer<
-    specfem::io::ASCII<specfem::io::write> >;
+template class specfem::periodic_tasks::wavefield_writer<specfem::io::ASCII>;

--- a/src/utilities/strings.cpp
+++ b/src/utilities/strings.cpp
@@ -13,5 +13,23 @@ std::string to_zero_lead(const int value, const int n_zero) {
   return new_str;
 }
 
+// Convert snake_case string to PascalCase
+std::string snake_to_pascal(const std::string &str) {
+  std::string result;
+  bool capitalizeNext = true; // Capitalize the first character
+
+  for (char ch : str) {
+    if (ch == '_') {
+      capitalizeNext = true;
+    } else if (capitalizeNext) {
+      result += std::toupper(ch);
+      capitalizeNext = false;
+    } else {
+      result += ch;
+    }
+  }
+  return result;
+}
+
 } // namespace utilities
 } // namespace specfem

--- a/uv.lock
+++ b/uv.lock
@@ -421,6 +421,27 @@ wheels = [
 ]
 
 [[package]]
+name = "h5py"
+version = "3.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/2e/a22d6a8bfa6f8be33e7febd985680fba531562795f0a9077ed1eb047bfb0/h5py-3.13.0.tar.gz", hash = "sha256:1870e46518720023da85d0895a1960ff2ce398c5671eac3b1a41ec696b7105c3", size = 414876 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/20/438f6366ba4ded80eadb38f8927f5e2cd6d2e087179552f20ae3dbcd5d5b/h5py-3.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:477c58307b6b9a2509c59c57811afb9f598aedede24a67da808262dfa0ee37b4", size = 3384442 },
+    { url = "https://files.pythonhosted.org/packages/10/13/cc1cb7231399617d9951233eb12fddd396ff5d4f7f057ee5d2b1ca0ee7e7/h5py-3.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:57c4c74f627c616f02b7aec608a8c706fe08cb5b0ba7c08555a4eb1dde20805a", size = 2917567 },
+    { url = "https://files.pythonhosted.org/packages/9e/d9/aed99e1c858dc698489f916eeb7c07513bc864885d28ab3689d572ba0ea0/h5py-3.13.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:357e6dc20b101a805ccfd0024731fbaf6e8718c18c09baf3b5e4e9d198d13fca", size = 4669544 },
+    { url = "https://files.pythonhosted.org/packages/a7/da/3c137006ff5f0433f0fb076b1ebe4a7bf7b5ee1e8811b5486af98b500dd5/h5py-3.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d6f13f9b5ce549448c01e4dfe08ea8d1772e6078799af2c1c8d09e941230a90d", size = 4932139 },
+    { url = "https://files.pythonhosted.org/packages/25/61/d897952629cae131c19d4c41b2521e7dd6382f2d7177c87615c2e6dced1a/h5py-3.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:21daf38171753899b5905f3d82c99b0b1ec2cbbe282a037cad431feb620e62ec", size = 2954179 },
+    { url = "https://files.pythonhosted.org/packages/60/43/f276f27921919a9144074320ce4ca40882fc67b3cfee81c3f5c7df083e97/h5py-3.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e520ec76de00943dd017c8ea3f354fa1d2f542eac994811943a8faedf2a7d5cb", size = 3358040 },
+    { url = "https://files.pythonhosted.org/packages/1b/86/ad4a4cf781b08d4572be8bbdd8f108bb97b266a14835c640dc43dafc0729/h5py-3.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e79d8368cd9295045956bfb436656bea3f915beaa11d342e9f79f129f5178763", size = 2892766 },
+    { url = "https://files.pythonhosted.org/packages/69/84/4c6367d6b58deaf0fa84999ec819e7578eee96cea6cbd613640d0625ed5e/h5py-3.13.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:56dd172d862e850823c4af02dc4ddbc308f042b85472ffdaca67f1598dff4a57", size = 4664255 },
+    { url = "https://files.pythonhosted.org/packages/fd/41/bc2df86b72965775f6d621e0ee269a5f3ac23e8f870abf519de9c7d93b4d/h5py-3.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be949b46b7388074c5acae017fbbe3e5ba303fd9daaa52157fdfef30bbdacadd", size = 4927580 },
+    { url = "https://files.pythonhosted.org/packages/97/34/165b87ea55184770a0c1fcdb7e017199974ad2e271451fd045cfe35f3add/h5py-3.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:4f97ecde7ac6513b21cd95efdfc38dc6d19f96f6ca6f2a30550e94e551458e0a", size = 2940890 },
+]
+
+[[package]]
 name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1463,6 +1484,7 @@ all = [
     { name = "clang-format" },
     { name = "doc8" },
     { name = "furo" },
+    { name = "h5py" },
     { name = "imageio" },
     { name = "jinja2" },
     { name = "numpy" },
@@ -1509,6 +1531,7 @@ doc = [
     { name = "sphinx-sitemap" },
 ]
 examples = [
+    { name = "h5py" },
     { name = "imageio" },
     { name = "jinja2" },
     { name = "numpy" },
@@ -1532,6 +1555,7 @@ all = [
     { name = "clang-format", specifier = "==19.1.7" },
     { name = "doc8", specifier = "==0.11.2" },
     { name = "furo", specifier = "==2024.8.6" },
+    { name = "h5py", specifier = "==3.13.0" },
     { name = "imageio", specifier = "==2.36.1" },
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "numpy", specifier = "==2.2.4" },
@@ -1578,6 +1602,7 @@ doc = [
     { name = "sphinx-sitemap", specifier = "==2.6.0" },
 ]
 examples = [
+    { name = "h5py", specifier = "==3.13.0" },
     { name = "imageio", specifier = "==2.36.1" },
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "numpy", specifier = "==2.2.4" },


### PR DESCRIPTION
## Description

- Add flush() method for writing changes to disk without closing the file
- Add h5py to examples group dependency for future analysis
- wavefield reader / writer is no longer subclass of io::reader / writer because the require an additional istep parameter as well as initializers
- Write coordinate information in wavefield writer
- Add initialize() / finalize() for periodic tasks

## Issue Number

Closes #793 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
