### PR TITLE
Issue 905 - add is_close() utility and apply to point tests

### DIFF
--- a/include/utilities/simd.hpp
+++ b/include/utilities/simd.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "datatypes/simd.hpp"
+
+namespace specfem {
+namespace utilities {
+
+template <typename T>
+KOKKOS_INLINE_FUNCTION bool is_close(const T &a, const T &b,
+                                     const T &tol = static_cast<T>(1e-6)) {
+  return specfem::datatype::all_of(
+      Kokkos::abs(a - b) <= tol * Kokkos::max(Kokkos::abs(a), Kokkos::abs(b)));
+}
+
+} // namespace utilities
+} // namespace specfem

--- a/include/utilities/simd.hpp
+++ b/include/utilities/simd.hpp
@@ -5,6 +5,22 @@
 namespace specfem {
 namespace utilities {
 
+/**
+ * @brief Check if two values are close within a tolerance.
+ *
+ * This function checks whether two values are considered "close" to each other
+ * within a specified tolerance. The comparison uses a relative error
+ * calculation that accounts for the magnitude of the values.
+ *
+ * @tparam T Type of values to compare. Must support arithmetic operations.
+ * @param a First value to compare.
+ * @param b Second value to compare.
+ * @param tol Relative tolerance for comparison (default: 1e-6).
+ * @return bool True if values are considered close according to the formula:
+ *              |a - b| <= tol * max(|a|, |b|)
+ *              For simd types, returns true only if all lanes meet the
+ * condition.
+ */
 template <typename T>
 KOKKOS_INLINE_FUNCTION bool is_close(const T &a, const T &b,
                                      const T &tol = static_cast<T>(1e-6)) {

--- a/tests/unit-tests/point/boundary_tests.cpp
+++ b/tests/unit-tests/point/boundary_tests.cpp
@@ -1,16 +1,13 @@
-#include "datatypes/simd.hpp"
 #include "enumerations/interface.hpp"
 #include "specfem/point/boundary.hpp"
 #include "specfem_setup.hpp"
 #include "test_macros.hpp"
+#include "utilities/simd.hpp"
 #include <Kokkos_Core.hpp>
 #include <gtest/gtest.h>
 #include <type_traits>
 
 using namespace specfem;
-
-// Define tolerance for floating point comparisons
-const type_real tol = 1e-6;
 
 // Base test fixture for boundary tests with template parameter for SIMD
 template <bool UseSIMD>
@@ -137,14 +134,14 @@ TYPED_TEST(PointBoundaryTest, StaceyBoundary2D) {
 
     // Verify values
     EXPECT_TRUE(boundary.tag == element::boundary_tag::none);
-    EXPECT_TRUE(specfem::datatype::all_of(
-        Kokkos::abs(boundary.edge_weight - 2.5) < tol))
+    EXPECT_TRUE(specfem::utilities::is_close(boundary.edge_weight,
+                                             static_cast<type_real>(2.5)))
         << ExpectedGot(2.5, boundary.edge_weight);
-    EXPECT_TRUE(specfem::datatype::all_of(
-        Kokkos::abs(boundary.edge_normal(0) - 0.8) < tol))
+    EXPECT_TRUE(specfem::utilities::is_close(boundary.edge_normal(0),
+                                             static_cast<type_real>(0.8)))
         << ExpectedGot(0.8, boundary.edge_normal(0));
-    EXPECT_TRUE(specfem::datatype::all_of(
-        Kokkos::abs(boundary.edge_normal(1) - 0.6) < tol))
+    EXPECT_TRUE(specfem::utilities::is_close(boundary.edge_normal(1),
+                                             static_cast<type_real>(0.6)))
         << ExpectedGot(0.6, boundary.edge_normal(1));
   }
 }
@@ -176,14 +173,14 @@ TYPED_TEST(PointBoundaryTest, CompositeStaceyDirichletBoundary2D) {
 
     // Verify values
     EXPECT_TRUE(boundary.tag == element::boundary_tag::none);
-    EXPECT_TRUE(specfem::datatype::all_of(
-        Kokkos::abs(boundary.edge_weight - 3.5) < tol))
+    EXPECT_TRUE(specfem::utilities::is_close(boundary.edge_weight,
+                                             static_cast<type_real>(3.5)))
         << ExpectedGot(3.5, boundary.edge_weight);
-    EXPECT_TRUE(specfem::datatype::all_of(
-        Kokkos::abs(boundary.edge_normal(0) - 0.6) < tol))
+    EXPECT_TRUE(specfem::utilities::is_close(boundary.edge_normal(0),
+                                             static_cast<type_real>(0.6)))
         << ExpectedGot(0.6, boundary.edge_normal(0));
-    EXPECT_TRUE(specfem::datatype::all_of(
-        Kokkos::abs(boundary.edge_normal(1) - 0.8) < tol))
+    EXPECT_TRUE(specfem::utilities::is_close(boundary.edge_normal(1),
+                                             static_cast<type_real>(0.8)))
         << ExpectedGot(0.8, boundary.edge_normal(1));
   }
 }
@@ -256,14 +253,14 @@ TEST_F(PointBoundaryTestSerial, ConversionCompositeToStacey) {
 
   // Verify that all values were copied
   EXPECT_TRUE(stacey.tag == element::boundary_tag::composite_stacey_dirichlet);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(stacey.edge_weight - 5.5) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(stacey.edge_weight,
+                                           static_cast<type_real>(5.5)))
       << ExpectedGot(5.5, stacey.edge_weight);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(stacey.edge_normal(0) - 0.3) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(stacey.edge_normal(0),
+                                           static_cast<type_real>(0.3)))
       << ExpectedGot(0.3, stacey.edge_normal(0));
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(stacey.edge_normal(1) - 0.9) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(stacey.edge_normal(1),
+                                           static_cast<type_real>(0.9)))
       << ExpectedGot(0.9, stacey.edge_normal(1));
 }
 
@@ -413,14 +410,11 @@ TEST_F(PointBoundaryTestSerial, BoundaryTagContainerOperators) {
 //   EXPECT_EQ(boundary.edge_normal.extent(0), 3);  // 3D has 3 components
 
 //   // Check initialization values
-//   EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(boundary.edge_normal(0))
-//   < tol))
+//   EXPECT_TRUE(specfem::utilities::is_close(boundary.edge_normal(0), 0.0))
 //       << ExpectedGot(0.0, boundary.edge_normal(0));
-//   EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(boundary.edge_normal(1))
-//   < tol))
+//   EXPECT_TRUE(specfem::utilities::is_close(boundary.edge_normal(1), 0.0))
 //       << ExpectedGot(0.0, boundary.edge_normal(1));
-//   EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(boundary.edge_normal(2))
-//   < tol))
+//   EXPECT_TRUE(specfem::utilities::is_close(boundary.edge_normal(2), 0.0))
 //       << ExpectedGot(0.0, boundary.edge_normal(2));
 
 //   // Set edge normal values
@@ -429,13 +423,10 @@ TEST_F(PointBoundaryTestSerial, BoundaryTagContainerOperators) {
 //   boundary.edge_normal(2) = 0.3;
 
 //   // Verify values
-//   EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(boundary.edge_normal(0) -
-//   0.1) < tol))
+//   EXPECT_TRUE(specfem::utilities::is_close(boundary.edge_normal(0), 0.1))
 //       << ExpectedGot(0.1, boundary.edge_normal(0));
-//   EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(boundary.edge_normal(1) -
-//   0.2) < tol))
+//   EXPECT_TRUE(specfem::utilities::is_close(boundary.edge_normal(1), 0.2))
 //       << ExpectedGot(0.2, boundary.edge_normal(1));
-//   EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(boundary.edge_normal(2) -
-//   0.3) < tol))
+//   EXPECT_TRUE(specfem::utilities::is_close(boundary.edge_normal(2), 0.3))
 //       << ExpectedGot(0.3, boundary.edge_normal(2));
 // }

--- a/tests/unit-tests/point/kernels/dim2/acoustic_isotropic.cpp
+++ b/tests/unit-tests/point/kernels/dim2/acoustic_isotropic.cpp
@@ -1,12 +1,10 @@
 #include "../kernels_tests.hpp"
-#include "datatypes/simd.hpp"
 #include "specfem/point/kernels.hpp"
 #include "specfem_setup.hpp"
 #include "test_macros.hpp"
+#include "utilities/simd.hpp"
 #include <Kokkos_Core.hpp>
 #include <gtest/gtest.h>
-
-const type_real tol = 1e-6; ///< Tolerance for floating point comparisons
 
 // ============================================================================
 // 2D Acoustic Tests
@@ -53,15 +51,12 @@ TYPED_TEST(PointKernelsTest, AcousticIsotropic2D) {
                           specfem::element::property_tag::isotropic, using_simd>
       kernels(rho, kappa);
 
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(kernels.rho() - rho) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.rho(), rho))
       << ExpectedGot(rho, kernels.rho());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(kernels.kappa() - kappa) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.kappa(), kappa))
       << ExpectedGot(kappa, kernels.kappa());
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(kernels.rhop() - expected_rhop) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.rhop(), expected_rhop))
       << ExpectedGot(expected_rhop, kernels.rhop());
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(kernels.alpha() - expected_alpha) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.alpha(), expected_alpha))
       << ExpectedGot(expected_alpha, kernels.alpha());
 }

