### PR TITLE
Sets SIMD flag to false for device code

### DIFF
--- a/include/kokkos_kernels/impl/compute_mass_matrix.tpp
+++ b/include/kokkos_kernels/impl/compute_mass_matrix.tpp
@@ -42,7 +42,11 @@ void specfem::kokkos_kernels::impl::compute_mass_matrix(
   if (nelements == 0)
     return;
 
+#ifdef KOKKOS_ENABLE_CUDA
+  constexpr bool using_simd = false;
+#else
   constexpr bool using_simd = true;
+#endif
   using simd = specfem::datatype::simd<type_real, using_simd>;
   using parallel_config = specfem::parallel_config::default_chunk_config<
       dimension, simd, Kokkos::DefaultExecutionSpace>;

--- a/include/kokkos_kernels/impl/compute_material_derivatives.tpp
+++ b/include/kokkos_kernels/impl/compute_material_derivatives.tpp
@@ -32,7 +32,12 @@ void specfem::kokkos_kernels::impl::compute_material_derivatives(
     return;
   }
 
-  constexpr static bool using_simd = true;
+#ifdef KOKKOS_ENABLE_CUDA
+  constexpr bool using_simd = false;
+#else
+  constexpr bool using_simd = true;
+#endif
+
   using simd = specfem::datatype::simd<type_real, using_simd>;
   using ParallelConfig = specfem::parallel_config::default_chunk_config<
       DimensionType, simd, Kokkos::DefaultExecutionSpace>;

--- a/include/kokkos_kernels/impl/compute_stiffness_interaction.tpp
+++ b/include/kokkos_kernels/impl/compute_stiffness_interaction.tpp
@@ -55,7 +55,12 @@ int specfem::kokkos_kernels::impl::compute_stiffness_interaction(
   const auto boundary_values =
       assembly.boundary_values.get_container<boundary_tag>();
 
+#ifdef KOKKOS_ENABLE_CUDA
+  constexpr bool using_simd = false;
+#else
   constexpr bool using_simd = true;
+#endif
+
   using simd = specfem::datatype::simd<type_real, using_simd>;
   using parallel_config = specfem::parallel_config::default_chunk_config<
       dimension, simd, Kokkos::DefaultExecutionSpace>;

--- a/include/parallel_configuration/chunk_config.hpp
+++ b/include/parallel_configuration/chunk_config.hpp
@@ -66,7 +66,7 @@ struct default_chunk_config;
 template <typename SIMD>
 struct default_chunk_config<specfem::dimension::type::dim2, SIMD, Kokkos::Cuda>
     : chunk_config<specfem::dimension::type::dim2, impl::cuda_chunk_size,
-                   impl::cuda_chunk_size, 160, 1, SIMD, Kokkos::Cuda> {};
+                   impl::cuda_chunk_size, 512, 1, SIMD, Kokkos::Cuda> {};
 #endif
 
 #ifdef KOKKOS_ENABLE_OPENMP


### PR DESCRIPTION
## Description

Setting `SIMD = false` greatly improves performance on device code 

Nsight systems report shows `compute_stiffness_interaction` routine speed up of ~30% (~900 microsec -> 600 microsec)

- [x] Updates CUDA simd flag for chunk policies
- [x] Updates default number of threads to 512

## Issue Number

Closes #466 

## Updated Performance chart

![image](https://github.com/user-attachments/assets/4b22cec8-3e91-49a8-9a8b-9671bcb4eafb)

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
