### PR TITLE
Issue-946-kernels - Add 3D specialization for assembly::kernels and kernels_container

### DIFF
--- a/core/specfem/assembly/element_types/dim3/element_types.hpp
+++ b/core/specfem/assembly/element_types/dim3/element_types.hpp
@@ -35,8 +35,8 @@ protected:
 public:
   int nspec; ///< total number of spectral elements
   int ngllz; ///< number of quadrature points in z dimension
-  int ngllx; ///< number of quadrature points in x dimension
   int nglly; ///< number of quadrature points in y dimension
+  int ngllx; ///< number of quadrature points in x dimension
 
   constexpr static auto dimension_tag =
       specfem::dimension::type::dim3; ///< Dimension tag
@@ -56,8 +56,8 @@ public:
    *
    * @param nspec Number of spectral elements
    * @param ngllz Number of quadrature points in z direction
-   * @param ngllx Number of quadrature points in x direction
    * @param nglly Number of quadrature points in y direction
+   * @param ngllx Number of quadrature points in x direction
    * @param mesh Mesh information
    * @param tags Element Tags for every spectral element
    */

--- a/core/specfem/assembly/impl/value_containers/dim3/value_containers.hpp
+++ b/core/specfem/assembly/impl/value_containers/dim3/value_containers.hpp
@@ -36,7 +36,7 @@ struct value_containers<specfem::dimension::type::dim3, containers_type> {
     }
   }
 
