### PR TITLE
Issue 805 - Optimize compilation for macros

### DIFF
--- a/include/enumerations/macros_impl/array.hpp
+++ b/include/enumerations/macros_impl/array.hpp
@@ -2,28 +2,23 @@
  * @brief Macro to create a constexpr array from a sequence
  * Used by medium_types(), material_systems() and element_types()
  */
-#define _MAKE_CONSTEXPR_ARRAY(seq, macro)                                      \
-  BOOST_PP_SEQ_ENUM(BOOST_PP_SEQ_TRANSFORM(macro, _, seq))
+#define _MAKE_CONSTEXPR_ARRAY(seq)                                             \
+  BOOST_PP_SEQ_ENUM(BOOST_PP_SEQ_TRANSFORM(                                    \
+      BOOST_PP_CAT(_MAKE_ARRAY_, BOOST_PP_SEQ_SIZE(seq)), _, seq))
 
 /**
- * @brief Sequence transformation function for _MAKE_CONSTEXPR_ARRAY.
+ * @brief Sequence transformation macros for _MAKE_CONSTEXPR_ARRAY.
  */
-#define _MAKE_ARRAY_ELEM_MEDIUM(s, data, elem)                                 \
+#define _MAKE_ARRAY_2(s, data, elem)                                           \
   std::make_tuple(_GET_TAG(BOOST_PP_TUPLE_ELEM(0, elem)),                      \
                   _GET_TAG(BOOST_PP_TUPLE_ELEM(1, elem)))
 
-/**
- * @brief Sequence transformation function for _MAKE_CONSTEXPR_ARRAY.
- */
-#define _MAKE_ARRAY_ELEM_MAT_SYS(s, data, elem)                                \
+#define _MAKE_ARRAY_3(s, data, elem)                                           \
   std::make_tuple(_GET_TAG(BOOST_PP_TUPLE_ELEM(0, elem)),                      \
                   _GET_TAG(BOOST_PP_TUPLE_ELEM(1, elem)),                      \
                   _GET_TAG(BOOST_PP_TUPLE_ELEM(2, elem)))
 
