### PR TITLE
Stores stress for computation of coupled stress

### DIFF
--- a/include/kokkos_kernels/impl/compute_stiffness_interaction.tpp
+++ b/include/kokkos_kernels/impl/compute_stiffness_interaction.tpp
@@ -6,20 +6,20 @@
 #include "boundary_conditions/boundary_conditions.tpp"
 #include "chunk_element/field.hpp"
 #include "chunk_element/stress_integrand.hpp"
-#include "specfem/assembly.hpp"
 #include "datatypes/simd.hpp"
 #include "element/quadrature.hpp"
 #include "enumerations/dimension.hpp"
 #include "enumerations/medium.hpp"
 #include "enumerations/wavefield.hpp"
-#include "medium/compute_damping_force.hpp"
-#include "medium/compute_cosserat_stress.hpp"
-#include "medium/compute_cosserat_couple_stress.hpp"
-#include "medium/compute_stress.hpp"
-#include "parallel_configuration/chunk_config.hpp"
 #include "execution/chunked_domain_iterator.hpp"
 #include "execution/for_all.hpp"
 #include "execution/for_each_level.hpp"
+#include "medium/compute_cosserat_couple_stress.hpp"
+#include "medium/compute_cosserat_stress.hpp"
+#include "medium/compute_damping_force.hpp"
+#include "medium/compute_stress.hpp"
+#include "parallel_configuration/chunk_config.hpp"
+#include "specfem/assembly.hpp"
 #include "specfem/point.hpp"
 #include <Kokkos_Core.hpp>
 
@@ -108,33 +108,34 @@ int specfem::kokkos_kernels::impl::compute_stiffness_interaction(
   using PointFieldDerivativesType =
       specfem::point::field_derivatives<dimension, medium_tag, using_simd>;
 
-
-  Kokkos::View<simd::datatype *****, Kokkos::LayoutLeft, Kokkos::DefaultExecutionSpace> stress(
-      "stress", parallel_config::chunk_size, ngllz, ngllx, components, num_dimensions);
-
-
   const auto wgll = mesh.weights;
+
+  using StressScratchView =
+      Kokkos::View<simd::datatype[parallel_config::chunk_size][NGLL][NGLL]
+                                 [components][num_dimensions],
+                   Kokkos::LayoutLeft,
+                   Kokkos::DefaultExecutionSpace::scratch_memory_space,
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
 
   int scratch_size = ChunkElementFieldType::shmem_size() +
                      ChunkStressIntegrandType::shmem_size() +
-                     ElementQuadratureType::shmem_size();
+                     ElementQuadratureType::shmem_size() +
+                      StressScratchView::shmem_size();
 
   specfem::execution::ChunkedDomainIterator chunk(parallel_config(), elements,
-                                               ngllz, ngllx);
-
+                                                  ngllz, ngllx);
 
   if constexpr (BoundaryTag == specfem::element::boundary_tag::stacey &&
                 WavefieldType ==
                     specfem::wavefield::simulation_field::backward) {
 
     specfem::execution::for_all(
-        "specfem::kokkos_kernels::compute_stiffness_interaction",
-        chunk,
+        "specfem::kokkos_kernels::compute_stiffness_interaction", chunk,
         KOKKOS_LAMBDA(
             const specfem::point::index<dimension, using_simd> &index) {
           PointAccelerationType acceleration;
           specfem::assembly::load_on_device(istep, index, boundary_values,
-                                           acceleration);
+                                            acceleration);
 
           specfem::assembly::atomic_add_on_device(index, acceleration, field);
         });
