### PR TITLE
Issue 993 - Add 3D specification for element_types

### DIFF
--- a/core/specfem/assembly/element_types.hpp
+++ b/core/specfem/assembly/element_types.hpp
@@ -13,3 +13,4 @@ template <specfem::dimension::type DimensionTag> struct element_types;
 } // namespace specfem::assembly
 
 #include "element_types/dim2/element_types.hpp"
+#include "element_types/dim3/element_types.hpp"

--- a/core/specfem/assembly/element_types/dim3/element_types.cpp
+++ b/core/specfem/assembly/element_types/dim3/element_types.cpp
@@ -1,0 +1,201 @@
+#include "specfem/assembly/element_types.hpp"
+
+specfem::assembly::element_types<specfem::dimension::type::dim3>::element_types(
+    const int nspec, const int ngllz, const int nglly, const int ngllx,
+    const specfem::assembly::mesh<specfem::dimension::type::dim3> &mesh,
+    const specfem::mesh::tags<specfem::dimension::type::dim3> &tags)
+    : nspec(nspec),
+      medium_tags("specfem::assembly::element_types::medium_tags", nspec),
+      property_tags("specfem::assembly::element_types::property_tags", nspec),
+      boundary_tags("specfem::assembly::element_types::boundary_tags", nspec) {
+
+  for (int ispec = 0; ispec < nspec; ispec++) {
+    medium_tags(ispec) = tags.tags_container(ispec).medium_tag;
+    property_tags(ispec) = tags.tags_container(ispec).property_tag;
+    boundary_tags(ispec) = tags.tags_container(ispec).boundary_tag;
+  }
+
+  FOR_EACH_IN_PRODUCT(
+      (DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC), PROPERTY_TAG(ISOTROPIC),
+       BOUNDARY_TAG(NONE)),
+      CAPTURE(elements, h_elements) {
+        int count = 0;
+        int index = 0;
+        for (int ispec = 0; ispec < nspec; ispec++) {
+          if (medium_tags(ispec) == _medium_tag_) {
+            count++;
+          }
+        }
+        _elements_ =
+            IndexViewType("specfem::assembly::element_types::elements", count);
+        _h_elements_ = Kokkos::create_mirror_view(_elements_);
+        for (int ispec = 0; ispec < nspec; ispec++) {
+          if (medium_tags(ispec) == _medium_tag_) {
+            _h_elements_(index) = ispec;
+            index++;
+          }
+        }
+        Kokkos::deep_copy(_elements_, _h_elements_);
+      })
+
+  FOR_EACH_IN_PRODUCT(
+      (DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC), PROPERTY_TAG(ISOTROPIC),
+       BOUNDARY_TAG(NONE)),
+      CAPTURE(elements, h_elements) {
+        int count = 0;
+        int index = 0;
+
+        for (int ispec = 0; ispec < nspec; ispec++) {
+          if (medium_tags(ispec) == _medium_tag_ &&
+              property_tags(ispec) == _property_tag_) {
+            count++;
+          }
+        }
+
+        _elements_ =
+            IndexViewType("specfem::assembly::element_types::elements", count);
+        _h_elements_ = Kokkos::create_mirror_view(_elements_);
+
+        for (int ispec = 0; ispec < nspec; ispec++) {
+          if (medium_tags(ispec) == _medium_tag_ &&
+              property_tags(ispec) == _property_tag_) {
+            _h_elements_(index) = ispec;
+            index++;
+          }
+        }
+
+        Kokkos::deep_copy(_elements_, _h_elements_);
+      })
+
+  FOR_EACH_IN_PRODUCT(
+      (DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC), PROPERTY_TAG(ISOTROPIC),
+       BOUNDARY_TAG(NONE)),
+      CAPTURE(elements, h_elements) {
+        int count = 0;
+        int index = 0;
+
+        for (int ispec = 0; ispec < nspec; ispec++) {
+          if (medium_tags(ispec) == _medium_tag_ &&
+              property_tags(ispec) == _property_tag_ &&
+              boundary_tags(ispec) == _boundary_tag_) {
+            count++;
+          }
+        }
+
+        _elements_ =
+            IndexViewType("specfem::assembly::element_types::elements", count);
+        _h_elements_ = Kokkos::create_mirror_view(_elements_);
+
+        for (int ispec = 0; ispec < nspec; ispec++) {
+          if (medium_tags(ispec) == _medium_tag_ &&
+              property_tags(ispec) == _property_tag_ &&
+              boundary_tags(ispec) == _boundary_tag_) {
+            _h_elements_(index) = ispec;
+            index++;
+          }
+        }
+
+        Kokkos::deep_copy(_elements_, _h_elements_);
+      })
+}
+
+Kokkos::View<int *, Kokkos::DefaultHostExecutionSpace>
+specfem::assembly::element_types<specfem::dimension::type::dim3>::
+    get_elements_on_host(const specfem::element::medium_tag medium_tag) const {
+  FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC),
+                       PROPERTY_TAG(ISOTROPIC), BOUNDARY_TAG(NONE)),
+                      CAPTURE(h_elements) {
+                        if (_medium_tag_ == medium_tag) {
+                          return _h_elements_;
+                        }
+                      })
+
+  throw std::runtime_error("Medium tag not found");
+}
+
+Kokkos::View<int *, Kokkos::DefaultExecutionSpace> specfem::assembly::
+    element_types<specfem::dimension::type::dim3>::get_elements_on_device(
+        const specfem::element::medium_tag medium_tag) const {
+  FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC),
+                       PROPERTY_TAG(ISOTROPIC), BOUNDARY_TAG(NONE)),
+                      CAPTURE(elements) {
+                        if (_medium_tag_ == medium_tag) {
+                          return _elements_;
+                        }
+                      })
+
+  throw std::runtime_error("Medium tag not found");
+}
+
+Kokkos::View<int *, Kokkos::DefaultHostExecutionSpace> specfem::assembly::
+    element_types<specfem::dimension::type::dim3>::get_elements_on_host(
+        const specfem::element::medium_tag medium_tag,
+        const specfem::element::property_tag property_tag) const {
+
+  FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC),
+                       PROPERTY_TAG(ISOTROPIC), BOUNDARY_TAG(NONE)),
+                      CAPTURE(h_elements) {
+                        if (_medium_tag_ == medium_tag &&
+                            _property_tag_ == property_tag) {
+                          return _h_elements_;
+                        }
+                      })
+
+  throw std::runtime_error("Medium tag or property tag not found");
+}
+
+Kokkos::View<int *, Kokkos::DefaultExecutionSpace> specfem::assembly::
+    element_types<specfem::dimension::type::dim3>::get_elements_on_device(
+        const specfem::element::medium_tag medium_tag,
+        const specfem::element::property_tag property_tag) const {
+
+  FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC),
+                       PROPERTY_TAG(ISOTROPIC), BOUNDARY_TAG(NONE)),
+                      CAPTURE(elements) {
+                        if (_medium_tag_ == medium_tag &&
+                            _property_tag_ == property_tag) {
+                          return _elements_;
+                        }
+                      })
+
+  throw std::runtime_error("Medium tag or property tag not found");
+}
+
+Kokkos::View<int *, Kokkos::DefaultHostExecutionSpace> specfem::assembly::
+    element_types<specfem::dimension::type::dim3>::get_elements_on_host(
+        const specfem::element::medium_tag medium_tag,
+        const specfem::element::property_tag property_tag,
+        const specfem::element::boundary_tag boundary_tag) const {
+  FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC),
+                       PROPERTY_TAG(ISOTROPIC), BOUNDARY_TAG(NONE)),
+                      CAPTURE(h_elements) {
+                        if (_medium_tag_ == medium_tag &&
+                            _property_tag_ == property_tag &&
+                            _boundary_tag_ == boundary_tag) {
+                          return _h_elements_;
+                        }
+                      })
+
+  throw std::runtime_error(
+      "Medium tag, property tag or boundary tag not found");
+}
+
+Kokkos::View<int *, Kokkos::DefaultExecutionSpace> specfem::assembly::
+    element_types<specfem::dimension::type::dim3>::get_elements_on_device(
+        const specfem::element::medium_tag medium_tag,
+        const specfem::element::property_tag property_tag,
+        const specfem::element::boundary_tag boundary_tag) const {
+
+  FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC),
+                       PROPERTY_TAG(ISOTROPIC), BOUNDARY_TAG(NONE)),
+                      CAPTURE(elements) {
+                        if (_medium_tag_ == medium_tag &&
+                            _property_tag_ == property_tag &&
+                            _boundary_tag_ == boundary_tag) {
+                          return _elements_;
+                        }
+                      })
+
+  throw std::runtime_error(
+      "Medium tag, property tag or boundary tag not found");
+}