--- a/tests/unit-tests/point/kernels/dim2/elastic_anisotropic.cpp
+++ b/tests/unit-tests/point/kernels/dim2/elastic_anisotropic.cpp
@@ -1,12 +1,10 @@
 #include "../kernels_tests.hpp"
-#include "datatypes/simd.hpp"
 #include "specfem/point/kernels.hpp"
 #include "specfem_setup.hpp"
 #include "test_macros.hpp"
+#include "utilities/simd.hpp"
 #include <Kokkos_Core.hpp>
 #include <gtest/gtest.h>
-
-const type_real tol = 1e-6; ///< Tolerance for floating point comparisons
 
 // ============================================================================
 // 2D Elastic Anisotropic Tests
@@ -65,18 +63,18 @@ TYPED_TEST(PointKernelsTest, ElasticAnisotropic2D) {
       specfem::element::property_tag::anisotropic, using_simd>
       kernels(rho, c11, c13, c15, c33, c35, c55);
 
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(kernels.rho() - rho) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.rho(), rho))
       << ExpectedGot(rho, kernels.rho());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(kernels.c11() - c11) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.c11(), c11))
       << ExpectedGot(c11, kernels.c11());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(kernels.c13() - c13) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.c13(), c13))
       << ExpectedGot(c13, kernels.c13());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(kernels.c15() - c15) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.c15(), c15))
       << ExpectedGot(c15, kernels.c15());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(kernels.c33() - c33) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.c33(), c33))
       << ExpectedGot(c33, kernels.c33());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(kernels.c35() - c35) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.c35(), c35))
       << ExpectedGot(c35, kernels.c35());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(kernels.c55() - c55) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.c55(), c55))
       << ExpectedGot(c55, kernels.c55());
 }

--- a/tests/unit-tests/point/kernels/dim2/elastic_isotropic.cpp
+++ b/tests/unit-tests/point/kernels/dim2/elastic_isotropic.cpp
@@ -1,12 +1,10 @@
 #include "../kernels_tests.hpp"
-#include "datatypes/simd.hpp"
 #include "specfem/point/kernels.hpp"
 #include "specfem_setup.hpp"
 #include "test_macros.hpp"
+#include "utilities/simd.hpp"
 #include <Kokkos_Core.hpp>
 #include <gtest/gtest.h>
-
-const type_real tol = 1e-6; ///< Tolerance for floating point comparisons
 
 // ============================================================================
 // 2D Elastic Isotropic Tests
@@ -61,20 +59,16 @@ TYPED_TEST(PointKernelsTest, ElasticIsotropic2D) {
                           specfem::element::property_tag::isotropic, using_simd>
       kernels(rho, mu, kappa, rhop, alpha, beta);
 
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(kernels.rho() - rho) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.rho(), rho))
       << ExpectedGot(rho, kernels.rho());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(kernels.mu() - mu) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.mu(), mu))
       << ExpectedGot(mu, kernels.mu());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(kernels.kappa() - kappa) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.kappa(), kappa))
       << ExpectedGot(kappa, kernels.kappa());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(kernels.rhop() - rhop) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.rhop(), rhop))
       << ExpectedGot(rhop, kernels.rhop());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(kernels.alpha() - alpha) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.alpha(), alpha))
       << ExpectedGot(alpha, kernels.alpha());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(kernels.beta() - beta) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.beta(), beta))
       << ExpectedGot(beta, kernels.beta());
 }

--- a/tests/unit-tests/point/kernels/dim2/poroelastic_isotropic.cpp
+++ b/tests/unit-tests/point/kernels/dim2/poroelastic_isotropic.cpp
@@ -1,12 +1,10 @@
 #include "../kernels_tests.hpp"
-#include "datatypes/simd.hpp"
 #include "specfem/point/kernels.hpp"
 #include "specfem_setup.hpp"
 #include "test_macros.hpp"
+#include "utilities/simd.hpp"
 #include <Kokkos_Core.hpp>
 #include <gtest/gtest.h>
-
-const type_real tol = 1e-6; ///< Tolerance for floating point comparisons
 
 // ============================================================================
 // 2D Poroelastic Tests
@@ -118,55 +116,43 @@ TYPED_TEST(PointKernelsTest, PoroelasticIsotropic2D) {
       kernels(rhot, rhof, eta, sm, mu_fr, B, C, M, cpI, cpII, cs, rhobb, rhofbb,
               ratio, phib);
 
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(kernels.rhot() - rhot) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.rhot(), rhot))
       << ExpectedGot(rhot, kernels.rhot());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(kernels.rhof() - rhof) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.rhof(), rhof))
       << ExpectedGot(rhof, kernels.rhof());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(kernels.eta() - eta) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.eta(), eta))
       << ExpectedGot(eta, kernels.eta());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(kernels.sm() - sm) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.sm(), sm))
       << ExpectedGot(sm, kernels.sm());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(kernels.mu_fr() - mu_fr) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.mu_fr(), mu_fr))
       << ExpectedGot(mu_fr, kernels.mu_fr());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(kernels.B() - B) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.B(), B))
       << ExpectedGot(B, kernels.B());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(kernels.C() - C) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.C(), C))
       << ExpectedGot(C, kernels.C());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(kernels.M() - M) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.M(), M))
       << ExpectedGot(M, kernels.M());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(kernels.cpI() - cpI) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.cpI(), cpI))
       << ExpectedGot(cpI, kernels.cpI());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(kernels.cpII() - cpII) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.cpII(), cpII))
       << ExpectedGot(cpII, kernels.cpII());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(kernels.cs() - cs) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.cs(), cs))
       << ExpectedGot(cs, kernels.cs());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(kernels.rhobb() - rhobb) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.rhobb(), rhobb))
       << ExpectedGot(rhobb, kernels.rhobb());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(kernels.rhofbb() - rhofbb) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.rhofbb(), rhofbb))
       << ExpectedGot(rhofbb, kernels.rhofbb());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(kernels.ratio() - ratio) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.ratio(), ratio))
       << ExpectedGot(ratio, kernels.ratio());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(kernels.phib() - phib) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.phib(), phib))
       << ExpectedGot(phib, kernels.phib());
 
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(kernels.mu_frb() - expected_mu_frb) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.mu_frb(), expected_mu_frb))
       << ExpectedGot(expected_mu_frb, kernels.mu_frb());
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(kernels.rhob() - expected_rhob) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.rhob(), expected_rhob))
       << ExpectedGot(expected_rhob, kernels.rhob());
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(kernels.rhofb() - expected_rhofb) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.rhofb(), expected_rhofb))
       << ExpectedGot(expected_rhofb, kernels.rhofb());
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(kernels.phi() - expected_phi) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.phi(), expected_phi))
       << ExpectedGot(expected_phi, kernels.phi());
 }

