### PR TITLE
Issue 919 - Add tests for macros in point_data and update operator==

### DIFF
--- a/core/specfem/point/impl/point_container.hpp
+++ b/core/specfem/point/impl/point_container.hpp
@@ -1,9 +1,7 @@
 #pragma once
 
 #include "datatypes/simd.hpp"
-#include "enumerations/accessor.hpp"
-#include "enumerations/dimension.hpp"
-#include "enumerations/medium.hpp"
+#include "enumerations/interface.hpp"
 #include "specfem_setup.hpp"
 #include <Kokkos_SIMD.hpp>
 #include <boost/preprocessor.hpp>
@@ -42,6 +40,13 @@
       if (std::abs(_point_data_container[i] -                                  \
                    other._point_data_container[i]) >                           \
           static_cast<type_real>(1e-6) * std::abs(_point_data_container[i])) { \
+        std::cout << "Point data mismatch at index " << i << ": "              \
+                  << _point_data_container[i]                                  \
+                  << " != " << other._point_data_container[i] << std::endl;    \
+        std::cout << "Difference: "                                            \
+                  << std::abs(_point_data_container[i] -                       \
+                              other._point_data_container[i])                  \
+                  << std::endl;                                                \
         return false;                                                          \
       }                                                                        \
     }                                                                          \

--- a/tests/unit-tests/point/kernels/dim2/acoustic_isotropic.cpp
+++ b/tests/unit-tests/point/kernels/dim2/acoustic_isotropic.cpp
@@ -46,10 +46,21 @@ TYPED_TEST(PointKernelsTest, AcousticIsotropic2D) {
   }
 
   // Create the kernels object
-  specfem::point::kernels<specfem::dimension::type::dim2,
-                          specfem::element::medium_tag::acoustic,
-                          specfem::element::property_tag::isotropic, using_simd>
-      kernels(rho, kappa);
+  using PointKernelType = specfem::point::kernels<
+      specfem::dimension::type::dim2, specfem::element::medium_tag::acoustic,
+      specfem::element::property_tag::isotropic, using_simd>;
+  PointKernelType kernels(rho, kappa);
+  PointKernelType kernels2;
+
+  kernels2.rho() = rho;
+  kernels2.kappa() = kappa;
+  kernels2.rhop() = expected_rhop;
+  kernels2.alpha() = expected_alpha;
+
+  simd_type data[] = { rho, kappa, expected_rhop, expected_alpha };
+
+  PointKernelType kernels3(data);
+  PointKernelType kernels4(rho);
 
   EXPECT_TRUE(specfem::utilities::is_close(kernels.rho(), rho))
       << ExpectedGot(rho, kernels.rho());
@@ -59,4 +70,14 @@ TYPED_TEST(PointKernelsTest, AcousticIsotropic2D) {
       << ExpectedGot(expected_rhop, kernels.rhop());
   EXPECT_TRUE(specfem::utilities::is_close(kernels.alpha(), expected_alpha))
       << ExpectedGot(expected_alpha, kernels.alpha());
+  EXPECT_TRUE(kernels == kernels2)
+      << ExpectedGot(kernels2.rho(), kernels.rho())
+      << ExpectedGot(kernels2.kappa(), kernels.kappa());
+  EXPECT_TRUE(kernels2 == kernels3)
+      << ExpectedGot(kernels3.rho(), kernels2.rho())
+      << ExpectedGot(kernels3.kappa(), kernels2.kappa());
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.rho(), rho))
+      << ExpectedGot(rho, kernels4.rho());
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.kappa(), rho))
+      << ExpectedGot(rho, kernels4.kappa());
 }

--- a/tests/unit-tests/point/kernels/dim2/elastic_anisotropic.cpp
+++ b/tests/unit-tests/point/kernels/dim2/elastic_anisotropic.cpp
@@ -58,10 +58,26 @@ TYPED_TEST(PointKernelsTest, ElasticAnisotropic2D) {
   }
 
   // Create the kernels object
-  specfem::point::kernels<
+  using PointKernelType = specfem::point::kernels<
       specfem::dimension::type::dim2, specfem::element::medium_tag::elastic,
