### PR TITLE
Edge-based locate point

### DIFF
--- a/include/algorithms/locate_point.hpp
+++ b/include/algorithms/locate_point.hpp
@@ -39,7 +39,19 @@ specfem::point::global_coordinates<specfem::dimension::type::dim3> locate_point(
         &coordinates,
     const specfem::assembly::mesh<specfem::dimension::type::dim3> &mesh);
 
-type_real locate_point_on_edge(
+/**
+ * @brief Given an edge (ispec, constraint), finds the best fit local coordinate
+ * on that edge to the given global coordinates.
+ *
+ * @param coordinates - global coordinates to match to
+ * @param mesh - assembly::mesh struct
+ * @param ispec - element index whose local coordinates to find
+ * @param constraint - edge to compute for
+ * @return std::pair<type_real,bool> - the edge local coordinate and whether or
+ * not the minimum found is a critical point (false is returned if the best fit
+ * coordinate is out of bounds).
+ */
+std::pair<type_real, bool> locate_point_on_edge(
     const specfem::point::global_coordinates<specfem::dimension::type::dim2>
         &coordinates,
     const specfem::assembly::mesh<specfem::dimension::type::dim2> &mesh,

--- a/include/algorithms/locate_point.hpp
+++ b/include/algorithms/locate_point.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "enumerations/mesh_entities.hpp"
 #include "specfem/assembly/mesh.hpp"
 #include "specfem/point.hpp"
 
@@ -37,6 +38,12 @@ specfem::point::global_coordinates<specfem::dimension::type::dim3> locate_point(
     const specfem::point::local_coordinates<specfem::dimension::type::dim3>
         &coordinates,
     const specfem::assembly::mesh<specfem::dimension::type::dim3> &mesh);
+
+type_real locate_point_on_edge(
+    const specfem::point::global_coordinates<specfem::dimension::type::dim2>
+        &coordinates,
+    const specfem::assembly::mesh<specfem::dimension::type::dim2> &mesh,
+    const int &ispec, const specfem::mesh_entity::type &constraint);
 
 } // namespace algorithms
 } // namespace specfem

--- a/include/algorithms/locate_point_impl.hpp
+++ b/include/algorithms/locate_point_impl.hpp
@@ -24,7 +24,7 @@ std::tuple<type_real, type_real> get_local_coordinates(
         Kokkos::HostSpace> &coorg,
     type_real xi, type_real gamma);
 
