### PR TITLE
Issue 1057 -- Splits mesh numbering intro testable functions, and implements tests

### DIFF
--- a/core/specfem/assembly/mesh/dim2/impl/points.hpp
+++ b/core/specfem/assembly/mesh/dim2/impl/points.hpp
@@ -13,6 +13,7 @@ template <> struct points<specfem::dimension::type::dim2> {
 public:
   constexpr static auto dimension =
       specfem::dimension::type::dim2; ///< Dimension
+  constexpr static int ndim = 2;      ///< Number of dimensions
   int nspec;                          ///< Number of spectral elements
   int ngllz; ///< Number of quadrature points in z dimension
   int ngllx; ///< Number of quadrature points in x dimension
@@ -45,6 +46,22 @@ public:
         coord("specfem::assembly::points::coord", ndim, nspec, ngllz, ngllx),
         h_index_mapping(Kokkos::create_mirror_view(index_mapping)),
         h_coord(Kokkos::create_mirror_view(coord)) {}
+
+  // Constructor that takes pre-computed coordinate arrays
+  points(const int &nspec, const int &ngllz, const int &ngllx,
+         IndexMappingViewType::HostMirror h_index_mapping_in,
+         CoordViewType::HostMirror h_coord_in, type_real xmin_in,
+         type_real xmax_in, type_real zmin_in, type_real zmax_in)
+      : nspec(nspec), ngllz(ngllz), ngllx(ngllx),
+        index_mapping("specfem::assembly::points::index_mapping", nspec, ngllz,
+                      ngllx),
+        coord("specfem::assembly::points::coord", ndim, nspec, ngllz, ngllx),
+        h_index_mapping(h_index_mapping_in), h_coord(h_coord_in), xmin(xmin_in),
+        xmax(xmax_in), zmin(zmin_in), zmax(zmax_in) {
+    // Copy host data to device
+    Kokkos::deep_copy(index_mapping, h_index_mapping);
+    Kokkos::deep_copy(coord, h_coord);
+  }
 };
 
 } // namespace specfem::assembly::mesh_impl

--- a/core/specfem/assembly/mesh/dim2/impl/utilities.hpp
+++ b/core/specfem/assembly/mesh/dim2/impl/utilities.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "kokkos_abstractions.h"
+
 #include <limits>
 #include <vector>
 
@@ -49,3 +50,5 @@ bounding_box compute_bounding_box(const std::vector<point> &points);
 } // namespace mesh_impl
 } // namespace assembly
 } // namespace specfem
+
+#include "utilities.tpp"

--- a/core/specfem/assembly/mesh/dim2/impl/utilities.hpp
+++ b/core/specfem/assembly/mesh/dim2/impl/utilities.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "kokkos_abstractions.h"
+#include <limits>
+#include <vector>
+
+/*
+ * Utility functions for 2D mesh operations
+ * This header is technically part of the implementation details, but the
+ * functions declared here are intended for testing as well and therefore
+ * exposed.
+ */
+
+namespace specfem {
+namespace assembly {
+namespace mesh_impl {
+namespace dim2 {
+namespace utilities {
+
+struct point {
+  type_real x = 0, z = 0;
+  int iloc = 0, iglob = 0;
+};
+
+struct bounding_box {
+  type_real xmin = std::numeric_limits<type_real>::max();
+  type_real xmax = std::numeric_limits<type_real>::min();
+  type_real zmin = std::numeric_limits<type_real>::max();
+  type_real zmax = std::numeric_limits<type_real>::min();
+};
+
+type_real compute_spatial_tolerance(const std::vector<point> &points, int nspec,
+                                    int ngllxz);
+
+std::vector<point> flatten_coordinates(
+    const specfem::kokkos::HostView4d<double> &global_coordinates);
+
+void sort_points_spatially(std::vector<point> &points);
+
+int assign_global_numbering(std::vector<point> &points, type_real tolerance);
+
+std::vector<point>
+reorder_to_original_layout(const std::vector<point> &sorted_points);
+
+bounding_box compute_bounding_box(const std::vector<point> &points);
+
+} // namespace utilities
+} // namespace dim2
+} // namespace mesh_impl
+} // namespace assembly
+} // namespace specfem

--- a/core/specfem/assembly/mesh/dim2/impl/utilities.tpp
+++ b/core/specfem/assembly/mesh/dim2/impl/utilities.tpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "utilities.hpp"
 #include "parallel_configuration/chunk_config.hpp"
 #include <algorithm>
 #include <cmath>