-      specfem::element::property_tag::anisotropic, using_simd>
-      kernels(rho, c11, c13, c15, c33, c35, c55);
+      specfem::element::property_tag::anisotropic, using_simd>;
+  PointKernelType kernels(rho, c11, c13, c15, c33, c35, c55);
+
+  // Additional constructors and assignment tests
+  simd_type data[] = { rho, c11, c13, c15, c33, c35, c55 };
+
+  PointKernelType kernels2;
+  kernels2.rho() = rho;
+  kernels2.c11() = c11;
+  kernels2.c13() = c13;
+  kernels2.c15() = c15;
+  kernels2.c33() = c33;
+  kernels2.c35() = c35;
+  kernels2.c55() = c55;
+
+  PointKernelType kernels3(data);
+
+  PointKernelType kernels4(rho);
 
   EXPECT_TRUE(specfem::utilities::is_close(kernels.rho(), rho))
       << ExpectedGot(rho, kernels.rho());
@@ -77,4 +93,29 @@ TYPED_TEST(PointKernelsTest, ElasticAnisotropic2D) {
       << ExpectedGot(c35, kernels.c35());
   EXPECT_TRUE(specfem::utilities::is_close(kernels.c55(), c55))
       << ExpectedGot(c55, kernels.c55());
+
+  EXPECT_TRUE(kernels == kernels2)
+      << ExpectedGot(kernels2.rho(), kernels.rho())
+      << ExpectedGot(kernels2.c11(), kernels.c11())
+      << ExpectedGot(kernels2.c13(), kernels.c13())
+      << ExpectedGot(kernels2.c15(), kernels.c15())
+      << ExpectedGot(kernels2.c33(), kernels.c33())
+      << ExpectedGot(kernels2.c35(), kernels.c35())
+      << ExpectedGot(kernels2.c55(), kernels.c55());
+  EXPECT_TRUE(kernels2 == kernels3)
+      << ExpectedGot(kernels3.rho(), kernels2.rho())
+      << ExpectedGot(kernels3.c11(), kernels2.c11())
+      << ExpectedGot(kernels3.c13(), kernels2.c13())
+      << ExpectedGot(kernels3.c15(), kernels2.c15())
+      << ExpectedGot(kernels3.c33(), kernels2.c33())
+      << ExpectedGot(kernels3.c35(), kernels2.c35())
+      << ExpectedGot(kernels3.c55(), kernels2.c55());
+
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.rho(), rho));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.c11(), rho));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.c13(), rho));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.c15(), rho));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.c33(), rho));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.c35(), rho));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.c55(), rho));
 }

--- a/tests/unit-tests/point/kernels/dim2/elastic_isotropic.cpp
+++ b/tests/unit-tests/point/kernels/dim2/elastic_isotropic.cpp
@@ -54,10 +54,24 @@ TYPED_TEST(PointKernelsTest, ElasticIsotropic2D) {
   }
 
   // Create the kernels object
-  specfem::point::kernels<specfem::dimension::type::dim2,
-                          specfem::element::medium_tag::elastic,
-                          specfem::element::property_tag::isotropic, using_simd>
-      kernels(rho, mu, kappa, rhop, alpha, beta);
+  using PointKernelType = specfem::point::kernels<
+      specfem::dimension::type::dim2, specfem::element::medium_tag::elastic,
+      specfem::element::property_tag::isotropic, using_simd>;
+  PointKernelType kernels(rho, mu, kappa, rhop, alpha, beta);
+
+  // Additional constructors and assignment tests
+  PointKernelType kernels2;
+  kernels2.rho() = rho;
+  kernels2.mu() = mu;
+  kernels2.kappa() = kappa;
+  kernels2.rhop() = rhop;
+  kernels2.alpha() = alpha;
+  kernels2.beta() = beta;
+
+  simd_type data[] = { rho, mu, kappa, rhop, alpha, beta };
+  PointKernelType kernels3(data);
+
+  PointKernelType kernels4(rho);
 
   EXPECT_TRUE(specfem::utilities::is_close(kernels.rho(), rho))
       << ExpectedGot(rho, kernels.rho());
@@ -71,4 +85,26 @@ TYPED_TEST(PointKernelsTest, ElasticIsotropic2D) {
       << ExpectedGot(alpha, kernels.alpha());
   EXPECT_TRUE(specfem::utilities::is_close(kernels.beta(), beta))
       << ExpectedGot(beta, kernels.beta());
+
+  EXPECT_TRUE(kernels == kernels2)
+      << ExpectedGot(kernels2.rho(), kernels.rho())
+      << ExpectedGot(kernels2.mu(), kernels.mu())
+      << ExpectedGot(kernels2.kappa(), kernels.kappa())
+      << ExpectedGot(kernels2.rhop(), kernels.rhop())
+      << ExpectedGot(kernels2.alpha(), kernels.alpha())
+      << ExpectedGot(kernels2.beta(), kernels.beta());
+  EXPECT_TRUE(kernels2 == kernels3)
+      << ExpectedGot(kernels3.rho(), kernels2.rho())
+      << ExpectedGot(kernels3.mu(), kernels2.mu())
+      << ExpectedGot(kernels3.kappa(), kernels2.kappa())
+      << ExpectedGot(kernels3.rhop(), kernels2.rhop())
+      << ExpectedGot(kernels3.alpha(), kernels2.alpha())
+      << ExpectedGot(kernels3.beta(), kernels2.beta());
+
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.rho(), rho));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.mu(), rho));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.kappa(), rho));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.rhop(), rho));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.alpha(), rho));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.beta(), rho));
 }

