### PR TITLE
Fix ASCII Reader/Writer

### DIFF
--- a/include/io/ASCII/impl/datasetbase.hpp
+++ b/include/io/ASCII/impl/datasetbase.hpp
@@ -15,7 +15,6 @@ namespace specfem {
 namespace io {
 namespace impl {
 namespace ASCII {
-
 template <typename OpType> class DatasetBase;
 
 template <> class DatasetBase<specfem::io::write> {


### PR DESCRIPTION
## Description

Please describe the changes/features in this pull request.

- [x] Fixes a bug in ASCII IO where small/big values outside precision level of float double could be written
- [x] Set small values to 0 before writing and errors out on big values

@icui we can run Tromp-2005 in ASCII mode after this update

## Issue Number

If there is an issue created for these changes, link it here

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