--- a/tests/unit-tests/point/kernels/dim3/elastic_isotropic.cpp
+++ b/tests/unit-tests/point/kernels/dim3/elastic_isotropic.cpp
@@ -1,8 +1,8 @@
 #include "../kernels_tests.hpp"
-#include "datatypes/simd.hpp"
 #include "specfem/point/kernels.hpp"
 #include "specfem_setup.hpp"
 #include "test_macros.hpp"
+#include "utilities/simd.hpp"
 #include <Kokkos_Core.hpp>
 #include <gtest/gtest.h>
 
@@ -61,20 +61,16 @@ TYPED_TEST(PointKernelsTest, ElasticIsotropic3D) {
                           specfem::element::property_tag::isotropic, using_simd>
       kernels(rho, mu, kappa, rhop, alpha, beta);
 
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(kernels.rho() - rho) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.rho(), rho))
       << ExpectedGot(rho, kernels.rho());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(kernels.mu() - mu) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.mu(), mu))
       << ExpectedGot(mu, kernels.mu());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(kernels.kappa() - kappa) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.kappa(), kappa))
       << ExpectedGot(kappa, kernels.kappa());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(kernels.rhop() - rhop) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.rhop(), rhop))
       << ExpectedGot(rhop, kernels.rhop());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(kernels.alpha() - alpha) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.alpha(), alpha))
       << ExpectedGot(alpha, kernels.alpha());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(kernels.beta() - beta) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(kernels.beta(), beta))
       << ExpectedGot(beta, kernels.beta());
 }

--- a/tests/unit-tests/point/partial_derivatives_tests.cpp
+++ b/tests/unit-tests/point/partial_derivatives_tests.cpp
@@ -5,14 +5,12 @@
 #include "specfem/point/partial_derivatives.hpp"
 #include "specfem_setup.hpp"
 #include "test_macros.hpp"
+#include "utilities/simd.hpp"
 #include <Kokkos_Core.hpp>
 #include <gtest/gtest.h>
 #include <type_traits>
 
 using namespace specfem;
-
-// Define tolerance for floating point comparisons
-const type_real tol = 1e-6;
 
 // Base test fixture for partial derivatives tests with template parameter for
 // SIMD
@@ -57,16 +55,17 @@ TYPED_TEST(PointPartialDerivativesTest,
   using pd_type =
       point::partial_derivatives<dimension::type::dim2, false, using_simd>;
   pd_type pd;
+  typename pd_type::value_type zero_val{ 0.0 };
   pd.init();
 
-  // Use all_of to check values for both SIMD and non-SIMD cases
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd.xix) < tol))
+  // Use is_close to check values for both SIMD and non-SIMD cases
+  EXPECT_TRUE(specfem::utilities::is_close(pd.xix, zero_val))
       << ExpectedGot(0.0, pd.xix);
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd.gammax) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd.gammax, zero_val))
       << ExpectedGot(0.0, pd.gammax);
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd.xiz) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd.xiz, zero_val))
       << ExpectedGot(0.0, pd.xiz);
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd.gammaz) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd.gammaz, zero_val))
       << ExpectedGot(0.0, pd.gammaz);
 }
 
@@ -94,16 +93,14 @@ TYPED_TEST(PointPartialDerivativesTest, PartialDerivatives2D_ValueConstructor) {
   point::partial_derivatives<dimension::type::dim2, false, using_simd> pd(
       xix_val, gammax_val, xiz_val, gammaz_val);
 
-  // Check values using all_of
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd.xix - xix_val) < tol))
+  // Check values using is_close
+  EXPECT_TRUE(specfem::utilities::is_close(pd.xix, xix_val))
       << ExpectedGot(xix_val, pd.xix);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd.gammax - gammax_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd.gammax, gammax_val))
       << ExpectedGot(gammax_val, pd.gammax);
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd.xiz - xiz_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd.xiz, xiz_val))
       << ExpectedGot(xiz_val, pd.xiz);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd.gammaz - gammaz_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd.gammaz, gammaz_val))
       << ExpectedGot(gammaz_val, pd.gammaz);
 }
 
@@ -123,16 +120,14 @@ TYPED_TEST(PointPartialDerivativesTest,
   point::partial_derivatives<dimension::type::dim2, false, using_simd> pd(
       const_val);
 
-  // Check values using all_of
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd.xix - const_val) < tol))
+  // Check values using is_close
+  EXPECT_TRUE(specfem::utilities::is_close(pd.xix, const_val))
       << ExpectedGot(const_val, pd.xix);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd.gammax - const_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd.gammax, const_val))
       << ExpectedGot(const_val, pd.gammax);
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd.xiz - const_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd.xiz, const_val))
       << ExpectedGot(const_val, pd.xiz);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd.gammaz - const_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd.gammaz, const_val))
       << ExpectedGot(const_val, pd.gammaz);
 }
 
@@ -157,18 +152,20 @@ TYPED_TEST(PointPartialDerivativesTest, PartialDerivatives2D_Init) {
     4.0
   };
 
-  point::partial_derivatives<dimension::type::dim2, false, using_simd> pd(
-      xix_val, gammax_val, xiz_val, gammaz_val);
+  using pd_type =
+      point::partial_derivatives<dimension::type::dim2, false, using_simd>;
+  pd_type pd(xix_val, gammax_val, xiz_val, gammaz_val);
+  typename pd_type::value_type zero_val{ 0.0 };
   pd.init();
 
   // Check values after init
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd.xix) < tol))
-      << ExpectedGot(0.0, pd.xix);
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd.gammax) < tol))
-      << ExpectedGot(0.0, pd.gammax);
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd.xiz) < tol))
-      << ExpectedGot(0.0, pd.xiz);
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd.gammaz) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd.xix, zero_val))
+      << ExpectedGot(zero_val, pd.xix);
+  EXPECT_TRUE(specfem::utilities::is_close(pd.gammax, zero_val))
+      << ExpectedGot(zero_val, pd.gammax);
+  EXPECT_TRUE(specfem::utilities::is_close(pd.xiz, zero_val))
+      << ExpectedGot(zero_val, pd.xiz);
+  EXPECT_TRUE(specfem::utilities::is_close(pd.gammaz, zero_val))
       << ExpectedGot(0.0, pd.gammaz);
 }
 