--- a/tests/unit-tests/point/kernels/dim2/poroelastic_isotropic.cpp
+++ b/tests/unit-tests/point/kernels/dim2/poroelastic_isotropic.cpp
@@ -110,11 +110,11 @@ TYPED_TEST(PointKernelsTest, PoroelasticIsotropic2D) {
   }
 
   // Create the kernels object
-  specfem::point::kernels<specfem::dimension::type::dim2,
-                          specfem::element::medium_tag::poroelastic,
-                          specfem::element::property_tag::isotropic, using_simd>
-      kernels(rhot, rhof, eta, sm, mu_fr, B, C, M, cpI, cpII, cs, rhobb, rhofbb,
-              ratio, phib);
+  using PointKernelType = specfem::point::kernels<
+      specfem::dimension::type::dim2, specfem::element::medium_tag::poroelastic,
+      specfem::element::property_tag::isotropic, using_simd>;
+  PointKernelType kernels(rhot, rhof, eta, sm, mu_fr, B, C, M, cpI, cpII, cs,
+                          rhobb, rhofbb, ratio, phib);
 
   EXPECT_TRUE(specfem::utilities::is_close(kernels.rhot(), rhot))
       << ExpectedGot(rhot, kernels.rhot());
@@ -155,4 +155,98 @@ TYPED_TEST(PointKernelsTest, PoroelasticIsotropic2D) {
       << ExpectedGot(expected_rhofb, kernels.rhofb());
   EXPECT_TRUE(specfem::utilities::is_close(kernels.phi(), expected_phi))
       << ExpectedGot(expected_phi, kernels.phi());
+
+  PointKernelType kernels2;
+  kernels2.rhot() = rhot;
+  kernels2.rhof() = rhof;
+  kernels2.eta() = eta;
+  kernels2.sm() = sm;
+  kernels2.mu_fr() = mu_fr;
+  kernels2.B() = B;
+  kernels2.C() = C;
+  kernels2.M() = M;
+  kernels2.cpI() = cpI;
+  kernels2.cpII() = cpII;
+  kernels2.cs() = cs;
+  kernels2.rhobb() = rhobb;
+  kernels2.rhofbb() = rhofbb;
+  kernels2.ratio() = ratio;
+  kernels2.phib() = phib;
+  kernels2.mu_frb() = expected_mu_frb;
+  kernels2.rhob() = expected_rhob;
+  kernels2.rhofb() = expected_rhofb;
+  kernels2.phi() = expected_phi;
+
+  simd_type data[] = { rhot,
+                       rhof,
+                       eta,
+                       sm,
+                       mu_fr,
+                       B,
+                       C,
+                       M,
+                       mu_fr,
+                       expected_rhob,
+                       expected_rhofb,
+                       expected_phi,
+                       cpI,
+                       cpII,
+                       cs,
+                       rhobb,
+                       rhofbb,
+                       ratio,
+                       phib };
+  PointKernelType kernels3(data);
+
+  PointKernelType kernels4(rhot);
+
+  EXPECT_TRUE(kernels == kernels2)
+      << ExpectedGot(kernels2.rhot(), kernels.rhot())
+      << ExpectedGot(kernels2.rhof(), kernels.rhof())
+      << ExpectedGot(kernels2.eta(), kernels.eta())
+      << ExpectedGot(kernels2.sm(), kernels.sm())
+      << ExpectedGot(kernels2.mu_fr(), kernels.mu_fr())
+      << ExpectedGot(kernels2.B(), kernels.B())
+      << ExpectedGot(kernels2.C(), kernels.C())
+      << ExpectedGot(kernels2.M(), kernels.M())
+      << ExpectedGot(kernels2.cpI(), kernels.cpI())
+      << ExpectedGot(kernels2.cpII(), kernels.cpII())
+      << ExpectedGot(kernels2.cs(), kernels.cs())
+      << ExpectedGot(kernels2.rhobb(), kernels.rhobb())
+      << ExpectedGot(kernels2.rhofbb(), kernels.rhofbb())
+      << ExpectedGot(kernels2.ratio(), kernels.ratio())
+      << ExpectedGot(kernels2.phib(), kernels.phib());
+
+  EXPECT_TRUE(kernels2 == kernels3)
+      << ExpectedGot(kernels3.rhot(), kernels2.rhot())
+      << ExpectedGot(kernels3.rhof(), kernels2.rhof())
+      << ExpectedGot(kernels3.eta(), kernels2.eta())
+      << ExpectedGot(kernels3.sm(), kernels2.sm())
+      << ExpectedGot(kernels3.mu_fr(), kernels2.mu_fr())
+      << ExpectedGot(kernels3.B(), kernels2.B())
+      << ExpectedGot(kernels3.C(), kernels2.C())
+      << ExpectedGot(kernels3.M(), kernels2.M())
+      << ExpectedGot(kernels3.cpI(), kernels2.cpI())
+      << ExpectedGot(kernels3.cpII(), kernels2.cpII())
+      << ExpectedGot(kernels3.cs(), kernels2.cs())
+      << ExpectedGot(kernels3.rhobb(), kernels2.rhobb())
+      << ExpectedGot(kernels3.rhofbb(), kernels2.rhofbb())
+      << ExpectedGot(kernels3.ratio(), kernels2.ratio())
+      << ExpectedGot(kernels3.phib(), kernels2.phib());
+
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.rhot(), rhot));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.rhof(), rhot));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.eta(), rhot));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.sm(), rhot));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.mu_fr(), rhot));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.B(), rhot));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.C(), rhot));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.M(), rhot));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.cpI(), rhot));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.cpII(), rhot));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.cs(), rhot));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.rhobb(), rhot));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.rhofbb(), rhot));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.ratio(), rhot));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.phib(), rhot));
 }