--- a/core/specfem/assembly/element_types/dim3/element_types.hpp
+++ b/core/specfem/assembly/element_types/dim3/element_types.hpp
@@ -1,0 +1,139 @@
+#pragma once
+
+#include "enumerations/material_definitions.hpp"
+#include "enumerations/medium.hpp"
+#include "mesh/mesh.hpp"
+#include "specfem/assembly/mesh.hpp"
+#include "specfem/point.hpp"
+#include <Kokkos_Core.hpp>
+
+namespace specfem::assembly {
+
+template <> struct element_types<specfem::dimension::type::dim3> {
+protected:
+  using MediumTagViewType =
+      Kokkos::View<specfem::element::medium_tag *,
+                   Kokkos::DefaultHostExecutionSpace>; ///< Underlying view type
+                                                       ///< to store medium tags
+  using PropertyTagViewType =
+      Kokkos::View<specfem::element::property_tag *,
+                   Kokkos::DefaultHostExecutionSpace>; ///< Underlying view type
+                                                       ///< to store property
+                                                       ///< tags
+  using BoundaryViewType =
+      Kokkos::View<specfem::element::boundary_tag *,
+                   Kokkos::DefaultHostExecutionSpace>; ///< Underlying view type
+                                                       ///< to store
+                                                       ///< boundary tags
+
+  using IndexViewType =
+      Kokkos::View<int *, Kokkos::DefaultExecutionSpace>; ///< Underlying view
+                                                          ///< type to store
+                                                          ///< indices of
+                                                          ///< elements
+
+public:
+  int nspec; ///< total number of spectral elements
+  int ngllz; ///< number of quadrature points in z dimension
+  int ngllx; ///< number of quadrature points in x dimension
+  int nglly; ///< number of quadrature points in y dimension
+
+  constexpr static auto dimension_tag =
+      specfem::dimension::type::dim3; ///< Dimension tag
+
+  MediumTagViewType medium_tags;     ///< View to store medium tags
+  PropertyTagViewType property_tags; ///< View to store property tags
+  BoundaryViewType boundary_tags;    ///< View to store boundary tags
+
+  /**
+   * @brief Default constructor
+   *
+   */
+  element_types() = default;
+
+  /**
+   * @brief Construct a new properties object from mesh information
+   *
+   * @param nspec Number of spectral elements
+   * @param ngllz Number of quadrature points in z direction
+   * @param ngllx Number of quadrature points in x direction
+   * @param nglly Number of quadrature points in y direction
+   * @param mesh Mesh information
+   * @param tags Element Tags for every spectral element
+   */
+  element_types(const int nspec, const int ngllz, const int nglly,
+                const int ngllx,
+                const specfem::assembly::mesh<dimension_tag> &mesh,
+                const specfem::mesh::tags<dimension_tag> &tags);
+
+  Kokkos::View<int *, Kokkos::DefaultHostExecutionSpace>
+  get_elements_on_host(const specfem::element::medium_tag tag) const;
+
+  int get_number_of_elements(const specfem::element::medium_tag tag) const {
+    return get_elements_on_host(tag).extent(0);
+  }
+
+  Kokkos::View<int *, Kokkos::DefaultExecutionSpace>
+  get_elements_on_device(const specfem::element::medium_tag tag) const;
+
+  Kokkos::View<int *, Kokkos::DefaultHostExecutionSpace>
+  get_elements_on_host(const specfem::element::medium_tag tag,
+                       const specfem::element::property_tag property) const;
+
+  int get_number_of_elements(
+      const specfem::element::medium_tag tag,
+      const specfem::element::property_tag property) const {
+    return get_elements_on_host(tag, property).extent(0);
+  }
+
+  Kokkos::View<int *, Kokkos::DefaultExecutionSpace>
+  get_elements_on_device(const specfem::element::medium_tag tag,
+                         const specfem::element::property_tag property) const;
+
+  Kokkos::View<int *, Kokkos::DefaultHostExecutionSpace>
+  get_elements_on_host(const specfem::element::medium_tag tag,
+                       const specfem::element::property_tag property,
+                       const specfem::element::boundary_tag boundary) const;
+
+  int get_number_of_elements(
+      const specfem::element::medium_tag tag,
+      const specfem::element::property_tag property,
+      const specfem::element::boundary_tag boundary) const {
+    return get_elements_on_host(tag, property, boundary).extent(0);
+  }
+
+  Kokkos::View<int *, Kokkos::DefaultExecutionSpace>
+  get_elements_on_device(const specfem::element::medium_tag tag,
+                         const specfem::element::property_tag property,
+                         const specfem::element::boundary_tag boundary) const;
+
+  specfem::element::medium_tag get_medium_tag(const int ispec) const {
+    return medium_tags(ispec);
+  }
+
+  specfem::element::property_tag get_property_tag(const int ispec) const {
+    return property_tags(ispec);
+  }
+
+  specfem::element::boundary_tag get_boundary_tag(const int ispec) const {
+    return boundary_tags(ispec);
+  }
+
+private:
+  FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC)),
+                      DECLARE((IndexViewType, elements),
+                              (IndexViewType::HostMirror, h_elements)))
+
+  FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC),
+                       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC,
+                                    ISOTROPIC_COSSERAT)),
+                      DECLARE((IndexViewType, elements),
+                              (IndexViewType::HostMirror, h_elements)))
+
+  FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC),
+                       PROPERTY_TAG(ISOTROPIC), BOUNDARY_TAG(NONE)),
+                      DECLARE((IndexViewType, elements),
+                              (IndexViewType::HostMirror, h_elements)))
+};
+
+} // namespace specfem::assembly