@@ -11,8 +10,8 @@ namespace mesh_impl {
 namespace dim2 {
 namespace utilities {
 
-type_real compute_spatial_tolerance(const std::vector<point>& points,
-                                   int nspec, int ngllxz) {
+inline type_real compute_spatial_tolerance(const std::vector<point>& points,
+                                           int nspec, int ngllxz) {
   type_real xtypdist = std::numeric_limits<type_real>::max();
 
   for (int ispec = 0; ispec < nspec; ispec++) {
@@ -36,7 +35,7 @@ type_real compute_spatial_tolerance(const std::vector<point>& points,
   return 1e-6 * xtypdist;
 }
 
-std::vector<point> flatten_coordinates(
+inline std::vector<point> flatten_coordinates(
     const specfem::kokkos::HostView4d<double>& global_coordinates) {
 
   int nspec = global_coordinates.extent(0);
@@ -67,7 +66,7 @@ std::vector<point> flatten_coordinates(
   return points;
 }
 
-void sort_points_spatially(std::vector<point>& points) {
+inline void sort_points_spatially(std::vector<point>& points) {
   std::sort(points.begin(), points.end(),
             [&](const point& p1, const point& p2) {
               if (p1.x != p2.x) {
@@ -77,7 +76,7 @@ void sort_points_spatially(std::vector<point>& points) {
             });
 }
 
-int assign_global_numbering(std::vector<point>& points, type_real tolerance) {
+inline int assign_global_numbering(std::vector<point>& points, type_real tolerance) {
   if (points.empty()) return 0;
 
   int ig = 0;
@@ -94,7 +93,7 @@ int assign_global_numbering(std::vector<point>& points, type_real tolerance) {
   return ig + 1;
 }
 
-std::vector<point> reorder_to_original_layout(const std::vector<point>& sorted_points) {
+inline std::vector<point> reorder_to_original_layout(const std::vector<point>& sorted_points) {
   std::vector<point> reordered(sorted_points.size());
 
   for (int i = 0; i < sorted_points.size(); i++) {
@@ -105,7 +104,7 @@ std::vector<point> reorder_to_original_layout(const std::vector<point>& sorted_p
   return reordered;
 }
 
-bounding_box compute_bounding_box(const std::vector<point>& points) {
+inline bounding_box compute_bounding_box(const std::vector<point>& points) {
   bounding_box bbox;
 
   for (const auto& p : points) {

--- a/core/specfem/assembly/mesh/dim2/impl/utilities.tpp
+++ b/core/specfem/assembly/mesh/dim2/impl/utilities.tpp
@@ -1,0 +1,125 @@
+#pragma once
+
+#include "utilities.hpp"
+#include "parallel_configuration/chunk_config.hpp"
+#include <algorithm>
+#include <cmath>
+
+namespace specfem {
+namespace assembly {
+namespace mesh_impl {
+namespace dim2 {
+namespace utilities {
+
+type_real compute_spatial_tolerance(const std::vector<point>& points,
+                                   int nspec, int ngllxz) {
+  type_real xtypdist = std::numeric_limits<type_real>::max();
+
+  for (int ispec = 0; ispec < nspec; ispec++) {
+    type_real xmax = std::numeric_limits<type_real>::min();
+    type_real xmin = std::numeric_limits<type_real>::max();
+    type_real ymax = std::numeric_limits<type_real>::min();
+    type_real ymin = std::numeric_limits<type_real>::max();
+
+    for (int xz = 0; xz < ngllxz; xz++) {
+      int iloc = ispec * ngllxz + xz;
+      xmax = std::max(xmax, points[iloc].x);
+      xmin = std::min(xmin, points[iloc].x);
+      ymax = std::max(ymax, points[iloc].z);
+      ymin = std::min(ymin, points[iloc].z);
+    }
+
+    xtypdist = std::min(xtypdist, xmax - xmin);
+    xtypdist = std::min(xtypdist, ymax - ymin);
+  }
+
+  return 1e-6 * xtypdist;
+}
+
+std::vector<point> flatten_coordinates(
+    const specfem::kokkos::HostView4d<double>& global_coordinates) {
+
+  int nspec = global_coordinates.extent(0);
+  int ngll = global_coordinates.extent(1);
+  int ngllxz = ngll * ngll;
+
+  std::vector<point> points(nspec * ngllxz);
+
+  constexpr int chunk_size = specfem::parallel_config::storage_chunk_size;
+
+  int iloc = 0;
+  for (int ichunk = 0; ichunk < nspec; ichunk += chunk_size) {
+    for (int iz = 0; iz < ngll; iz++) {
+      for (int ix = 0; ix < ngll; ix++) {
+        for (int ielement = 0; ielement < chunk_size; ielement++) {
+          int ispec = ichunk + ielement;
+          if (ispec >= nspec)
+            break;
+          points[iloc].x = global_coordinates(ispec, iz, ix, 0);
+          points[iloc].z = global_coordinates(ispec, iz, ix, 1);
+          points[iloc].iloc = iloc;
+          iloc++;
+        }
+      }
+    }
+  }
+
+  return points;
+}
+
+void sort_points_spatially(std::vector<point>& points) {
+  std::sort(points.begin(), points.end(),
+            [&](const point& p1, const point& p2) {
+              if (p1.x != p2.x) {
+                return p1.x < p2.x;
+              }
+              return p1.z < p2.z;
+            });
+}
+
+int assign_global_numbering(std::vector<point>& points, type_real tolerance) {
+  if (points.empty()) return 0;
+
+  int ig = 0;
+  points[0].iglob = ig;
+
+  for (int i = 1; i < points.size(); i++) {
+    if ((std::abs(points[i].x - points[i - 1].x) > tolerance) ||
+        (std::abs(points[i].z - points[i - 1].z) > tolerance)) {
+      ig++;
+    }
+    points[i].iglob = ig;
+  }
+
+  return ig + 1;
+}
+
+std::vector<point> reorder_to_original_layout(const std::vector<point>& sorted_points) {
+  std::vector<point> reordered(sorted_points.size());
+
+  for (int i = 0; i < sorted_points.size(); i++) {
+    int iloc = sorted_points[i].iloc;
+    reordered[iloc] = sorted_points[i];
+  }
+
+  return reordered;
+}
+
+bounding_box compute_bounding_box(const std::vector<point>& points) {
+  bounding_box bbox;
+
+  for (const auto& p : points) {
+    bbox.xmin = std::min(bbox.xmin, p.x);
+    bbox.xmax = std::max(bbox.xmax, p.x);
+    bbox.zmin = std::min(bbox.zmin, p.z);
+    bbox.zmax = std::max(bbox.zmax, p.z);
+  }
+
+  return bbox;
+}
+
+} // namespace utilities
+} // namespace dim2
+} // namespace mesh_impl
+} // namespace assembly
+} // namespace specfem

--- a/core/specfem/assembly/mesh/dim2/mesh.tpp
+++ b/core/specfem/assembly/mesh/dim2/mesh.tpp
@@ -9,40 +9,70 @@
 #include "quadrature/interface.hpp"
 #include "specfem/assembly.hpp"
 #include "specfem_setup.hpp"
+#include "impl/utilities.tpp"
 #include <Kokkos_Core.hpp>
 #include <tuple>
 #include <vector>
 
 namespace {
-struct qp {
-  type_real x = 0, z = 0;
-  int iloc = 0, iglob = 0;
-};
+using point = specfem::assembly::mesh_impl::dim2::utilities::point;
+using bounding_box = specfem::assembly::mesh_impl::dim2::utilities::bounding_box;
 
-type_real get_tolerance(std::vector<qp> cart_cord, const int nspec,
-                        const int ngllxz) {
+specfem::assembly::mesh_impl::points<specfem::dimension::type::dim2>
+create_mesh_points(
+    const std::vector<point>& reordered_points,
+    const bounding_box& bbox,
+    int nspec, int ngll, int nglob) {
 
-  assert(cart_cord.size() == ngllxz * nspec);
+  specfem::assembly::mesh_impl::points<specfem::dimension::type::dim2> mesh_points(
+      nspec, ngll, ngll);
 
-  type_real xtypdist = std::numeric_limits<type_real>::max();
-  for (int ispec = 0; ispec < nspec; ispec++) {
-    type_real xmax = std::numeric_limits<type_real>::min();
-    type_real xmin = std::numeric_limits<type_real>::max();
-    type_real ymax = std::numeric_limits<type_real>::min();
-    type_real ymin = std::numeric_limits<type_real>::max();
-    for (int xz = 0; xz < ngllxz; xz++) {
-      int iloc = ispec * (ngllxz) + xz;
-      xmax = std::max(xmax, cart_cord[iloc].x);
-      xmin = std::min(xmin, cart_cord[iloc].x);
-      ymax = std::max(ymax, cart_cord[iloc].z);
-      ymin = std::min(ymin, cart_cord[iloc].z);
+  std::vector<int> iglob_counted(nglob, -1);
+  constexpr int chunk_size = specfem::parallel_config::storage_chunk_size;
+  int iloc = 0;
+  int inum = 0;
+
+  for (int ichunk = 0; ichunk < nspec; ichunk += chunk_size) {
+    for (int iz = 0; iz < ngll; iz++) {
+      for (int ix = 0; ix < ngll; ix++) {
+        for (int ielement = 0; ielement < chunk_size; ielement++) {
+          int ispec = ichunk + ielement;
+          if (ispec >= nspec)
+            break;
+          if (iglob_counted[reordered_points[iloc].iglob] == -1) {
+            const type_real x_cor = reordered_points[iloc].x;
+            const type_real z_cor = reordered_points[iloc].z;
+
+            iglob_counted[reordered_points[iloc].iglob] = inum;
+            mesh_points.h_index_mapping(ispec, iz, ix) = inum;
+            mesh_points.h_coord(0, ispec, iz, ix) = x_cor;
+            mesh_points.h_coord(1, ispec, iz, ix) = z_cor;
+            inum++;
+          } else {
+            mesh_points.h_index_mapping(ispec, iz, ix) =
+                iglob_counted[reordered_points[iloc].iglob];
+            mesh_points.h_coord(0, ispec, iz, ix) = reordered_points[iloc].x;
+            mesh_points.h_coord(1, ispec, iz, ix) = reordered_points[iloc].z;
+          }
+          iloc++;
+        }
+      }
     }
-
-    xtypdist = std::min(xtypdist, xmax - xmin);
-    xtypdist = std::min(xtypdist, ymax - ymin);
   }
 
-  return 1e-6 * xtypdist;
+  mesh_points.xmin = bbox.xmin;
+  mesh_points.xmax = bbox.xmax;
+  mesh_points.zmin = bbox.zmin;
+  mesh_points.zmax = bbox.zmax;
+
+  int ngllxz = ngll * ngll;
+  assert(nglob != (nspec * ngllxz));
+  assert(inum == nglob);
+
+  Kokkos::deep_copy(mesh_points.index_mapping, mesh_points.h_index_mapping);
+  Kokkos::deep_copy(mesh_points.coord, mesh_points.h_coord);
+
+  return mesh_points;
 }
 
 specfem::assembly::mesh_impl::points<specfem::dimension::type::dim2>
@@ -52,125 +82,27 @@ assign_numbering(specfem::kokkos::HostView4d<double> global_coordinates) {
   int ngll = global_coordinates.extent(1);
   int ngllxz = ngll * ngll;
 
-  std::vector<qp> cart_cord(nspec * ngllxz);
+  // Extract coordinates into testable utility functions
+  auto points = specfem::assembly::mesh_impl::dim2::utilities::flatten_coordinates(global_coordinates);
 
-  constexpr int chunk_size = specfem::parallel_config::storage_chunk_size;
+  // Sort points spatially
+  auto sorted_points = points;
+  specfem::assembly::mesh_impl::dim2::utilities::sort_points_spatially(sorted_points);
 
-  int iloc = 0;
-  for (int ichunk = 0; ichunk < nspec; ichunk += chunk_size) {
-    for (int iz = 0; iz < ngll; iz++) {
-      for (int ix = 0; ix < ngll; ix++) {
-        for (int ielement = 0; ielement < chunk_size; ielement++) {
-          int ispec = ichunk + ielement;
-          if (ispec >= nspec)
-            break;
-          cart_cord[iloc].x = global_coordinates(ispec, iz, ix, 0);
-          cart_cord[iloc].z = global_coordinates(ispec, iz, ix, 1);
-          cart_cord[iloc].iloc = iloc;
-          iloc++;
-        }
-      }
-    }
-  }
+  // Compute spatial tolerance
+  type_real tolerance = specfem::assembly::mesh_impl::dim2::utilities::compute_spatial_tolerance(sorted_points, nspec, ngllxz);
 
-  // Sort cartesian coordinates in ascending order i.e.
-  // cart_cord = [{0,0}, {0, 25}, {0, 50}, ..., {50, 0}, {50, 25}, {50, 50}]
-  std::sort(cart_cord.begin(), cart_cord.end(),
-            [&](const qp qp1, const qp qp2) {
-              if (qp1.x != qp2.x) {
-                return qp1.x < qp2.x;
-              }
+  // Assign global numbering
+  int nglob = specfem::assembly::mesh_impl::dim2::utilities::assign_global_numbering(sorted_points, tolerance);
 
-              return qp1.z < qp2.z;
-            });
+  // Reorder points to original layout
+  auto reordered_points = specfem::assembly::mesh_impl::dim2::utilities::reorder_to_original_layout(sorted_points);
 
-  // Setup numbering
-  int ig = 0;
-  cart_cord[0].iglob = ig;
+  // Calculate bounding box using utilities
+  auto bbox = specfem::assembly::mesh_impl::dim2::utilities::compute_bounding_box(reordered_points);
 
-  type_real xtol = get_tolerance(cart_cord, nspec, ngllxz);
-
-  for (int iloc = 1; iloc < cart_cord.size(); iloc++) {
-    // check if the previous point is same as current
-    if ((std::abs(cart_cord[iloc].x - cart_cord[iloc - 1].x) > xtol) ||
-        (std::abs(cart_cord[iloc].z - cart_cord[iloc - 1].z) > xtol)) {
-      ig++;
-    }
-    cart_cord[iloc].iglob = ig;
-  }
-
-  std::vector<qp> copy_cart_cord(nspec * ngllxz);
-
-  // reorder cart cord in original format
-  for (int i = 0; i < cart_cord.size(); i++) {
-    int iloc = cart_cord[i].iloc;
-    copy_cart_cord[iloc] = cart_cord[i];
-  }
-
-  int nglob = ig + 1;
-
-  specfem::assembly::mesh_impl::points<specfem::dimension::type::dim2> points(
-      nspec, ngll, ngll);
-
-  // Assign numbering to corresponding ispec, iz, ix
-  std::vector<int> iglob_counted(nglob, -1);
-  iloc = 0;
-  int inum = 0;
-  type_real xmin = std::numeric_limits<type_real>::max();
-  type_real xmax = std::numeric_limits<type_real>::min();
-  type_real zmin = std::numeric_limits<type_real>::max();
-  type_real zmax = std::numeric_limits<type_real>::min();
-
-  for (int ichunk = 0; ichunk < nspec; ichunk += chunk_size) {
-    for (int iz = 0; iz < ngll; iz++) {
-      for (int ix = 0; ix < ngll; ix++) {
-        for (int ielement = 0; ielement < chunk_size; ielement++) {
-          int ispec = ichunk + ielement;
-          if (ispec >= nspec)
-            break;
-          if (iglob_counted[copy_cart_cord[iloc].iglob] == -1) {
-
-            const type_real x_cor = copy_cart_cord[iloc].x;
-            const type_real z_cor = copy_cart_cord[iloc].z;
-            if (xmin > x_cor)
-              xmin = x_cor;
-            if (zmin > z_cor)
-              zmin = z_cor;
-            if (xmax < x_cor)
-              xmax = x_cor;
-            if (zmax < z_cor)
-              zmax = z_cor;
-
-            iglob_counted[copy_cart_cord[iloc].iglob] = inum;
-            points.h_index_mapping(ispec, iz, ix) = inum;
-            points.h_coord(0, ispec, iz, ix) = x_cor;
-            points.h_coord(1, ispec, iz, ix) = z_cor;
-            inum++;
-          } else {
-            points.h_index_mapping(ispec, iz, ix) =
-                iglob_counted[copy_cart_cord[iloc].iglob];
-            points.h_coord(0, ispec, iz, ix) = copy_cart_cord[iloc].x;
-            points.h_coord(1, ispec, iz, ix) = copy_cart_cord[iloc].z;
-          }
-          iloc++;
-        }
-      }
-    }
-  }
-
-  points.xmin = xmin;
-  points.xmax = xmax;
-  points.zmin = zmin;
-  points.zmax = zmax;
-
-  assert(nglob != (nspec * ngllxz));
-
-  assert(inum == nglob);
-
-  Kokkos::deep_copy(points.index_mapping, points.h_index_mapping);
-  Kokkos::deep_copy(points.coord, points.h_coord);
-
-  return points;
+  // Create and populate mesh points object
+  return create_mesh_points(reordered_points, bbox, nspec, ngll, nglob);
 }
 
 } // namespace

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -301,6 +301,7 @@ add_executable(
   assembly/sources/sources.cpp
   assembly/check_jacobian/check_jacobian.cpp
   assembly/locate/locate_point.cpp
+  assembly/mesh/utilities.cpp
 )
 
 target_compile_definitions(assembly_tests PRIVATE TEST_OUTPUT_DIR=${TEST_OUTPUT_DIR})

--- a/tests/unit-tests/assembly/mesh/utilities.cpp
+++ b/tests/unit-tests/assembly/mesh/utilities.cpp
@@ -1,0 +1,622 @@
+#include "specfem/assembly/mesh/dim2/impl/utilities.hpp"
+#include "kokkos_abstractions.h"
+#include "parallel_configuration/chunk_config.hpp"
+#include "test_macros.hpp"
+#include "utilities/utilities.hpp"
+#include <gtest/gtest.h>
+#include <set>
+#include <vector>
+
+using namespace specfem::assembly::mesh_impl::dim2::utilities;
+
+class MeshUtilitiesTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    // Initialize Kokkos if not already done
+    if (!Kokkos::is_initialized()) {
+      Kokkos::initialize();
+    }
+  }
+
+  void TearDown() override {
+    // Kokkos cleanup handled by test environment
+  }
+
+  // Helper to create 4D coordinate array
+  specfem::kokkos::HostView4d<double>
+  create_coordinates(const std::vector<std::vector<std::pair<double, double> > >
+                         &element_coords) {
+    int nspec = element_coords.size();
+    int ngll = std::sqrt(element_coords[0].size());
+
+    specfem::kokkos::HostView4d<double> coords("coords", nspec, ngll, ngll, 2);
+
+    for (int ispec = 0; ispec < nspec; ispec++) {
+      int idx = 0;
+      for (int iz = 0; iz < ngll; iz++) {
+        for (int ix = 0; ix < ngll; ix++) {
+          coords(ispec, iz, ix, 0) = element_coords[ispec][idx].first;  // x
+          coords(ispec, iz, ix, 1) = element_coords[ispec][idx].second; // z
+          idx++;
+        }
+      }
+    }
+    return coords;
+  }
+};
+
+class MeshLayoutFixtures : public MeshUtilitiesTest {
+protected:
+  // Unit square element (2x2 GLL points)
+  std::vector<std::vector<std::pair<double, double> > > unit_square_2x2 = { {
+      { -1.0, -1.0 },
+      { 1.0, -1.0 }, // iz=0: ix=0,1
+      { -1.0, 1.0 },
+      { 1.0, 1.0 } // iz=1: ix=0,1
+  } };
+
+  // Unit square element (5x5 GLL points) - more realistic spectral element
+  std::vector<std::vector<std::pair<double, double> > > unit_square_5x5 = {
+    { // iz=0: ix=0,1,2,3,4
+      { -1.0, -1.0 },
+      { -0.5, -1.0 },
+      { 0.0, -1.0 },
+      { 0.5, -1.0 },
+      { 1.0, -1.0 },
+      // iz=1: ix=0,1,2,3,4
+      { -1.0, -0.5 },
+      { -0.5, -0.5 },
+      { 0.0, -0.5 },
+      { 0.5, -0.5 },
+      { 1.0, -0.5 },
+      // iz=2: ix=0,1,2,3,4
+      { -1.0, 0.0 },
+      { -0.5, 0.0 },
+      { 0.0, 0.0 },
+      { 0.5, 0.0 },
+      { 1.0, 0.0 },
+      // iz=3: ix=0,1,2,3,4
+      { -1.0, 0.5 },
+      { -0.5, 0.5 },
+      { 0.0, 0.5 },
+      { 0.5, 0.5 },
+      { 1.0, 0.5 },
+      // iz=4: ix=0,1,2,3,4
+      { -1.0, 1.0 },
+      { -0.5, 1.0 },
+      { 0.0, 1.0 },
+      { 0.5, 1.0 },
+      { 1.0, 1.0 } }
+  };
+
+  // Sheared element (2x2 GLL points)
+  std::vector<std::vector<std::pair<double, double> > > sheared_element_2x2 = {
+    {
+        { -1.0, -1.0 },
+        { 2.0, -1.0 }, // iz=0: ix=0,1
+        { 0.0, 2.0 },
+        { 3.0, 2.0 } // iz=1: ix=0,1
+    }
+  };
+
+  // Two adjacent unit squares sharing edge (2x2 GLL points)
+  std::vector<std::vector<std::pair<double, double> > >
+      two_adjacent_squares_2x2 = {
+        // Element 0: left square
+        {
+            { -2.0, -1.0 },
+            { 0.0, -1.0 }, // iz=0: ix=0,1
+            { -2.0, 1.0 },
+            { 0.0, 1.0 } // iz=1: ix=0,1
+        },
+        // Element 1: right square (shares x=0 edge with element 0)
+        {
+            { 0.0, -1.0 },
+            { 2.0, -1.0 }, // iz=0: ix=0,1
+            { 0.0, 1.0 },
+            { 2.0, 1.0 } // iz=1: ix=0,1
+        }
+      };
+
+  // Two adjacent unit squares sharing edge (5x5 GLL points)
+  std::vector<std::vector<std::pair<double, double> > >
+      two_adjacent_squares_5x5 = {
+        // Element 0: left square
+        { // iz=0: ix=0,1,2,3,4
+          { -2.0, -1.0 },
+          { -1.0, -1.0 },
+          { 0.0, -1.0 },
+          { 1.0, -1.0 },
+          { 2.0, -1.0 },
+          // iz=1: ix=0,1,2,3,4
+          { -2.0, -0.5 },
+          { -1.0, -0.5 },
+          { 0.0, -0.5 },
+          { 1.0, -0.5 },
+          { 2.0, -0.5 },
+          // iz=2: ix=0,1,2,3,4
+          { -2.0, 0.0 },
+          { -1.0, 0.0 },
+          { 0.0, 0.0 },
+          { 1.0, 0.0 },
+          { 2.0, 0.0 },
+          // iz=3: ix=0,1,2,3,4
+          { -2.0, 0.5 },
+          { -1.0, 0.5 },
+          { 0.0, 0.5 },
+          { 1.0, 0.5 },
+          { 2.0, 0.5 },
+          // iz=4: ix=0,1,2,3,4
+          { -2.0, 1.0 },
+          { -1.0, 1.0 },
+          { 0.0, 1.0 },
+          { 1.0, 1.0 },
+          { 2.0, 1.0 } },
+        // Element 1: right square (shares x=2 edge with element 0)
+        { // iz=0: ix=0,1,2,3,4
+          { 2.0, -1.0 },
+          { 3.0, -1.0 },
+          { 4.0, -1.0 },
+          { 5.0, -1.0 },
+          { 6.0, -1.0 },
+          // iz=1: ix=0,1,2,3,4
+          { 2.0, -0.5 },
+          { 3.0, -0.5 },
+          { 4.0, -0.5 },
+          { 5.0, -0.5 },
+          { 6.0, -0.5 },
+          // iz=2: ix=0,1,2,3,4
+          { 2.0, 0.0 },
+          { 3.0, 0.0 },
+          { 4.0, 0.0 },
+          { 5.0, 0.0 },
+          { 6.0, 0.0 },
+          // iz=3: ix=0,1,2,3,4
+          { 2.0, 0.5 },
+          { 3.0, 0.5 },
+          { 4.0, 0.5 },
+          { 5.0, 0.5 },
+          { 6.0, 0.5 },
+          // iz=4: ix=0,1,2,3,4
+          { 2.0, 1.0 },
+          { 3.0, 1.0 },
+          { 4.0, 1.0 },
+          { 5.0, 1.0 },
+          { 6.0, 1.0 } }
+      };
+
+  // 2x2 grid of elements (2x2 GLL points each)
+  std::vector<std::vector<std::pair<double, double> > >
+      grid_2x2_elements_2x2 = { // Element 0: bottom-left
+                                {
+                                    { 0.0, 0.0 },
+                                    { 1.0, 0.0 }, // iz=0: ix=0,1
+                                    { 0.0, 1.0 },
+                                    { 1.0, 1.0 } // iz=1: ix=0,1
+                                },
+                                // Element 1: bottom-right
+                                {
+                                    { 1.0, 0.0 },
+                                    { 2.0, 0.0 }, // iz=0: ix=0,1
+                                    { 1.0, 1.0 },
+                                    { 2.0, 1.0 } // iz=1: ix=0,1
+                                },
+                                // Element 2: top-left
+                                {
+                                    { 0.0, 1.0 },
+                                    { 1.0, 1.0 }, // iz=0: ix=0,1
+                                    { 0.0, 2.0 },
+                                    { 1.0, 2.0 } // iz=1: ix=0,1
+                                },
+                                // Element 3: top-right
+                                {
+                                    { 1.0, 1.0 },
+                                    { 2.0, 1.0 }, // iz=0: ix=0,1
+                                    { 1.0, 2.0 },
+                                    { 2.0, 2.0 } // iz=1: ix=0,1
+                                }
+      };
+};
+
+// Test flatten_coordinates function
+TEST_F(MeshLayoutFixtures, FlattenCoordinatesUnitSquare) {
+  auto coords = create_coordinates(unit_square_2x2);
+  auto flattened = flatten_coordinates(coords);
+
+  ASSERT_EQ(flattened.size(), 4); // 1 element * 2*2 points
+
+  // Check coordinates are preserved
+  EXPECT_DOUBLE_EQ(flattened[0].x, -1.0);
+  EXPECT_DOUBLE_EQ(flattened[0].z, -1.0);
+  EXPECT_EQ(flattened[0].iloc, 0);
+
+  EXPECT_DOUBLE_EQ(flattened[3].x, 1.0);
+  EXPECT_DOUBLE_EQ(flattened[3].z, 1.0);
+  EXPECT_EQ(flattened[3].iloc, 3);
+}
+
+TEST_F(MeshLayoutFixtures, FlattenCoordinatesMultipleElements) {
+  auto coords = create_coordinates(two_adjacent_squares_2x2);
+  auto flattened = flatten_coordinates(coords);
+
+  ASSERT_EQ(flattened.size(), 8); // 2 elements * 2*2 points
+
+  // Check that we have coordinates from both elements
+  // The exact ordering depends on chunked iteration but coordinates should be
+  // preserved
+  bool found_element1_corner = false;
+  for (const auto &p : flattened) {
+    if (p.x == 0.0 && p.z == -1.0) {
+      found_element1_corner = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found_element1_corner);
+}
+
+// Test flatten_coordinates with 5x5 GLL points
+TEST_F(MeshLayoutFixtures, FlattenCoordinatesUnitSquare5x5) {
+  auto coords = create_coordinates(unit_square_5x5);
+  auto flattened = flatten_coordinates(coords);
+
+  ASSERT_EQ(flattened.size(), 25); // 1 element * 5*5 points
+
+  // Check corners are preserved
+  EXPECT_DOUBLE_EQ(flattened[0].x, -1.0); // First point
+  EXPECT_DOUBLE_EQ(flattened[0].z, -1.0);
+  EXPECT_EQ(flattened[0].iloc, 0);
+
+  EXPECT_DOUBLE_EQ(flattened[24].x, 1.0); // Last point
+  EXPECT_DOUBLE_EQ(flattened[24].z, 1.0);
+  EXPECT_EQ(flattened[24].iloc, 24);
+
+  // Check center point
+  EXPECT_DOUBLE_EQ(flattened[12].x, 0.0); // Center point (iz=2, ix=2)
+  EXPECT_DOUBLE_EQ(flattened[12].z, 0.0);
+  EXPECT_EQ(flattened[12].iloc, 12);
+}
+
+TEST_F(MeshLayoutFixtures, FlattenCoordinatesMultipleElements5x5) {
+  auto coords = create_coordinates(two_adjacent_squares_5x5);
+  auto flattened = flatten_coordinates(coords);
+
+  ASSERT_EQ(flattened.size(), 50); // 2 elements * 5*5 points
+
+  // Check that we have coordinates from both elements
+  bool found_shared_edge = false;
+  int shared_count = 0;
+  for (const auto &p : flattened) {
+    if (p.x == 2.0) { // Shared edge at x=2
+      shared_count++;
+      found_shared_edge = true;
+    }
+  }
+  EXPECT_TRUE(found_shared_edge);
+  EXPECT_EQ(shared_count, 10); // 5 points on each element share x=2
+}
+
+// Test spatial sorting
+TEST_F(MeshLayoutFixtures, SortPointsSpatiallyUnitSquare) {
+  auto coords = create_coordinates(unit_square_2x2);
+  auto points = flatten_coordinates(coords);
+
+  sort_points_spatially(points);
+
+  // Should be sorted by x, then z
+  // Expected order: (-1,-1), (-1,1), (1,-1), (1,1)
+  EXPECT_DOUBLE_EQ(points[0].x, -1.0);
+  EXPECT_DOUBLE_EQ(points[0].z, -1.0);
+
+  EXPECT_DOUBLE_EQ(points[1].x, -1.0);
+  EXPECT_DOUBLE_EQ(points[1].z, 1.0);
+
+  EXPECT_DOUBLE_EQ(points[2].x, 1.0);
+  EXPECT_DOUBLE_EQ(points[2].z, -1.0);
+
+  EXPECT_DOUBLE_EQ(points[3].x, 1.0);
+  EXPECT_DOUBLE_EQ(points[3].z, 1.0);
+}
+
+// Test tolerance calculation
+TEST_F(MeshLayoutFixtures, ComputeSpatialToleranceUnitSquare) {
+  auto coords = create_coordinates(unit_square_2x2);
+  auto points = flatten_coordinates(coords);
+
+  type_real tolerance = compute_spatial_tolerance(points, 1, 4);
+
+  // For unit square: min dimension = 2.0, tolerance = 1e-6 * 2.0
+  EXPECT_TRUE(specfem::utilities::is_close(tolerance, type_real(2e-6)))
+      << expected_got(2e-6, tolerance);
+}
+
+TEST_F(MeshLayoutFixtures, ComputeSpatialToleranceSheared) {
+  auto coords = create_coordinates(sheared_element_2x2);
+  auto points = flatten_coordinates(coords);
+
+  type_real tolerance = compute_spatial_tolerance(points, 1, 4);
+
+  // For sheared element: x range = 4.0, z range = 3.0, min = 3.0
+  EXPECT_TRUE(specfem::utilities::is_close(tolerance, type_real(3e-6)))
+      << expected_got(3e-6, tolerance);
+}
+
+// Test global numbering assignment
+TEST_F(MeshLayoutFixtures, AssignGlobalNumberingUnitSquare) {
+  auto coords = create_coordinates(unit_square_2x2);
+  auto points = flatten_coordinates(coords);
+  sort_points_spatially(points);
+
+  type_real tolerance = compute_spatial_tolerance(points, 1, 4);
+  int nglob = assign_global_numbering(points, tolerance);
+
+  // All points are distinct, should get 4 unique global numbers
+  EXPECT_EQ(nglob, 4);
+
+  // Check numbering is sequential
+  EXPECT_EQ(points[0].iglob, 0);
+  EXPECT_EQ(points[1].iglob, 1);
+  EXPECT_EQ(points[2].iglob, 2);
+  EXPECT_EQ(points[3].iglob, 3);
+}
+
+TEST_F(MeshLayoutFixtures, AssignGlobalNumberingSharedPoints) {
+  auto coords = create_coordinates(two_adjacent_squares_2x2);
+  auto points = flatten_coordinates(coords);
+  sort_points_spatially(points);
+
+  type_real tolerance = compute_spatial_tolerance(points, 2, 4);
+  int nglob = assign_global_numbering(points, tolerance);
+
+  // Elements share edge (2 points), so 8 - 2 = 6 unique points
+  EXPECT_EQ(nglob, 6);
+
+  // Find shared points (x=0.0, z=-1.0) and (x=0.0, z=1.0)
+  int shared_count = 0;
+  for (int i = 0; i < points.size(); i++) {
+    for (int j = i + 1; j < points.size(); j++) {
+      if (points[i].iglob == points[j].iglob) {
+        shared_count++;
+        // Verify they are actually the same coordinate
+        EXPECT_DOUBLE_EQ(points[i].x, points[j].x);
+        EXPECT_DOUBLE_EQ(points[i].z, points[j].z);
+      }
+    }
+  }
+  EXPECT_EQ(shared_count, 2); // Two shared points
+}
+
+// Critical test: Shared points with 5x5 GLL points
+TEST_F(MeshLayoutFixtures, AssignGlobalNumberingSharedPoints5x5) {
+  auto coords = create_coordinates(two_adjacent_squares_5x5);
+  auto points = flatten_coordinates(coords);
+  sort_points_spatially(points);
+
+  type_real tolerance = compute_spatial_tolerance(points, 2, 25);
+  int nglob = assign_global_numbering(points, tolerance);
+
+  // Elements share edge (5 points along x=2), so 50 - 5 = 45 unique points
+  EXPECT_EQ(nglob, 45);
+
+  // Find shared points along x=2.0 edge
+  int shared_pairs = 0;
+  for (int i = 0; i < points.size(); i++) {
+    for (int j = i + 1; j < points.size(); j++) {
+      if (points[i].iglob == points[j].iglob) {
+        shared_pairs++;
+        // Verify they are actually the same coordinate
+        EXPECT_TRUE(specfem::utilities::is_close(points[i].x, points[j].x))
+            << expected_got(points[j].x, points[i].x);
+        EXPECT_TRUE(specfem::utilities::is_close(points[i].z, points[j].z))
+            << expected_got(points[j].z, points[i].z);
+        // All shared points should be at x=2.0
+        EXPECT_TRUE(specfem::utilities::is_close(points[i].x, type_real(2.0)))
+            << expected_got(2.0, points[i].x);
+      }
+    }
+  }
+  EXPECT_EQ(shared_pairs, 5); // Five shared points along edge
+}
+
+TEST_F(MeshLayoutFixtures, AssignGlobalNumberingGrid2x2) {
+  auto coords = create_coordinates(grid_2x2_elements_2x2);
+  auto points = flatten_coordinates(coords);
+  sort_points_spatially(points);
+
+  type_real tolerance = compute_spatial_tolerance(points, 4, 4);
+  int nglob = assign_global_numbering(points, tolerance);
+
+  // 2x2 grid should have 3x3 = 9 unique global points
+  EXPECT_EQ(nglob, 9);
+}
+
+// Test point reordering
+TEST_F(MeshLayoutFixtures, ReorderToOriginalLayout) {
+  auto coords = create_coordinates(unit_square_2x2);
+  auto points = flatten_coordinates(coords);
+  auto original_order = points;
+
+  sort_points_spatially(points);
+
+  type_real tolerance = compute_spatial_tolerance(points, 1, 4);
+  assign_global_numbering(points, tolerance);
+
+  auto reordered = reorder_to_original_layout(points);
+
+  ASSERT_EQ(reordered.size(), original_order.size());
+
+  // Check that iloc indices match original
+  for (int i = 0; i < reordered.size(); i++) {
+    EXPECT_EQ(reordered[i].iloc, i);
+    // Coordinates should match original positions
+    EXPECT_DOUBLE_EQ(reordered[i].x, original_order[i].x);
+    EXPECT_DOUBLE_EQ(reordered[i].z, original_order[i].z);
+  }
+}
+
+// Test bounding box calculation
+TEST_F(MeshLayoutFixtures, ComputeBoundingBoxUnitSquare) {
+  auto coords = create_coordinates(unit_square_2x2);
+  auto points = flatten_coordinates(coords);
+
+  auto bbox = compute_bounding_box(points);
+
+  EXPECT_DOUBLE_EQ(bbox.xmin, -1.0);
+  EXPECT_DOUBLE_EQ(bbox.xmax, 1.0);
+  EXPECT_DOUBLE_EQ(bbox.zmin, -1.0);
+  EXPECT_DOUBLE_EQ(bbox.zmax, 1.0);
+}
+
+TEST_F(MeshLayoutFixtures, ComputeBoundingBoxSheared) {
+  auto coords = create_coordinates(sheared_element_2x2);
+  auto points = flatten_coordinates(coords);
+
+  auto bbox = compute_bounding_box(points);
+
+  EXPECT_DOUBLE_EQ(bbox.xmin, -1.0);
+  EXPECT_DOUBLE_EQ(bbox.xmax, 3.0);
+  EXPECT_DOUBLE_EQ(bbox.zmin, -1.0);
+  EXPECT_DOUBLE_EQ(bbox.zmax, 2.0);
+}
+
+TEST_F(MeshLayoutFixtures, ComputeBoundingBoxGrid) {
+  auto coords = create_coordinates(grid_2x2_elements_2x2);
+  auto points = flatten_coordinates(coords);
+
+  auto bbox = compute_bounding_box(points);
+
+  EXPECT_DOUBLE_EQ(bbox.xmin, 0.0);
+  EXPECT_DOUBLE_EQ(bbox.xmax, 2.0);
+  EXPECT_DOUBLE_EQ(bbox.zmin, 0.0);
+  EXPECT_DOUBLE_EQ(bbox.zmax, 2.0);
+}
+
+// Integration test for full workflow
+TEST_F(MeshLayoutFixtures, FullWorkflowIntegration) {
+  auto coords = create_coordinates(two_adjacent_squares_2x2);
+
+  // Complete workflow
+  auto points = flatten_coordinates(coords);
+  auto sorted_points = points;
+  sort_points_spatially(sorted_points);
+
+  type_real tolerance = compute_spatial_tolerance(sorted_points, 2, 4);
+  int nglob = assign_global_numbering(sorted_points, tolerance);
+
+  auto reordered = reorder_to_original_layout(sorted_points);
+  auto bbox = compute_bounding_box(reordered);
+
+  // Verify end-to-end results
+  EXPECT_EQ(nglob, 6);
+  EXPECT_EQ(reordered.size(), 8);
+
+  EXPECT_DOUBLE_EQ(bbox.xmin, -2.0);
+  EXPECT_DOUBLE_EQ(bbox.xmax, 2.0);
+  EXPECT_DOUBLE_EQ(bbox.zmin, -1.0);
+  EXPECT_DOUBLE_EQ(bbox.zmax, 1.0);
+
+  // Verify shared points have same iglob
+  bool found_shared = false;
+  for (int i = 0; i < reordered.size(); i++) {
+    for (int j = i + 1; j < reordered.size(); j++) {
+      if (std::abs(reordered[i].x - reordered[j].x) < tolerance &&
+          std::abs(reordered[i].z - reordered[j].z) < tolerance) {
+        EXPECT_EQ(reordered[i].iglob, reordered[j].iglob);
+        found_shared = true;
+      }
+    }
+  }
+  EXPECT_TRUE(found_shared);
+}
+
+// Integration test for 5x5 GLL points - critical for spectral elements
+TEST_F(MeshLayoutFixtures, FullWorkflowIntegration5x5) {
+  auto coords = create_coordinates(two_adjacent_squares_5x5);
+
+  // Complete workflow
+  auto points = flatten_coordinates(coords);
+  auto sorted_points = points;
+  sort_points_spatially(sorted_points);
+
+  type_real tolerance = compute_spatial_tolerance(sorted_points, 2, 25);
+  int nglob = assign_global_numbering(sorted_points, tolerance);
+
+  auto reordered = reorder_to_original_layout(sorted_points);
+  auto bbox = compute_bounding_box(reordered);
+
+  // Verify end-to-end results for 5x5 GLL points
+  EXPECT_EQ(nglob, 45); // 50 total - 5 shared edge points
+  EXPECT_EQ(reordered.size(), 50);
+
+  EXPECT_DOUBLE_EQ(bbox.xmin, -2.0);
+  EXPECT_DOUBLE_EQ(bbox.xmax, 6.0);
+  EXPECT_DOUBLE_EQ(bbox.zmin, -1.0);
+  EXPECT_DOUBLE_EQ(bbox.zmax, 1.0);
+
+  // Verify edge sharing is correct - count points at shared edge x=2
+  int points_at_shared_edge = 0;
+  std::set<int> unique_iglobs_at_edge;
+
+  for (const auto &p : reordered) {
+    if (specfem::utilities::is_close(p.x, type_real(2.0))) {
+      points_at_shared_edge++;
+      unique_iglobs_at_edge.insert(p.iglob);
+    }
+  }
+
+  EXPECT_EQ(points_at_shared_edge, 10); // 5 from each element
+  EXPECT_EQ(unique_iglobs_at_edge.size(),
+            5); // But only 5 unique global numbers
+
+  // Verify all points have been assigned global numbers
+  for (const auto &p : reordered) {
+    EXPECT_GE(p.iglob, 0);
+    EXPECT_LT(p.iglob, nglob);
+  }
+}
+
+// Test edge cases and error conditions
+TEST_F(MeshLayoutFixtures, EdgeCaseEmptyPoints) {
+  std::vector<point> empty_points;
+
+  // Empty points should return 0 global points
+  type_real tolerance = 1e-6;
+  int nglob = assign_global_numbering(empty_points, tolerance);
+  EXPECT_EQ(nglob, 0);
+
+  // Bounding box of empty points should have max/min limits
+  auto bbox = compute_bounding_box(empty_points);
+  EXPECT_EQ(bbox.xmin, std::numeric_limits<type_real>::max());
+  EXPECT_EQ(bbox.xmax, std::numeric_limits<type_real>::min());
+}
+
+TEST_F(MeshLayoutFixtures, EdgeCaseSinglePoint) {
+  std::vector<point> single_point = { { 1.0, 2.0, 0, 0 } };
+
+  type_real tolerance = 1e-6;
+  int nglob = assign_global_numbering(single_point, tolerance);
+  EXPECT_EQ(nglob, 1);
+  EXPECT_EQ(single_point[0].iglob, 0);
+
+  auto bbox = compute_bounding_box(single_point);
+  EXPECT_DOUBLE_EQ(bbox.xmin, 1.0);
+  EXPECT_DOUBLE_EQ(bbox.xmax, 1.0);
+  EXPECT_DOUBLE_EQ(bbox.zmin, 2.0);
+  EXPECT_DOUBLE_EQ(bbox.zmax, 2.0);
+}
+
+TEST_F(MeshLayoutFixtures, EdgeCaseIdenticalPoints) {
+  std::vector<point> identical_points = { { 1.0, 2.0, 0, 0 },
+                                          { 1.0, 2.0, 1, 0 },
+                                          { 1.0, 2.0, 2, 0 } };
+
+  sort_points_spatially(identical_points);
+
+  type_real tolerance = 1e-6;
+  int nglob = assign_global_numbering(identical_points, tolerance);
+
+  // All identical points should get same global number
+  EXPECT_EQ(nglob, 1);
+  for (const auto &p : identical_points) {
+    EXPECT_EQ(p.iglob, 0);
+  }
+}


### PR DESCRIPTION
## Description

Implements testable functions for the assign numbering function, which makes the numbering scheme usable without an assembly. which in turn can be used for the locate point unit tests in the following PR.

## Issue Number

Updates #1057 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [x] I ran the code through pre-commit to check style
- [x] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [x] I have added labels to the PR (see right hand side of the PR page)
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
