### PR TITLE
Issue 945 - Updates the STF and force implementations to match SPECFEM2D Fortran

### DIFF
--- a/core/specfem/source/dim2/vector_source/force_source.cpp
+++ b/core/specfem/source/dim2/vector_source/force_source.cpp
@@ -46,22 +46,23 @@ specfem::sources::force<specfem::dimension::type::dim2>::get_force_vector()
   // Elastic P-SV
   else if (medium_tag == specfem::element::medium_tag::elastic_psv) {
     force_vector = specfem::kokkos::HostView1d<type_real>("force_vector", 2);
+    // angle measured clockwise vertical direction
     force_vector(0) = std::sin(angle_in_rad);
-    force_vector(1) = static_cast<type_real>(-1.0) * std::cos(angle_in_rad);
+    force_vector(1) = std::cos(angle_in_rad);
   }
   // Poroelastic
   else if (medium_tag == specfem::element::medium_tag::poroelastic) {
     force_vector = specfem::kokkos::HostView1d<type_real>("force_vector", 4);
     force_vector(0) = std::sin(angle_in_rad);
-    force_vector(1) = static_cast<type_real>(-1.0) * std::cos(angle_in_rad);
+    force_vector(1) = std::cos(angle_in_rad);
     force_vector(2) = std::sin(angle_in_rad);
-    force_vector(3) = static_cast<type_real>(-1.0) * std::cos(angle_in_rad);
+    force_vector(3) = std::cos(angle_in_rad);
   }
   // Elastic P-SV-T
   else if (medium_tag == specfem::element::medium_tag::elastic_psv_t) {
     force_vector = specfem::kokkos::HostView1d<type_real>("force_vector", 3);
     force_vector(0) = std::sin(angle_in_rad);
-    force_vector(1) = static_cast<type_real>(-1.0) * std::cos(angle_in_rad);
+    force_vector(1) = std::cos(angle_in_rad);
     force_vector(2) = static_cast<type_real>(0.0);
   } else {
     KOKKOS_ABORT_WITH_LOCATION("Force source array computation not "

--- a/include/medium/dim2/acoustic/isotropic/source.hpp
+++ b/include/medium/dim2/acoustic/isotropic/source.hpp
@@ -27,7 +27,12 @@ KOKKOS_INLINE_FUNCTION auto impl_compute_source_contribution(
 
   PointAccelerationType result;
 
-  result(0) = point_source.stf(0) * point_source.lagrange_interpolant(0) /
+  /* note: for acoustic medium, the source is a pressure source and gets divided
+   *       by Kappa of the fluid. The sign is negative because pressure p = -
+   *       Chi_dot_dot therefore we need to add minus the source to Chi_dot_dot
+   *       to get plus the source in pressure
+   */
+  result(0) = -point_source.stf(0) * point_source.lagrange_interpolant(0) /
               point_properties.kappa();
 
   return result;

--- a/include/source_time_function/ricker.hpp
+++ b/include/source_time_function/ricker.hpp
@@ -8,6 +8,12 @@
 
 namespace specfem {
 namespace forcing_function {
+
+/**
+ * @brief Ricker source time function. The Ricker wavelet is a commonly used
+ *        source time function in seismic modeling. We define it here as the
+ * first derivative of a Ga
+ */
 class Ricker : public stf {
 
 public:

--- a/src/source_time_function/dgaussian.cpp
+++ b/src/source_time_function/dgaussian.cpp
@@ -39,13 +39,11 @@ type_real specfem::forcing_function::dGaussian::compute(type_real t) {
   type_real val;
 
   if (this->__use_trick_for_better_pressure) {
-    val = -1.0 * this->__factor *
-          specfem::forcing_function::impl::d3gaussian(t - this->__tshift,
-                                                      this->__f0);
+    val = this->__factor * specfem::forcing_function::impl::d3gaussian(
+                               t - this->__tshift, this->__f0);
   } else {
-    val = -1.0 * this->__factor *
-          specfem::forcing_function::impl::d1gaussian(t - this->__tshift,
-                                                      this->__f0);
+    val = this->__factor * specfem::forcing_function::impl::d1gaussian(
+                               t - this->__tshift, this->__f0);
   }
 
   return val;

--- a/src/source_time_function/dirac.cpp
+++ b/src/source_time_function/dirac.cpp
@@ -40,13 +40,11 @@ type_real specfem::forcing_function::Dirac::compute(type_real t) {
   type_real val;
 
   if (this->__use_trick_for_better_pressure) {
-    val = -1.0 * this->__factor *
-          specfem::forcing_function::impl::d2gaussian(t - this->__tshift,
-                                                      this->__f0);
+    val = this->__factor * specfem::forcing_function::impl::d2gaussian(
+                               t - this->__tshift, this->__f0);
   } else {
-    val = -1.0 * this->__factor *
-          specfem::forcing_function::impl::gaussian(t - this->__tshift,
-                                                    this->__f0);
+    val = this->__factor * specfem::forcing_function::impl::gaussian(
+                               t - this->__tshift, this->__f0);
   }
 
   return val;

--- a/src/source_time_function/ricker.cpp
+++ b/src/source_time_function/ricker.cpp
@@ -41,13 +41,11 @@ type_real specfem::forcing_function::Ricker::compute(type_real t) {
   type_real val;
 
   if (this->__use_trick_for_better_pressure) {
-    val = -1.0 * this->__factor *
-          specfem::forcing_function::impl::d4gaussian(t - this->__tshift,
-                                                      this->__f0);
+    val = this->__factor * specfem::forcing_function::impl::d4gaussian(
+                               t - this->__tshift, this->__f0);
   } else {
-    val = -1.0 * this->__factor *
-          specfem::forcing_function::impl::d2gaussian(t - this->__tshift,
-                                                      this->__f0);
+    val = this->__factor * specfem::forcing_function::impl::d2gaussian(
+                               t - this->__tshift, this->__f0);
   }
 
   return val;

--- a/tests/unit-tests/displacement_tests/Newmark/serial/HomogeneousElasticIsotropicDomainSH/sources.yaml
+++ b/tests/unit-tests/displacement_tests/Newmark/serial/HomogeneousElasticIsotropicDomainSH/sources.yaml
@@ -9,5 +9,5 @@ sources:
       vz : 0.0
       Ricker:
         f0: 10.0
-        factor: 1e10
+        factor: -1e10
         tshift: 0.0

--- a/tests/unit-tests/source/dim2/vector_sources/force_source.hpp
+++ b/tests/unit-tests/source/dim2/vector_sources/force_source.hpp
@@ -73,15 +73,15 @@ std::vector<ForceSource2DParametersAndSolution> get_parameters_and_solutions<
                                 specfem::wavefield::simulation_field::forward,
                                 specfem::element::medium_tag::elastic_psv),
         ForceSource2DSolution(0.0, 0.0, 0.0,
-                              std::vector<type_real>{ 0., -1.0 })),
-    // Test elastic_psv_t source at origin with 45 angle
+                              std::vector<type_real>{ 0., 1.0 })),
+    // Test elastic PSV source at origin with 45 angle
     std::make_tuple(
-        ForceSource2DParameters("elastic_psv_t and 45 angle", 4.0, 4.0, 45.0,
+        ForceSource2DParameters("elastic_psv and 45 degree angle", 0.0, 0.0,
+                                45.0,
                                 specfem::wavefield::simulation_field::forward,
-                                specfem::element::medium_tag::elastic_psv_t),
+                                specfem::element::medium_tag::elastic_psv),
         ForceSource2DSolution(
-            4.0, 4.0, 45.0,
-            std::vector<type_real>{ sqrt2over2, -sqrt2over2, 0.0 })),
+            0.0, 0.0, 45.0, std::vector<type_real>{ sqrt2over2, sqrt2over2 })),
     // Test elastic isotropic source at origin with 90 degree angle
     std::make_tuple(ForceSource2DParameters(
                         "elastic_isotropic and 90 angle", 3.0, 3.0, 90.0,
@@ -110,7 +110,7 @@ std::vector<ForceSource2DParametersAndSolution> get_parameters_and_solutions<
                                 specfem::element::medium_tag::elastic_psv_t),
         ForceSource2DSolution(
             4.0, 4.0, 45.0,
-            std::vector<type_real>{ sqrt2over2, -sqrt2over2, 0.0 }))
+            std::vector<type_real>{ sqrt2over2, sqrt2over2, 0.0 }))
   };
 }
 


### PR DESCRIPTION
## Description

The changes should reflect [SPECFEM2D's PR #1259](https://github.com/SPECFEM/specfem2d/pull/1259) that updates the implementation of the source time function to more accurately match SPECFEM3D.

## Problem

The way the acoustic force source_array was applied in the medium/compute_source had the wrong sign as a result of legacy code. One result of this is the definition of the source angle was inverted.

## Solutions

- Removing of negative signs in the compute_source_time_function member functions of the Ricker, Delta, dGaussian functions, e.g. 
- Updating sign and cosines in the angle computation of the elastic force 
- change sign of the operation of the potential in `medium/compute_source<acoustic>` from 
  acc(...) += source_array(...) to   acc(...) -= source_array(...) 

## Issue Number

Closes #945

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
