### PR TITLE
Removed the seismogram type and replaced it with wavefield type

### DIFF
--- a/include/compute/assembly/assembly.hpp
+++ b/include/compute/assembly/assembly.hpp
@@ -13,6 +13,7 @@
 #include "compute/sources/sources.hpp"
 #include "enumerations/display.hpp"
 #include "enumerations/interface.hpp"
+#include "enumerations/wavefield.hpp"
 #include "io/reader.hpp"
 #include "mesh/mesh.hpp"
 #include "receiver/interface.hpp"
@@ -78,9 +79,9 @@ struct assembly {
       const std::vector<std::shared_ptr<specfem::sources::source> > &sources,
       const std::vector<std::shared_ptr<specfem::receivers::receiver> >
           &receivers,
-      const std::vector<specfem::enums::seismogram::type> &stypes,
-      const type_real t0, const type_real dt, const int max_timesteps,
-      const int max_sig_step, const int nsteps_between_samples,
+      const std::vector<specfem::wavefield::type> &stypes, const type_real t0,
+      const type_real dt, const int max_timesteps, const int max_sig_step,
+      const int nsteps_between_samples,
       const specfem::simulation::type simulation,
       const std::shared_ptr<specfem::io::reader> &property_reader);
 
@@ -106,7 +107,6 @@ struct assembly {
   }
 
   std::string print() const;
-
 };
 
 } // namespace compute

--- a/include/compute/receivers/receivers.hpp
+++ b/include/compute/receivers/receivers.hpp
@@ -313,7 +313,7 @@ public:
             const int nsteps_between_samples,
             const std::vector<std::shared_ptr<specfem::receivers::receiver> >
                 &receivers,
-            const std::vector<specfem::enums::seismogram::type> &stypes,
+            const std::vector<specfem::wavefield::type> &stypes,
             const specfem::compute::mesh &mesh,
             const specfem::mesh::tags<specfem::dimension::type::dim2> &tags,
             const specfem::compute::element_types &element_types);