--- a/tests/unit-tests/point/kernels/dim3/elastic_isotropic.cpp
+++ b/tests/unit-tests/point/kernels/dim3/elastic_isotropic.cpp
@@ -56,10 +56,24 @@ TYPED_TEST(PointKernelsTest, ElasticIsotropic3D) {
   }
 
   // Create the kernels object
-  specfem::point::kernels<specfem::dimension::type::dim3,
-                          specfem::element::medium_tag::elastic,
-                          specfem::element::property_tag::isotropic, using_simd>
-      kernels(rho, mu, kappa, rhop, alpha, beta);
+  using PointKernelType = specfem::point::kernels<
+      specfem::dimension::type::dim3, specfem::element::medium_tag::elastic,
+      specfem::element::property_tag::isotropic, using_simd>;
+  PointKernelType kernels(rho, mu, kappa, rhop, alpha, beta);
+
+  // Additional constructors and assignment tests (like 2D)
+  PointKernelType kernels2;
+  kernels2.rho() = rho;
+  kernels2.mu() = mu;
+  kernels2.kappa() = kappa;
+  kernels2.rhop() = rhop;
+  kernels2.alpha() = alpha;
+  kernels2.beta() = beta;
+
+  simd_type data[] = { rho, mu, kappa, rhop, alpha, beta };
+  PointKernelType kernels3(data);
+
+  PointKernelType kernels4(rho);
 
   EXPECT_TRUE(specfem::utilities::is_close(kernels.rho(), rho))
       << ExpectedGot(rho, kernels.rho());
@@ -73,4 +87,27 @@ TYPED_TEST(PointKernelsTest, ElasticIsotropic3D) {
       << ExpectedGot(alpha, kernels.alpha());
   EXPECT_TRUE(specfem::utilities::is_close(kernels.beta(), beta))
       << ExpectedGot(beta, kernels.beta());
+
+  EXPECT_TRUE(kernels == kernels2)
+      << ExpectedGot(kernels2.rho(), kernels.rho())
+      << ExpectedGot(kernels2.mu(), kernels.mu())
+      << ExpectedGot(kernels2.kappa(), kernels.kappa())
+      << ExpectedGot(kernels2.rhop(), kernels.rhop())
+      << ExpectedGot(kernels2.alpha(), kernels.alpha())
+      << ExpectedGot(kernels2.beta(), kernels.beta());
+
+  EXPECT_TRUE(kernels2 == kernels3)
+      << ExpectedGot(kernels3.rho(), kernels2.rho())
+      << ExpectedGot(kernels3.mu(), kernels2.mu())
+      << ExpectedGot(kernels3.kappa(), kernels2.kappa())
+      << ExpectedGot(kernels3.rhop(), kernels2.rhop())
+      << ExpectedGot(kernels3.alpha(), kernels2.alpha())
+      << ExpectedGot(kernels3.beta(), kernels2.beta());
+
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.rho(), rho));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.mu(), rho));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.kappa(), rho));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.rhop(), rho));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.alpha(), rho));
+  EXPECT_TRUE(specfem::utilities::is_close(kernels4.beta(), rho));
 }