@@ -209,32 +206,28 @@ TYPED_TEST(PointPartialDerivativesTest, PartialDerivatives2D_Arithmetic) {
 
   // Addition
   PD c = a + b;
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(c.xix - (a_xix_val + b_xix_val)) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(c.xix, a_xix_val + b_xix_val))
       << ExpectedGot(a_xix_val + b_xix_val, c.xix);
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(c.gammax - (a_gammax_val + b_gammax_val)) < tol))
+  EXPECT_TRUE(
+      specfem::utilities::is_close(c.gammax, a_gammax_val + b_gammax_val))
       << ExpectedGot(a_gammax_val + b_gammax_val, c.gammax);
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(c.xiz - (a_xiz_val + b_xiz_val)) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(c.xiz, a_xiz_val + b_xiz_val))
       << ExpectedGot(a_xiz_val + b_xiz_val, c.xiz);
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(c.gammaz - (a_gammaz_val + b_gammaz_val)) < tol))
+  EXPECT_TRUE(
+      specfem::utilities::is_close(c.gammaz, a_gammaz_val + b_gammaz_val))
       << ExpectedGot(a_gammaz_val + b_gammaz_val, c.gammaz);
 
   // Addition assignment
   a += b;
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(a.xix - (a_xix_val + b_xix_val)) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(a.xix, a_xix_val + b_xix_val))
       << ExpectedGot(a_xix_val + b_xix_val, a.xix);
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(a.gammax - (a_gammax_val + b_gammax_val)) < tol))
+  EXPECT_TRUE(
+      specfem::utilities::is_close(a.gammax, a_gammax_val + b_gammax_val))
       << ExpectedGot(a_gammax_val + b_gammax_val, a.gammax);
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(a.xiz - (a_xiz_val + b_xiz_val)) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(a.xiz, a_xiz_val + b_xiz_val))
       << ExpectedGot(a_xiz_val + b_xiz_val, a.xiz);
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(a.gammaz - (a_gammaz_val + b_gammaz_val)) < tol))
+  EXPECT_TRUE(
+      specfem::utilities::is_close(a.gammaz, a_gammaz_val + b_gammaz_val))
       << ExpectedGot(a_gammaz_val + b_gammaz_val, a.gammaz);
 
   // Scalar multiplication (object * scalar)
@@ -242,17 +235,13 @@ TYPED_TEST(PointPartialDerivativesTest, PartialDerivatives2D_Arithmetic) {
     type_real scalar_2 = 2.0;
 
     PD d = b * scalar_2;
-    EXPECT_TRUE(specfem::datatype::all_of(
-        Kokkos::abs(d.xix - (b_xix_val * scalar_2)) < tol))
+    EXPECT_TRUE(specfem::utilities::is_close(d.xix, b_xix_val * scalar_2))
         << ExpectedGot(b_xix_val * scalar_2, d.xix);
-    EXPECT_TRUE(specfem::datatype::all_of(
-        Kokkos::abs(d.gammax - (b_gammax_val * scalar_2)) < tol))
+    EXPECT_TRUE(specfem::utilities::is_close(d.gammax, b_gammax_val * scalar_2))
         << ExpectedGot(b_gammax_val * scalar_2, d.gammax);
-    EXPECT_TRUE(specfem::datatype::all_of(
-        Kokkos::abs(d.xiz - (b_xiz_val * scalar_2)) < tol))
+    EXPECT_TRUE(specfem::utilities::is_close(d.xiz, b_xiz_val * scalar_2))
         << ExpectedGot(b_xiz_val * scalar_2, d.xiz);
-    EXPECT_TRUE(specfem::datatype::all_of(
-        Kokkos::abs(d.gammaz - (b_gammaz_val * scalar_2)) < tol))
+    EXPECT_TRUE(specfem::utilities::is_close(d.gammaz, b_gammaz_val * scalar_2))
         << ExpectedGot(b_gammaz_val * scalar_2, d.gammaz);
 
     // Scalar multiplication (scalar * object)
@@ -261,17 +250,13 @@ TYPED_TEST(PointPartialDerivativesTest, PartialDerivatives2D_Arithmetic) {
     };
 
     PD e = scalar_3 * b;
-    EXPECT_TRUE(specfem::datatype::all_of(
-        Kokkos::abs(e.xix - (scalar_3 * b_xix_val)) < tol))
+    EXPECT_TRUE(specfem::utilities::is_close(e.xix, scalar_3 * b_xix_val))
         << ExpectedGot(scalar_3 * b_xix_val, e.xix);
-    EXPECT_TRUE(specfem::datatype::all_of(
-        Kokkos::abs(e.gammax - (scalar_3 * b_gammax_val)) < tol))
+    EXPECT_TRUE(specfem::utilities::is_close(e.gammax, scalar_3 * b_gammax_val))
         << ExpectedGot(scalar_3 * b_gammax_val, e.gammax);
-    EXPECT_TRUE(specfem::datatype::all_of(
-        Kokkos::abs(e.xiz - (scalar_3 * b_xiz_val)) < tol))
+    EXPECT_TRUE(specfem::utilities::is_close(e.xiz, scalar_3 * b_xiz_val))
         << ExpectedGot(scalar_3 * b_xiz_val, e.xiz);
-    EXPECT_TRUE(specfem::datatype::all_of(
-        Kokkos::abs(e.gammaz - (scalar_3 * b_gammaz_val)) < tol))
+    EXPECT_TRUE(specfem::utilities::is_close(e.gammaz, scalar_3 * b_gammaz_val))
         << ExpectedGot(scalar_3 * b_gammaz_val, e.gammaz);
   }
 }
@@ -317,52 +302,43 @@ TYPED_TEST(PointPartialDerivativesTest,
   PD pd1;
   pd1.init();
 
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd1.xix - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.xix, zero_val))
       << ExpectedGot(zero_val, pd1.xix);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd1.gammax - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.gammax, zero_val))
       << ExpectedGot(zero_val, pd1.gammax);
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd1.xiz - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.xiz, zero_val))
       << ExpectedGot(zero_val, pd1.xiz);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd1.gammaz - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.gammaz, zero_val))
       << ExpectedGot(zero_val, pd1.gammaz);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd1.jacobian - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.jacobian, zero_val))
       << ExpectedGot(zero_val, pd1.jacobian);
 
   // Value constructor
   PD pd2(one_val, two_val, three_val, four_val, five_val);
 
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd2.xix - one_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.xix, one_val))
       << ExpectedGot(one_val, pd2.xix);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd2.gammax - two_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.gammax, two_val))
       << ExpectedGot(two_val, pd2.gammax);
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd2.xiz - three_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.xiz, three_val))
       << ExpectedGot(three_val, pd2.xiz);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd2.gammaz - four_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.gammaz, four_val))
       << ExpectedGot(four_val, pd2.gammaz);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd2.jacobian - five_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.jacobian, five_val))
       << ExpectedGot(five_val, pd2.jacobian);
 
   // Constant constructor
   PD pd3(const_val);
 
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd3.xix - const_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.xix, const_val))
       << ExpectedGot(const_val, pd3.xix);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd3.gammax - const_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.gammax, const_val))
       << ExpectedGot(const_val, pd3.gammax);
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd3.xiz - const_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.xiz, const_val))
       << ExpectedGot(const_val, pd3.xiz);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd3.gammaz - const_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.gammaz, const_val))
       << ExpectedGot(const_val, pd3.gammaz);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd3.jacobian - const_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.jacobian, const_val))
       << ExpectedGot(const_val, pd3.jacobian);
 }
 
@@ -399,18 +375,15 @@ TYPED_TEST(PointPartialDerivativesTest,
   PD pd(one_val, two_val, three_val, four_val, five_val);
   pd.init();
 
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd.xix - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd.xix, zero_val))
       << ExpectedGot(zero_val, pd.xix);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd.gammax - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd.gammax, zero_val))
       << ExpectedGot(zero_val, pd.gammax);
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd.xiz - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd.xiz, zero_val))
       << ExpectedGot(zero_val, pd.xiz);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd.gammaz - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd.gammaz, zero_val))
       << ExpectedGot(zero_val, pd.gammaz);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd.jacobian - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd.jacobian, zero_val))
       << ExpectedGot(zero_val, pd.jacobian);
 }
 