--- a/include/enumerations/material_definitions.hpp
+++ b/include/enumerations/material_definitions.hpp
@@ -25,7 +25,7 @@
   (4, specfem::element::medium_tag::poroelastic, poroelastic)
 #define MEDIUM_TAG_ELECTROMAGNETIC_TE                                          \
   (5, specfem::element::medium_tag::electromagnetic_te, electromagnetic_te)
-#define MEDIUM_TAG_ELASTIC (0, specfem::element::medium_tag::elastic, elastic)
+#define MEDIUM_TAG_ELASTIC (6, specfem::element::medium_tag::elastic, elastic)
 
 #define PROPERTY_TAG_ISOTROPIC                                                 \
   (0, specfem::element::property_tag::isotropic, isotropic)

--- a/include/enumerations/material_definitions.hpp
+++ b/include/enumerations/material_definitions.hpp
@@ -25,6 +25,7 @@
   (4, specfem::element::medium_tag::poroelastic, poroelastic)
 #define MEDIUM_TAG_ELECTROMAGNETIC_TE                                          \
   (5, specfem::element::medium_tag::electromagnetic_te, electromagnetic_te)
+#define MEDIUM_TAG_ELASTIC (0, specfem::element::medium_tag::elastic, elastic)
 
 #define PROPERTY_TAG_ISOTROPIC                                                 \
   (0, specfem::element::property_tag::isotropic, isotropic)