-/**
- * @brief Sequence transformation function for _MAKE_CONSTEXPR_ARRAY.
- */
-#define _MAKE_ARRAY_ELEM_ELEM(s, data, elem)                                   \
+#define _MAKE_ARRAY_4(s, data, elem)                                           \
   std::make_tuple(_GET_TAG(BOOST_PP_TUPLE_ELEM(0, elem)),                      \
                   _GET_TAG(BOOST_PP_TUPLE_ELEM(1, elem)),                      \
                   _GET_TAG(BOOST_PP_TUPLE_ELEM(2, elem)),                      \

--- a/include/enumerations/macros_impl/array.hpp
+++ b/include/enumerations/macros_impl/array.hpp
@@ -3,22 +3,24 @@
  * Used by medium_types(), material_systems() and element_types()
  */
 #define _MAKE_CONSTEXPR_ARRAY(seq)                                             \
-  BOOST_PP_SEQ_ENUM(BOOST_PP_SEQ_TRANSFORM(                                    \
-      BOOST_PP_CAT(_MAKE_ARRAY_, BOOST_PP_SEQ_SIZE(seq)), _, seq))
+  BOOST_PP_SEQ_ENUM(BOOST_PP_SEQ_TRANSFORM(_MAKE_ARRAY, _, seq))
 
 /**
  * @brief Sequence transformation macros for _MAKE_CONSTEXPR_ARRAY.
  */
-#define _MAKE_ARRAY_2(s, data, elem)                                           \
+#define _MAKE_ARRAY(s, data, elem)                                             \
+  BOOST_PP_CAT(_MAKE_ARRAY_, BOOST_PP_TUPLE_SIZE(elem))(elem)
+
+#define _MAKE_ARRAY_2(elem)                                                    \
   std::make_tuple(_GET_TAG(BOOST_PP_TUPLE_ELEM(0, elem)),                      \
                   _GET_TAG(BOOST_PP_TUPLE_ELEM(1, elem)))
 
-#define _MAKE_ARRAY_3(s, data, elem)                                           \
+#define _MAKE_ARRAY_3(elem)                                                    \
   std::make_tuple(_GET_TAG(BOOST_PP_TUPLE_ELEM(0, elem)),                      \
                   _GET_TAG(BOOST_PP_TUPLE_ELEM(1, elem)),                      \
                   _GET_TAG(BOOST_PP_TUPLE_ELEM(2, elem)))
 
-#define _MAKE_ARRAY_4(s, data, elem)                                           \
+#define _MAKE_ARRAY_4(elem)                                                    \
   std::make_tuple(_GET_TAG(BOOST_PP_TUPLE_ELEM(0, elem)),                      \
                   _GET_TAG(BOOST_PP_TUPLE_ELEM(1, elem)),                      \
                   _GET_TAG(BOOST_PP_TUPLE_ELEM(2, elem)),                      \

--- a/include/enumerations/macros_impl/expand_seq.hpp
+++ b/include/enumerations/macros_impl/expand_seq.hpp
@@ -1,87 +1,73 @@
-// clang-format off
-
 /**
  * @brief Call a macro for each element in the sequence.
- *  Built-in macros like BOOST_PP_SEQ_FOR_EACH cannot be used here because they cannot
- *  correctly expand angle brackets with comma, like property<elastic, isotropic>.
+ *  Built-in macros like BOOST_PP_SEQ_FOR_EACH_R cannot be used here because
+ * they cannot correctly expand angle brackets with comma, like
+ * property<elastic, isotropic>.
  * @param MACRO The macro to be called
  * @param data data to be passed to the macro
  * @param seq sequence to be expanded
  * @param n size of the sequence
  */
-#define _EXPAND_SEQ_N(MACRO, data, seq, n)                                           \
-  BOOST_PP_IF(BOOST_PP_LESS(0, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(0, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(1, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(1, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(2, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(2, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(3, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(3, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(4, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(4, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(5, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(5, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(6, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(6, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(7, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(7, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(8, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(8, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(9, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(9, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(10, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(10, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(11, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(11, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(12, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(12, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(13, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(13, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(14, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(14, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(15, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(15, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(16, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(16, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(17, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(17, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(18, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(18, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(19, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(19, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(20, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(20, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(21, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(21, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(22, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(22, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(23, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(23, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(24, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(24, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(25, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(25, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(26, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(26, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(27, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(27, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(28, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(28, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(29, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(29, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(30, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(30, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(31, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(31, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(32, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(32, seq))
+#define _EXPAND_SEQ(MACRO, data, seq)                                          \
+  BOOST_PP_CAT(_EXPAND_SEQ_, BOOST_PP_SEQ_SIZE(seq))(MACRO, data, seq)
 
-#define _EXPAND_SEQ(MACRO, data, seq) _EXPAND_SEQ_N(MACRO, data, seq, BOOST_PP_SEQ_SIZE(seq))
+// clang-format off
+#define _EXPAND_SEQ_1(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(0, seq))
+#define _EXPAND_SEQ_2(MACRO, data , seq) _EXPAND_SEQ_1(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(1, seq))
+#define _EXPAND_SEQ_3(MACRO, data , seq) _EXPAND_SEQ_2(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(2, seq))
+#define _EXPAND_SEQ_4(MACRO, data , seq) _EXPAND_SEQ_3(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(3, seq))
+#define _EXPAND_SEQ_5(MACRO, data , seq) _EXPAND_SEQ_4(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(4, seq))
+#define _EXPAND_SEQ_6(MACRO, data , seq) _EXPAND_SEQ_5(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(5, seq))
+#define _EXPAND_SEQ_7(MACRO, data , seq) _EXPAND_SEQ_6(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(6, seq))
+#define _EXPAND_SEQ_8(MACRO, data , seq) _EXPAND_SEQ_7(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(7, seq))
+#define _EXPAND_SEQ_9(MACRO, data , seq) _EXPAND_SEQ_8(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(8, seq))
+#define _EXPAND_SEQ_10(MACRO, data , seq) _EXPAND_SEQ_9(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(9, seq))
+#define _EXPAND_SEQ_11(MACRO, data , seq) _EXPAND_SEQ_10(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(10, seq))
+#define _EXPAND_SEQ_12(MACRO, data , seq) _EXPAND_SEQ_11(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(11, seq))
+#define _EXPAND_SEQ_13(MACRO, data , seq) _EXPAND_SEQ_12(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(12, seq))
+#define _EXPAND_SEQ_14(MACRO, data , seq) _EXPAND_SEQ_13(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(13, seq))
+#define _EXPAND_SEQ_15(MACRO, data , seq) _EXPAND_SEQ_14(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(14, seq))
+#define _EXPAND_SEQ_16(MACRO, data , seq) _EXPAND_SEQ_15(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(15, seq))
+#define _EXPAND_SEQ_17(MACRO, data , seq) _EXPAND_SEQ_16(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(16, seq))
+#define _EXPAND_SEQ_18(MACRO, data , seq) _EXPAND_SEQ_17(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(17, seq))
+#define _EXPAND_SEQ_19(MACRO, data , seq) _EXPAND_SEQ_18(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(18, seq))
+#define _EXPAND_SEQ_20(MACRO, data , seq) _EXPAND_SEQ_19(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(19, seq))
+#define _EXPAND_SEQ_21(MACRO, data , seq) _EXPAND_SEQ_20(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(20, seq))
+#define _EXPAND_SEQ_22(MACRO, data , seq) _EXPAND_SEQ_21(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(21, seq))
+#define _EXPAND_SEQ_23(MACRO, data , seq) _EXPAND_SEQ_22(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(22, seq))
+#define _EXPAND_SEQ_24(MACRO, data , seq) _EXPAND_SEQ_23(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(23, seq))
+#define _EXPAND_SEQ_25(MACRO, data , seq) _EXPAND_SEQ_24(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(24, seq))
+#define _EXPAND_SEQ_26(MACRO, data , seq) _EXPAND_SEQ_25(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(25, seq))
+#define _EXPAND_SEQ_27(MACRO, data , seq) _EXPAND_SEQ_26(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(26, seq))
+#define _EXPAND_SEQ_28(MACRO, data , seq) _EXPAND_SEQ_27(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(27, seq))
+#define _EXPAND_SEQ_29(MACRO, data , seq) _EXPAND_SEQ_28(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(28, seq))
+#define _EXPAND_SEQ_30(MACRO, data , seq) _EXPAND_SEQ_29(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(29, seq))
+#define _EXPAND_SEQ_31(MACRO, data , seq) _EXPAND_SEQ_30(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(30, seq))
+#define _EXPAND_SEQ_32(MACRO, data , seq) _EXPAND_SEQ_31(MACRO, data , seq) MACRO(data, BOOST_PP_SEQ_ELEM(31, seq))
+// clang-format on
 
 /**
- * @brief Same as _EXPAND_SEQ, but defined separately to enable nested macro call from _EXPAND_SEQ.
+ * @brief Similar as _EXPAND_SEQ, but defined separately to enable nested macro
+ * call from _EXPAND_SEQ.
  */
-#define _EXPAND_SEQ2_N(MACRO, data, seq, n)                                           \
-  BOOST_PP_IF(BOOST_PP_LESS(0, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(0, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(1, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(1, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(2, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(2, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(3, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(3, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(4, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(4, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(5, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(5, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(6, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(6, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(7, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(7, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(8, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(8, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(9, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(9, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(10, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(10, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(11, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(11, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(12, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(12, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(13, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(13, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(14, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(14, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(15, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(15, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(16, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(16, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(17, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(17, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(18, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(18, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(19, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(19, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(20, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(20, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(21, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(21, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(22, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(22, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(23, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(23, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(24, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(24, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(25, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(25, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(26, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(26, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(27, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(27, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(28, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(28, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(29, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(29, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(30, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(30, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(31, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(31, seq))  \
-  BOOST_PP_IF(BOOST_PP_LESS(32, n), MACRO, _EMPTY_MACRO)(data, BOOST_PP_SEQ_ELEM(32, seq))
+#define _EXPAND_TUPLE(MACRO, data, seq)                                        \
+  BOOST_PP_CAT(_EXPAND_TUPLE_, BOOST_PP_TUPLE_SIZE(seq))(MACRO, data, seq)
 
-#define _EXPAND_SEQ2(MACRO, data, seq) _EXPAND_SEQ2_N(MACRO, data, seq, BOOST_PP_SEQ_SIZE(seq))
+// clang-format off
+#define _EXPAND_TUPLE_1(MACRO, data , seq) MACRO(data, BOOST_PP_TUPLE_ELEM(0, seq))
+#define _EXPAND_TUPLE_2(MACRO, data , seq) _EXPAND_TUPLE_1(MACRO, data , seq) MACRO(data, BOOST_PP_TUPLE_ELEM(1, seq))
+#define _EXPAND_TUPLE_3(MACRO, data , seq) _EXPAND_TUPLE_2(MACRO, data , seq) MACRO(data, BOOST_PP_TUPLE_ELEM(2, seq))
+#define _EXPAND_TUPLE_4(MACRO, data , seq) _EXPAND_TUPLE_3(MACRO, data , seq) MACRO(data, BOOST_PP_TUPLE_ELEM(3, seq))
+#define _EXPAND_TUPLE_5(MACRO, data , seq) _EXPAND_TUPLE_4(MACRO, data , seq) MACRO(data, BOOST_PP_TUPLE_ELEM(4, seq))
+#define _EXPAND_TUPLE_6(MACRO, data , seq) _EXPAND_TUPLE_5(MACRO, data , seq) MACRO(data, BOOST_PP_TUPLE_ELEM(5, seq))
+#define _EXPAND_TUPLE_7(MACRO, data , seq) _EXPAND_TUPLE_6(MACRO, data , seq) MACRO(data, BOOST_PP_TUPLE_ELEM(6, seq))
+#define _EXPAND_TUPLE_8(MACRO, data , seq) _EXPAND_TUPLE_7(MACRO, data , seq) MACRO(data, BOOST_PP_TUPLE_ELEM(7, seq))
+#define _EXPAND_TUPLE_9(MACRO, data , seq) _EXPAND_TUPLE_8(MACRO, data , seq) MACRO(data, BOOST_PP_TUPLE_ELEM(8, seq))
+#define _EXPAND_TUPLE_10(MACRO, data , seq) _EXPAND_TUPLE_9(MACRO, data , seq) MACRO(data, BOOST_PP_TUPLE_ELEM(9, seq))
+#define _EXPAND_TUPLE_11(MACRO, data , seq) _EXPAND_TUPLE_10(MACRO, data , seq) MACRO(data, BOOST_PP_TUPLE_ELEM(10, seq))
+#define _EXPAND_TUPLE_12(MACRO, data , seq) _EXPAND_TUPLE_11(MACRO, data , seq) MACRO(data, BOOST_PP_TUPLE_ELEM(11, seq))
+#define _EXPAND_TUPLE_13(MACRO, data , seq) _EXPAND_TUPLE_12(MACRO, data , seq) MACRO(data, BOOST_PP_TUPLE_ELEM(12, seq))
+#define _EXPAND_TUPLE_14(MACRO, data , seq) _EXPAND_TUPLE_13(MACRO, data , seq) MACRO(data, BOOST_PP_TUPLE_ELEM(13, seq))
+#define _EXPAND_TUPLE_15(MACRO, data , seq) _EXPAND_TUPLE_14(MACRO, data , seq) MACRO(data, BOOST_PP_TUPLE_ELEM(14, seq))
+#define _EXPAND_TUPLE_16(MACRO, data , seq) _EXPAND_TUPLE_15(MACRO, data , seq) MACRO(data, BOOST_PP_TUPLE_ELEM(15, seq))
+// clang-format on

--- a/include/enumerations/macros_impl/utils.hpp
+++ b/include/enumerations/macros_impl/utils.hpp
@@ -154,11 +154,10 @@
   [[maybe_unused]] constexpr auto tag = _GET_TAG(BOOST_PP_TUPLE_ELEM(i, data));
 
 // clang-format off
-#define _WRITE_TAGS(data, n)                                                            \
-  BOOST_PP_IF(BOOST_PP_LESS(0, n), _WRITE_TAG, _EMPTY_MACRO)(_dimension_tag_, data, 0)  \
-  BOOST_PP_IF(BOOST_PP_LESS(1, n), _WRITE_TAG, _EMPTY_MACRO)(_medium_tag_, data, 1)     \
-  BOOST_PP_IF(BOOST_PP_LESS(2, n), _WRITE_TAG, _EMPTY_MACRO)(_property_tag_, data, 2)   \
-  BOOST_PP_IF(BOOST_PP_LESS(3, n), _WRITE_TAG, _EMPTY_MACRO)(_boundary_tag_, data, 3)
+#define _WRITE_TAGS_1(data) _WRITE_TAG(_dimension_tag_, data, 0)
+#define _WRITE_TAGS_2(data) _WRITE_TAGS_1(data) _WRITE_TAG(_medium_tag_, data, 1)
+#define _WRITE_TAGS_3(data) _WRITE_TAGS_2(data) _WRITE_TAG(_property_tag_, data, 2)
+#define _WRITE_TAGS_4(data) _WRITE_TAGS_3(data) _WRITE_TAG(_boundary_tag_, data, 3)
 // clang-format on
 
 /**
@@ -169,7 +168,7 @@
  * @param code code block to be executed for each material system.
  */
 #define _WRITE_BLOCK(data, seq, code)                                          \
-  { _WRITE_TAGS(data, BOOST_PP_TUPLE_SIZE(data))                               \
+  { BOOST_PP_CAT(_WRITE_TAGS_, BOOST_PP_TUPLE_SIZE(data))(data)                \
         _EXPAND_SEQ(_WRITE_CAPTURE, data, _GET_CAPTURE_SEQ(seq, code))         \
             BOOST_PP_SEQ_ENUM(_REMOVE_CAPTURE_FROM_CODE(code)) }
 

--- a/include/enumerations/macros_impl/utils.hpp
+++ b/include/enumerations/macros_impl/utils.hpp
@@ -21,6 +21,8 @@
 
 #define _REFLECT_1(data, elem) elem
 
+#define _REFLECT_2(s, data, elem) elem
+
 #define _TRANSFORM_TAGS(s, data, elem) BOOST_PP_CAT(data, elem)
 
 #define _TRANSFORM_INSTANTIATE(s, data, elem) (elem, )
@@ -46,16 +48,11 @@
  * template, e.g. template property<elastic, isotropic>;
  */
 #define _WRITE_DECLARE(data, elem)                                             \
-  BOOST_PP_IF(BOOST_VMD_IS_TUPLE(BOOST_PP_TUPLE_ELEM(0, elem)), _EXPAND_SEQ2,  \
-              _EMPTY_MACRO)                                                    \
-  (_DECLARE_TYPE, data, BOOST_PP_TUPLE_TO_SEQ(BOOST_PP_TUPLE_ELEM(0, elem)))   \
-      BOOST_PP_IF(                                                             \
-          BOOST_PP_NOT(BOOST_VMD_IS_TUPLE(BOOST_PP_TUPLE_ELEM(0, elem))),      \
-          BOOST_PP_TUPLE_ELEM(0, elem), BOOST_PP_EMPTY())                      \
-          BOOST_PP_IF(                                                         \
-              BOOST_PP_IS_EMPTY(BOOST_PP_TUPLE_ELEM(1, elem)),                 \
-              BOOST_PP_EMPTY(),                                                \
-              _VAR_NAME_FROM_TAGS(data, BOOST_PP_TUPLE_ELEM(1, elem));)
+  BOOST_PP_IF(BOOST_VMD_IS_TUPLE(BOOST_PP_TUPLE_ELEM(0, elem)), _EXPAND_TUPLE, \
+              _REFLECT_2)                                                      \
+  (_DECLARE_TYPE, data, BOOST_PP_TUPLE_ELEM(0, elem)) BOOST_PP_IF(             \
+      BOOST_PP_IS_EMPTY(BOOST_PP_TUPLE_ELEM(1, elem)), BOOST_PP_EMPTY(),       \
+      _VAR_NAME_FROM_TAGS(data, BOOST_PP_TUPLE_ELEM(1, elem));)
 
 /**
  * @brief Create a reference to the variable to be captured inside the code
@@ -157,10 +154,10 @@
   [[maybe_unused]] constexpr auto tag = _GET_TAG(BOOST_PP_TUPLE_ELEM(i, data));
 
 // clang-format off
-#define _WRITE_TAGS(data, n)                                           \
+#define _WRITE_TAGS(data, n)                                                            \
   BOOST_PP_IF(BOOST_PP_LESS(0, n), _WRITE_TAG, _EMPTY_MACRO)(_dimension_tag_, data, 0)  \
   BOOST_PP_IF(BOOST_PP_LESS(1, n), _WRITE_TAG, _EMPTY_MACRO)(_medium_tag_, data, 1)     \
-  BOOST_PP_IF(BOOST_PP_LESS(2, n), _WRITE_TAG, _EMPTY_MACRO)(_property_tag_, data, 2)     \
+  BOOST_PP_IF(BOOST_PP_LESS(2, n), _WRITE_TAG, _EMPTY_MACRO)(_property_tag_, data, 2)   \
   BOOST_PP_IF(BOOST_PP_LESS(3, n), _WRITE_TAG, _EMPTY_MACRO)(_boundary_tag_, data, 3)
 // clang-format on
 

--- a/include/enumerations/material_definitions.hpp
+++ b/include/enumerations/material_definitions.hpp
@@ -179,8 +179,7 @@ constexpr auto medium_types() {
   constexpr int total_medium_types = BOOST_PP_SEQ_SIZE(MEDIUM_TAGS);
   constexpr std::array<std::tuple<specfem::dimension::type, medium_tag>,
                        total_medium_types>
-      medium_types{ _MAKE_CONSTEXPR_ARRAY(MEDIUM_TAGS,
-                                          _MAKE_ARRAY_ELEM_MEDIUM) };
+      medium_types{ _MAKE_CONSTEXPR_ARRAY(MEDIUM_TAGS) };
 
   return medium_types;
 }
@@ -202,8 +201,7 @@ constexpr auto material_systems() {
       std::tuple<specfem::dimension::type, specfem::element::medium_tag,
                  specfem::element::property_tag>,
       total_material_systems>
-      material_systems{ _MAKE_CONSTEXPR_ARRAY(MATERIAL_SYSTEMS,
-                                              _MAKE_ARRAY_ELEM_MAT_SYS) };
+      material_systems{ _MAKE_CONSTEXPR_ARRAY(MATERIAL_SYSTEMS) };
 
   return material_systems;
 }
@@ -226,8 +224,7 @@ constexpr auto element_types() {
                  specfem::element::property_tag,
                  specfem::element::boundary_tag>,
       total_element_types>
-      material_systems{ _MAKE_CONSTEXPR_ARRAY(ELEMENT_TYPES,
-                                              _MAKE_ARRAY_ELEM_ELEM) };
+      material_systems{ _MAKE_CONSTEXPR_ARRAY(ELEMENT_TYPES) };
 
   return material_systems;
 }


### PR DESCRIPTION
## Description

Rewrite `_EXPAND_SEQ` in a similar way as `BOOST_PP_SEQ_FOR_EACH` to reduce the amout of preprocessing.

## Issue Number

Closes #805 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