@@ -461,67 +434,55 @@ TYPED_TEST(PointPartialDerivativesTest,
   PD pd1;
   pd1.init();
 
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd1.xix - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.xix, zero_val))
       << ExpectedGot(zero_val, pd1.xix);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd1.gammax - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.gammax, zero_val))
       << ExpectedGot(zero_val, pd1.gammax);
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd1.xiy - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.xiy, zero_val))
       << ExpectedGot(zero_val, pd1.xiy);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd1.gammay - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.gammay, zero_val))
       << ExpectedGot(zero_val, pd1.gammay);
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd1.xiz - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.xiz, zero_val))
       << ExpectedGot(zero_val, pd1.xiz);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd1.gammaz - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.gammaz, zero_val))
       << ExpectedGot(zero_val, pd1.gammaz);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd1.jacobian - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.jacobian, zero_val))
       << ExpectedGot(zero_val, pd1.jacobian);
 
   // Value constructor
   PD pd2(one_val, two_val, three_val, four_val, five_val, six_val, seven_val);
 
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd2.xix - one_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.xix, one_val))
       << ExpectedGot(one_val, pd2.xix);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd2.gammax - two_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.gammax, two_val))
       << ExpectedGot(two_val, pd2.gammax);
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd2.xiy - three_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.xiy, three_val))
       << ExpectedGot(three_val, pd2.xiy);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd2.gammay - four_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.gammay, four_val))
       << ExpectedGot(four_val, pd2.gammay);
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd2.xiz - five_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.xiz, five_val))
       << ExpectedGot(five_val, pd2.xiz);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd2.gammaz - six_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.gammaz, six_val))
       << ExpectedGot(six_val, pd2.gammaz);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd2.jacobian - seven_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.jacobian, seven_val))
       << ExpectedGot(seven_val, pd2.jacobian);
 
   // Constant constructor
   PD pd3(const_val);
 
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd3.xix - const_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.xix, const_val))
       << ExpectedGot(const_val, pd3.xix);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd3.gammax - const_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.gammax, const_val))
       << ExpectedGot(const_val, pd3.gammax);
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd3.xiy - const_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.xiy, const_val))
       << ExpectedGot(const_val, pd3.xiy);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd3.gammay - const_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.gammay, const_val))
       << ExpectedGot(const_val, pd3.gammay);
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd3.xiz - const_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.xiz, const_val))
       << ExpectedGot(const_val, pd3.xiz);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd3.gammaz - const_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.gammaz, const_val))
       << ExpectedGot(const_val, pd3.gammaz);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd3.jacobian - const_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.jacobian, const_val))
       << ExpectedGot(const_val, pd3.jacobian);
 }
 
@@ -564,23 +525,19 @@ TYPED_TEST(PointPartialDerivativesTest,
   PD pd(one_val, two_val, three_val, four_val, five_val, six_val, seven_val);
   pd.init();
 
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd.xix - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd.xix, zero_val))
       << ExpectedGot(zero_val, pd.xix);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd.gammax - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd.gammax, zero_val))
       << ExpectedGot(zero_val, pd.gammax);
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd.xiy - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd.xiy, zero_val))
       << ExpectedGot(zero_val, pd.xiy);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd.gammay - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd.gammay, zero_val))
       << ExpectedGot(zero_val, pd.gammay);
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(pd.xiz - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd.xiz, zero_val))
       << ExpectedGot(zero_val, pd.xiz);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd.gammaz - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd.gammaz, zero_val))
       << ExpectedGot(zero_val, pd.gammaz);
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(pd.jacobian - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(pd.jacobian, zero_val))
       << ExpectedGot(zero_val, pd.jacobian);
 }
 

--- a/tests/unit-tests/point/properties/dim2/acoustic_isotropic.cpp
+++ b/tests/unit-tests/point/properties/dim2/acoustic_isotropic.cpp
@@ -1,12 +1,10 @@
 #include "../properties_tests.hpp"
-#include "datatypes/simd.hpp"
 #include "specfem/point/properties.hpp"
 #include "specfem_setup.hpp"
 #include "test_macros.hpp"
+#include "utilities/simd.hpp"
 #include <Kokkos_Core.hpp>
 #include <gtest/gtest.h>
-
-const type_real tol = 1e-6; ///< Tolerance for floating point comparisons
 
 // ============================================================================
 // 2D Acoustic Tests
@@ -58,17 +56,13 @@ TYPED_TEST(PointPropertiesTest, AcousticIsotropic2D) {
       specfem::element::property_tag::isotropic, using_simd>
       props(rho_inv, kappa);
 
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(props.rho_inverse() - rho_inv) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.rho_inverse(), rho_inv))
       << ExpectedGot(kappa, props.rho_inverse());
 
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(props.kappa() - kappa) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.kappa(), kappa))
       << ExpectedGot(kappa, props.kappa());
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(props.kappa_inverse() - kappa_inv) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.kappa_inverse(), kappa_inv))
       << ExpectedGot(kappa_inv, props.kappa_inverse());
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(props.rho_vpinverse() - rho_vpinv) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.rho_vpinverse(), rho_vpinv))
       << ExpectedGot(rho_vpinv, props.rho_vpinverse());
 }

--- a/tests/unit-tests/point/properties/dim2/elastic_anisotropic.cpp
+++ b/tests/unit-tests/point/properties/dim2/elastic_anisotropic.cpp
@@ -1,12 +1,10 @@
 #include "../properties_tests.hpp"
-#include "datatypes/simd.hpp"
 #include "specfem/point/properties.hpp"
 #include "specfem_setup.hpp"
 #include "test_macros.hpp"
+#include "utilities/simd.hpp"
 #include <Kokkos_Core.hpp>
 #include <gtest/gtest.h>
-
-const type_real tol = 1e-6; ///< Tolerance for floating point comparisons
 
 // ============================================================================
 // 2D Elastic Anisotropic Tests
@@ -91,31 +89,29 @@ TYPED_TEST(PointPropertiesTest, ElasticAnisotropic2D) {
       specfem::element::property_tag::anisotropic, using_simd>
       props(c11, c13, c15, c33, c35, c55, c12, c23, c25, rho);
 
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(props.c11() - c11) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.c11(), c11))
       << ExpectedGot(c11, props.c11());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(props.c13() - c13) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.c13(), c13))
       << ExpectedGot(c13, props.c13());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(props.c15() - c15) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.c15(), c15))
       << ExpectedGot(c15, props.c15());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(props.c33() - c33) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.c33(), c33))
       << ExpectedGot(c33, props.c33());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(props.c35() - c35) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.c35(), c35))
       << ExpectedGot(c35, props.c35());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(props.c55() - c55) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.c55(), c55))
       << ExpectedGot(c55, props.c55());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(props.c12() - c12) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.c12(), c12))
       << ExpectedGot(c12, props.c12());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(props.c23() - c23) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.c23(), c23))
       << ExpectedGot(c23, props.c23());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(props.c25() - c25) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.c25(), c25))
       << ExpectedGot(c25, props.c25());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(props.rho() - rho) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.rho(), rho))
       << ExpectedGot(rho, props.rho());
 
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(props.rho_vp() - rho_vp_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.rho_vp(), rho_vp_val))
       << ExpectedGot(rho_vp_val, props.rho_vp());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(props.rho_vs() - rho_vs_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.rho_vs(), rho_vs_val))
       << ExpectedGot(rho_vs_val, props.rho_vs());
 }

--- a/tests/unit-tests/point/properties/dim2/elastic_isotropic.cpp
+++ b/tests/unit-tests/point/properties/dim2/elastic_isotropic.cpp
@@ -1,12 +1,10 @@
 #include "../properties_tests.hpp"