--- a/tests/unit-tests/point/properties/dim2/acoustic_isotropic.cpp
+++ b/tests/unit-tests/point/properties/dim2/acoustic_isotropic.cpp
@@ -51,10 +51,10 @@ TYPED_TEST(PointPropertiesTest, AcousticIsotropic2D) {
   }
 
   // Create the properties object
-  specfem::point::properties<
+  using PointPropertiesType = specfem::point::properties<
       specfem::dimension::type::dim2, specfem::element::medium_tag::acoustic,
-      specfem::element::property_tag::isotropic, using_simd>
-      props(rho_inv, kappa);
+      specfem::element::property_tag::isotropic, using_simd>;
+  PointPropertiesType props(rho_inv, kappa);
 
   EXPECT_TRUE(specfem::utilities::is_close(props.rho_inverse(), rho_inv))
       << ExpectedGot(kappa, props.rho_inverse());
@@ -65,4 +65,24 @@ TYPED_TEST(PointPropertiesTest, AcousticIsotropic2D) {
       << ExpectedGot(kappa_inv, props.kappa_inverse());
   EXPECT_TRUE(specfem::utilities::is_close(props.rho_vpinverse(), rho_vpinv))
       << ExpectedGot(rho_vpinv, props.rho_vpinverse());
+
+  PointPropertiesType props2;
+  props2.rho_inverse() = rho_inv;
+  props2.kappa() = kappa;
+
+  simd_type data[] = { rho_inv, kappa };
+  PointPropertiesType props3(data);
+
+  PointPropertiesType props4(rho_inv);
+
+  EXPECT_TRUE(props2 == props)
+      << ExpectedGot(props2.rho_inverse(), props.rho_inverse())
+      << ExpectedGot(props2.kappa(), props.kappa());
+
+  EXPECT_TRUE(props2 == props3)
+      << ExpectedGot(props3.rho_inverse(), props2.rho_inverse())
+      << ExpectedGot(props3.kappa(), props2.kappa());
+
+  EXPECT_TRUE(specfem::utilities::is_close(props4.rho_inverse(), rho_inv));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.kappa(), rho_inv));
 }

--- a/tests/unit-tests/point/properties/dim2/elastic_anisotropic.cpp
+++ b/tests/unit-tests/point/properties/dim2/elastic_anisotropic.cpp
@@ -84,10 +84,61 @@ TYPED_TEST(PointPropertiesTest, ElasticAnisotropic2D) {
   }
 
   // Create the properties object
-  specfem::point::properties<
+  using PointPropertiesType = specfem::point::properties<
       specfem::dimension::type::dim2, specfem::element::medium_tag::elastic,
-      specfem::element::property_tag::anisotropic, using_simd>
-      props(c11, c13, c15, c33, c35, c55, c12, c23, c25, rho);
+      specfem::element::property_tag::anisotropic, using_simd>;
+  PointPropertiesType props(c11, c13, c15, c33, c35, c55, c12, c23, c25, rho);
+
+  // Additional constructors and assignment tests
+  PointPropertiesType props2;
+  props2.c11() = c11;
+  props2.c13() = c13;
+  props2.c15() = c15;
+  props2.c33() = c33;
+  props2.c35() = c35;
+  props2.c55() = c55;
+  props2.c12() = c12;
+  props2.c23() = c23;
+  props2.c25() = c25;
+  props2.rho() = rho;
+
+  simd_type data[] = { c11, c13, c15, c33, c35, c55, c12, c23, c25, rho };
+  PointPropertiesType props3(data);
+
+  PointPropertiesType props4(c11);
+
+  EXPECT_TRUE(props2 == props) << ExpectedGot(props2.c11(), props.c11())
+                               << ExpectedGot(props2.c13(), props.c13())
+                               << ExpectedGot(props2.c15(), props.c15())
+                               << ExpectedGot(props2.c33(), props.c33())
+                               << ExpectedGot(props2.c35(), props.c35())
+                               << ExpectedGot(props2.c55(), props.c55())
+                               << ExpectedGot(props2.c12(), props.c12())
+                               << ExpectedGot(props2.c23(), props.c23())
+                               << ExpectedGot(props2.c25(), props.c25())
+                               << ExpectedGot(props2.rho(), props.rho());
+
+  EXPECT_TRUE(props2 == props3) << ExpectedGot(props3.c11(), props2.c11())
+                                << ExpectedGot(props3.c13(), props2.c13())
+                                << ExpectedGot(props3.c15(), props2.c15())
+                                << ExpectedGot(props3.c33(), props2.c33())
+                                << ExpectedGot(props3.c35(), props2.c35())
+                                << ExpectedGot(props3.c55(), props2.c55())
+                                << ExpectedGot(props3.c12(), props2.c12())
+                                << ExpectedGot(props3.c23(), props2.c23())
+                                << ExpectedGot(props3.c25(), props2.c25())
+                                << ExpectedGot(props3.rho(), props2.rho());
+
+  EXPECT_TRUE(specfem::utilities::is_close(props4.c11(), c11));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.c13(), c11));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.c15(), c11));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.c33(), c11));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.c35(), c11));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.c55(), c11));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.c12(), c11));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.c23(), c11));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.c25(), c11));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.rho(), c11));
 
   EXPECT_TRUE(specfem::utilities::is_close(props.c11(), c11))
       << ExpectedGot(c11, props.c11());

