### PR TITLE
Use references for 'const std::string' function arguments.

### DIFF
--- a/core/specfem/receivers/dim2/receiver.hpp
+++ b/core/specfem/receivers/dim2/receiver.hpp
@@ -31,7 +31,7 @@ public:
    * @param z Z coordinate of the station
    * @param angle Angle of the station
    */
-  receiver(const std::string network_name, const std::string station_name,
+  receiver(const std::string &network_name, const std::string &station_name,
            const type_real x, const type_real z, const type_real angle)
       : network_name(network_name), station_name(station_name), x(x), z(z),
         angle(angle) {};

--- a/include/io/interface.hpp
+++ b/include/io/interface.hpp
@@ -21,7 +21,7 @@ namespace io {
  *
  */
 specfem::mesh::mesh<specfem::dimension::type::dim2>
-read_2d_mesh(const std::string filename,
+read_2d_mesh(const std::string &filename,
              const specfem::enums::elastic_wave wave,
              const specfem::enums::electromagnetic_wave electromagnetic_wave,
              const specfem::MPI::MPI *mpi);
@@ -37,8 +37,8 @@ read_2d_mesh(const std::string filename,
  *
  */
 specfem::mesh::mesh<specfem::dimension::type::dim3>
-read_3d_mesh(const std::string mesh_parameters_file,
-             const std::string mesh_databases_file,
+read_3d_mesh(const std::string &mesh_parameters_file,
+             const std::string &mesh_databases_file,
              const specfem::MPI::MPI *mpi);
 
 /**
@@ -53,7 +53,7 @@ read_3d_mesh(const std::string mesh_parameters_file,
  */
 std::vector<std::shared_ptr<
     specfem::receivers::receiver<specfem::dimension::type::dim2> > >
-read_receivers(const std::string stations_file, const type_real angle);
+read_receivers(const std::string &stations_file, const type_real angle);
 
 /**
  * @overload
@@ -98,7 +98,7 @@ read_receivers(const YAML::Node &stations, const type_real angle);
  * objects
  */
 std::tuple<std::vector<std::shared_ptr<specfem::sources::source> >, type_real>
-read_sources(const std::string sources_file, const int nsteps,
+read_sources(const std::string &sources_file, const int nsteps,
              const type_real user_t0, const type_real dt,
              const specfem::simulation::type simulation_type);
 

--- a/include/io/kernel/writer.hpp
+++ b/include/io/kernel/writer.hpp
@@ -25,7 +25,7 @@ public:
    * @param output_folder Path to output location (will be an .h5 file if using
    * HDF5, and a folder if using ASCII)
    */
-  kernel_writer(const std::string output_folder);
+  kernel_writer(const std::string &output_folder);
 
   /**
    * @brief write the kernel data to disk

--- a/include/io/kernel/writer.tpp
+++ b/include/io/kernel/writer.tpp
@@ -10,7 +10,7 @@ namespace specfem {
 namespace io {
 
 template <typename OutputLibrary>
-kernel_writer<OutputLibrary>::kernel_writer(const std::string output_folder)
+kernel_writer<OutputLibrary>::kernel_writer(const std::string &output_folder)
     : output_folder(output_folder) {}
 
 template <typename OutputLibrary>

--- a/include/io/property/reader.hpp
+++ b/include/io/property/reader.hpp
@@ -24,7 +24,7 @@ public:
    * @param output_folder Path to input location (will be an .h5 file if using
    * HDF5, and a folder if using ASCII)
    */
-  property_reader(const std::string input_folder);
+  property_reader(const std::string &input_folder);
 
   /**
    * @brief read the property from disk

--- a/include/io/property/reader.tpp
+++ b/include/io/property/reader.tpp
@@ -10,7 +10,7 @@
 
 template <typename InputLibrary>
 specfem::io::property_reader<InputLibrary>::property_reader(
-    const std::string input_folder)
+    const std::string &input_folder)
     : input_folder(input_folder) {}
 
 template <typename InputLibrary>

--- a/include/io/property/writer.hpp
+++ b/include/io/property/writer.hpp
@@ -24,7 +24,7 @@ public:
    * @param output_folder Path to output location (will be an .h5 file if using
    * HDF5, and a folder if using ASCII)
    */
-  property_writer(const std::string output_folder);
+  property_writer(const std::string &output_folder);
 
   /**
    * @brief write the property data to disk

--- a/include/io/property/writer.tpp
+++ b/include/io/property/writer.tpp
@@ -10,7 +10,7 @@ namespace specfem {
 namespace io {
 
 template <typename OutputLibrary>
-property_writer<OutputLibrary>::property_writer(const std::string output_folder)
+property_writer<OutputLibrary>::property_writer(const std::string &output_folder)
     : output_folder(output_folder) {}
 
 template <typename OutputLibrary>

--- a/include/io/wavefield/writer.hpp
+++ b/include/io/wavefield/writer.hpp
@@ -26,7 +26,7 @@ public:
    * @param output_folder Path to output location (will be an .h5 file if using
    * HDF5, and a folder if using ASCII)
    */
-  wavefield_writer(const std::string output_folder,
+  wavefield_writer(const std::string &output_folder,
                    const bool save_boundary_values);
   ///@}
 

--- a/include/io/wavefield/writer.tpp
+++ b/include/io/wavefield/writer.tpp
@@ -7,7 +7,7 @@
 
 template <typename OutputLibrary>
 specfem::io::wavefield_writer<OutputLibrary>::wavefield_writer(
-    const std::string output_folder, const bool save_boundary_values)
+    const std::string &output_folder, const bool save_boundary_values)
     : output_folder(output_folder), save_boundary_values(save_boundary_values),
       file(typename OutputLibrary::File(output_folder + "/ForwardWavefield")) {}
 

--- a/include/parameter_parser/quadrature.hpp
+++ b/include/parameter_parser/quadrature.hpp
@@ -38,7 +38,7 @@ public:
    * @param quadrature pre-defined quadratures. e.g. GLL4 for 4th order GLL
    * quadrature
    */
-  quadrature(const std::string quadrature);
+  quadrature(const std::string &quadrature);
   /**
    * @brief Instantiate quadrature objects in x and z dimensions
    *

--- a/include/parameter_parser/solver/solver.hpp
+++ b/include/parameter_parser/solver/solver.hpp
@@ -29,7 +29,7 @@ public:
    *
    * @param simulation_type Type of the simulation (forward or combined)
    */
-  solver(const std::string simulation_type)
+  solver(const std::string &simulation_type)
       : simulation_type(simulation_type) {}
 
   /**

--- a/include/parameter_parser/writer/kernel.hpp
+++ b/include/parameter_parser/writer/kernel.hpp
@@ -9,7 +9,7 @@ namespace specfem {
 namespace runtime_configuration {
 class kernel {
 public:
-  kernel(const std::string output_format, const std::string output_folder,
+  kernel(const std::string &output_format, const std::string &output_folder,
          const specfem::simulation::type type)
       : output_format(output_format), output_folder(output_folder),
         simulation_type(type) {}

--- a/include/parameter_parser/writer/plot_wavefield.hpp
+++ b/include/parameter_parser/writer/plot_wavefield.hpp
@@ -29,9 +29,9 @@ public:
    * @param wavefield_type type of wavefield to plot (displacement, velocity,
    * acceleration)
    */
-  plot_wavefield(const std::string output_format,
-                 const std::string output_folder, const std::string component,
-                 const std::string wavefield_type, const int time_interval)
+  plot_wavefield(const std::string &output_format,
+                 const std::string &output_folder, const std::string &component,
+                 const std::string &wavefield_type, const int time_interval)
       : output_format(output_format), output_folder(output_folder),
         component(component), wavefield_type(wavefield_type),
         time_interval(time_interval) {}

--- a/include/parameter_parser/writer/property.hpp
+++ b/include/parameter_parser/writer/property.hpp
@@ -8,7 +8,7 @@ namespace specfem {
 namespace runtime_configuration {
 class property {
 public:
-  property(const std::string output_format, const std::string output_folder,
+  property(const std::string &output_format, const std::string &output_folder,
            const bool write_mode)
       : output_format(output_format), output_folder(output_folder),
         write_mode(write_mode) {}

--- a/include/parameter_parser/writer/seismogram.hpp
+++ b/include/parameter_parser/writer/seismogram.hpp
@@ -24,7 +24,7 @@ public:
    * @param output_folder Path to folder location where seismogram will be
    * stored
    */
-  seismogram(const std::string output_format, const std::string output_folder)
+  seismogram(const std::string &output_format, const std::string &output_folder)
       : output_format(output_format), output_folder(output_folder) {};
   /**
    * @brief Construct a new seismogram object

--- a/include/parameter_parser/writer/wavefield.hpp
+++ b/include/parameter_parser/writer/wavefield.hpp
@@ -32,9 +32,9 @@ public:
    * timesteps between wavefield by the memory value provided, e.g. 100MB, 20GB.
    * @param include_last_step Whether or not to write the final time step.
    */
-  wavefield(const std::string output_format, const std::string output_folder,
+  wavefield(const std::string &output_format, const std::string &output_folder,
             const specfem::simulation::type type, const int time_interval,
-            const std::string time_interval_by_memory,
+            const std::string &time_interval_by_memory,
             const bool include_last_step, bool for_adjoint_simulations)
       : output_format(output_format), output_folder(output_folder),
         simulation_type(type), time_interval(time_interval),

--- a/include/periodic_tasks/wavefield_reader.hpp
+++ b/include/periodic_tasks/wavefield_reader.hpp
@@ -17,7 +17,7 @@ private:
   specfem::io::wavefield_reader<IOLibrary<specfem::io::read> > reader;
 
 public:
-  wavefield_reader(const std::string output_folder, const int time_interval,
+  wavefield_reader(const std::string &output_folder, const int time_interval,
                    const bool include_last_step)
       : periodic_task(time_interval, include_last_step),
         reader(specfem::io::wavefield_reader<IOLibrary<specfem::io::read> >(

--- a/include/periodic_tasks/wavefield_writer.hpp
+++ b/include/periodic_tasks/wavefield_writer.hpp
@@ -17,7 +17,7 @@ private:
   specfem::io::wavefield_writer<IOLibrary<specfem::io::write> > writer;
 
 public:
-  wavefield_writer(const std::string output_folder, const int time_interval,
+  wavefield_writer(const std::string &output_folder, const int time_interval,
                    const bool include_last_step,
                    const bool save_boundary_values)
       : periodic_task(time_interval, include_last_step),

--- a/src/io/mesh/impl/fortran/dim2/mesh.cpp
+++ b/src/io/mesh/impl/fortran/dim2/mesh.cpp
@@ -24,7 +24,7 @@
 #include <vector>
 
 specfem::mesh::mesh<specfem::dimension::type::dim2> specfem::io::read_2d_mesh(
-    const std::string filename, const specfem::enums::elastic_wave elastic_wave,
+    const std::string &filename, const specfem::enums::elastic_wave elastic_wave,
     const specfem::enums::electromagnetic_wave electromagnetic_wave,
     const specfem::MPI::MPI *mpi) {
 

--- a/src/io/mesh/impl/fortran/dim3/mesh.cpp
+++ b/src/io/mesh/impl/fortran/dim3/mesh.cpp
@@ -40,8 +40,8 @@ std::string try_print_medium_element(
 }
 
 specfem::mesh::mesh<specfem::dimension::type::dim3>
-specfem::io::read_3d_mesh(const std::string mesh_parameters_file,
-                          const std::string mesh_databases_file,
+specfem::io::read_3d_mesh(const std::string &mesh_parameters_file,
+                          const std::string &mesh_databases_file,
                           const specfem::MPI::MPI *mpi) {
 
   // Creating aliases for Checking functions

--- a/src/io/receivers.cpp
+++ b/src/io/receivers.cpp
@@ -13,7 +13,7 @@
 
 std::vector<std::shared_ptr<
     specfem::receivers::receiver<specfem::dimension::type::dim2> > >
-specfem::io::read_receivers(const std::string stations_file,
+specfem::io::read_receivers(const std::string &stations_file,
                             const type_real angle) {
 
   boost::char_separator<char> sep(" ");

--- a/src/io/sources.cpp
+++ b/src/io/sources.cpp
@@ -13,7 +13,7 @@
 #include <vector>
 
 std::tuple<std::vector<std::shared_ptr<specfem::sources::source> >, type_real>
-specfem::io::read_sources(const std::string sources_file, const int nsteps,
+specfem::io::read_sources(const std::string &sources_file, const int nsteps,
                           const type_real user_t0, const type_real dt,
                           const specfem::simulation::type simulation_type) {
   YAML::Node source_node = YAML::LoadFile(sources_file);

--- a/src/parameter_parser/quadrature.cpp
+++ b/src/parameter_parser/quadrature.cpp
@@ -22,7 +22,7 @@ specfem::runtime_configuration::quadrature::instantiate() {
 }
 
 specfem::runtime_configuration::quadrature::quadrature(
-    const std::string quadrature) {
+    const std::string &quadrature) {
 
   if (specfem::utilities::is_gll4_string(quadrature)) {
     *this = specfem::runtime_configuration::quadrature(0.0, 0.0, 5);


### PR DESCRIPTION
Copying `std::string` objects is pretty expensive. When a function (or constructor) takes a `const std::string` argument, the `const` indicates that it has no interest in modifying the string, and so it should take the argument by `const` reference instead to avoid the copy.