-#include "datatypes/simd.hpp"
 #include "specfem/point/properties.hpp"
 #include "specfem_setup.hpp"
 #include "test_macros.hpp"
+#include "utilities/simd.hpp"
 #include <Kokkos_Core.hpp>
 #include <gtest/gtest.h>
-
-const type_real tol = 1e-6; ///< Tolerance for floating point comparisons
 
 // ============================================================================
 // 2D Elastic Isotropic Tests
@@ -74,38 +72,20 @@ TYPED_TEST(PointPropertiesTest, ElasticIsotropic2D) {
       specfem::element::property_tag::isotropic, using_simd>
       props(lambdaplus2mu, mu, rho);
 
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(props.lambdaplus2mu() - lambdaplus2mu) < tol))
+  EXPECT_TRUE(
+      specfem::utilities::is_close(props.lambdaplus2mu(), lambdaplus2mu))
       << ExpectedGot(lambdaplus2mu, props.lambdaplus2mu());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(props.mu() - mu) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.mu(), mu))
       << ExpectedGot(mu, props.mu());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(props.rho() - rho) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.rho(), rho))
       << ExpectedGot(rho, props.rho());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(props.rho_vp() - rho_vp) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.rho_vp(), rho_vp))
       << ExpectedGot(rho_vp, props.rho_vp());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(props.rho_vs() - rho_vs) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.rho_vs(), rho_vs))
       << ExpectedGot(rho_vs, props.rho_vs());
 
-  /**
-   * THIS FAILS due to loss of precision in the computation of lambda
-   * internally lambda plus 2 mu is computed and stored
-   * lambda is computed from lambdaplus2mu and mu
-   * the resulting lambda is not exactly the same as the input lambda!
-   * the implementation of elastic isotropic stress uses lambda, this should
-   * be fixed in the future
-   * @code
-   * sigma_xx =
-   *     properties.lambdaplus2mu() * du(0, 0) + properties.lambda() * du(1, 1);
-   * sigma_zz =
-   *     properties.lambdaplus2mu() * du(1, 1) + properties.lambda() * du(0, 0);
-   * @endcode
-   */
-  // EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(props.lambda() - lambda)
-  // < tol)) << ExpectedGot(lambda, props.lambda());
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(props.lambda() -
-                  (lambdaplus2mu - static_cast<type_real>(2.0) * mu)) < tol))
+  // See note in original code about lambda precision
+  EXPECT_TRUE(specfem::utilities::is_close(
+      props.lambda(), lambdaplus2mu - static_cast<type_real>(2.0) * mu))
       << ExpectedGot(lambda, props.lambda());
 }

--- a/tests/unit-tests/point/properties/dim2/electromagnetic_isotropic.cpp
+++ b/tests/unit-tests/point/properties/dim2/electromagnetic_isotropic.cpp
@@ -1,12 +1,10 @@
 #include "../properties_tests.hpp"
-#include "datatypes/simd.hpp"
 #include "specfem/point/properties.hpp"
 #include "specfem_setup.hpp"
 #include "test_macros.hpp"
+#include "utilities/simd.hpp"
 #include <Kokkos_Core.hpp>
 #include <gtest/gtest.h>
-
-const type_real tol = 1e-6; ///< Tolerance for floating point comparisons
 
 // ============================================================================
 // 2D Electromagnetic Tests
@@ -52,19 +50,14 @@ TYPED_TEST(PointPropertiesTest, ElectromagneticIsotropic2D) {
                              using_simd>
       props(mu0_inv, eps11, eps33, sig11, sig33);
 
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(props.mu0_inv() - mu0_inv) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.mu0_inv(), mu0_inv))
       << ExpectedGot(mu0_inv, props.mu0_inv());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(props.eps11() - eps11) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.eps11(), eps11))
       << ExpectedGot(eps11, props.eps11());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(props.eps33() - eps33) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.eps33(), eps33))
       << ExpectedGot(eps33, props.eps33());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(props.sig11() - sig11) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.sig11(), sig11))
       << ExpectedGot(sig11, props.sig11());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(props.sig33() - sig33) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.sig33(), sig33))
       << ExpectedGot(sig33, props.sig33());
 }

--- a/tests/unit-tests/point/properties/dim2/poroelastic_isotropic.cpp
+++ b/tests/unit-tests/point/properties/dim2/poroelastic_isotropic.cpp
@@ -1,12 +1,10 @@
 #include "../properties_tests.hpp"
-#include "datatypes/simd.hpp"
 #include "specfem/point/properties.hpp"
 #include "specfem_setup.hpp"
 #include "test_macros.hpp"
+#include "utilities/simd.hpp"
 #include <Kokkos_Core.hpp>
 #include <gtest/gtest.h>
-
-const type_real tol = 1e-6; ///< Tolerance for floating point comparisons
 
 // ============================================================================
 // 2D Poroelastic Tests
@@ -136,75 +134,61 @@ TYPED_TEST(PointPropertiesTest, PoroelasticIsotropic2D) {
       props(phi, rho_s, rho_f, tortuosity, mu_G, H_Biot, C_Biot, M_Biot, permxx,
             permxz, permzz, eta_f);
 
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(props.phi() - phi) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.phi(), phi))
       << ExpectedGot(phi, props.phi());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(props.rho_s() - rho_s) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.rho_s(), rho_s))
       << ExpectedGot(rho_s, props.rho_s());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(props.rho_f() - rho_f) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.rho_f(), rho_f))
       << ExpectedGot(rho_f, props.rho_f());
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(props.tortuosity() - tortuosity) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.tortuosity(), tortuosity))
       << ExpectedGot(tortuosity, props.tortuosity());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(props.mu_G() - mu_G) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.mu_G(), mu_G))
       << ExpectedGot(mu_G, props.mu_G());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(props.H_Biot() - H_Biot) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.H_Biot(), H_Biot))
       << ExpectedGot(H_Biot, props.H_Biot());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(props.C_Biot() - C_Biot) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.C_Biot(), C_Biot))
       << ExpectedGot(C_Biot, props.C_Biot());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(props.M_Biot() - M_Biot) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.M_Biot(), M_Biot))
       << ExpectedGot(M_Biot, props.M_Biot());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(props.permxx() - permxx) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.permxx(), permxx))
       << ExpectedGot(permxx, props.permxx());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(props.permxz() - permxz) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.permxz(), permxz))
       << ExpectedGot(permxz, props.permxz());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(props.permzz() - permzz) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.permzz(), permzz))
       << ExpectedGot(permzz, props.permzz());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(props.eta_f() - eta_f) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.eta_f(), eta_f))
       << ExpectedGot(eta_f, props.eta_f());
 
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(props.lambda_G() - lambda_G_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.lambda_G(), lambda_G_val))
       << ExpectedGot(lambda_G_val, props.lambda_G());
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(props.lambdaplus2mu_G() - H_Biot) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.lambdaplus2mu_G(), H_Biot))
       << ExpectedGot(H_Biot, props.lambdaplus2mu_G());
 
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(props.inverse_permxx() - inverse_permxx_val) < tol))
+  EXPECT_TRUE(
+      specfem::utilities::is_close(props.inverse_permxx(), inverse_permxx_val))
       << ExpectedGot(inverse_permxx_val, props.inverse_permxx());
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(props.inverse_permxz() - inverse_permxz_val) < tol))
+  EXPECT_TRUE(
+      specfem::utilities::is_close(props.inverse_permxz(), inverse_permxz_val))
       << ExpectedGot(inverse_permxz_val, props.inverse_permxz());
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(props.inverse_permzz() - inverse_permzz_val) < tol))
+  EXPECT_TRUE(
+      specfem::utilities::is_close(props.inverse_permzz(), inverse_permzz_val))
       << ExpectedGot(inverse_permzz_val, props.inverse_permzz());
 
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(props.rho_bar() - rho_bar_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.rho_bar(), rho_bar_val))
       << ExpectedGot(rho_bar_val, props.rho_bar());
 
   // Wave velocities are complex calculations, so we just check they return
   // reasonable values
   simd_type zero{ static_cast<type_real>(0.0) };