-type_real get_local_edge_coordinate(
+std::pair<type_real, bool> get_local_edge_coordinate(
     const specfem::point::global_coordinates<specfem::dimension::type::dim2>
         &global,
     const Kokkos::View<

--- a/include/algorithms/locate_point_impl.hpp
+++ b/include/algorithms/locate_point_impl.hpp
@@ -24,6 +24,14 @@ std::tuple<type_real, type_real> get_local_coordinates(
         Kokkos::HostSpace> &coorg,
     type_real xi, type_real gamma);
 
+type_real get_local_edge_coordinate(
+    const specfem::point::global_coordinates<specfem::dimension::type::dim2>
+        &global,
+    const Kokkos::View<
+        specfem::point::global_coordinates<specfem::dimension::type::dim2> *,
+        Kokkos::HostSpace> &coorg,
+    const specfem::mesh_entity::type &mesh_entity, type_real coord);
+
 // Core locate_point logic that can be tested with raw data arrays
 specfem::point::local_coordinates<specfem::dimension::type::dim2>
 locate_point_core(

--- a/src/algorithms/dim2/locate_point.cpp
+++ b/src/algorithms/dim2/locate_point.cpp
@@ -81,19 +81,17 @@ specfem::algorithms::locate_point(
   return jacobian::compute_locations(coorg, ngnod, xi, gamma);
 }
 
-type_real specfem::algorithms::locate_point_on_edge(
+std::pair<type_real, bool> specfem::algorithms::locate_point_on_edge(
     const specfem::point::global_coordinates<specfem::dimension::type::dim2>
         &coordinates,
     const specfem::assembly::mesh<specfem::dimension::type::dim2> &mesh,
     const int &ispec, const specfem::mesh_entity::type &mesh_entity) {
 
-  if (mesh_entity == specfem::mesh_entity::type::bottom_left ||
-      mesh_entity == specfem::mesh_entity::type::bottom_right ||
-      mesh_entity == specfem::mesh_entity::type::top_left ||
-      mesh_entity == specfem::mesh_entity::type::top_right) {
+  if (specfem::mesh_entity::contains(specfem::mesh_entity::corners,
+                                     mesh_entity)) {
     throw std::runtime_error(
         "locate_point_on_edge mesh_entity must be an edge. Found a corner.");
-    return 0;
+    return { 0, false };
   }
   const Kokkos::View<
       specfem::point::global_coordinates<specfem::dimension::type::dim2> *,
@@ -104,10 +102,7 @@ type_real specfem::algorithms::locate_point_on_edge(
     coorg(i).z = mesh.h_control_node_coord(1, ispec, i);
   }
 
-  type_real coord_guess = 0;
-  coord_guess =
-      specfem::algorithms::locate_point_impl::get_local_edge_coordinate(
-          coordinates, coorg, mesh_entity, coord_guess);
-
-  return coord_guess;
+  // initial guess of 0 (center of edge)
+  return specfem::algorithms::locate_point_impl::get_local_edge_coordinate(
+      coordinates, coorg, mesh_entity, 0);
 }

--- a/src/algorithms/dim2/locate_point.cpp
+++ b/src/algorithms/dim2/locate_point.cpp
@@ -1,10 +1,12 @@
 #include "algorithms/locate_point.hpp"
+#include "Serial/Kokkos_Serial_Parallel_Range.hpp"
 #include "algorithms/locate_point_impl.hpp"
 #include "algorithms/locate_point_impl.tpp"
 #include "specfem/assembly.hpp"
 #include "specfem/jacobian.hpp"
 #include "specfem/point.hpp"
 #include <Kokkos_Core.hpp>
+#include <stdexcept>
 
 specfem::point::local_coordinates<specfem::dimension::type::dim2>
 specfem::algorithms::locate_point(
@@ -77,4 +79,35 @@ specfem::algorithms::locate_point(
   team_member.team_barrier();
 
   return jacobian::compute_locations(coorg, ngnod, xi, gamma);
+}
+
+type_real specfem::algorithms::locate_point_on_edge(
+    const specfem::point::global_coordinates<specfem::dimension::type::dim2>
+        &coordinates,
+    const specfem::assembly::mesh<specfem::dimension::type::dim2> &mesh,
+    const int &ispec, const specfem::mesh_entity::type &mesh_entity) {
+
+  if (mesh_entity == specfem::mesh_entity::type::bottom_left ||
+      mesh_entity == specfem::mesh_entity::type::bottom_right ||
+      mesh_entity == specfem::mesh_entity::type::top_left ||
+      mesh_entity == specfem::mesh_entity::type::top_right) {
+    throw std::runtime_error(
+        "locate_point_on_edge mesh_entity must be an edge. Found a corner.");
+    return 0;
+  }
+  const Kokkos::View<
+      specfem::point::global_coordinates<specfem::dimension::type::dim2> *,
+      Kokkos::HostSpace>
+      coorg("coorg", mesh.ngnod);
+  for (int i = 0; i < mesh.ngnod; i++) {
+    coorg(i).x = mesh.h_control_node_coord(0, ispec, i);
+    coorg(i).z = mesh.h_control_node_coord(1, ispec, i);
+  }
+
+  type_real coord_guess = 0;
+  coord_guess =
+      specfem::algorithms::locate_point_impl::get_local_edge_coordinate(
+          coordinates, coorg, mesh_entity, coord_guess);
+
+  return coord_guess;
 }

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -362,6 +362,7 @@ add_executable(
   assembly/sources/sources.cpp
   assembly/check_jacobian/check_jacobian.cpp
   assembly/locate/locate_point.cpp
+  assembly/locate/locate_point_on_edge.cpp
   assembly/mesh/utilities.cpp
   assembly/sources/locate_sources.cpp
   assembly/compute_source_array/dim2/compute_source_array_from_vector.cpp

--- a/tests/unit-tests/assembly/locate/locate_point_on_edge.cpp
+++ b/tests/unit-tests/assembly/locate/locate_point_on_edge.cpp
@@ -5,6 +5,7 @@
 #include "specfem/point.hpp"
 #include "specfem/point/coordinates.hpp"
 #include <gtest/gtest.h>
+#include <ios>
 #include <utility>
 
 using specfem::point::global_coordinates;
@@ -21,8 +22,6 @@ void test_locate_point_on_edge(
   const type_real zmin = assembly.mesh.zmin;
   const type_real zmax = assembly.mesh.zmax;
 
-  const type_real eps_local = 1e-6;
-
   /* =============================
    * - test_locate_point_on_edge -
    * =============================
@@ -30,8 +29,15 @@ void test_locate_point_on_edge(
    * For each trial, choose an element and a point on the
    * perimeter of that element. locate_point_on_edge should give the correct
    * value.
+   *
+   * Additionally, we check for points with a parameter extended past -1 or 1,
+   * for which locate_point_on_edge should still give the respective -1 or 1,
+   * but the was_interior flag should be false.
    */
   constexpr int num_trials = 10;
+
+  const type_real eps_local = 1e-4;
+  constexpr type_real propability_of_exterior_sample = 0.2;
 
   const int nspec = assembly.get_total_number_of_elements();
 
@@ -70,7 +76,17 @@ void test_locate_point_on_edge(
 
     type_real &local_target =
         get_edge_coordinate(xi_target, gamma_target, edge);
-    local_target = ((((type_real)std::rand()) / RAND_MAX) * 2) - 1;
+    const bool sample_outside =
+        (((type_real)std::rand()) / RAND_MAX) < propability_of_exterior_sample;
+
+    if (sample_outside) {
+      local_target = ((((type_real)std::rand()) / RAND_MAX) + 1.01);
+      if (std::rand() % 2 != 0) {
+        local_target *= -1;
+      }
+    } else {
+      local_target = ((((type_real)std::rand()) / RAND_MAX) * 2) - 1;
+    }
 
     // target point on perimeter selected. Get global coordinates.
     const auto global_coords = specfem::algorithms::locate_point(
@@ -79,11 +95,12 @@ void test_locate_point_on_edge(
         assembly.mesh);
 
     // attempt to recover local edge coordinate
-    const type_real local_test = specfem::algorithms::locate_point_on_edge(
-        global_coords, assembly.mesh, ispec, edge);
+    const auto [local_test, inside_domain] =
+        specfem::algorithms::locate_point_on_edge(global_coords, assembly.mesh,
+                                                  ispec, edge);
 
-    // Check if the local coordinates are within the expected range
-    if (std::abs(local_test) > 1.0 + 1e-3) {
+    // Check if the local coordinates are within the domain
+    if (std::abs(local_test) > 1.0 + eps_local) {
       std::ostringstream message;
       message << "Local coordinates out of bounds: \n"
               << "\tOriginal point: (" << std::scientific << global_coords.x
@@ -94,17 +111,54 @@ void test_locate_point_on_edge(
       throw std::runtime_error(message.str());
     }
 
-    if (std::abs(local_test - local_target) > 1.0 + 1e-3) {
+    // is the computed local_test value what we expect?
+    if (sample_outside) {
+      type_real clamped_local_target =
+          std::min((type_real)1, std::max((type_real)-1, local_target));
+      if (std::abs(local_test - clamped_local_target) > eps_local) {
+        std::ostringstream message;
+        message << "Failed to locate point along edge: \n"
+                << "\tOriginal point: " << local_target << "\n"
+                << "\tExpected point: " << clamped_local_target << "\n"
+                << "\tLocated point:  " << local_test << "\n";
+
+        throw std::runtime_error(message.str());
+      }
+    } else {
+      if (std::abs(local_test - local_target) > eps_local) {
+        std::ostringstream message;
+        message << "Failed to locate point along edge: \n"
+                << "\tOriginal point: " << local_target << "\n"
+                << "\tLocated point:  " << local_test << "\n"
+                << "\t     (" << std::scientific << std::showpos
+                << (local_test - local_target) << ")\n";
+
+        throw std::runtime_error(message.str());
+      }
+    }
+
+    // is the inside_domain flag what we expect?
+    if (inside_domain == sample_outside) {
       std::ostringstream message;
-      message << "Failed to locate point along edge: \n"
-              << "\tOriginal point: " << local_target << "\n"
-              << "\tLocated point:  " << local_test << "\n";
+      message << "Correctly located point along edge, but failed to whether or "
+                 "not the point was in bounds: \n"
+              << "\tOriginal point:     " << local_target;
+      if (sample_outside) {
+        message << " (out of bounds)\n";
+      } else {
+        message << " (in bounds)\n";
+      }
+      message << "\n"
+              << "\tLocated point:      " << local_test << "\n"
+              << "\tLocated in bounds?  ";
+      if (inside_domain) {
+        message << "true\n";
+      } else {
+        message << "false\n";
+      }
 
       throw std::runtime_error(message.str());
     }
-
-    std::cout << "(" << xi_target << ", " << gamma_target << ") -- "
-              << local_target << ": " << local_test << std::endl;
   }
 }
 

--- a/tests/unit-tests/assembly/locate/locate_point_on_edge.cpp
+++ b/tests/unit-tests/assembly/locate/locate_point_on_edge.cpp
@@ -1,0 +1,135 @@
+#include "../test_fixture/test_fixture.hpp"
+#include "algorithms/locate_point.hpp"
+#include "enumerations/dimension.hpp"
+#include "enumerations/mesh_entities.hpp"
+#include "specfem/point.hpp"
+#include "specfem/point/coordinates.hpp"
+#include <gtest/gtest.h>
+#include <utility>
+
+using specfem::point::global_coordinates;
+using specfem::point::local_coordinates;
+
+void test_locate_point_on_edge(
+    const specfem::assembly::assembly<specfem::dimension::type::dim2>
+        &assembly) {
+
+  constexpr auto dim = specfem::dimension::type::dim2;
+
+  const type_real xmin = assembly.mesh.xmin;
+  const type_real xmax = assembly.mesh.xmax;
+  const type_real zmin = assembly.mesh.zmin;
+  const type_real zmax = assembly.mesh.zmax;
+
+  const type_real eps_local = 1e-6;
+
+  /* =============================
+   * - test_locate_point_on_edge -
+   * =============================
+   *
+   * For each trial, choose an element and a point on the
+   * perimeter of that element. locate_point_on_edge should give the correct
+   * value.
+   */
+  constexpr int num_trials = 10;
+
+  const int nspec = assembly.get_total_number_of_elements();
+
+  // sets xi,gamma constraint on edge, returns free (edge) coordinate.
+  const auto get_edge_coordinate =
+      [](type_real &xi, type_real &gamma,
+         const specfem::mesh_entity::type &edgetype) -> type_real & {
+    if (edgetype == specfem::mesh_entity::type::bottom ||
+        edgetype == specfem::mesh_entity::type::top) {
+      gamma = (edgetype == specfem::mesh_entity::type::bottom) ? -1 : 1;
+      return xi;
+    } else {
+      xi = (edgetype == specfem::mesh_entity::type::left) ? -1 : 1;
+      return gamma;
+    }
+  };
+
+  // we could seed by anything. Here's one:
+  std::srand(nspec);
+
+  for (int itrial = 0; itrial < num_trials; itrial++) {
+    const int ispec = std::rand() % nspec;
+    const int edge_select = std::rand() % 4;
+    specfem::mesh_entity::type edge;
+    if (edge_select == 0) {
+      edge = specfem::mesh_entity::type::bottom;
+    } else if (edge_select == 1) {
+      edge = specfem::mesh_entity::type::right;
+    } else if (edge_select == 2) {
+      edge = specfem::mesh_entity::type::top;
+    } else {
+      edge = specfem::mesh_entity::type::left;
+    }
+
+    type_real xi_target, gamma_target;
+
+    type_real &local_target =
+        get_edge_coordinate(xi_target, gamma_target, edge);
+    local_target = ((((type_real)std::rand()) / RAND_MAX) * 2) - 1;
+
+    // target point on perimeter selected. Get global coordinates.
+    const auto global_coords = specfem::algorithms::locate_point(
+        specfem::point::local_coordinates<specfem::dimension::type::dim2>(
+            ispec, xi_target, gamma_target),
+        assembly.mesh);
+
+    // attempt to recover local edge coordinate
+    const type_real local_test = specfem::algorithms::locate_point_on_edge(
+        global_coords, assembly.mesh, ispec, edge);
+
+    // Check if the local coordinates are within the expected range
+    if (std::abs(local_test) > 1.0 + 1e-3) {
+      std::ostringstream message;
+      message << "Local coordinates out of bounds: \n"
+              << "\tOriginal point: (" << std::scientific << global_coords.x
+              << ", " << global_coords.z << ")\n"
+              << "\tLocal coordinates: (" << xi_target << ", " << gamma_target
+              << ")\n";
+
+      throw std::runtime_error(message.str());
+    }
+
+    if (std::abs(local_test - local_target) > 1.0 + 1e-3) {
+      std::ostringstream message;
+      message << "Failed to locate point along edge: \n"
+              << "\tOriginal point: " << local_target << "\n"
+              << "\tLocated point:  " << local_test << "\n";
+
+      throw std::runtime_error(message.str());
+    }
+
+    std::cout << "(" << xi_target << ", " << gamma_target << ") -- "
+              << local_target << ": " << local_test << std::endl;
+  }
+}
+
+TEST_F(ASSEMBLY, LocatePointOnEdge) {
+  for (auto parameters : *this) {
+    const auto Test = std::get<0>(parameters);
+    specfem::assembly::assembly<specfem::dimension::type::dim2> assembly =
+        std::get<5>(parameters);
+
+    try {
+      test_locate_point_on_edge(assembly);
+
+      std::cout << "-------------------------------------------------------\n"
+                << "\033[0;32m[PASSED]\033[0m " << Test.name << "\n"
+                << "-------------------------------------------------------\n\n"
+                << std::endl;
+    } catch (std::exception &e) {
+      std::cout << "-------------------------------------------------------\n"
+                << "\033[0;31m[FAILED]\033[0m \n"
+                << "-------------------------------------------------------\n"
+                << "- Test: " << Test.name << "\n"
+                << "- Error: " << e.what() << "\n"
+                << "-------------------------------------------------------\n\n"
+                << std::endl;
+      ADD_FAILURE();
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds a function in `specfem::algorithms` to compute local coordinates on a known edge and element, using a similar argument configuration as the other `locate_point` functions.

This will be needed for computing the reparameterizations of nonconforming interfaces.

## Issue Number

resolves #1155

## Checklist

Please make sure to check developer documentation on specfem docs.

- [x] I ran the code through pre-commit to check style
- [x] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