@@ -54,7 +55,7 @@
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_POROELASTIC))(                           \
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELECTROMAGNETIC_TE))
 
-#define MEDIUM_TAGS_DIM3 ((DIMENSION_TAG_DIM3, MEDIUM_TAG_ELASTIC_PSV))
+#define MEDIUM_TAGS_DIM3 ((DIMENSION_TAG_DIM3, MEDIUM_TAG_ELASTIC))
 
 #define MEDIUM_TAGS MEDIUM_TAGS_DIM2 MEDIUM_TAGS_DIM3
 
@@ -75,7 +76,7 @@
        PROPERTY_TAG_ISOTROPIC))
 
 #define MATERIAL_SYSTEMS_DIM3                                                  \
-  ((DIMENSION_TAG_DIM3, MEDIUM_TAG_ELASTIC_PSV, PROPERTY_TAG_ISOTROPIC))
+  ((DIMENSION_TAG_DIM3, MEDIUM_TAG_ELASTIC, PROPERTY_TAG_ISOTROPIC))
 
 #define MATERIAL_SYSTEMS MATERIAL_SYSTEMS_DIM2 MATERIAL_SYSTEMS_DIM3
 
@@ -115,7 +116,7 @@
        PROPERTY_TAG_ISOTROPIC, BOUNDARY_TAG_NONE))
 
 #define ELEMENT_TYPES_DIM3                                                     \