--- a/tests/unit-tests/point/properties/dim2/elastic_isotropic.cpp
+++ b/tests/unit-tests/point/properties/dim2/elastic_isotropic.cpp
@@ -67,10 +67,10 @@ TYPED_TEST(PointPropertiesTest, ElasticIsotropic2D) {
   }
 
   // Create the properties object
-  specfem::point::properties<
+  using PointPropertiesType = specfem::point::properties<
       specfem::dimension::type::dim2, specfem::element::medium_tag::elastic,
-      specfem::element::property_tag::isotropic, using_simd>
-      props(lambdaplus2mu, mu, rho);
+      specfem::element::property_tag::isotropic, using_simd>;
+  PointPropertiesType props(lambdaplus2mu, mu, rho);
 
   EXPECT_TRUE(
       specfem::utilities::is_close(props.lambdaplus2mu(), lambdaplus2mu))
@@ -88,4 +88,30 @@ TYPED_TEST(PointPropertiesTest, ElasticIsotropic2D) {
   EXPECT_TRUE(specfem::utilities::is_close(
       props.lambda(), lambdaplus2mu - static_cast<type_real>(2.0) * mu))
       << ExpectedGot(lambda, props.lambda());
+
+  // Additional constructors and assignment tests
+  PointPropertiesType props2;
+  props2.lambdaplus2mu() = lambdaplus2mu;
+  props2.mu() = mu;
+  props2.rho() = rho;
+
+  simd_type data[] = { lambdaplus2mu, mu, rho };
+  PointPropertiesType props3(data);
+
+  PointPropertiesType props4(lambdaplus2mu);
+
+  EXPECT_TRUE(props2 == props)
+      << ExpectedGot(props2.lambdaplus2mu(), props.lambdaplus2mu())
+      << ExpectedGot(props2.mu(), props.mu())
+      << ExpectedGot(props2.rho(), props.rho());
+
+  EXPECT_TRUE(props2 == props3)
+      << ExpectedGot(props3.lambdaplus2mu(), props2.lambdaplus2mu())
+      << ExpectedGot(props3.mu(), props2.mu())
+      << ExpectedGot(props3.rho(), props2.rho());
+
+  EXPECT_TRUE(
+      specfem::utilities::is_close(props4.lambdaplus2mu(), lambdaplus2mu));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.mu(), lambdaplus2mu));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.rho(), lambdaplus2mu));
 }

--- a/tests/unit-tests/point/properties/dim2/electromagnetic_isotropic.cpp
+++ b/tests/unit-tests/point/properties/dim2/electromagnetic_isotropic.cpp
@@ -44,11 +44,12 @@ TYPED_TEST(PointPropertiesTest, ElectromagneticIsotropic2D) {
   }
 
   // Create the properties object
-  specfem::point::properties<specfem::dimension::type::dim2,
-                             specfem::element::medium_tag::electromagnetic,
-                             specfem::element::property_tag::isotropic,
-                             using_simd>
-      props(mu0_inv, eps11, eps33, sig11, sig33);
+  using PointPropertiesType =
+      specfem::point::properties<specfem::dimension::type::dim2,
+                                 specfem::element::medium_tag::electromagnetic,
+                                 specfem::element::property_tag::isotropic,
+                                 using_simd>;
+  PointPropertiesType props(mu0_inv, eps11, eps33, sig11, sig33);
 
   EXPECT_TRUE(specfem::utilities::is_close(props.mu0_inv(), mu0_inv))
       << ExpectedGot(mu0_inv, props.mu0_inv());