-  EXPECT_TRUE(specfem::datatype::all_of(props.vpI() > zero))
+  EXPECT_TRUE(specfem::utilities::is_close(props.vpI(), zero) == false)
       << ExpectedGot(zero, props.vpI());
-  EXPECT_TRUE(specfem::datatype::all_of(props.vpII() > zero))
+  EXPECT_TRUE(specfem::utilities::is_close(props.vpII(), zero) == false)
       << ExpectedGot(zero, props.vpII());
-  EXPECT_TRUE(specfem::datatype::all_of(props.vs() > zero))
+  EXPECT_TRUE(specfem::utilities::is_close(props.vs(), zero) == false)
       << ExpectedGot(zero, props.vs());
-  EXPECT_TRUE(specfem::datatype::all_of(props.vpII() < props.vpI()))
+  EXPECT_TRUE(specfem::utilities::is_close(props.vpII(), props.vpI()) == false)
       << "vpII is typically slower than vpI\n"
-      << ExpectedGot(props.vpII(), props.vpI()); //
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(props.vs() - vs_expected) < tol))
+      << ExpectedGot(props.vpII(), props.vpI());
+  EXPECT_TRUE(specfem::utilities::is_close(props.vs(), vs_expected))
       << ExpectedGot(vs_expected, props.vs());
 }

--- a/tests/unit-tests/point/properties/dim3/elastic_isotropic.cpp
+++ b/tests/unit-tests/point/properties/dim3/elastic_isotropic.cpp
@@ -1,8 +1,8 @@
 #include "../properties_tests.hpp"
-#include "datatypes/simd.hpp"
 #include "specfem/point/properties.hpp"
 #include "specfem_setup.hpp"
 #include "test_macros.hpp"
+#include "utilities/simd.hpp"
 #include <Kokkos_Core.hpp>
 #include <gtest/gtest.h>
 
@@ -72,24 +72,20 @@ TYPED_TEST(PointPropertiesTest, ElasticIsotropic3D) {
       specfem::element::property_tag::isotropic, using_simd>
       props(kappa, mu, rho);
 
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(props.kappa() - kappa) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.kappa(), kappa))
       << ExpectedGot(kappa, props.kappa());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(props.mu() - mu) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.mu(), mu))
       << ExpectedGot(mu, props.mu());
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(props.rho() - rho) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.rho(), rho))
       << ExpectedGot(rho, props.rho());
 
-  EXPECT_TRUE(specfem::datatype::all_of(
-      Kokkos::abs(props.lambdaplus2mu() - lambdaplus2mu_val) < tol))
+  EXPECT_TRUE(
+      specfem::utilities::is_close(props.lambdaplus2mu(), lambdaplus2mu_val))
       << ExpectedGot(lambdaplus2mu_val, props.lambdaplus2mu());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(props.lambda() - lambda_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.lambda(), lambda_val))
       << ExpectedGot(lambda_val, props.lambda());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(props.rho_vp() - rho_vp_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.rho_vp(), rho_vp_val))
       << ExpectedGot(rho_vp_val, props.rho_vp());
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(props.rho_vs() - rho_vs_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(props.rho_vs(), rho_vs_val))
       << ExpectedGot(rho_vs_val, props.rho_vs());
 }

--- a/tests/unit-tests/point/stress_integrand_tests.cpp
+++ b/tests/unit-tests/point/stress_integrand_tests.cpp
@@ -1,16 +1,13 @@
-#include "datatypes/simd.hpp"
 #include "enumerations/interface.hpp"
 #include "specfem/point/stress_integrand.hpp"
 #include "specfem_setup.hpp"
 #include "test_macros.hpp"
+#include "utilities/simd.hpp"
 #include <Kokkos_Core.hpp>
 #include <gtest/gtest.h>
 #include <type_traits>
 
 using namespace specfem;
-
-// Define tolerance for floating point comparisons
-const type_real tol = 1e-6;
 
 // Base test fixture for stress integrand tests with template parameter for SIMD
 template <bool UseSIMD>
@@ -79,10 +76,10 @@ TYPED_TEST(PointStressIntegrandTest, StressIntegrand2DAcoustic) {
   // Construct stress_integrand object
   stress_integrand_type si(F);
 
-  // Verify values with all_of pattern
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(si.F(0, 0) - val1) < tol))
+  // Verify values with is_close
+  EXPECT_TRUE(specfem::utilities::is_close(si.F(0, 0), val1))
       << ExpectedGot(val1, si.F(0, 0));
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(si.F(0, 1) - val2) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(si.F(0, 1), val2))
       << ExpectedGot(val2, si.F(0, 1));
 }
 
@@ -131,14 +128,14 @@ TYPED_TEST(PointStressIntegrandTest, StressIntegrand2DElastic) {
   // Construct stress_integrand object
   stress_integrand_type si(F);
 
-  // Verify values using all_of pattern
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(si.F(0, 0) - val11) < tol))
+  // Verify values using is_close
+  EXPECT_TRUE(specfem::utilities::is_close(si.F(0, 0), val11))
       << ExpectedGot(val11, si.F(0, 0));
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(si.F(1, 0) - val21) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(si.F(1, 0), val21))
       << ExpectedGot(val21, si.F(1, 0));
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(si.F(0, 1) - val12) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(si.F(0, 1), val12))
       << ExpectedGot(val12, si.F(0, 1));
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(si.F(1, 1) - val22) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(si.F(1, 1), val22))
       << ExpectedGot(val22, si.F(1, 1));
 }
 