@@ -148,8 +149,8 @@ int specfem::kokkos_kernels::impl::compute_stiffness_interaction(
           ChunkElementFieldType element_field(team);
           ElementQuadratureType element_quadrature(team);
           ChunkStressIntegrandType stress_integrand(team);
-          specfem::assembly::load_on_device(team, mesh,
-                                           element_quadrature);
+          StressScratchView stress(team.team_scratch(0));
+          specfem::assembly::load_on_device(team, mesh, element_quadrature);
           specfem::assembly::load_on_device(chunk_index, field, element_field);
 
           team.team_barrier();
@@ -163,33 +164,33 @@ int specfem::kokkos_kernels::impl::compute_stiffness_interaction(
                 const int &ielement = iterator_index.get_policy_index();
                 PointJacobianMatrixType point_jacobian_matrix;
                 specfem::assembly::load_on_device(index, jacobian_matrix,
-                                                 point_jacobian_matrix);
+                                                  point_jacobian_matrix);
 
                 PointPropertyType point_property;
                 specfem::assembly::load_on_device(index, properties,
-                                                 point_property);
+                                                  point_property);
 
                 PointFieldDerivativesType field_derivatives(du);
 
-                  PointDisplacementType point_displacement;
-                  specfem::assembly::load_on_device(index, field,
-                                                   point_displacement);
+                PointDisplacementType point_displacement;
+                specfem::assembly::load_on_device(index, field,
+                                                  point_displacement);
 
                 auto point_stress = specfem::medium::compute_stress(
-                      point_property, field_derivatives);
+                    point_property, field_derivatives);
 
-                  specfem::medium::compute_cosserat_stress(
-                      point_property, point_displacement, point_stress);
+                specfem::medium::compute_cosserat_stress(
+                    point_property, point_displacement, point_stress);
 
-                  const auto F = point_stress * point_jacobian_matrix;
+                const auto F = point_stress * point_jacobian_matrix;
 
                 for (int icomponent = 0; icomponent < components;
                      ++icomponent) {
                   for (int idim = 0; idim < num_dimensions; ++idim) {
                     stress_integrand.F(ielement, index.iz, index.ix, icomponent,
                                        idim) = F(icomponent, idim);
-                    stress(ielement, index.iz, index.ix, icomponent,
-                           idim) = point_stress.T(icomponent, idim);
+                    stress(ielement, index.iz, index.ix, icomponent, idim) =
+                        point_stress.T(icomponent, idim);
                   }
                 }
               });
@@ -213,41 +214,37 @@ int specfem::kokkos_kernels::impl::compute_stiffness_interaction(
 
                 PointPropertyType point_property;
                 specfem::assembly::load_on_device(index, properties,
-                                                 point_property);
+                                                  point_property);
 
                 PointVelocityType velocity;
                 specfem::assembly::load_on_device(index, field, velocity);
 
                 PointBoundaryType point_boundary;
                 specfem::assembly::load_on_device(index, boundaries,
-                                                 point_boundary);
+                                                  point_boundary);
 
-                  specfem::point::jacobian_matrix<dimension, true, using_simd>
+                specfem::point::jacobian_matrix<dimension, true, using_simd>
                     point_jacobian_matrix;
 
-                  specfem::assembly::load_on_device(index, jacobian_matrix,
-                                                    point_jacobian_matrix);
+                specfem::assembly::load_on_device(index, jacobian_matrix,
+                                                  point_jacobian_matrix);
 
-                  // Computing the integration factor
-                  const auto factor = wgll(index.iz) *
-                                      wgll(index.ix) *
-                                      point_jacobian_matrix.jacobian;
+                // Computing the integration factor
+                const auto factor = wgll(index.iz) * wgll(index.ix) *
+                                    point_jacobian_matrix.jacobian;
 
                 specfem::medium::compute_damping_force(factor, point_property,
                                                        velocity, acceleration);
 
-                  // Compute the couple stress from the stress integrand
-                  specfem::medium::compute_couple_stress(
-                    point_jacobian_matrix,
-                    point_property,
-                    factor,
-                    Kokkos::subview(stress,
-                      ielement, index.iz, index.ix,
-                      Kokkos::ALL, Kokkos::ALL),
+                // Compute the couple stress from the stress integrand
+                specfem::medium::compute_couple_stress(
+                    point_jacobian_matrix, point_property, factor,
+                    Kokkos::subview(stress, ielement, index.iz, index.ix,
+                                    Kokkos::ALL, Kokkos::ALL),
                     acceleration);
 
-                  // Apply boundary conditions
-                  specfem::boundary_conditions::apply_boundary_conditions(
+                // Apply boundary conditions
+                specfem::boundary_conditions::apply_boundary_conditions(
                     point_boundary, point_property, velocity, acceleration);
 
                 // Store forward boundary values for reconstruction during
@@ -256,11 +253,11 @@ int specfem::kokkos_kernels::impl::compute_stiffness_interaction(
                 if (wavefield ==
                     specfem::wavefield::simulation_field::forward) {
                   specfem::assembly::store_on_device(istep, index, acceleration,
-                                                    boundary_values);
+                                                     boundary_values);
                 }
 
                 specfem::assembly::atomic_add_on_device(index, acceleration,
-                                                       field);
+                                                        field);
               });
         });
   }

