### PR TITLE
Add 3D material definitions.

### DIFF
--- a/core/specfem/assembly/mesh/dim2/impl/mesh_to_compute_mapping.hpp
+++ b/core/specfem/assembly/mesh/dim2/impl/mesh_to_compute_mapping.hpp
@@ -23,7 +23,7 @@ namespace specfem::assembly::mesh_impl {
  *
  */
 template <> struct mesh_to_compute_mapping<specfem::dimension::type::dim2> {
-  constexpr static auto dimension =
+  constexpr static auto dimension_tag =
       specfem::dimension::type::dim2; ///< Dimension
   int nspec;                          ///< Number of spectral elements
 
@@ -47,6 +47,6 @@ template <> struct mesh_to_compute_mapping<specfem::dimension::type::dim2> {
    *
    * @param tags Tags for every spectral element within the mesh
    */
-  mesh_to_compute_mapping(const specfem::mesh::tags<dimension> &tags);
+  mesh_to_compute_mapping(const specfem::mesh::tags<dimension_tag> &tags);
 };
 } // namespace specfem::assembly::mesh_impl

--- a/core/specfem/assembly/mesh/dim2/impl/mesh_to_compute_mapping.tpp
+++ b/core/specfem/assembly/mesh/dim2/impl/mesh_to_compute_mapping.tpp
@@ -15,14 +15,14 @@ specfem::assembly::mesh_impl::mesh_to_compute_mapping<
 
   const int nspec = tags.nspec;
 
-  constexpr auto element_types = specfem::element::element_types();
+  constexpr auto element_types = specfem::element::element_types<dimension_tag>();
   constexpr int total_element_types = element_types.size();
 
   std::array<std::vector<int>, total_element_types> element_type_ispec;
   int total_counted = 0;
 
   for (int i = 0; i < total_element_types; i++) {
-    const auto [dimension, medium_tag, property_tag, boundary_tag] =
+    const auto [dimension_tag, medium_tag, property_tag, boundary_tag] =
         element_types[i];
     for (int ispec = 0; ispec < nspec; ispec++) {
       const auto tag = tags.tags_container(ispec);

--- a/include/enumerations/material_definitions.hpp
+++ b/include/enumerations/material_definitions.hpp
@@ -11,6 +11,7 @@
  */
 /// @{
 #define DIMENSION_TAG_DIM2 (0, specfem::dimension::type::dim2, dim2)
+#define DIMENSION_TAG_DIM3 (1, specfem::dimension::type::dim3, dim3)
 
 #define MEDIUM_TAG_ELASTIC_PSV                                                 \
   (0, specfem::element::medium_tag::elastic_psv, elastic_psv)
@@ -51,7 +52,8 @@
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_PSV_T))(                         \
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_ACOUSTIC))(                              \
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_POROELASTIC))(                           \
-      (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELECTROMAGNETIC_TE))
+      (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELECTROMAGNETIC_TE))(                    \
+      (DIMENSION_TAG_DIM3, MEDIUM_TAG_ELASTIC_PSV))
 
 /**
  * @brief Macro to generate a list of material systems
@@ -67,7 +69,8 @@
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_ACOUSTIC, PROPERTY_TAG_ISOTROPIC))(      \
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_POROELASTIC, PROPERTY_TAG_ISOTROPIC))(   \
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELECTROMAGNETIC_TE,                      \
-       PROPERTY_TAG_ISOTROPIC))
+       PROPERTY_TAG_ISOTROPIC))(                                               \
+      (DIMENSION_TAG_DIM3, MEDIUM_TAG_ELASTIC_PSV, PROPERTY_TAG_ISOTROPIC))
 
 /**
  * @brief Macro to generate a list of element types
@@ -100,7 +103,9 @@
        BOUNDARY_TAG_NONE))((DIMENSION_TAG_DIM2, MEDIUM_TAG_POROELASTIC,        \
                             PROPERTY_TAG_ISOTROPIC, BOUNDARY_TAG_STACEY))(     \
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELECTROMAGNETIC_TE,                      \
-       PROPERTY_TAG_ISOTROPIC, BOUNDARY_TAG_NONE))
+       PROPERTY_TAG_ISOTROPIC,                                                 \
+       BOUNDARY_TAG_NONE))((DIMENSION_TAG_DIM3, MEDIUM_TAG_ELASTIC_PSV,        \
+                            PROPERTY_TAG_ISOTROPIC, BOUNDARY_TAG_NONE))
 
 /**
  * @brief Tag getters. The macros are intended to be used only in @ref DECLARE

--- a/include/enumerations/material_definitions.hpp
+++ b/include/enumerations/material_definitions.hpp
@@ -46,20 +46,23 @@
  * @brief Macro to generate a list of medium types
  *
  */
-#define MEDIUM_TAGS                                                            \
+#define MEDIUM_TAGS_DIM2                                                       \
   ((DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_PSV))(                              \
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_SH))(                            \
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_PSV_T))(                         \
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_ACOUSTIC))(                              \
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_POROELASTIC))(                           \
-      (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELECTROMAGNETIC_TE))(                    \
-      (DIMENSION_TAG_DIM3, MEDIUM_TAG_ELASTIC_PSV))
+      (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELECTROMAGNETIC_TE))
+
+#define MEDIUM_TAGS_DIM3 ((DIMENSION_TAG_DIM3, MEDIUM_TAG_ELASTIC_PSV))
+
+#define MEDIUM_TAGS MEDIUM_TAGS_DIM2 MEDIUM_TAGS_DIM3
 
 /**
  * @brief Macro to generate a list of material systems
  *
  */