@@ -60,4 +61,36 @@ TYPED_TEST(PointPropertiesTest, ElectromagneticIsotropic2D) {
       << ExpectedGot(sig11, props.sig11());
   EXPECT_TRUE(specfem::utilities::is_close(props.sig33(), sig33))
       << ExpectedGot(sig33, props.sig33());
+
+  // Additional constructors and assignment tests
+  PointPropertiesType props2;
+  props2.mu0_inv() = mu0_inv;
+  props2.eps11() = eps11;
+  props2.eps33() = eps33;
+  props2.sig11() = sig11;
+  props2.sig33() = sig33;
+
+  simd_type data[] = { mu0_inv, eps11, eps33, sig11, sig33 };
+  PointPropertiesType props3(data);
+
+  PointPropertiesType props4(mu0_inv);
+
+  EXPECT_TRUE(props2 == props) << ExpectedGot(props2.mu0_inv(), props.mu0_inv())
+                               << ExpectedGot(props2.eps11(), props.eps11())
+                               << ExpectedGot(props2.eps33(), props.eps33())
+                               << ExpectedGot(props2.sig11(), props.sig11())
+                               << ExpectedGot(props2.sig33(), props.sig33());
+
+  EXPECT_TRUE(props2 == props3)
+      << ExpectedGot(props3.mu0_inv(), props2.mu0_inv())
+      << ExpectedGot(props3.eps11(), props2.eps11())
+      << ExpectedGot(props3.eps33(), props2.eps33())
+      << ExpectedGot(props3.sig11(), props2.sig11())
+      << ExpectedGot(props3.sig33(), props2.sig33());
+
+  EXPECT_TRUE(specfem::utilities::is_close(props4.mu0_inv(), mu0_inv));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.eps11(), mu0_inv));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.eps33(), mu0_inv));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.sig11(), mu0_inv));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.sig33(), mu0_inv));
 }

--- a/tests/unit-tests/point/properties/dim2/poroelastic_isotropic.cpp
+++ b/tests/unit-tests/point/properties/dim2/poroelastic_isotropic.cpp
@@ -128,11 +128,11 @@ TYPED_TEST(PointPropertiesTest, PoroelasticIsotropic2D) {
   }
 
   // Create the properties object
-  specfem::point::properties<
+  using PointPropertiesType = specfem::point::properties<
       specfem::dimension::type::dim2, specfem::element::medium_tag::poroelastic,
-      specfem::element::property_tag::isotropic, using_simd>
-      props(phi, rho_s, rho_f, tortuosity, mu_G, H_Biot, C_Biot, M_Biot, permxx,
-            permxz, permzz, eta_f);
+      specfem::element::property_tag::isotropic, using_simd>;
+  PointPropertiesType props(phi, rho_s, rho_f, tortuosity, mu_G, H_Biot, C_Biot,
+                            M_Biot, permxx, permxz, permzz, eta_f);
 
   EXPECT_TRUE(specfem::utilities::is_close(props.phi(), phi))
       << ExpectedGot(phi, props.phi());