--- a/include/enumerations/specfem_enums.hpp
+++ b/include/enumerations/specfem_enums.hpp
@@ -28,11 +28,6 @@ enum class electromagnetic_wave { te, tm };
 enum class axes { x, y, z };
 
 namespace seismogram {
-/**
- * @brief Seismogram type enumeration
- *
- */
-enum class type { displacement, velocity, acceleration, pressure };
 
 /**
  * @brief Output format of seismogram enumeration

--- a/include/parameter_parser/receivers.hpp
+++ b/include/parameter_parser/receivers.hpp
@@ -3,6 +3,7 @@
 
 #include "constants.hpp"
 #include "enumerations/specfem_enums.hpp"
+#include "enumerations/wavefield.hpp"
 #include "yaml-cpp/yaml.h"
 #include <string>
 
@@ -47,9 +48,9 @@ public:
   /**
    * @brief Get the types of seismogram requested
    *
-   * @return std::vector<specfem::seismogram::type> vector seismogram types
+   * @return std::vector<specfem::wavefield::type> vector seismogram types
    */
-  std::vector<specfem::enums::seismogram::type> get_seismogram_types() const;
+  std::vector<specfem::wavefield::type> get_seismogram_types() const;
 
 private:
   YAML::Node receivers_node; /// Node that contains receiver information

--- a/include/parameter_parser/setup.hpp
+++ b/include/parameter_parser/setup.hpp
@@ -156,7 +156,7 @@ public:
    * @return std::vector<specfem::seismogram::type> Types of seismograms to be
    * calculated
    */
-  std::vector<specfem::enums::seismogram::type> get_seismogram_types() const {
+  std::vector<specfem::wavefield::type> get_seismogram_types() const {
     return this->receivers->get_seismogram_types();
   }
 

--- a/src/compute/assembly/assembly.cpp
+++ b/src/compute/assembly/assembly.cpp
@@ -9,9 +9,9 @@ specfem::compute::assembly::assembly(
     const std::vector<std::shared_ptr<specfem::sources::source> > &sources,
     const std::vector<std::shared_ptr<specfem::receivers::receiver> >
         &receivers,
-    const std::vector<specfem::enums::seismogram::type> &stypes,
-    const type_real t0, const type_real dt, const int max_timesteps,
-    const int max_sig_step, const int nsteps_between_samples,
+    const std::vector<specfem::wavefield::type> &stypes, const type_real t0,
+    const type_real dt, const int max_timesteps, const int max_sig_step,
+    const int nsteps_between_samples,
     const specfem::simulation::type simulation,
     const std::shared_ptr<specfem::io::reader> &property_reader) {
   this->mesh = { mesh.tags, mesh.control_nodes, quadratures };

--- a/src/compute/compute_receivers.cpp
+++ b/src/compute/compute_receivers.cpp
@@ -14,7 +14,7 @@ specfem::compute::receivers::receivers(
     const type_real dt, const type_real t0, const int nsteps_between_samples,
     const std::vector<std::shared_ptr<specfem::receivers::receiver> >
         &receivers,
-    const std::vector<specfem::enums::seismogram::type> &stypes,
+    const std::vector<specfem::wavefield::type> &stypes,
     const specfem::compute::mesh &mesh,
     const specfem::mesh::tags<specfem::dimension::type::dim2> &tags,
     const specfem::compute::element_types &element_types)
@@ -30,27 +30,18 @@ specfem::compute::receivers::receivers(
                                dt, t0, nsteps_between_samples) {
 
   for (int isies = 0; isies < stypes.size(); ++isies) {
+
     auto seis_type = stypes[isies];
-    switch (seis_type) {
-    case specfem::enums::seismogram::type::displacement:
-      seismogram_types[isies] = specfem::wavefield::type::displacement;
-      seismogram_type_map[specfem::wavefield::type::displacement] = isies;
-      break;
-    case specfem::enums::seismogram::type::velocity:
-      seismogram_types[isies] = specfem::wavefield::type::velocity;
-      seismogram_type_map[specfem::wavefield::type::velocity] = isies;
-      break;
-    case specfem::enums::seismogram::type::acceleration:
-      seismogram_types[isies] = specfem::wavefield::type::acceleration;
-      seismogram_type_map[specfem::wavefield::type::acceleration] = isies;
-      break;
-    case specfem::enums::seismogram::type::pressure:
-      seismogram_types[isies] = specfem::wavefield::type::pressure;
-      seismogram_type_map[specfem::wavefield::type::pressure] = isies;
-      break;
-    default:
+
+    if (seis_type != specfem::wavefield::type::displacement &&
+        seis_type != specfem::wavefield::type::velocity &&
+        seis_type != specfem::wavefield::type::acceleration &&
+        seis_type != specfem::wavefield::type::pressure) {
       throw std::runtime_error("Invalid seismogram type");
     }
+
+    seismogram_types[isies] = seis_type;
+    seismogram_type_map[seis_type] = isies;
   }
 
   for (int ireceiver = 0; ireceiver < receivers.size(); ++ireceiver) {

--- a/src/parameter_parser/receivers.cpp
+++ b/src/parameter_parser/receivers.cpp
@@ -9,23 +9,23 @@
 #include <string>
 #include <vector>
 
-std::vector<specfem::enums::seismogram::type>
+std::vector<specfem::wavefield::type>
 specfem::runtime_configuration::receivers::get_seismogram_types() const {
 
-  std::vector<specfem::enums::seismogram::type> stypes;
+  std::vector<specfem::wavefield::type> stypes;
 
   // Allocate seismogram types
   assert(this->receivers_node["seismogram-type"].IsSequence());
 
   for (YAML::Node seismogram_type : this->receivers_node["seismogram-type"]) {
     if (seismogram_type.as<std::string>() == "displacement") {
-      stypes.push_back(specfem::enums::seismogram::type::displacement);
+      stypes.push_back(specfem::wavefield::type::displacement);
     } else if (seismogram_type.as<std::string>() == "velocity") {
-      stypes.push_back(specfem::enums::seismogram::type::velocity);
+      stypes.push_back(specfem::wavefield::type::velocity);
     } else if (seismogram_type.as<std::string>() == "acceleration") {
-      stypes.push_back(specfem::enums::seismogram::type::acceleration);
+      stypes.push_back(specfem::wavefield::type::acceleration);
     } else if (seismogram_type.as<std::string>() == "pressure") {
-      stypes.push_back(specfem::enums::seismogram::type::pressure);
+      stypes.push_back(specfem::wavefield::type::pressure);
     } else {
       std::ostringstream message;
 

--- a/tests/unit-tests/assembly/test_fixture/test_fixture.cpp
+++ b/tests/unit-tests/assembly/test_fixture/test_fixture.cpp
@@ -51,8 +51,8 @@ ASSEMBLY::ASSEMBLY() {
 
     this->Stations.push_back(receivers);
 
-    std::vector<specfem::enums::seismogram::type> seismogram_types = {
-      specfem::enums::seismogram::type::displacement
+    std::vector<specfem::wavefield::type> seismogram_types = {
+      specfem::wavefield::type::displacement
     };
 
     this->assemblies.push_back(specfem::compute::assembly(

--- a/tests/unit-tests/domain/rmass_inverse_tests.cpp
+++ b/tests/unit-tests/domain/rmass_inverse_tests.cpp
@@ -125,7 +125,7 @@ TEST(DOMAIN_TESTS, rmass_inverse) {
     // Setup dummy sources and receivers for testing
     std::vector<std::shared_ptr<specfem::sources::source> > sources(0);
     std::vector<std::shared_ptr<specfem::receivers::receiver> > receivers(0);
-    std::vector<specfem::enums::seismogram::type> stypes(0);
+    std::vector<specfem::wavefield::type> stypes(0);
 
     // Generate compute structs to be used by the solver
     specfem::compute::assembly assembly(mesh, quadratures, sources, receivers,


### PR DESCRIPTION
## Description

- Removed seismogram type because the only place it was used was to convert it to wavefield type

## Issue Number

Closes #773 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [x] I ran the code through pre-commit to check style
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
