### PR TITLE
Issue 856 - implemented a clean target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,12 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setup/specfem_setup.hpp.in
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setup/constants.hpp.in
                ${CMAKE_BINARY_DIR}/include/constants.hpp)
 
+# Add the configure files to the clean target
+set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+    ${CMAKE_BINARY_DIR}/include/specfem_setup.hpp
+    ${CMAKE_BINARY_DIR}/include/constants.hpp
+)
+
 # Add the include directories so that the generated files can be found
 include_directories(include)
 include_directories(core)
@@ -795,6 +801,7 @@ if (BUILD_BENCHMARKS)
         message(STATUS "BENCHMARKS_BUILD_DIR was not defined, using default: ${BENCHMARKS_BUILD_DIR}")
     endif()
 
+    # Create the benchmarks build directory if it does not exist
     message(STATUS "Building benchmarks...")
     add_subdirectory(benchmarks/src)
     message(STATUS "Benchmarks built.")
@@ -813,6 +820,9 @@ if (DOXYGEN_FOUND)
     # request to configure the file
     configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
     message(STATUS "Doxygen build started")
+    set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+        ${DOXYGEN_OUT}
+    )
 
     # Note: do not put "ALL" - this builds docs together with application EVERY TIME!
     add_custom_target( docs
@@ -859,4 +869,10 @@ if (SPECFEM_INSTALL)
         # Make this run after your main targets
         DEPENDS specfem2d specfem3d xmeshfem2D xmeshfem3D xadj_seismogram xgenerate_databases # list all your targets here
     )
+
+    # Add the prefix directory to the clean target
+    set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+        ${CMAKE_INSTALL_PREFIX}
+    )
+
 endif(SPECFEM_INSTALL)

--- a/benchmarks/src/CMakeLists.txt
+++ b/benchmarks/src/CMakeLists.txt
@@ -4,6 +4,11 @@ if (NOT DEFINED BENCHMARKS_BUILD_DIR)
     set(BENCHMARKS_BUILD_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../build)
 endif()
 
+# Add the benchmarks build dir to the clean target
+set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+    ${BENCHMARKS_BUILD_DIR}
+)
+
 # 2D
 add_subdirectory(dim2/anisotropic-crystal)
 add_subdirectory(dim2/homogeneous-medium-flat-topography)

--- a/fortran/meshfem2d/setup/CMakeLists.txt
+++ b/fortran/meshfem2d/setup/CMakeLists.txt
@@ -80,23 +80,35 @@ message(STATUS "Generated FC_FUNC_(name,NAME) ${FC_FUNC_}")
 # Generate config.h file
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/config.h @ONLY)
+set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/config.h
+)
 
 # ===================== config.h.in END =====================
 
 # ===================== config.fh.in START ==================
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.fh.in
                ${CMAKE_CURRENT_BINARY_DIR}/config.fh @ONLY)
+set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/config.fh
+)
 # ===================== config.fh.in END ====================
 
 
 # ===================== constants.h.in START ================
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/constants.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/constants.h @ONLY)
+set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/constants.h
+)
 # ===================== constants.h.in END ==================
 
 # ===================== precision.h.in START ================
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/precision.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/precision.h @ONLY)
+set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/precision.h
+)
 # ===================== precision.h.in END ==================
 
 
@@ -105,7 +117,9 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/precision.h.in
 # Configure the config.h file
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.fh.in
                ${CMAKE_CURRENT_BINARY_DIR}/version.fh @ONLY)
-
+set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/version.fh
+)
 # ===================== version.h.in START ================
 
 # Set Header interfaces

--- a/fortran/meshfem3d/setup/CMakeLists.txt
+++ b/fortran/meshfem3d/setup/CMakeLists.txt
@@ -150,7 +150,9 @@ message(STATUS "Generated FC_FUNC_(name,NAME) ${FC_FUNC_}")
 # Generate config.h file
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/config.h @ONLY)
-
+set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/config.h
+)
 # ===================== config.h.in END =====================
 
 # ===================== config.fh.in START ==================
@@ -159,23 +161,35 @@ set(CONFIGURE_FLAGS "FC=${CMAKE_Fortran_COMPILER_ID} FCFLAGS=${CMAKE_Fortran_FLA
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.fh.in
                ${CMAKE_CURRENT_BINARY_DIR}/config.fh @ONLY)
+set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/config.fh
+)
 # ===================== config.fh.in END ====================
 
 
 # ===================== constants.h.in START ================
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/constants.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/constants.h @ONLY)
+set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/constants.h
+)
 # ===================== constants.h.in END ==================
 
 # ===================== precision.h.in START ================
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/precision.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/precision.h @ONLY)
+set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/precision.h
+)
 # ===================== precision.h.in END ==================
 
 
 # ===================== version.fh.in START ================
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.fh.in
                ${CMAKE_CURRENT_BINARY_DIR}/version.fh @ONLY)
+set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/version.fh
+)
 # ===================== version.h.in START ================
 
 add_library(meshfem3D_config INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/config.h)


### PR DESCRIPTION
## Description

Added all remaining files to the clean target.

The user now can 

```bash
cmake --build <build_dir> --target clean
# or in the build dir
make clean
# or 
cmake --build --preset <presetname>--target clean
```

## Issue Number

Closes #856 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [x] I ran the code through pre-commit to check style
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
