### PR TITLE
Reorder mass matrix computation

### DIFF
--- a/include/medium/compute_mass_matrix.hpp
+++ b/include/medium/compute_mass_matrix.hpp
@@ -35,10 +35,8 @@ KOKKOS_INLINE_FUNCTION specfem::point::field<DimensionTag, MediumTag, false,
                                              false, false, true, UseSIMD>
 mass_matrix_component(
     const specfem::point::properties<DimensionTag, MediumTag, PropertyTag,
-                                     UseSIMD> &properties,
-    const specfem::point::partial_derivatives<DimensionTag, true, UseSIMD>
-        &partial_derivatives) {
-  return impl_mass_matrix_component(properties, partial_derivatives);
+                                     UseSIMD> &properties) {
+  return impl_mass_matrix_component(properties);
 }
 
 } // namespace medium

--- a/include/medium/dim2/acoustic/isotropic/mass_matrix.hpp
+++ b/include/medium/dim2/acoustic/isotropic/mass_matrix.hpp
@@ -15,9 +15,7 @@ KOKKOS_FUNCTION specfem::point::field<specfem::dimension::type::dim2,
 impl_mass_matrix_component(
     const specfem::point::properties<
         specfem::dimension::type::dim2, specfem::element::medium_tag::acoustic,
-        specfem::element::property_tag::isotropic, UseSIMD> &properties,
-    const specfem::point::partial_derivatives<
-        specfem::dimension::type::dim2, true, UseSIMD> &partial_derivatives);
+        specfem::element::property_tag::isotropic, UseSIMD> &properties);
 
 } // namespace medium
 } // namespace specfem

--- a/include/medium/dim2/acoustic/isotropic/mass_matrix.tpp
+++ b/include/medium/dim2/acoustic/isotropic/mass_matrix.tpp
@@ -9,10 +9,8 @@ KOKKOS_FUNCTION specfem::point::field<specfem::dimension::type::dim2,
 specfem::medium::impl_mass_matrix_component(
     const specfem::point::properties<
         specfem::dimension::type::dim2, specfem::element::medium_tag::acoustic,
-        specfem::element::property_tag::isotropic, UseSIMD> &properties,
-    const specfem::point::partial_derivatives<
-        specfem::dimension::type::dim2, true, UseSIMD> &partial_derivatives) {
+        specfem::element::property_tag::isotropic, UseSIMD> &properties) {
 
   return specfem::datatype::ScalarPointViewType<type_real, 1, UseSIMD>(
-      partial_derivatives.jacobian / properties.kappa());
+      static_cast<type_real>(1.0) / properties.kappa());
 }

--- a/include/medium/dim2/elastic/isotropic/mass_matrix.hpp
+++ b/include/medium/dim2/elastic/isotropic/mass_matrix.hpp
@@ -16,9 +16,7 @@ KOKKOS_FUNCTION specfem::point::field<specfem::dimension::type::dim2,
 impl_mass_matrix_component(
     const specfem::point::properties<specfem::dimension::type::dim2,
                                      specfem::element::medium_tag::elastic_psv,
-                                     PropertyTag, UseSIMD> &properties,
-    const specfem::point::partial_derivatives<
-        specfem::dimension::type::dim2, true, UseSIMD> &partial_derivatives);
+                                     PropertyTag, UseSIMD> &properties);
 
 template <bool UseSIMD, specfem::element::property_tag PropertyTag>
 KOKKOS_FUNCTION specfem::point::field<specfem::dimension::type::dim2,
@@ -27,9 +25,7 @@ KOKKOS_FUNCTION specfem::point::field<specfem::dimension::type::dim2,
 impl_mass_matrix_component(
     const specfem::point::properties<specfem::dimension::type::dim2,
                                      specfem::element::medium_tag::elastic_sh,
-                                     PropertyTag, UseSIMD> &properties,
-    const specfem::point::partial_derivatives<
-        specfem::dimension::type::dim2, true, UseSIMD> &partial_derivatives);
+                                     PropertyTag, UseSIMD> &properties);
 
 } // namespace medium
 } // namespace specfem