-  ((DIMENSION_TAG_DIM3, MEDIUM_TAG_ELASTIC_PSV, PROPERTY_TAG_ISOTROPIC,        \
+  ((DIMENSION_TAG_DIM3, MEDIUM_TAG_ELASTIC, PROPERTY_TAG_ISOTROPIC,            \
     BOUNDARY_TAG_NONE))
 
 #define ELEMENT_TYPES ELEMENT_TYPES_DIM2 ELEMENT_TYPES_DIM3
@@ -200,13 +201,26 @@ namespace element {
  *
  * @return constexpr auto list of medium types
  */
-constexpr auto medium_types() {
+template <specfem::dimension::type DimensionTag> constexpr auto medium_types();
+
+template <> constexpr auto medium_types<specfem::dimension::type::dim2>() {
   // Use boost preprocessor library to generate a list of medium
   // types
-  constexpr int total_medium_types = BOOST_PP_SEQ_SIZE(MEDIUM_TAGS);
+  constexpr int total_medium_types = BOOST_PP_SEQ_SIZE(MEDIUM_TAGS_DIM2);
   constexpr std::array<std::tuple<specfem::dimension::type, medium_tag>,
                        total_medium_types>
-      medium_types{ _MAKE_CONSTEXPR_ARRAY(MEDIUM_TAGS) };
+      medium_types{ _MAKE_CONSTEXPR_ARRAY(MEDIUM_TAGS_DIM2) };
+
+  return medium_types;
+}
+
+template <> constexpr auto medium_types<specfem::dimension::type::dim3>() {
+  // Use boost preprocessor library to generate a list of medium
+  // types
+  constexpr int total_medium_types = BOOST_PP_SEQ_SIZE(MEDIUM_TAGS_DIM3);
+  constexpr std::array<std::tuple<specfem::dimension::type, medium_tag>,
+                       total_medium_types>
+      medium_types{ _MAKE_CONSTEXPR_ARRAY(MEDIUM_TAGS_DIM3) };
 
   return medium_types;
 }
@@ -237,6 +251,20 @@ template <> constexpr auto material_systems<specfem::dimension::type::dim2>() {
   return material_systems;
 }
 
+template <> constexpr auto material_systems<specfem::dimension::type::dim3>() {
+  // Use boost preprocessor library to generate a list of
+  // material systems
+  constexpr int total_material_systems =
+      BOOST_PP_SEQ_SIZE(MATERIAL_SYSTEMS_DIM3);
+  constexpr std::array<
+      std::tuple<specfem::dimension::type, specfem::element::medium_tag,
+                 specfem::element::property_tag>,
+      total_material_systems>
+      material_systems{ _MAKE_CONSTEXPR_ARRAY(MATERIAL_SYSTEMS_DIM3) };
+
+  return material_systems;
+}
+
 /**
  * @brief A constexpr function to generate a list of element types within the
  * simulation
@@ -258,6 +286,20 @@ template <> constexpr auto element_types<specfem::dimension::type::dim2>() {
                  specfem::element::boundary_tag>,
       total_element_types>
       material_systems{ _MAKE_CONSTEXPR_ARRAY(ELEMENT_TYPES_DIM2) };
+
+  return material_systems;
+}
+
+template <> constexpr auto element_types<specfem::dimension::type::dim3>() {
+  // Use boost preprocessor library to generate a list of
+  // material systems
+  constexpr int total_element_types = BOOST_PP_SEQ_SIZE(ELEMENT_TYPES_DIM3);
+  constexpr std::array<
+      std::tuple<specfem::dimension::type, specfem::element::medium_tag,
+                 specfem::element::property_tag,
+                 specfem::element::boundary_tag>,
+      total_element_types>
+      material_systems{ _MAKE_CONSTEXPR_ARRAY(ELEMENT_TYPES_DIM3) };
 
   return material_systems;
 }


### PR DESCRIPTION
## Description

Adds `element_types`
Change 3D tag `ELASTIC_PSV` to `ELASTIC`
Add 3D specifications for `material_definitions.hpp`

## Issue Number

Closes #993 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