@@ -189,8 +186,7 @@ TYPED_TEST(PointStressIntegrandTest, StressIntegrand2DPoroelastic) {
   for (int i = 0; i < 4; ++i) {
     for (int j = 0; j < 2; ++j) {
       int idx = i + j * 4;
-      EXPECT_TRUE(
-          specfem::datatype::all_of(Kokkos::abs(si.F(i, j) - vals[idx]) < tol))
+      EXPECT_TRUE(specfem::utilities::is_close(si.F(i, j), vals[idx]))
           << ExpectedGot(vals[idx], si.F(i, j)) << " at index (" << i << ","
           << j << ")";
     }
@@ -233,11 +229,11 @@ TYPED_TEST(PointStressIntegrandTest, StressIntegrand3DAcoustic) {
   stress_integrand_type si(F);
 
   // Verify values
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(si.F(0, 0) - val1) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(si.F(0, 0), val1))
       << ExpectedGot(val1, si.F(0, 0));
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(si.F(0, 1) - val2) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(si.F(0, 1), val2))
       << ExpectedGot(val2, si.F(0, 1));
-  EXPECT_TRUE(specfem::datatype::all_of(Kokkos::abs(si.F(0, 2) - val3) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(si.F(0, 2), val3))
       << ExpectedGot(val3, si.F(0, 2));
 }
 
@@ -289,8 +285,7 @@ TYPED_TEST(PointStressIntegrandTest, StressIntegrand3DElastic) {
   for (int i = 0; i < 3; ++i) {
     for (int j = 0; j < 3; ++j) {
       int idx = i + j * 3;
-      EXPECT_TRUE(
-          specfem::datatype::all_of(Kokkos::abs(si.F(i, j) - vals[idx]) < tol))
+      EXPECT_TRUE(specfem::utilities::is_close(si.F(i, j), vals[idx]))
           << ExpectedGot(vals[idx], si.F(i, j)) << " at index (" << i << ","
           << j << ")";
     }
@@ -315,11 +310,9 @@ TYPED_TEST(PointStressIntegrandTest, DefaultConstructor) {
   };
 
   // The values should be default initialized (to zero)
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(si.F(0, 0) - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(si.F(0, 0), zero_val))
       << ExpectedGot(zero_val, si.F(0, 0));
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(si.F(0, 1) - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(si.F(0, 1), zero_val))
       << ExpectedGot(zero_val, si.F(0, 1));
 }
 
@@ -346,17 +339,13 @@ TYPED_TEST(PointStressIntegrandTest, ConstantConstructor) {
   stress_integrand_type si(F);
 
   // Verify all values are set to the constant
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(si.F(0, 0) - const_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(si.F(0, 0), const_val))
       << ExpectedGot(const_val, si.F(0, 0));
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(si.F(0, 1) - const_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(si.F(0, 1), const_val))
       << ExpectedGot(const_val, si.F(0, 1));
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(si.F(1, 0) - const_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(si.F(1, 0), const_val))
       << ExpectedGot(const_val, si.F(1, 0));
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(si.F(1, 1) - const_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(si.F(1, 1), const_val))
       << ExpectedGot(const_val, si.F(1, 1));
 }
 

--- a/tests/unit-tests/point/stress_tests.cpp
+++ b/tests/unit-tests/point/stress_tests.cpp
@@ -1,17 +1,14 @@
-#include "datatypes/simd.hpp"
 #include "enumerations/interface.hpp"
 #include "specfem/point/partial_derivatives.hpp"
 #include "specfem/point/stress.hpp"
 #include "specfem_setup.hpp"
 #include "test_macros.hpp"
+#include "utilities/simd.hpp"
 #include <Kokkos_Core.hpp>
 #include <gtest/gtest.h>
 #include <type_traits>
 
 using namespace specfem;
-
-// Define tolerance for floating point comparisons
-const type_real tol = 1e-6;
 
 // Base test fixture for stress tests with template parameter for SIMD
 template <bool UseSIMD> class PointStressTestUntyped : public ::testing::Test {
@@ -80,11 +77,9 @@ TYPED_TEST(PointStressTest, Stress2DAcoustic) {
   stress_type stress(T);
 
   // Verify values with transposed indexing
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(stress.T(0, 0) - val1) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(stress.T(0, 0), val1))
       << ExpectedGot(val1, stress.T(0, 0));
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(stress.T(0, 1) - val2) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(stress.T(0, 1), val2))
       << ExpectedGot(val2, stress.T(0, 1));
 }
 
@@ -134,17 +129,13 @@ TYPED_TEST(PointStressTest, Stress2DElastic) {
   stress_type stress(T);
 
   // Verify values with transposed indexing
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(stress.T(0, 0) - val11) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(stress.T(0, 0), val11))
       << ExpectedGot(val11, stress.T(0, 0));
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(stress.T(1, 0) - val21) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(stress.T(1, 0), val21))
       << ExpectedGot(val21, stress.T(1, 0));
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(stress.T(0, 1) - val12) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(stress.T(0, 1), val12))
       << ExpectedGot(val12, stress.T(0, 1));
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(stress.T(1, 1) - val22) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(stress.T(1, 1), val22))
       << ExpectedGot(val22, stress.T(1, 1));
 }
 
@@ -196,8 +187,7 @@ TYPED_TEST(PointStressTest, Stress2DPoroelastic) {
   for (int i = 0; i < 4; ++i) {
     for (int j = 0; j < 2; ++j) {
       int idx = i + j * 4;
-      EXPECT_TRUE(specfem::datatype::all_of(
-          Kokkos::abs(stress.T(i, j) - vals[idx]) < tol))
+      EXPECT_TRUE(specfem::utilities::is_close(stress.T(i, j), vals[idx]))
           << ExpectedGot(vals[idx], stress.T(i, j)) << " at index (" << i << ","
           << j << ")";
     }
@@ -240,14 +230,11 @@ TYPED_TEST(PointStressTest, Stress3DAcoustic) {
   stress_type stress(T);
 
   // Verify values with transposed indexing
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(stress.T(0, 0) - val1) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(stress.T(0, 0), val1))
       << ExpectedGot(val1, stress.T(0, 0));
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(stress.T(0, 1) - val2) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(stress.T(0, 1), val2))
       << ExpectedGot(val2, stress.T(0, 1));
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(stress.T(0, 2) - val3) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(stress.T(0, 2), val3))
       << ExpectedGot(val3, stress.T(0, 2));
 }
 
@@ -297,8 +284,7 @@ TYPED_TEST(PointStressTest, Stress3DElastic) {
   for (int i = 0; i < 3; ++i) {
     for (int j = 0; j < 3; ++j) {
       int idx = i + j * 3;
-      EXPECT_TRUE(specfem::datatype::all_of(
-          Kokkos::abs(stress.T(i, j) - vals[idx]) < tol))
+      EXPECT_TRUE(specfem::utilities::is_close(stress.T(i, j), vals[idx]))
           << ExpectedGot(vals[idx], stress.T(i, j)) << " at index (" << i << ","
           << j << ")";
     }
@@ -324,11 +310,9 @@ TYPED_TEST(PointStressTest, DefaultConstructor) {
   stress_type stress;
 
   // The values should be default initialized (to zero)
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(stress.T(0, 0) - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(stress.T(0, 0), zero_val))
       << ExpectedGot(zero_val, stress.T(0, 0));
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(stress.T(0, 1) - zero_val) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(stress.T(0, 1), zero_val))
       << ExpectedGot(zero_val, stress.T(0, 1));
 }
 
@@ -378,17 +362,13 @@ TEST_F(PointStressTestSerial, StressOperatorMultiply2D) {
   type_real expected_F11 = 5.3; // 3.0*0.7 + 4.0*0.8
 
   // Verify the calculation with transposed indexing
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(F(0, 0) - expected_F00) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(F(0, 0), expected_F00))
       << ExpectedGot(expected_F00, F(0, 0));
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(F(0, 1) - expected_F01) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(F(0, 1), expected_F01))
       << ExpectedGot(expected_F01, F(0, 1));
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(F(1, 0) - expected_F10) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(F(1, 0), expected_F10))
       << ExpectedGot(expected_F10, F(1, 0));
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(F(1, 1) - expected_F11) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(F(1, 1), expected_F11))
       << ExpectedGot(expected_F11, F(1, 1));
 }
 
@@ -423,11 +403,9 @@ TEST_F(PointStressTestSerial, StressOperatorMultiply2DAcoustic) {
   type_real expected_F01 = 8.3; // 5.0*0.7 + 6.0*0.8
 
   // Verify the calculation with transposed indexing
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(F(0, 0) - expected_F00) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(F(0, 0), expected_F00))
       << ExpectedGot(expected_F00, F(0, 0));
-  EXPECT_TRUE(
-      specfem::datatype::all_of(Kokkos::abs(F(0, 1) - expected_F01) < tol))
+  EXPECT_TRUE(specfem::utilities::is_close(F(0, 1), expected_F01))
       << ExpectedGot(expected_F01, F(0, 1));
 }
 


### PR DESCRIPTION
## Description

- Added function `specfem::utilities::is_close` that checks relative tolerance for both simd and non-simd values.
- Apply `is_close` to point tests.

## Issue Number

Closes #905

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