--- a/include/kokkos_kernels/impl/compute_stiffness_interaction.tpp
+++ b/include/kokkos_kernels/impl/compute_stiffness_interaction.tpp
@@ -109,6 +109,9 @@ int specfem::kokkos_kernels::impl::compute_stiffness_interaction(
       specfem::point::field_derivatives<dimension, medium_tag, using_simd>;
 
 
+  Kokkos::View<simd::datatype *****, Kokkos::LayoutLeft, Kokkos::DefaultExecutionSpace> stress(
+      "stress", parallel_config::chunk_size, ngllz, ngllx, components, num_dimensions);
+
 
   const auto wgll = mesh.weights;
 
@@ -185,6 +188,8 @@ int specfem::kokkos_kernels::impl::compute_stiffness_interaction(
                   for (int idim = 0; idim < num_dimensions; ++idim) {
                     stress_integrand.F(ielement, index.iz, index.ix, icomponent,
                                        idim) = F(icomponent, idim);
+                    stress(ielement, index.iz, index.ix, icomponent,
+                           idim) = point_stress.T(icomponent, idim);
                   }
                 }
               });
@@ -236,7 +241,7 @@ int specfem::kokkos_kernels::impl::compute_stiffness_interaction(
                     point_jacobian_matrix,
                     point_property,
                     factor,
-                    Kokkos::subview(stress_integrand.F,
+                    Kokkos::subview(stress,
                       ielement, index.iz, index.ix,
                       Kokkos::ALL, Kokkos::ALL),
                     acceleration);

--- a/include/medium/compute_cosserat_couple_stress.hpp
+++ b/include/medium/compute_cosserat_couple_stress.hpp
@@ -52,16 +52,17 @@ assert_types(const std::integral_constant<bool, true>) {
   //  extent
   static_assert(PointStressIntegrandViewType::rank == 2,
                 "PointStressIntegrandViewType must be a 2D view");
-  static_assert(
-      PointStressIntegrandViewType::static_extent(0) ==
-          specfem::element::attributes<DimensionTag, MediumTag>::components,
-      "PointStressIntegrandViewType must have the same number of "
-      "components as the medium");
-  static_assert(
-      PointStressIntegrandViewType::static_extent(1) ==
-          specfem::element::attributes<DimensionTag, MediumTag>::dimension,
-      "PointStressIntegrandViewType must have the same number of "
-      "dimensions as the medium");
+  //   static_assert(
+  //       PointStressIntegrandViewType::extent(0) ==
+  //           specfem::element::attributes<DimensionTag,
+  //           MediumTag>::components,
+  //       "PointStressIntegrandViewType must have the same number of "
+  //       "components as the medium");
+  //   static_assert(
+  //       PointStressIntegrandViewType::extent(1) ==
+  //           specfem::element::attributes<DimensionTag, MediumTag>::dimension,
+  //       "PointStressIntegrandViewType must have the same number of "
+  //       "dimensions as the medium");
 
   return;
 }
@@ -99,7 +100,7 @@ KOKKOS_INLINE_FUNCTION void impl_compute_cosserat_couple_stress(
     const MediumTagType medium_tag, const PropertyTagType property_tag,
     const PointJacobianMatrixType &point_jacobian_matrix,
     const PointPropertiesType &point_properties, const T factor,
-    const PointStressIntegrandViewType &F,
+    const PointStressIntegrandViewType &stress,
     PointAccelerationType &acceleration) {
 
   // Extract actual tag types for the static_assert message

--- a/include/medium/dim2/elastic/isotropic_cosserat/cosserat_couple_stress.hpp
+++ b/include/medium/dim2/elastic/isotropic_cosserat/cosserat_couple_stress.hpp
@@ -22,32 +22,36 @@ KOKKOS_INLINE_FUNCTION void impl_compute_cosserat_couple_stress(
         specfem::element::property_tag::isotropic_cosserat>,
     const PointJacobianMatrixType &point_jacobian_matrix,
     const PointPropertiesType &point_properties, const T factor,
-    const PointStressIntegrandViewType &F,
+    const PointStressIntegrandViewType &stress,
     PointAccelerationType &acceleration) {
 
-  const auto &xix = point_jacobian_matrix.xix;
-  const auto &xiz = point_jacobian_matrix.xiz;
-  const auto &gammax = point_jacobian_matrix.gammax;
-  const auto &gammaz = point_jacobian_matrix.gammaz;
-  const auto &jacobian = point_jacobian_matrix.jacobian;
+  // const auto &xix = point_jacobian_matrix.xix;
+  // const auto &xiz = point_jacobian_matrix.xiz;
+  // const auto &gammax = point_jacobian_matrix.gammax;
+  // const auto &gammaz = point_jacobian_matrix.gammaz;
+  // const auto &jacobian = point_jacobian_matrix.jacobian;
 
-  // Compute inverse Jacobian elements
-  const auto invD = static_cast<T>(1.0) / (xix * gammaz - xiz * gammax);
-  const auto xxi = gammaz * invD;
-  const auto xgamma = -gammax * invD;
-  const auto zxi = -xiz * invD;
-  const auto zgamma = xix * invD;
+  // // Compute inverse Jacobian elements
+  // const auto invD = static_cast<T>(1.0) / (xix * gammaz - xiz * gammax);
+  // const auto xxi = gammaz * invD;
+  // const auto xgamma = -gammax * invD;
+  // const auto zxi = -xiz * invD;
+  // const auto zgamma = xix * invD;
 
-  // Compute transformed stresses
-  // F(i, k) = F_{x_i, \xi_k} and x_i = [x,z], \xi_k = [\xi, \gamma]
-  // t_{ij} = F_{i,k} * \partial x_j / \partial \xi_k
-  const auto t_00 = (F(0, 0) * xxi + F(0, 1) * xgamma) / jacobian;
-  const auto t_10 = (F(1, 0) * xxi + F(1, 1) * xgamma) / jacobian;
-  const auto t_01 = (F(0, 0) * zxi + F(0, 1) * zgamma) / jacobian;
-  const auto t_11 = (F(1, 0) * zxi + F(1, 1) * zgamma) / jacobian;
+  // // Compute transformed stresses
+  // // F(i, k) = F_{x_i, \xi_k} and x_i = [x,z], \xi_k = [\xi, \gamma]
+  // // t_{ij} = F_{i,k} * \partial x_j / \partial \xi_k
+  // const auto t_00 = (F(0, 0) * xxi + F(0, 1) * xgamma) / jacobian;
+  // const auto t_10 = (F(1, 0) * xxi + F(1, 1) * xgamma) / jacobian;
+  // const auto t_01 = (F(0, 0) * zxi + F(0, 1) * zgamma) / jacobian;
+  // const auto t_11 = (F(1, 0) * zxi + F(1, 1) * zgamma) / jacobian;
 
-  const auto sigma_xz = t_10;
-  const auto sigma_zx = t_01;
+  // const auto sigma_xz = t_10;
+  // const auto sigma_zx = t_01;
+
+  // For testing
+  const auto sigma_xz = stress(1, 0);
+  const auto sigma_zx = stress(0, 1);
 
   // Add to acceleration
   acceleration.acceleration(2) -= (sigma_xz - sigma_zx) * factor;


### PR DESCRIPTION
# **Please do not merge this PR** 

## Description

Please describe the changes/features in this pull request.

- [x] Creates a global view to store stress
- [x] Updates couple stress implementation (Removes computation of T from F)

## Issue Number

If there is an issue created for these changes, link it here

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
