### PR TITLE
Issue 861 - Updating the tests to be able to run the executable from the test directory

### DIFF
--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -327,12 +327,12 @@ target_link_libraries(
 )
 
 add_executable(
-  policies
+  policies_tests
   policies/policies.cpp
 )
 
 target_link_libraries(
-  policies
+  policies_tests
   mesh
   source_class
   receiver_class
@@ -507,29 +507,59 @@ target_link_libraries(
 #   -lpthread -lm
 # )
 
-# Link to gtest only if MPI is enabled
+
+
+
+# Link to gtest only if MPI is disabled
 if (NOT MPI_PARALLEL)
   include(GoogleTest)
-  gtest_discover_tests(gll_tests WORKING_DIRECTORY ${TEST_DIR})
-  gtest_discover_tests(lagrange_tests WORKING_DIRECTORY ${TEST_DIR})
-  gtest_discover_tests(jacobian_tests WORKING_DIRECTORY ${TEST_DIR})
-  gtest_discover_tests(fortranio_test WORKING_DIRECTORY ${TEST_DIR})
-  gtest_discover_tests(io_tests WORKING_DIRECTORY ${TEST_DIR})
-  gtest_discover_tests(mesh_tests WORKING_DIRECTORY ${TEST_DIR})
-  gtest_discover_tests(compute_jacobian_matrix_tests WORKING_DIRECTORY ${TEST_DIR})
-  # gtest_discover_tests(compute_elastic_tests WORKING_DIRECTORY ${TEST_DIR})
-  # # gtest_discover_tests(compute_acoustic_tests WORKING_DIRECTORY ${TEST_DIR})
-  # gtest_discover_tests(compute_coupled_interfaces_tests WORKING_DIRECTORY ${TEST_DIR})
-  gtest_discover_tests(point_tests WORKING_DIRECTORY ${TEST_DIR})
-  gtest_discover_tests(compute_tests WORKING_DIRECTORY ${TEST_DIR})
-  gtest_discover_tests(assembly_tests WORKING_DIRECTORY ${TEST_DIR})
-  gtest_discover_tests(policies WORKING_DIRECTORY ${TEST_DIR})
-  gtest_discover_tests(interpolate_function WORKING_DIRECTORY ${TEST_DIR})
-  gtest_discover_tests(mass_matrix_tests WORKING_DIRECTORY ${TEST_DIR})
-  gtest_discover_tests(stress_tests WORKING_DIRECTORY ${TEST_DIR})
-  gtest_discover_tests(rmass_inverse_tests WORKING_DIRECTORY ${TEST_DIR})
-  gtest_discover_tests(simd_tests WORKING_DIRECTORY ${TEST_DIR})
-  gtest_discover_tests(displacement_newmark_tests WORKING_DIRECTORY ${TEST_DIR})
+  gtest_discover_tests(gll_tests)
+  gtest_discover_tests(lagrange_tests)
+  gtest_discover_tests(jacobian_tests)
+  gtest_discover_tests(fortranio_test)
+  gtest_discover_tests(io_tests)
+  gtest_discover_tests(mesh_tests)
+  gtest_discover_tests(compute_jacobian_matrix_tests)
+  # gtest_discover_tests(compute_elastic_tests)
+  # # gtest_discover_tests(compute_acoustic_tests)
+  # gtest_discover_tests(compute_coupled_interfaces_tests)
+  gtest_discover_tests(point_tests)
+  gtest_discover_tests(compute_tests)
+  gtest_discover_tests(assembly_tests)
+  gtest_discover_tests(policies_tests)
+  gtest_discover_tests(interpolate_function)
+  gtest_discover_tests(mass_matrix_tests)
+  gtest_discover_tests(stress_tests)
+  gtest_discover_tests(rmass_inverse_tests)
+  gtest_discover_tests(simd_tests)
+  gtest_discover_tests(displacement_newmark_tests)
+
+  # For tests that require data files from the tests directory,
+  # create symbolic links to the test data directory so that
+  # the tests can access them from the build folder.
+
+  set(LINK_DIRS
+    algorithms
+    assembly
+    data
+    displacement_tests
+    domain
+    fortran_io
+    io
+    mesh
+    policies
+  )
+
+  foreach(dir_name IN LISTS LINK_DIRS)
+      file(CREATE_LINK
+          ${CMAKE_CURRENT_SOURCE_DIR}/${dir_name}
+          ${CMAKE_CURRENT_BINARY_DIR}/${dir_name}
+          SYMBOLIC)
+  endforeach()
+
+
+
+
   # gtest_discover_tests(seismogram_elastic_tests)
   # gtest_discover_tests(seismogram_acoustic_tests)
 endif(NOT MPI_PARALLEL)


### PR DESCRIPTION
## Description

This update enables to 
```bash
cd build/release/tests/unit-tests/
#e.g.
./displacement_newmark_tests
```
for easier debugging of single executable tests in the working directory.

## Issue Number

Closes #861

## Checklist

Please make sure to check developer documentation on specfem docs.

- [x] I ran the code through pre-commit to check style
- [x] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [x] I have added labels to the PR (see right hand side of the PR page)
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