--- a/include/medium/dim2/elastic/isotropic/mass_matrix.tpp
+++ b/include/medium/dim2/elastic/isotropic/mass_matrix.tpp
@@ -9,13 +9,10 @@ KOKKOS_FUNCTION specfem::point::field<specfem::dimension::type::dim2,
 specfem::medium::impl_mass_matrix_component(
     const specfem::point::properties<specfem::dimension::type::dim2,
                                      specfem::element::medium_tag::elastic_psv,
-                                     PropertyTag, UseSIMD> &properties,
-    const specfem::point::partial_derivatives<
-        specfem::dimension::type::dim2, true, UseSIMD> &partial_derivatives) {
+                                     PropertyTag, UseSIMD> &properties) {
 
   return specfem::datatype::ScalarPointViewType<type_real, 2, UseSIMD>(
-      partial_derivatives.jacobian * properties.rho(),
-      partial_derivatives.jacobian * properties.rho());
+      properties.rho(), properties.rho());
 }
 
 template <bool UseSIMD, specfem::element::property_tag PropertyTag>
@@ -25,10 +22,8 @@ KOKKOS_FUNCTION specfem::point::field<specfem::dimension::type::dim2,
 specfem::medium::impl_mass_matrix_component(
     const specfem::point::properties<specfem::dimension::type::dim2,
                                      specfem::element::medium_tag::elastic_sh,
-                                     PropertyTag, UseSIMD> &properties,
-    const specfem::point::partial_derivatives<
-        specfem::dimension::type::dim2, true, UseSIMD> &partial_derivatives) {
+                                     PropertyTag, UseSIMD> &properties) {
 
   return specfem::datatype::ScalarPointViewType<type_real, 1, UseSIMD>(
-      partial_derivatives.jacobian * properties.rho());
+      properties.rho());
 }

--- a/include/medium/dim2/poroelastic/isotropic/mass_matrix.hpp
+++ b/include/medium/dim2/poroelastic/isotropic/mass_matrix.hpp
@@ -16,9 +16,7 @@ impl_mass_matrix_component(
     const specfem::point::properties<specfem::dimension::type::dim2,
                                      specfem::element::medium_tag::poroelastic,
                                      specfem::element::property_tag::isotropic,
-                                     UseSIMD> &properties,
-    const specfem::point::partial_derivatives<
-        specfem::dimension::type::dim2, true, UseSIMD> &partial_derivatives);
+                                     UseSIMD> &properties);
 
 } // namespace medium
 } // namespace specfem

--- a/include/medium/dim2/poroelastic/isotropic/mass_matrix.tpp
+++ b/include/medium/dim2/poroelastic/isotropic/mass_matrix.tpp
@@ -7,14 +7,19 @@ KOKKOS_FUNCTION specfem::point::field<specfem::dimension::type::dim2,
                                       specfem::element::medium_tag::poroelastic,
                                       false, false, false, true, UseSIMD>
 specfem::medium::impl_mass_matrix_component(
-    const specfem::point::properties<
-        specfem::dimension::type::dim2, specfem::element::medium_tag::poroelastic,
-        specfem::element::property_tag::isotropic, UseSIMD> &properties,
-    const specfem::point::partial_derivatives<
-        specfem::dimension::type::dim2, true, UseSIMD> &partial_derivatives) {
+    const specfem::point::properties<specfem::dimension::type::dim2,
+                                     specfem::element::medium_tag::poroelastic,
+                                     specfem::element::property_tag::isotropic,
+                                     UseSIMD> &properties) {
 
-const auto solid_component = partial_derivatives.jacobian * (properties.rho_bar()-properties.phi()*properties.rho_f()/properties.tortuosity());
-const auto fluid_component = partial_derivatives.jacobian * (properties.rho_f()*properties.tortuosity()*properties.rho_bar()-properties.phi()*properties.rho_f()*properties.rho_f())/(properties.phi()*properties.rho_bar());
+  const auto solid_component =
+      (properties.rho_bar() -
+       properties.phi() * properties.rho_f() / properties.tortuosity());
+  const auto fluid_component =
+      (properties.rho_f() * properties.tortuosity() * properties.rho_bar() -
+       properties.phi() * properties.rho_f() * properties.rho_f()) /
+      (properties.phi() * properties.rho_bar());
 
-  return specfem::datatype::ScalarPointViewType<type_real, 4, UseSIMD>(solid_component, solid_component, fluid_component, fluid_component);
+  return specfem::datatype::ScalarPointViewType<type_real, 4, UseSIMD>(
+      solid_component, solid_component, fluid_component, fluid_component);
 }


### PR DESCRIPTION
## Description

This PR reorders mass matrix computation so that jacobian is multiplied within the calling kernel. This better reflects the spectral element equations as defined in Komatitsch et. al.

The mass matrix is now the strong from mass matrix.

## Issue Number

If there is an issue created for these changes, link it here

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
