### PR TITLE
Fixes cmake issues with boost etc.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,100 +110,6 @@ include("${CMAKE_SOURCE_DIR}/cmake/adios2.cmake")
 # the pugixml dependency than ADIOS2)
 include("${CMAKE_SOURCE_DIR}/cmake/vtk.cmake")
 
-
-if (VTK_CXX_BUILD)
-
-    find_package(VTK COMPONENTS
-        CommonColor
-        CommonCore
-        FiltersSources
-        InteractionStyle
-        RenderingContextOpenGL2
-        RenderingCore
-        RenderingFreeType
-        RenderingGL2PSOpenGL2
-        RenderingOpenGL2
-    )
-
-    if (VTK_FOUND)
-        message(STATUS "VTK libs/ and incs/:")
-        message(STATUS "    LIB:   ${VTK_LIBRARY_DIRS}")
-        message(STATUS "    INC:   ${VTK_INCLUDE_DIRS}")
-        message(STATUS "    LIBSO: ${VTK_LIBRARIES}")
-    else(NOT VTK_FOUND)
-        message(STATUS "VTK not found. Building without VTK.")
-        set(VTK_CXX_BUILD OFF)
-    endif()
-else ()
-    set(VTK_FOUND OFF)
-    message(STATUS "Building without VTK.")
-endif()
-
-
-# Try finding boost and if not found install.
-find_package(Boost 1.85.0 COMPONENTS program_options filesystem system graph)
-
-if (NOT ${Boost_FOUND})
-    set(SPECFEMPP_SAVE_UNITY_BUILD ${CMAKE_UNITY_BUILD})
-    set(CMAKE_UNITY_BUILD OFF)
-    # Add boost lib sources
-    set(BOOST_INCLUDE_LIBRARIES program_options filesystem system algorithm tokenizer preprocessor vmd graph)
-    set(BOOST_LIBS Boost::program_options Boost::filesystem Boost::system
-                   Boost::algorithm Boost::tokenizer Boost::preprocessor Boost::vmd Boost::graph)
-    set(BOOST_ENABLE_CMAKE ON)
-    set(BOOST_ENABLE_MPI OFF CACHE INTERNAL "Boost MPI Switch") # Assume outer variable
-    set(BOOST_ENABLE_PYTHON OFF CACHE INTERNAL "Boost Python Switch") # Assume outer variable
-    set(BOOST_BUILD_TESTING OFF CACHE BOOL INTERNAL "Boost Test Switch") # Disable testing for boost
-    # The test flag is not really working... added it for completeness
-
-    # Download and extract the boost library from GitHub
-    set(BOOST_VERSION 1.87.0)
-    message(STATUS "Downloading and extracting boost (${BOOST_VERSION}) library sources. This will take <1 min.")
-    include(FetchContent)
-
-    # Fetch boost from the Github release zip file to reduce download time
-    FetchContent_Declare(
-        Boost
-        URL https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}-cmake.tar.gz # downloading a zip release speeds up the download
-        USES_TERMINAL_DOWNLOAD True
-        GIT_PROGRESS TRUE
-        DOWNLOAD_NO_EXTRACT FALSE
-        DOWNLOAD_EXTRACT_TIMESTAMP FALSE
-    )
-
-    # Disable Boost installation
-    set(BOOST_INSTALL OFF CACHE BOOL "Don't install Boost" FORCE)
-    set(BOOST_INSTALL_LIBRARIES OFF CACHE BOOL "Don't install Boost libraries" FORCE)
-    set(BOOST_SKIP_INSTALL_RULES ON CACHE BOOL "Skip Boost install rules" FORCE)
-
-    FetchContent_MakeAvailable(Boost)
-
-    set(CMAKE_UNITY_BUILD ${SPECFEMPP_SAVE_UNITY_BUILD})
-    unset(SPECFEMPP_SAVE_UNITY_BUILD)
-
-else()
-    # Check which boost LIBRARY_DIRS to use
-    set(BOOST_LIBS Boost::boost Boost::program_options Boost::filesystem Boost::system Boost::graph)
-    message(STATUS "Boost libs/ and incs/:")
-    message(STATUS "    LIB:   ${Boost_LIBRARY_DIRS}")
-    message(STATUS "    INC:   ${Boost_INCLUDE_DIRS}")
-    message(STATUS "    LIBSO: ${Boost_LIBRARIES}")
-endif()
-
-# Install HDF5 as a dependency if not found
-find_package(HDF5 COMPONENTS CXX)
-
-if (NOT ${HDF5_FOUND})
-    message(STATUS "HDF5 not found. Building without HDF5.")
-    set(HDF5_CXX_BUILD OFF)
-else()
-    message(STATUS "HDF5 libs/ and incs/:.")
-    message(STATUS "    LIB:   ${HDF5_LIBRARIES}")
-    message(STATUS "    INC:   ${HDF5_INCLUDE_DIRS}")
-    message(STATUS "    LIBSO: ${HDF5_CXX_LIBRARIES}")
-endif()
-
-
 if (SPECFEM_ENABLE_SIMD)
     message(STATUS "Enabling SIMD")
     add_compile_definitions(SPECFEM_ENABLE_SIMD)
@@ -244,7 +150,6 @@ message(STATUS "INCLUDE DIRECTORIES:")
 message(STATUS "    core: ${CMAKE_CURRENT_SOURCE_DIR}/core")
 message(STATUS "    include: ${CMAKE_SOURCE_DIR}/include")
 message(STATUS "    binary: ${CMAKE_BINARY_DIR}/include")
-
 
 
 # Set loglevel to STATUS if build type is debug


### PR DESCRIPTION
## Description

A merge from devel-dg into devel caused remnants to be re-added to the CMakeLists.txt. This PR - removes these remnants
- fixes an issue that is introduced by using Boost==1.89 and cmake 4, where cmake won't find the Boost::system library since it is header only

## Checklist

Please make sure to check developer documentation on specfem docs.

- [x] I ran the code through pre-commit to check style
- [x] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [x] I have added labels to the PR (see right hand side of the PR page)
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