@@ -191,4 +191,66 @@ TYPED_TEST(PointPropertiesTest, PoroelasticIsotropic2D) {
       << ExpectedGot(props.vpII(), props.vpI());
   EXPECT_TRUE(specfem::utilities::is_close(props.vs(), vs_expected))
       << ExpectedGot(vs_expected, props.vs());
+
+  // Additional constructors and assignment tests
+  PointPropertiesType props2;
+  props2.phi() = phi;
+  props2.rho_s() = rho_s;
+  props2.rho_f() = rho_f;
+  props2.tortuosity() = tortuosity;
+  props2.mu_G() = mu_G;
+  props2.H_Biot() = H_Biot;
+  props2.C_Biot() = C_Biot;
+  props2.M_Biot() = M_Biot;
+  props2.permxx() = permxx;
+  props2.permxz() = permxz;
+  props2.permzz() = permzz;
+  props2.eta_f() = eta_f;
+
+  simd_type data[] = { phi,    rho_s,  rho_f,  tortuosity, mu_G,   H_Biot,
+                       C_Biot, M_Biot, permxx, permxz,     permzz, eta_f };
+  PointPropertiesType props3(data);
+
+  PointPropertiesType props4(phi);
+
+  EXPECT_TRUE(props2 == props)
+      << ExpectedGot(props2.phi(), props.phi())
+      << ExpectedGot(props2.rho_s(), props.rho_s())
+      << ExpectedGot(props2.rho_f(), props.rho_f())
+      << ExpectedGot(props2.tortuosity(), props.tortuosity())
+      << ExpectedGot(props2.mu_G(), props.mu_G())
+      << ExpectedGot(props2.H_Biot(), props.H_Biot())
+      << ExpectedGot(props2.C_Biot(), props.C_Biot())
+      << ExpectedGot(props2.M_Biot(), props.M_Biot())
+      << ExpectedGot(props2.permxx(), props.permxx())
+      << ExpectedGot(props2.permxz(), props.permxz())
+      << ExpectedGot(props2.permzz(), props.permzz())
+      << ExpectedGot(props2.eta_f(), props.eta_f());
+
+  EXPECT_TRUE(props2 == props3)
+      << ExpectedGot(props3.phi(), props2.phi())
+      << ExpectedGot(props3.rho_s(), props2.rho_s())
+      << ExpectedGot(props3.rho_f(), props2.rho_f())
+      << ExpectedGot(props3.tortuosity(), props2.tortuosity())
+      << ExpectedGot(props3.mu_G(), props2.mu_G())
+      << ExpectedGot(props3.H_Biot(), props2.H_Biot())
+      << ExpectedGot(props3.C_Biot(), props2.C_Biot())
+      << ExpectedGot(props3.M_Biot(), props2.M_Biot())
+      << ExpectedGot(props3.permxx(), props2.permxx())
+      << ExpectedGot(props3.permxz(), props2.permxz())
+      << ExpectedGot(props3.permzz(), props2.permzz())
+      << ExpectedGot(props3.eta_f(), props2.eta_f());
+
+  EXPECT_TRUE(specfem::utilities::is_close(props4.phi(), phi));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.rho_s(), phi));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.rho_f(), phi));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.tortuosity(), phi));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.mu_G(), phi));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.H_Biot(), phi));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.C_Biot(), phi));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.M_Biot(), phi));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.permxx(), phi));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.permxz(), phi));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.permzz(), phi));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.eta_f(), phi));
 }

--- a/tests/unit-tests/point/properties/dim3/elastic_isotropic.cpp
+++ b/tests/unit-tests/point/properties/dim3/elastic_isotropic.cpp
@@ -67,10 +67,10 @@ TYPED_TEST(PointPropertiesTest, ElasticIsotropic3D) {
   }
 
   // Create the properties object
-  specfem::point::properties<
+  using PointPropertiesType = specfem::point::properties<
       specfem::dimension::type::dim3, specfem::element::medium_tag::elastic,
-      specfem::element::property_tag::isotropic, using_simd>
-      props(kappa, mu, rho);
+      specfem::element::property_tag::isotropic, using_simd>;
+  PointPropertiesType props(kappa, mu, rho);
 
   EXPECT_TRUE(specfem::utilities::is_close(props.kappa(), kappa))
       << ExpectedGot(kappa, props.kappa());
@@ -88,4 +88,27 @@ TYPED_TEST(PointPropertiesTest, ElasticIsotropic3D) {
       << ExpectedGot(rho_vp_val, props.rho_vp());
   EXPECT_TRUE(specfem::utilities::is_close(props.rho_vs(), rho_vs_val))
       << ExpectedGot(rho_vs_val, props.rho_vs());
+
+  // Additional constructors and assignment tests
+  PointPropertiesType props2;
+  props2.kappa() = kappa;
+  props2.mu() = mu;
+  props2.rho() = rho;
+
+  simd_type data[] = { kappa, mu, rho };
+  PointPropertiesType props3(data);
+
+  PointPropertiesType props4(kappa);
+
+  EXPECT_TRUE(props2 == props) << ExpectedGot(props2.kappa(), props.kappa())
+                               << ExpectedGot(props2.mu(), props.mu())
+                               << ExpectedGot(props2.rho(), props.rho());
+
+  EXPECT_TRUE(props2 == props3) << ExpectedGot(props3.kappa(), props2.kappa())
+                                << ExpectedGot(props3.mu(), props2.mu())
+                                << ExpectedGot(props3.rho(), props2.rho());
+
+  EXPECT_TRUE(specfem::utilities::is_close(props4.kappa(), kappa));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.mu(), kappa));
+  EXPECT_TRUE(specfem::utilities::is_close(props4.rho(), kappa));
 }


### PR DESCRIPTION
## Description

- Update `point_data operator==` with `is_close`
- Add tests to cover constructors and operators in `point_data`

## Issue Number

Closes #919 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
