### PR TITLE
Added tiling for Range loops

### DIFF
--- a/include/kokkos_kernels/impl/compute_seismogram.tpp
+++ b/include/kokkos_kernels/impl/compute_seismogram.tpp
@@ -108,16 +108,12 @@ void specfem::kokkos_kernels::impl::compute_seismograms(
 
           for (int tile = 0; tile < ChunkPolicy::tile_size * simd_size;
                tile += ChunkPolicy::chunk_size * simd_size) {
-            const int starting_element_index =
-                team_member.league_rank() * ChunkPolicy::tile_size * simd_size +
-                tile;
-
-            if (starting_element_index >= nreceivers) {
-              break;
-            }
-
             const auto iterator =
-                policy.mapped_league_iterator(starting_element_index);
+                policy.mapped_league_iterator(team_member.league_rank(), tile);
+
+            if (iterator.is_end()) {
+              return;
+            }
 
             specfem::compute::load_on_device(team_member, iterator, field,
                                              element_field);

--- a/include/kokkos_kernels/impl/compute_source_interaction.tpp
+++ b/include/kokkos_kernels/impl/compute_source_interaction.tpp
@@ -1,10 +1,10 @@
 #pragma once
 
+#include "boundary_conditions/boundary_conditions.hpp"
+#include "boundary_conditions/boundary_conditions.tpp"
 #include "chunk_element/field.hpp"
 #include "compute/assembly/assembly.hpp"
 #include "datatypes/simd.hpp"
-#include "boundary_conditions/boundary_conditions.hpp"
-#include "boundary_conditions/boundary_conditions.tpp"
 #include "enumerations/dimension.hpp"
 #include "enumerations/medium.hpp"
 #include "enumerations/wavefield.hpp"
@@ -25,114 +25,113 @@ template <specfem::dimension::type DimensionType,
 void specfem::kokkos_kernels::impl::compute_source_interaction(
     specfem::compute::assembly &assembly, const int &timestep) {
 
-constexpr auto medium_tag = MediumTag;
-constexpr auto property_tag = PropertyTag;
-constexpr auto boundary_tag = BoundaryTag;
-constexpr auto dimension = DimensionType;
-constexpr int ngll = NGLL;
-constexpr auto wavefield = WavefieldType;
+  constexpr auto medium_tag = MediumTag;
+  constexpr auto property_tag = PropertyTag;
+  constexpr auto boundary_tag = BoundaryTag;
+  constexpr auto dimension = DimensionType;
+  constexpr int ngll = NGLL;
+  constexpr auto wavefield = WavefieldType;
 
-const auto [element_indices, source_indices] = assembly.sources.get_sources_on_device(
-    MediumTag, PropertyTag, BoundaryTag, WavefieldType);
+  const auto [element_indices, source_indices] =
+      assembly.sources.get_sources_on_device(MediumTag, PropertyTag,
+                                             BoundaryTag, WavefieldType);
 
-auto &sources = assembly.sources;
+  auto &sources = assembly.sources;
 
-const int nsources = source_indices.extent(0);
+  const int nsources = source_indices.extent(0);
 
-if (nsources == 0)
-  return;
+  if (nsources == 0)
+    return;
 
-// Some aliases
-const auto &properties = assembly.properties;
-const auto &boundaries = assembly.boundaries;
-const auto field = assembly.fields.get_simulation_field<wavefield>();
+  // Some aliases
+  const auto &properties = assembly.properties;
+  const auto &boundaries = assembly.boundaries;
+  const auto field = assembly.fields.get_simulation_field<wavefield>();
 
-sources.update_timestep(timestep);
+  sources.update_timestep(timestep);
 
-using PointSourcesType =
-    specfem::point::source<dimension, medium_tag, wavefield>;
-using PointPropertiesType =
-    specfem::point::properties<dimension, medium_tag, property_tag, false>;
-using PointBoundaryType =
-    specfem::point::boundary<boundary_tag, dimension, false>;
-using PointVelocityType = specfem::point::field<dimension, medium_tag, false,
-                                                true, false, false, false>;
+  using PointSourcesType =
+      specfem::point::source<dimension, medium_tag, wavefield>;
+  using PointPropertiesType =
+      specfem::point::properties<dimension, medium_tag, property_tag, false>;
+  using PointBoundaryType =
+      specfem::point::boundary<boundary_tag, dimension, false>;
+  using PointVelocityType = specfem::point::field<dimension, medium_tag, false,
+                                                  true, false, false, false>;
 
-using simd = specfem::datatype::simd<type_real, false>;
-constexpr int simd_size = simd::size();
+  using simd = specfem::datatype::simd<type_real, false>;
+  constexpr int simd_size = simd::size();
 
 #ifdef KOKKOS_ENABLE_CUDA
-constexpr int nthreads = 32;
-constexpr int lane_size = 1;
+  constexpr int nthreads = 32;
+  constexpr int lane_size = 1;
 #else
-constexpr int nthreads = 1;
-constexpr int lane_size = 1;
+  constexpr int nthreads = 1;
+  constexpr int lane_size = 1;
 #endif
 
-using ParallelConfig =
-    specfem::parallel_config::chunk_config<DimensionType, 1, 1, nthreads,
-                                           lane_size, simd,
-                                           Kokkos::DefaultExecutionSpace>;
+  using ParallelConfig =
+      specfem::parallel_config::chunk_config<DimensionType, 1, 1, nthreads,
+                                             lane_size, simd,
+                                             Kokkos::DefaultExecutionSpace>;
 
-using ChunkPolicy = specfem::policy::mapped_element_chunk<ParallelConfig>;
+  using ChunkPolicy = specfem::policy::mapped_element_chunk<ParallelConfig>;
 
-ChunkPolicy mapped_policy(element_indices, source_indices, NGLL, NGLL);
+  ChunkPolicy mapped_policy(element_indices, source_indices, NGLL, NGLL);
 
-Kokkos::parallel_for(
-    "specfem::kernels::impl::domain_kernels::compute_source_interaction",
-    static_cast<const typename ChunkPolicy::policy_type &>(mapped_policy),
-    KOKKOS_LAMBDA(const typename ChunkPolicy::member_type &team) {
-      for (int tile = 0; tile < ChunkPolicy::tile_size * simd_size;
-           tile += ChunkPolicy::chunk_size * simd_size) {
-        const int starting_element_index =
-            team.league_rank() * ChunkPolicy::tile_size * simd_size + tile;
+  Kokkos::parallel_for(
+      "specfem::kernels::impl::domain_kernels::compute_source_interaction",
+      static_cast<const typename ChunkPolicy::policy_type &>(mapped_policy),
+      KOKKOS_LAMBDA(const typename ChunkPolicy::member_type &team) {
+        for (int tile = 0; tile < ChunkPolicy::tile_size * simd_size;
+             tile += ChunkPolicy::chunk_size * simd_size) {
+          const auto mapped_iterator =
+              mapped_policy.mapped_league_iterator(team.league_rank(), tile);
 
-        if (starting_element_index >= nsources) {
-          break;
+          if (mapped_iterator.is_end()) {
+            return;
+          }
+
+          Kokkos::parallel_for(
+              Kokkos::TeamThreadRange(team, mapped_iterator.chunk_size()),
+              [&](const int i) {
+                // mapped_chunk_index_type
+                const auto mapped_iterator_index = mapped_iterator(i);
+
+                // element_index is specfem::point::index
+                const auto element_index = mapped_iterator_index.index;
+
+                // need mapped_chunk_index here to get the imap=isource
+                PointSourcesType point_source;
+                specfem::compute::load_on_device(mapped_iterator_index, sources,
+                                                 point_source);
+
+                PointPropertiesType point_property;
+                specfem::compute::load_on_device(element_index, properties,
+                                                 point_property);
+
+                auto acceleration =
+                    specfem::medium::compute_source_contribution(
+                        point_source, point_property);
+
+                //   PointBoundaryType point_boundary;
+                //   specfem::compute::load_on_device(element_index, boundaries,
+                //                                    point_boundary);
+
+                //   PointVelocityType velocity;
+                //   specfem::compute::load_on_device(element_index, field,
+                //   velocity);
+
+                //   specfem::boundary_conditions::
+                //       apply_boundary_conditions(point_boundary,
+                //       point_property,
+                //                                 velocity, acceleration);
+
+                specfem::compute::atomic_add_on_device(element_index,
+                                                       acceleration, field);
+              });
         }
+      });
 
-        // This is a mapped_chunk iterator
-        const auto mapped_iterator =
-            mapped_policy.mapped_league_iterator(starting_element_index);
-
-        Kokkos::parallel_for(
-            Kokkos::TeamThreadRange(team, mapped_iterator.chunk_size()),
-            [&](const int i) {
-              // mapped_chunk_index_type
-              const auto mapped_iterator_index = mapped_iterator(i);
-
-              // element_index is specfem::point::index
-              const auto element_index = mapped_iterator_index.index;
-
-              // need mapped_chunk_index here to get the imap=isource
-              PointSourcesType point_source;
-              specfem::compute::load_on_device(mapped_iterator_index, sources,
-                                               point_source);
-
-              PointPropertiesType point_property;
-              specfem::compute::load_on_device(element_index, properties,
-                                               point_property);
-
-              auto acceleration =
-                  specfem::medium::compute_source_contribution(point_source,
-                                                               point_property);
-
-            //   PointBoundaryType point_boundary;
-            //   specfem::compute::load_on_device(element_index, boundaries,
-            //                                    point_boundary);
-
-            //   PointVelocityType velocity;
-            //   specfem::compute::load_on_device(element_index, field, velocity);
-
-            //   specfem::boundary_conditions::
-            //       apply_boundary_conditions(point_boundary, point_property,
-            //                                 velocity, acceleration);
-
-              specfem::compute::atomic_add_on_device(element_index, acceleration,
-                                                     field);
-            });
-      }
-    });
-
-Kokkos::fence();
+  Kokkos::fence();
 }

--- a/include/parallel_configuration/range_config.hpp
+++ b/include/parallel_configuration/range_config.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+
 namespace specfem {
 namespace parallel_config {
 
@@ -9,10 +11,14 @@ namespace parallel_config {
  * @tparam SIMD SIMD type @ref specfem::datatype::simd
  * @tparam ExecutionSpace Execution space
  */
-template <typename SIMD, typename ExecutionSpace> struct range_config {
+template <typename SIMD, typename ExecutionSpace, std::size_t ChunkSize,
+          std::size_t TileSize>
+struct range_config {
   using simd = SIMD;
   using execution_space = ExecutionSpace;
   static constexpr bool is_point_parallel_config = true;
+  constexpr static std::size_t chunk_size = ChunkSize;
+  constexpr static std::size_t tile_size = TileSize;
 };
 
 /**
@@ -22,7 +28,7 @@ template <typename SIMD, typename ExecutionSpace> struct range_config {
  * @tparam ExecutionSpace Execution space
  */
 template <typename SIMD, typename ExecutionSpace>
-using default_range_config = range_config<SIMD, ExecutionSpace>;
+using default_range_config = range_config<SIMD, ExecutionSpace, 1, 1>;
 
 } // namespace parallel_config
 } // namespace specfem

--- a/include/policies/chunk.hpp
+++ b/include/policies/chunk.hpp
@@ -119,9 +119,10 @@ protected:
   constexpr static int simd_size = simd::size();
 
   ViewType indices; ///< View of indices of elements within this iterator
-  int num_elements; ///< Number of elements within this iterator
-  int ngllz;        ///< Number of GLL points in the z-direction
-  int ngllx;        ///< Number of GLL points in the x-direction
+  bool end_iterator = false; ///< Flag to indicate if the iterator is at the end
+  int num_elements;          ///< Number of elements within this iterator
+  int ngllz;                 ///< Number of GLL points in the z-direction
+  int ngllx;                 ///< Number of GLL points in the x-direction
 
   KOKKOS_INLINE_FUNCTION
   chunk(const ViewType &indices, const int ngllz, const int ngllx,
@@ -188,6 +189,13 @@ public:
    */
   ///@{
   /**
+   * @brief Construct a new chunk iterator with a given end iterator flag.
+   *
+   * @param end_iterator Flag to indicate if the iterator is at the end
+   */
+  KOKKOS_INLINE_FUNCTION
+  chunk(const bool end_iterator) : end_iterator(end_iterator) {}
+  /**
    * @brief Construct a new chunk iterator with a given view of indices.
    *
    * @param indices View of indices of elements within this iterator
@@ -230,6 +238,11 @@ public:
    */
   KOKKOS_INLINE_FUNCTION
   index_type operator()(const int i) const {
+#ifndef NDEBUG
+    if (end_iterator) {
+      Kokkos::abort("Chunk iterator is at the end, cannot access index.");
+    }
+#endif
     return operator()(i, std::integral_constant<bool, using_simd>());
   }
 
@@ -241,8 +254,22 @@ public:
    */
   KOKKOS_INLINE_FUNCTION
   Kokkos::pair<int, int> get_range() const {
+#ifndef NDEBUG
+    if (end_iterator) {
+      Kokkos::abort("Chunk iterator is at the end, cannot access index.");
+    }
+#endif
     return Kokkos::make_pair(indices(0), indices(num_elements - 1) + 1);
   }
+
+  /**
+   * @brief Check if the iterator is at the end.
+   *
+   * @return true If the iterator is at the end.
+   * @return false If the iterator is not at the end.
+   */
+  KOKKOS_INLINE_FUNCTION
+  bool is_end() const { return end_iterator; }
 };
 
 template <typename ViewType, specfem::dimension::type DimensionType,
@@ -262,6 +289,9 @@ public:
   mapped_chunk(const ViewType &indices, const ViewType &mapping,
                const int ngllz, const int ngllx)
       : base_type(indices, ngllz, ngllx), mapping(mapping) {}
+
+  KOKKOS_INLINE_FUNCTION
+  mapped_chunk(const bool end_iterator) : base_type(end_iterator) {}
 
   KOKKOS_INLINE_FUNCTION
   mapped_index_type operator()(const int i) const {
@@ -361,7 +391,7 @@ public:
   element_chunk(const IndexViewType &view, int ngllz, int ngllx)
       : policy_type(view.extent(0) / (tile_size * simd_size) +
                         (view.extent(0) % (tile_size * simd_size) != 0),
-                    num_threads, vector_lanes),
+                    Kokkos::AUTO, Kokkos::AUTO),
         elements(view), ngllz(ngllz), ngllx(ngllx) {
 #if KOKKOS_VERSION < 40100
     static_assert(IndexViewType::Rank == 1, "View must be rank 1");
@@ -382,12 +412,19 @@ public:
    * @brief Get iterator to iterator over chunk of elements associated with
    * Kokkos team
    *
-   * @param start_index Starting index for the element within the team
+   * @param league_index Index of the league (team) within the Kokkos team
+   * @param tile_index Index of the tile within the league
    * @return iterator_type Iterator for the team
    */
   KOKKOS_INLINE_FUNCTION
-  iterator_type league_iterator(const int start_index) const {
-    const int start = start_index;
+  iterator_type league_iterator(const std::size_t league_index,
+                                const std::size_t tile_index) const {
+    const int start = league_index * tile_size * simd_size + tile_index;
+    if (start >= elements.extent(0)) {
+      return iterator_type(true); // Return an empty iterator if the start
+                                  // index is out of bounds
+    }
+
     const int end = (start + chunk_size * simd_size > elements.extent(0))
                         ? elements.extent(0)
                         : start + chunk_size * simd_size;
@@ -417,8 +454,15 @@ struct mapped_element_chunk : public element_chunk<ParallelConfig> {
       : base_type(view, ngllz, ngllx), mapping(mapping) {}
 
   KOKKOS_INLINE_FUNCTION
-  mapped_iterator_type mapped_league_iterator(const int start_index) const {
-    const int start = start_index;
+  mapped_iterator_type
+  mapped_league_iterator(const std::size_t league_index,
+                         const std::size_t tile_index) const {
+    const int start =
+        league_index * base_type::tile_size * base_type::simd_size + tile_index;
+    if (start >= base_type::elements.extent(0)) {
+      mapped_iterator_type(true); // Return an empty iterator if the start
+                                  // index is out of bounds
+    }
     const int end = (start + base_type::chunk_size * base_type::simd_size >
                      base_type::elements.extent(0))
                         ? base_type::elements.extent(0)

--- a/include/policies/range.hpp
+++ b/include/policies/range.hpp
@@ -138,7 +138,7 @@ public:
   index_type operator()() const {
 #ifndef NDEBUG
     if (end_iterator) {
-      KOKKOS_ABORT("Range iterator is at the end, cannot access index.");
+      Kokkos::abort("Range iterator is at the end, cannot access index.");
     }
 #endif
     return operator()(std::integral_constant<bool, using_simd>());

--- a/include/policies/range.hpp
+++ b/include/policies/range.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "point/assembly_index.hpp"
+#include <iostream>
 #include <type_traits>
 
 namespace specfem {
@@ -58,6 +59,7 @@ private:
   int starting_index; ///< Starting index for the iterator range.
   int number_points;  ///< Number of points in the iterator range. Equal to or
                       ///< less than SIMD size when using SIMD.
+  bool end_iterator = false; ///< Flag to indicate if the iterator is at the end
 
   constexpr static bool using_simd = SIMD::using_simd;
   constexpr static int simd_size = SIMD::size();
@@ -72,7 +74,7 @@ private:
 
   // range_index_type operator for simd execution
   KOKKOS_INLINE_FUNCTION
-  impl::range_index_type<true> operator()(const int i, std::true_type) const {
+  impl::range_index_type<true> operator()(std::true_type) const {
     return impl::range_index_type<true>(
         specfem::point::simd_assembly_index{ starting_index, number_points });
   }
@@ -84,7 +86,7 @@ private:
       : starting_index(starting_index), number_points(number_points) {}
 
   KOKKOS_INLINE_FUNCTION
-  impl::range_index_type<false> operator()(const int i, std::false_type) const {
+  impl::range_index_type<false> operator()(std::false_type) const {
     return impl::range_index_type<false>(
         specfem::point::assembly_index<false>{ starting_index });
   }
@@ -112,6 +114,9 @@ public:
   KOKKOS_INLINE_FUNCTION
   range() = default;
 
+  KOKKOS_INLINE_FUNCTION
+  range(const bool end_iterator) : end_iterator(end_iterator) {}
+
   /**
    * @brief Construct a range iterator with a given starting index and number of
    * points.
@@ -127,15 +132,25 @@ public:
   /**
    * @brief Returns the index within this iterator at the i-th location.
    *
-   * @param i Location within the iterator. Ignored in the current
-   * implementation since iterator only holds a single index when not using SIMD
-   * or <= SIMD size number of indices when using SIMD.
    * @return index_type Index for the given iterator at the i-th location.
    */
   KOKKOS_INLINE_FUNCTION
-  index_type operator()(const int i) const {
-    return operator()(i, std::integral_constant<bool, using_simd>());
+  index_type operator()() const {
+#ifndef NDEBUG
+    if (end_iterator) {
+      KOKKOS_ABORT("Range iterator is at the end, cannot access index.");
+    }
+#endif
+    return operator()(std::integral_constant<bool, using_simd>());
   }
+
+  /**
+   * @brief Check if there is any work to be done by this iterator.
+   *
+   * @return bool True if there are no points to iterate over, false otherwise.
+   */
+  KOKKOS_INLINE_FUNCTION
+  bool is_end() const { return end_iterator; }
 };
 } // namespace iterator
 
@@ -166,6 +181,10 @@ public:
                                             ///< type
 
   using iterator_type = specfem::iterator::range<simd>; ///< Iterator type
+  constexpr static std::size_t chunk_size =
+      ParallelConfig::chunk_size; ///< Chunk size for the range policy
+  constexpr static std::size_t tile_size =
+      ParallelConfig::tile_size; ///< Tile size for the range policy
   ///@}
 
   /**
@@ -185,9 +204,6 @@ public:
       false; ///< Indicates that this is not a element face policy
   constexpr static bool isElementPolicy =
       false; ///< Indicates that this is not an element policy
-  constexpr static int chunk_size =
-      1; ///< Number of chunks a range can be divided into. Indices within a
-         ///< chunk are processed serially in a single thread.
   ///@}
 
 private:
@@ -216,7 +232,15 @@ public:
    * @param range_size Size of the range.
    */
   KOKKOS_FUNCTION range(const int range_size)
-      : policy_type(0, range_size / simd_size + (range_size % simd_size != 0)),
+      : simd_range_size(range_size / simd_size +
+                        ((range_size % simd_size) != 0)),
+        policy_type(
+            0,
+            ((range_size / simd_size + ((range_size % simd_size) != 0)) /
+                 tile_size +
+             (((range_size / simd_size + ((range_size % simd_size) != 0)) %
+               tile_size) != 0)),
+            Kokkos::ChunkSize(chunk_size)),
         range_size(range_size) {}
   ///@}
 
@@ -231,10 +255,27 @@ public:
    * @brief Get the range iterator for a given range index.
    *
    * @param range_index starting index within the range.
+   * @param tile_index Index of the tile within the range.
    * @return iterator_type Range iterator.
    */
-  KOKKOS_FUNCTION iterator_type range_iterator(const int range_index) const {
-    const int starting_index = range_index * simd_size;
+  KOKKOS_FUNCTION iterator_type range_iterator(
+      const std::size_t range_index, const std::size_t tile_index) const {
+#ifdef KOKKOS_ENABLE_CUDA
+    const int starting_index =
+        (tile_index * (simd_range_size / tile_size +
+                       (simd_range_size % tile_size != 0)) +
+         range_index) *
+        simd_size;
+#else
+    const int starting_index =
+        (range_index * tile_size + tile_index) * simd_size;
+#endif
+    // // Ensure that the starting index does not exceed the range size
+    if (starting_index > range_size) {
+      return iterator_type(true); // Return an empty iterator if the starting
+                                  // index is out of bounds
+    }
+
     const int number_elements = (starting_index + simd_size < range_size)
                                     ? simd_size
                                     : range_size - starting_index;
@@ -242,7 +283,8 @@ public:
   }
 
 private:
-  int range_size; ///< Size of the range.
+  int range_size;      ///< Size of the range.
+  int simd_range_size; ///< Size of the range when using SIMD
 };
 } // namespace policy
 } // namespace specfem

--- a/src/compute/assembly/helper.hpp
+++ b/src/compute/assembly/helper.hpp
@@ -102,13 +102,13 @@ public:
             specfem::compute::load_on_device(team, iterator, buffer, field);
             team.team_barrier();
 
-            const auto psv_wavefield =
+            const auto wavefield =
                 Kokkos::subview(wavefield_on_entire_grid, iterator.get_range(),
                                 Kokkos::ALL, Kokkos::ALL, Kokkos::ALL);
 
             specfem::medium::compute_wavefield<MediumTag, PropertyTag>(
                 team, iterator, assembly, quadrature, field, wavefield_type,
-                psv_wavefield);
+                wavefield);
           }
         });
 

--- a/src/compute/assembly/helper.hpp
+++ b/src/compute/assembly/helper.hpp
@@ -92,15 +92,13 @@ public:
 
           for (int tile = 0; tile < ChunkPolicyType::tile_size;
                tile += ChunkPolicyType::chunk_size) {
-            const int starting_element_index =
-                team.league_rank() * ChunkPolicyType::tile_size + tile;
+            const auto iterator =
+                chunk_policy.league_iterator(team.league_rank(), tile);
 
-            if (starting_element_index >= nelements) {
-              break;
+            if (iterator.is_end()) {
+              return; // No elements to process in this tile
             }
 
-            const auto iterator =
-                chunk_policy.league_iterator(starting_element_index);
             specfem::compute::load_on_device(team, iterator, buffer, field);
             team.team_barrier();
 


### PR DESCRIPTION
## Description

- [ ] Adds a tiling parameter for range loops
- [ ] Updates `range_iterator` and `league_iterator` methods so that starting index of the thread can be computed internall within the policies
- [ ] Adds `is_end` method to check if the iterator is out of bounds (should be only true when tile_size > 1)
- [ ] Uses `Kokkos::AUTO` when determining chunk policy configuration

## Issue Number

Closes #714 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