-  FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC_PSV),
+  FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC),
                        PROPERTY_TAG(ISOTROPIC)),
                       DECLARE(((containers_type, (_DIMENSION_TAG_, _MEDIUM_TAG_,
                                                   _PROPERTY_TAG_)),

--- a/core/specfem/assembly/kernels.hpp
+++ b/core/specfem/assembly/kernels.hpp
@@ -223,3 +223,4 @@ void add_on_host(const IndexType &index, const PointKernelType &point_kernels,
 } // namespace specfem::assembly
 
 #include "kernels/dim2/kernels.hpp"
+#include "kernels/dim3/kernels.hpp"

--- a/core/specfem/assembly/kernels/dim3/kernels.cpp
+++ b/core/specfem/assembly/kernels/dim3/kernels.cpp
@@ -22,8 +22,7 @@ specfem::assembly::kernels<specfem::dimension::type::dim3>::kernels(
   }
 
   FOR_EACH_IN_PRODUCT(
-      (DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC), PROPERTY_TAG(ISOTROPIC),
-       BOUNDARY_TAG(NONE)),
+      (DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC), PROPERTY_TAG(ISOTROPIC)),
       CAPTURE(value) {
         _value_ = specfem::medium::kernels_container<
             _dimension_tag_, _medium_tag_, _property_tag_>(

--- a/core/specfem/assembly/kernels/dim3/kernels.cpp
+++ b/core/specfem/assembly/kernels/dim3/kernels.cpp
@@ -1,0 +1,37 @@
+#include "specfem/assembly/kernels.hpp"
+
+specfem::assembly::kernels<specfem::dimension::type::dim3>::kernels(
+    const int nspec, const int ngllz, const int nglly, const int ngllx,
+    const specfem::assembly::element_types<specfem::dimension::type::dim3>
+        &element_types) {
+
+  this->nspec = nspec;
+  this->ngllz = ngllz;
+  this->nglly = nglly;
+  this->ngllx = ngllx;
+
+  this->property_index_mapping =
+      Kokkos::View<int *, Kokkos::DefaultExecutionSpace>(
+          "specfem::assembly::kernels::property_index_mapping", nspec);
+
+  this->h_property_index_mapping =
+      Kokkos::create_mirror_view(property_index_mapping);
+
+  for (int ispec = 0; ispec < nspec; ++ispec) {
+    h_property_index_mapping(ispec) = -1;
+  }
+
+  FOR_EACH_IN_PRODUCT(
+      (DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC), PROPERTY_TAG(ISOTROPIC),
+       BOUNDARY_TAG(NONE)),
+      CAPTURE(value) {
+        _value_ = specfem::medium::kernels_container<
+            _dimension_tag_, _medium_tag_, _property_tag_>(
+            element_types.get_elements_on_host(_medium_tag_, _property_tag_),
+            nglly, ngllz, ngllx, h_property_index_mapping);
+      })
+
+  Kokkos::deep_copy(property_index_mapping, h_property_index_mapping);
+
+  return;
+}

--- a/core/specfem/assembly/kernels/dim3/kernels.hpp
+++ b/core/specfem/assembly/kernels/dim3/kernels.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "enumerations/interface.hpp"
+#include "medium/kernels_container.hpp"
+#include "specfem/assembly/element_types.hpp"
+#include "specfem/assembly/impl/value_containers.hpp"
+#include "specfem/point.hpp"
+#include <Kokkos_Core.hpp>
+
+namespace specfem::assembly {
+
+template <>
+struct kernels<specfem::dimension::type::dim3>
+    : public impl::value_containers<specfem::dimension::type::dim3,
+                                    specfem::medium::kernels_container> {
+public:
+  /**
+   * @name Constructors
+   *
+   */
+
+  ///@{
+  /**
+   * @brief Default constructor
+   *
+   */
+  kernels() = default;
+
+  /**
+   * @brief Construct a new kernels object
+   *
+   * @param nspec Total number of spectral elements
+   * @param ngllz Number of quadrature points in z dimension
+   * @param nglly Number of quadrature points in y dimension
+   * @param ngllx Number of quadrature points in x dimension
+   * @param mapping mesh to compute mapping
+   * @param tags Tags for every element in spectral element mesh
+   */
+  kernels(const int nspec, const int ngllz, const int nglly, const int ngllx,
+          const specfem::assembly::element_types<dimension_tag> &element_types);
+  ///@}
+
+  /**
+   * @brief Copy misfit kernel data to host
+   *
+   */
+  void copy_to_host() {
+    impl::value_containers<dimension_tag,
+                           specfem::medium::kernels_container>::copy_to_host();
+  }
+
+  void copy_to_device() {
+    impl::value_containers<
+        dimension_tag, specfem::medium::kernels_container>::copy_to_device();
+  }
+};
+
+} // namespace specfem::assembly

--- a/include/medium/impl/accessor.hpp
+++ b/include/medium/impl/accessor.hpp
@@ -10,8 +10,6 @@ namespace impl {
 template <typename DataContainer> class Accessor {
 
 private:
-  constexpr static auto dimension = specfem::dimension::type::dim2;
-
   template <typename PointValues>
   KOKKOS_INLINE_FUNCTION void
   get_data_on_device(const specfem::point::index<dimension> &index,

--- a/include/medium/impl/accessor.hpp
+++ b/include/medium/impl/accessor.hpp
@@ -7,9 +7,12 @@ namespace specfem {
 namespace medium {
 namespace impl {
 
-template <typename DataContainer> class Accessor {
+template <specfem::dimension::type DimensionTag, typename DataContainer>
+class Accessor {
 
 private:
+  constexpr static auto dimension = DimensionTag;
+
   template <typename PointValues>
   KOKKOS_INLINE_FUNCTION void
   get_data_on_device(const specfem::point::index<dimension> &index,

--- a/include/medium/impl/data_container.hpp
+++ b/include/medium/impl/data_container.hpp
@@ -86,7 +86,19 @@
       : BOOST_PP_SEQ_ENUM(                                                     \
             BOOST_PP_SEQ_TRANSFORM(_INSTANCE_DEVICE_VIEW, _, seq)),            \
         BOOST_PP_SEQ_ENUM(                                                     \
-            BOOST_PP_SEQ_TRANSFORM(_INSTANCE_HOST_VIEW, _, seq)) {}
+            BOOST_PP_SEQ_TRANSFORM(_INSTANCE_HOST_VIEW, _, seq)) {             \
+    static_assert(dimension_tag == specfem::dimension::type::dim2,             \
+                  "Calling a 2D constructor from non-2D container");           \
+  }                                                                            \
+  data_container(const int nspec, const int ngllz, const int nglly,            \
+                 const int ngllx)                                              \
+      : BOOST_PP_SEQ_ENUM(                                                     \
+            BOOST_PP_SEQ_TRANSFORM(_INSTANCE_DEVICE_VIEW, _, seq)),            \
+        BOOST_PP_SEQ_ENUM(                                                     \
+            BOOST_PP_SEQ_TRANSFORM(_INSTANCE_HOST_VIEW, _, seq)) {             \
+    static_assert(dimension_tag == specfem::dimension::type::dim3,             \
+                  "Calling a 3D constructor from non-3D container");           \
+  }
 
 #define _SYNC_DEVICE(r, data, elem)                                            \
   specfem::kokkos::deep_copy(BOOST_PP_SEQ_ELEM(0, elem),                       \

--- a/include/medium/impl/data_container.hpp
+++ b/include/medium/impl/data_container.hpp
@@ -82,23 +82,21 @@
 
 #define _DATA_CONSTRUCTORS(seq)                                                \
   data_container() = default;                                                  \
+  template <specfem::dimension::type U = dimension_tag,                        \
+            std::enable_if_t<U == specfem::dimension::type::dim2, int> = 0>    \
   data_container(const int nspec, const int ngllz, const int ngllx)            \
       : BOOST_PP_SEQ_ENUM(                                                     \
             BOOST_PP_SEQ_TRANSFORM(_INSTANCE_DEVICE_VIEW, _, seq)),            \
         BOOST_PP_SEQ_ENUM(                                                     \
-            BOOST_PP_SEQ_TRANSFORM(_INSTANCE_HOST_VIEW, _, seq)) {             \
-    static_assert(dimension_tag == specfem::dimension::type::dim2,             \
-                  "Calling 2D constructor from non-2D container");             \
-  }                                                                            \
+            BOOST_PP_SEQ_TRANSFORM(_INSTANCE_HOST_VIEW, _, seq)) {}            \
+  template <specfem::dimension::type U = dimension_tag,                        \
+            std::enable_if_t<U == specfem::dimension::type::dim3, int> = 0>    \
   data_container(const int nspec, const int ngllz, const int nglly,            \
                  const int ngllx)                                              \
       : BOOST_PP_SEQ_ENUM(                                                     \
             BOOST_PP_SEQ_TRANSFORM(_INSTANCE_DEVICE_VIEW, _, seq)),            \
         BOOST_PP_SEQ_ENUM(                                                     \
-            BOOST_PP_SEQ_TRANSFORM(_INSTANCE_HOST_VIEW, _, seq)) {             \
-    static_assert(dimension_tag == specfem::dimension::type::dim3,             \
-                  "Calling 3D constructor from non-3D container");             \
-  }
+            BOOST_PP_SEQ_TRANSFORM(_INSTANCE_HOST_VIEW, _, seq)) {}
 
 #define _SYNC_DEVICE(r, data, elem)                                            \
   specfem::kokkos::deep_copy(BOOST_PP_SEQ_ELEM(0, elem),                       \

--- a/include/medium/impl/data_container.hpp
+++ b/include/medium/impl/data_container.hpp
@@ -88,7 +88,7 @@
         BOOST_PP_SEQ_ENUM(                                                     \
             BOOST_PP_SEQ_TRANSFORM(_INSTANCE_HOST_VIEW, _, seq)) {             \
     static_assert(dimension_tag == specfem::dimension::type::dim2,             \
-                  "Calling a 2D constructor from non-2D container");           \
+                  "Calling 2D constructor from non-2D container");             \
   }                                                                            \
   data_container(const int nspec, const int ngllz, const int nglly,            \
                  const int ngllx)                                              \
@@ -97,7 +97,7 @@
         BOOST_PP_SEQ_ENUM(                                                     \
             BOOST_PP_SEQ_TRANSFORM(_INSTANCE_HOST_VIEW, _, seq)) {             \
     static_assert(dimension_tag == specfem::dimension::type::dim3,             \
-                  "Calling a 3D constructor from non-3D container");           \
+                  "Calling 3D constructor from non-3D container");             \
   }
 
 #define _SYNC_DEVICE(r, data, elem)                                            \
@@ -180,7 +180,17 @@
  *     : rho("rho", nspec, ngllz, ngllx),
  *       kappa("kappa", nspec, ngllz, ngllx),
  *       h_rho(specfem::kokkos::create_mirror_view(rho)),
- *       h_kappa(specfem::kokkos::create_mirror_view(kappa)) {}
+ *       h_kappa(specfem::kokkos::create_mirror_view(kappa)) {
+ *  static_assert(dimension_tag == specfem::dimension::type::dim2,
+ *                "Calling 2D constructor from non-2D container");
+ * }
+ * data_container(const int nspec, const int ngllz, const int nglly, const int
+ * ngllx) : rho("rho", nspec, ngllz, ngllx), kappa("kappa", nspec, ngllz,
+ * ngllx), h_rho(specfem::kokkos::create_mirror_view(rho)),
+ *       h_kappa(specfem::kokkos::create_mirror_view(kappa)) {
+ *  static_assert(dimension_tag == specfem::dimension::type::dim3,
+ *                "Calling 3D constructor from non-3D container");
+ * }
  * template <typename FunctorType, typename IndexType>
  * KOKKOS_INLINE_FUNCTION
  * void for_each_on_device(const IndexType &index, FunctorType f) const {

--- a/include/medium/kernels_container.hpp
+++ b/include/medium/kernels_container.hpp
@@ -50,6 +50,41 @@ struct kernels_container<specfem::dimension::type::dim2, MediumTag, PropertyTag>
     }
   }
 };
+
+template <specfem::element::medium_tag MediumTag,
+          specfem::element::property_tag PropertyTag>
+struct kernels_container<specfem::dimension::type::dim3, MediumTag, PropertyTag>
+    : public kernels::data_container<specfem::dimension::type::dim3, MediumTag,
+                                     PropertyTag>,
+      public impl::Accessor<kernels_container<specfem::dimension::type::dim3,
+                                              MediumTag, PropertyTag> > {
+
+  using base_type = kernels::data_container<specfem::dimension::type::dim3,
+                                            MediumTag, PropertyTag>;
+  using base_type::base_type;
+
+  constexpr static auto dimension_tag =
+      base_type::dimension_tag; ///< Dimension of the material
+  constexpr static auto medium_tag = base_type::medium_tag; ///< Medium type
+  constexpr static auto property_tag =
+      base_type::property_tag; ///< Property type
+
+  kernels_container() = default;
+
+  kernels_container(
+      const Kokkos::View<int *, Kokkos::DefaultHostExecutionSpace> elements,
+      const int ngllz, const int nglly, const int ngllx,
+      const specfem::kokkos::HostView1d<int> property_index_mapping)
+      : base_type(elements.extent(0), ngllz, nglly, ngllx) {
+    const int nelement = elements.extent(0);
+    int count = 0;
+    for (int i = 0; i < nelement; ++i) {
+      const int ispec = elements(i);
+      property_index_mapping(ispec) = count;
+      count++;
+    }
+  }
+};
 } // namespace medium
 } // namespace specfem
 

--- a/include/medium/kernels_container.hpp
+++ b/include/medium/kernels_container.hpp
@@ -21,7 +21,8 @@ template <specfem::element::medium_tag MediumTag,
 struct kernels_container<specfem::dimension::type::dim2, MediumTag, PropertyTag>
     : public kernels::data_container<specfem::dimension::type::dim2, MediumTag,
                                      PropertyTag>,
-      public impl::Accessor<kernels_container<specfem::dimension::type::dim2,
+      public impl::Accessor<specfem::dimension::type::dim2,
+                            kernels_container<specfem::dimension::type::dim2,
                                               MediumTag, PropertyTag> > {
 
   using base_type = kernels::data_container<specfem::dimension::type::dim2,
@@ -56,7 +57,8 @@ template <specfem::element::medium_tag MediumTag,
 struct kernels_container<specfem::dimension::type::dim3, MediumTag, PropertyTag>
     : public kernels::data_container<specfem::dimension::type::dim3, MediumTag,
                                      PropertyTag>,
-      public impl::Accessor<kernels_container<specfem::dimension::type::dim3,
+      public impl::Accessor<specfem::dimension::type::dim3,
+                            kernels_container<specfem::dimension::type::dim3,
                                               MediumTag, PropertyTag> > {
 
   using base_type = kernels::data_container<specfem::dimension::type::dim3,

--- a/include/medium/properties_container.hpp
+++ b/include/medium/properties_container.hpp
@@ -28,7 +28,8 @@ struct properties_container<specfem::dimension::type::dim2, MediumTag,
                             PropertyTag>
     : public properties::data_container<specfem::dimension::type::dim2,
                                         MediumTag, PropertyTag>,
-      public impl::Accessor<properties_container<specfem::dimension::type::dim2,
+      public impl::Accessor<specfem::dimension::type::dim2,
+                            properties_container<specfem::dimension::type::dim2,
                                                  MediumTag, PropertyTag> > {
 
   using base_type = properties::data_container<specfem::dimension::type::dim2,


### PR DESCRIPTION
## Description

- Add 3D specialization for assembly::kernels and kernels_container
- Update macros in `include/medium/impl/data_container.hpp` to support 2D and 3D at the same time.
- Tests will be added in a separate PR.

## Issue Number

Adds to #946 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