-#define MATERIAL_SYSTEMS                                                       \
+#define MATERIAL_SYSTEMS_DIM2                                                  \
   ((DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_PSV, PROPERTY_TAG_ISOTROPIC))(      \
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_PSV, PROPERTY_TAG_ANISOTROPIC))( \
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_SH, PROPERTY_TAG_ISOTROPIC))(    \
@@ -69,14 +72,18 @@
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_ACOUSTIC, PROPERTY_TAG_ISOTROPIC))(      \
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_POROELASTIC, PROPERTY_TAG_ISOTROPIC))(   \
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELECTROMAGNETIC_TE,                      \
-       PROPERTY_TAG_ISOTROPIC))(                                               \
-      (DIMENSION_TAG_DIM3, MEDIUM_TAG_ELASTIC_PSV, PROPERTY_TAG_ISOTROPIC))
+       PROPERTY_TAG_ISOTROPIC))
+
+#define MATERIAL_SYSTEMS_DIM3                                                  \
+  ((DIMENSION_TAG_DIM3, MEDIUM_TAG_ELASTIC_PSV, PROPERTY_TAG_ISOTROPIC))
+
+#define MATERIAL_SYSTEMS MATERIAL_SYSTEMS_DIM2 MATERIAL_SYSTEMS_DIM3
 
 /**
  * @brief Macro to generate a list of element types
  *
  */
-#define ELEMENT_TYPES                                                          \
+#define ELEMENT_TYPES_DIM2                                                     \
   ((DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_PSV, PROPERTY_TAG_ISOTROPIC,        \
     BOUNDARY_TAG_NONE))((DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_PSV,           \
                          PROPERTY_TAG_ISOTROPIC, BOUNDARY_TAG_STACEY))(        \
@@ -103,9 +110,13 @@
        BOUNDARY_TAG_NONE))((DIMENSION_TAG_DIM2, MEDIUM_TAG_POROELASTIC,        \
                             PROPERTY_TAG_ISOTROPIC, BOUNDARY_TAG_STACEY))(     \
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELECTROMAGNETIC_TE,                      \
-       PROPERTY_TAG_ISOTROPIC,                                                 \
-       BOUNDARY_TAG_NONE))((DIMENSION_TAG_DIM3, MEDIUM_TAG_ELASTIC_PSV,        \
-                            PROPERTY_TAG_ISOTROPIC, BOUNDARY_TAG_NONE))
+       PROPERTY_TAG_ISOTROPIC, BOUNDARY_TAG_NONE))
+
+#define ELEMENT_TYPES_DIM3                                                     \
+  ((DIMENSION_TAG_DIM3, MEDIUM_TAG_ELASTIC_PSV, PROPERTY_TAG_ISOTROPIC,        \
+    BOUNDARY_TAG_NONE))
+
+#define ELEMENT_TYPES ELEMENT_TYPES_DIM2 ELEMENT_TYPES_DIM3
 
 /**
  * @brief Tag getters. The macros are intended to be used only in @ref DECLARE
@@ -207,15 +218,19 @@ constexpr auto medium_types() {
  *
  * @return constexpr auto list of material systems
  */
-constexpr auto material_systems() {
+template <specfem::dimension::type DimensionTag>
+constexpr auto material_systems();
+
+template <> constexpr auto material_systems<specfem::dimension::type::dim2>() {
   // Use boost preprocessor library to generate a list of
   // material systems
-  constexpr int total_material_systems = BOOST_PP_SEQ_SIZE(MATERIAL_SYSTEMS);
+  constexpr int total_material_systems =
+      BOOST_PP_SEQ_SIZE(MATERIAL_SYSTEMS_DIM2);
   constexpr std::array<
       std::tuple<specfem::dimension::type, specfem::element::medium_tag,
                  specfem::element::property_tag>,
       total_material_systems>
-      material_systems{ _MAKE_CONSTEXPR_ARRAY(MATERIAL_SYSTEMS) };
+      material_systems{ _MAKE_CONSTEXPR_ARRAY(MATERIAL_SYSTEMS_DIM2) };
 
   return material_systems;
 }
@@ -229,16 +244,18 @@ constexpr auto material_systems() {
  *
  * @return constexpr auto list of element types
  */
-constexpr auto element_types() {
+template <specfem::dimension::type DimensionTag> constexpr auto element_types();
+
+template <> constexpr auto element_types<specfem::dimension::type::dim2>() {
   // Use boost preprocessor library to generate a list of
   // material systems
-  constexpr int total_element_types = BOOST_PP_SEQ_SIZE(ELEMENT_TYPES);
+  constexpr int total_element_types = BOOST_PP_SEQ_SIZE(ELEMENT_TYPES_DIM2);
   constexpr std::array<
       std::tuple<specfem::dimension::type, specfem::element::medium_tag,
                  specfem::element::property_tag,
                  specfem::element::boundary_tag>,
       total_element_types>
-      material_systems{ _MAKE_CONSTEXPR_ARRAY(ELEMENT_TYPES) };
+      material_systems{ _MAKE_CONSTEXPR_ARRAY(ELEMENT_TYPES_DIM2) };
 
   return material_systems;
 }


### PR DESCRIPTION
## Description

- [ ] Template `material_systems`, `element_types`, `medium_tags` with dimension.
- [ ] `dimension` -> `dimension_tag` for `mesh_to_compute_mapping`
- [ ]  Add tags to that the following macro can be called
```cpp
FOR_EACH_IN_PRODUCT(
      (DIMENSION_TAG(DIM3),
       MEDIUM_TAG(ELASTIC_PSV),
       PROPERTY_TAG(ISOTROPIC))
```

## Issue Number

Closes #998

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
