### PR TITLE
Issue 1187(patch) - Updates the mesh to have element_grid, deprecates ngllx,z

### DIFF
--- a/core/specfem/assembly/assembly/dim2/assembly.cpp
+++ b/core/specfem/assembly/assembly/dim2/assembly.cpp
@@ -19,23 +19,27 @@ specfem::assembly::assembly<specfem::dimension::type::dim2>::assembly(
     const std::shared_ptr<specfem::io::reader> &property_reader) {
   this->mesh = { mesh.tags, mesh.control_nodes, quadratures,
                  mesh.adjacency_graph };
-  this->element_types = { this->mesh.nspec, this->mesh.ngllz, this->mesh.ngllx,
-                          this->mesh, mesh.tags };
+
+  this->element_types = { this->mesh.nspec, this->mesh.element_grid.ngllz,
+                          this->mesh.element_grid.ngllx, this->mesh,
+                          mesh.tags };
   this->jacobian_matrix = { this->mesh };
-  this->properties = {
-    this->mesh.nspec,          this->mesh.ngllz, this->mesh.ngllx,
-    this->element_types,       this->mesh,       mesh.materials,
-    property_reader != nullptr
-  };
-  this->kernels = { this->mesh.nspec, this->mesh.ngllz, this->mesh.ngllx,
-                    this->element_types };
+  this->properties = { this->mesh.nspec,
+                       this->mesh.element_grid.ngllz,
+                       this->mesh.element_grid.ngllx,
+                       this->element_types,
+                       this->mesh,
+                       mesh.materials,
+                       property_reader != nullptr };
+  this->kernels = { this->mesh.nspec, this->mesh.element_grid.ngllz,
+                    this->mesh.element_grid.ngllx, this->element_types };
   this->sources = {
     sources, this->mesh, this->jacobian_matrix, this->element_types,
     t0,      dt,         max_timesteps
   };
   this->receivers = { this->mesh.nspec,
-                      this->mesh.ngllz,
-                      this->mesh.ngllz,
+                      this->mesh.element_grid.ngllz,
+                      this->mesh.element_grid.ngllz,
                       max_sig_step,
                       dt,
                       t0,
@@ -45,9 +49,12 @@ specfem::assembly::assembly<specfem::dimension::type::dim2>::assembly(
                       this->mesh,
                       mesh.tags,
                       this->element_types };
-  this->boundaries = { this->mesh.nspec, this->mesh.ngllz,
-                       this->mesh.ngllx, mesh,
-                       this->mesh,       this->jacobian_matrix };
+  this->boundaries = { this->mesh.nspec,
+                       this->mesh.element_grid.ngllz,
+                       this->mesh.element_grid.ngllx,
+                       mesh,
+                       this->mesh,
+                       this->jacobian_matrix };
   this->coupled_interfaces = { mesh, this->mesh, this->jacobian_matrix,
                                this->element_types };
   this->fields = { this->mesh, this->element_types, simulation };
@@ -84,7 +91,8 @@ specfem::assembly::assembly<specfem::dimension::type::dim2>::print() const {
   message << "Assembly information:\n"
           << "------------------------------\n"
           << "Total number of spectral elements : " << this->mesh.nspec << "\n"
-          << "Total number of geometric points : " << this->mesh.ngllz << "\n"
+          << "Total number of geometric points : "
+          << this->mesh.element_grid.ngllz << "\n"
           << "Total number of distinct quadrature points : " << this->mesh.nglob
           << "\n";
 

--- a/core/specfem/assembly/assembly/dim2/check_jacobian/check_jacobian.cpp
+++ b/core/specfem/assembly/assembly/dim2/check_jacobian/check_jacobian.cpp
@@ -52,8 +52,8 @@ map_small_jacobian(
                                                      // large jacobian grey
 
   const int nspec = mesh.nspec;
-  const int ngllx = mesh.ngllx;
-  const int ngllz = mesh.ngllz;
+  const int ngllx = mesh.element_grid.ngllx;
+  const int ngllz = mesh.element_grid.ngllz;
 
   const auto &coordinates = mesh.h_coord;
 

--- a/core/specfem/assembly/assembly/dim2/compute_wavefield/compute_wavefield.cpp
+++ b/core/specfem/assembly/assembly/dim2/compute_wavefield/compute_wavefield.cpp
@@ -17,7 +17,7 @@ void get_wavefield_on_entire_grid(
                  Kokkos::DefaultExecutionSpace>
         wavefield_on_entire_grid) {
 
-  const auto element_grid = assembly.mesh.get_element_grid();
+  const auto &element_grid = assembly.mesh.element_grid;
 
   if (element_grid == 5) {
     impl::helper<MediumTag, PropertyTag, 5> helper(assembly,
@@ -78,7 +78,8 @@ specfem::assembly::assembly<specfem::dimension::type::dim2>::
   Kokkos::View<type_real ****, Kokkos::LayoutLeft,
                Kokkos::DefaultExecutionSpace>
       wavefield_on_entire_grid("wavefield_on_entire_grid", this->mesh.nspec,
-                               this->mesh.ngllz, this->mesh.ngllx, ncomponents);
+                               this->mesh.element_grid.ngllz,
+                               this->mesh.element_grid.ngllx, ncomponents);
 
   // Create host mirror for the wavefield on the entire grid
   const auto h_wavefield_on_entire_grid =

--- a/core/specfem/assembly/assembly/dim2/compute_wavefield/helper.hpp
+++ b/core/specfem/assembly/assembly/dim2/compute_wavefield/helper.hpp
@@ -27,7 +27,7 @@ public:
                       Kokkos::DefaultExecutionSpace>
              wavefield_on_entire_grid)
       : assembly(assembly), wavefield_on_entire_grid(wavefield_on_entire_grid) {
-    const auto element_grid = assembly.mesh.get_element_grid();
+    const auto &element_grid = assembly.mesh.element_grid;
     if (element_grid != ngll) {
       throw std::runtime_error("Number of quadrature points not supported");
     }
@@ -37,7 +37,7 @@ public:
     const auto buffer = assembly.fields.buffer;
 
     // Get the element grid (ngllx, ngllz)
-    const auto element_grid = assembly.mesh.get_element_grid();
+    const auto &element_grid = assembly.mesh.element_grid;
 
     const auto elements =
         assembly.element_types.get_elements_on_device(medium_tag, property_tag);

--- a/core/specfem/assembly/boundary_values/dim2/impl/boundary_medium_container.tpp
+++ b/core/specfem/assembly/boundary_values/dim2/impl/boundary_medium_container.tpp
@@ -19,8 +19,8 @@ specfem::assembly::boundary_values_impl::boundary_medium_container<
 
   int nelements = 0;
   const int nspec = mesh.nspec;
-  const int nz = mesh.ngllz;
-  const int nx = mesh.ngllx;
+  const int nz = mesh.element_grid.ngllz;
+  const int nx = mesh.element_grid.ngllx;
 
   for (int ispec = 0; ispec < nspec; ispec++) {
     if (element_types.get_medium_tag(ispec) == MediumTag &&

--- a/core/specfem/assembly/coupled_interfaces/dim2/impl/interface_container.tpp
+++ b/core/specfem/assembly/coupled_interfaces/dim2/impl/interface_container.tpp
@@ -114,7 +114,7 @@ compute_edge_factors_and_normals(
     const int ispec2, const specfem::enums::edge::type edge1,
     const specfem::enums::edge::type edge2) {
 
-  const int ngll = mesh.ngllx;
+  const int ngll = mesh.element_grid.ngllx;
 
   const auto edge1_points = get_points_on_edge(edge1, ngll);
   const auto edge2_points = get_points_on_edge(edge2, ngll);
@@ -285,7 +285,7 @@ specfem::assembly::interface_container<specfem::dimension::type::dim2, MediumTag
       mesh.coupled_interfaces.get<MediumTag1, MediumTag2>());
 
   int num_interfaces = interface_container.num_interfaces;
-  const int ngll = mesh_assembly.ngllx;
+  const int ngll = mesh_assembly.element_grid.ngllx;
 
   if (num_interfaces == 0) {
     this->num_interfaces = 0;

--- a/core/specfem/assembly/fields/impl/field_impl.tpp
+++ b/core/specfem/assembly/fields/impl/field_impl.tpp
@@ -25,8 +25,8 @@ void assign_assembly_index_mapping<specfem::dimension::type::dim2>(
     int &nglob, const specfem::element::medium_tag MediumTag) {
   const auto index_mapping = mesh.h_index_mapping;
   const int nspec = mesh.nspec;
-  const int ngllz = mesh.ngllz;
-  const int ngllx = mesh.ngllx;
+  const int ngllz = mesh.element_grid.ngllz;
+  const int ngllx = mesh.element_grid.ngllx;
 
   int count = 0;
 

--- a/core/specfem/assembly/jacobian_matrix/dim2/jacobian_matrix.cpp
+++ b/core/specfem/assembly/jacobian_matrix/dim2/jacobian_matrix.cpp
@@ -29,7 +29,8 @@ specfem::assembly::jacobian_matrix<
 specfem::assembly::jacobian_matrix<specfem::dimension::type::dim2>::
     jacobian_matrix(
         const specfem::assembly::mesh<specfem::dimension::type::dim2> &mesh)
-    : nspec(mesh.nspec), ngllz(mesh.ngllz), ngllx(mesh.ngllx),
+    : nspec(mesh.nspec), ngllz(mesh.element_grid.ngllz),
+      ngllx(mesh.element_grid.ngllx),
       xix("specfem::assembly::jacobian_matrix::xix", nspec, ngllz, ngllx),
       xiz("specfem::assembly::jacobian_matrix::xiz", nspec, ngllz, ngllx),
       gammax("specfem::assembly::jacobian_matrix::gammax", nspec, ngllz, ngllx),

--- a/core/specfem/assembly/mesh/dim2/impl/assemble.tpp
+++ b/core/specfem/assembly/mesh/dim2/impl/assemble.tpp
@@ -9,8 +9,8 @@
 void specfem::assembly::mesh<specfem::dimension::type::dim2>::assemble() {
 
   const int nspec = this->nspec;
-  const int ngllx = this->ngllx;
-  const int ngllz = this->ngllz;
+  const int ngllx = this->element_grid.ngllx;
+  const int ngllz = this->element_grid.ngllz;
 
   const int ngnod = this->ngnod;
 

--- a/core/specfem/assembly/mesh/dim2/mesh.hpp
+++ b/core/specfem/assembly/mesh/dim2/mesh.hpp
@@ -22,8 +22,7 @@ namespace specfem::assembly {
  */
 template <>
 struct mesh<specfem::dimension::type::dim2>
-    : public specfem::mesh_entity::element<specfem::dimension::type::dim2>,
-      public specfem::assembly::mesh_impl::points<
+    : public specfem::assembly::mesh_impl::points<
           specfem::dimension::type::dim2>,
       public specfem::assembly::mesh_impl::quadrature<
           specfem::dimension::type::dim2>,
@@ -41,12 +40,10 @@ public:
       specfem::dimension::type::dim2; ///< Dimension
   int nspec;                          ///< Number of spectral
                                       ///< elements
-  int ngllz;                          ///< Number of quadrature
-                                      ///< points in z dimension
-  int ngllx;                          ///< Number of quadrature
-                                      ///< points in x dimension
   int ngnod;                          ///< Number of control
                                       ///< nodes
+  specfem::mesh_entity::element<dimension_tag> element_grid; ///< Element number
+                                                             ///< of GLL points
 
   mesh() = default;
 
@@ -58,9 +55,6 @@ public:
   void assemble_legacy();
 
   void assemble();
-
-  specfem::mesh_entity::element<specfem::dimension::type::dim2>
-  get_element_grid() const;
 
   bool adjacency_graph_empty() const {
     return static_cast<const specfem::assembly::mesh_impl::adjacency_graph<

--- a/core/specfem/assembly/receivers/dim2/receivers.cpp
+++ b/core/specfem/assembly/receivers/dim2/receivers.cpp
@@ -22,7 +22,8 @@ specfem::assembly::receivers<specfem::dimension::type::dim2>::receivers(
         &element_types)
     : nspec(nspec),
       lagrange_interpolant("specfem::assembly::receivers::lagrange_interpolant",
-                           receivers.size(), mesh.ngllz, mesh.ngllx),
+                           receivers.size(), mesh.element_grid.ngllz,
+                           mesh.element_grid.ngllx),
       h_lagrange_interpolant(Kokkos::create_mirror_view(lagrange_interpolant)),
       elements("specfem::assembly::receivers::elements", receivers.size()),
       h_elements(Kokkos::create_mirror_view(elements)),
@@ -81,14 +82,14 @@ specfem::assembly::receivers<specfem::dimension::type::dim2>::receivers(
 
     auto [hxi_receiver, hpxi_receiver] =
         specfem::quadrature::gll::Lagrange::compute_lagrange_interpolants(
-            lcoord.xi, mesh.ngllx, xi);
+            lcoord.xi, mesh.element_grid.ngllx, xi);
 
     auto [hgamma_receiver, hpgamma_receiver] =
         specfem::quadrature::gll::Lagrange::compute_lagrange_interpolants(
-            lcoord.gamma, mesh.ngllx, gamma);
+            lcoord.gamma, mesh.element_grid.ngllx, gamma);
 
-    for (int iz = 0; iz < mesh.ngllz; ++iz) {
-      for (int ix = 0; ix < mesh.ngllx; ++ix) {
+    for (int iz = 0; iz < mesh.element_grid.ngllz; ++iz) {
+      for (int ix = 0; ix < mesh.element_grid.ngllx; ++ix) {
         type_real hlagrange = hxi_receiver(ix) * hgamma_receiver(iz);
 
         h_lagrange_interpolant(ireceiver, iz, ix, 0) = hlagrange;

--- a/core/specfem/assembly/sources/impl/dim2/source_medium.tpp
+++ b/core/specfem/assembly/sources/impl/dim2/source_medium.tpp
@@ -39,7 +39,7 @@ specfem::assembly::sources_impl::source_medium<DimensionTag, MediumTag>::source_
       h_source_index_mapping(Kokkos::create_mirror_view(source_index_mapping)),
       source_time_function("specfem::sources::source_time_function", nsteps, sources.size(), components),
       h_source_time_function(Kokkos::create_mirror_view(source_time_function)),
-      source_array("specfem::sources::source_array", sources.size(), components, mesh.ngllz, mesh.ngllx),
+      source_array("specfem::sources::source_array", sources.size(), components, mesh.element_grid.ngllz, mesh.element_grid.ngllx),
       h_source_array(Kokkos::create_mirror_view(source_array)) {
 
   for (int isource = 0; isource < sources.size(); isource++) {

--- a/include/enumerations/mesh_entities.hpp
+++ b/include/enumerations/mesh_entities.hpp
@@ -138,7 +138,6 @@ template <specfem::dimension::type Dimension> struct element;
 template <> struct element<specfem::dimension::type::dim2> {
 
 public:
-  int ngll;   ///< Number of Gauss-Lobatto-Legendre points in the element
   int ngllz;  ///< Number of Gauss-Lobatto-Legendre points in the z-direction
   int ngllx;  ///< Number of Gauss-Lobatto-Legendre points in the x-direction
   int orderz; ///< Polynomial order of the element

--- a/include/enumerations/mesh_entities.hpp
+++ b/include/enumerations/mesh_entities.hpp
@@ -125,9 +125,24 @@ std::list<type> edges_of_corner(const type &corner);
  */
 std::list<type> corners_of_edge(const type &edge);
 
+/**
+ * @brief Mesh element structure for a specific dimension
+ *
+ * @tparam Dimension The dimension type (e.g., dim2, dim3)
+ */
 template <specfem::dimension::type Dimension> struct element;
 
+/**
+ * @brief Mesh element structure for 2D elements (Specialization)
+ */
 template <> struct element<specfem::dimension::type::dim2> {
+
+public:
+  int ngll;   ///< Number of Gauss-Lobatto-Legendre points in the element
+  int ngllz;  ///< Number of Gauss-Lobatto-Legendre points in the z-direction
+  int ngllx;  ///< Number of Gauss-Lobatto-Legendre points in the x-direction
+  int orderz; ///< Polynomial order of the element
+  int orderx; ///< Polynomial order of the element
 
   /**
    * @brief Default constructor for the element struct
@@ -140,8 +155,13 @@ template <> struct element<specfem::dimension::type::dim2> {
    *
    * @param ngll The number of Gauss-Lobatto-Legendre points
    */
-  element(const int ngll, const int ngllz, const int ngllx)
-      : ngll(ngll), ngllz(ngllz), ngllx(ngllx), order(ngll - 1) {};
+  element(const int ngllz, const int ngllx)
+      : ngllz(ngllz), ngllx(ngllx), orderz(ngllz - 1), orderx(ngllx - 1) {
+    if (ngllz != ngllx) {
+      throw std::invalid_argument(
+          "Different number of GLL points for Z and X are not supported.");
+    }
+  };
 
   /**
    * @brief Checks if the element is consistent across dimensions against a
@@ -152,8 +172,7 @@ template <> struct element<specfem::dimension::type::dim2> {
    * @return false If any dimension does not match
    */
   bool operator==(const int ngll_in) const {
-    return ngll_in == this->ngll && ngll_in == this->ngllz &&
-           ngll_in == this->ngllx;
+    return ngll_in == this->ngllz && ngll_in == this->ngllx;
   }
 
   /**
@@ -166,12 +185,6 @@ template <> struct element<specfem::dimension::type::dim2> {
    *
    */
   bool operator!=(const int ngll_in) const { return !(*this == ngll_in); }
-
-public:
-  int order; ///< Polynomial order of the element
-  int ngll;  ///< Number of Gauss-Lobatto-Legendre points in the element
-  int ngllz; ///< Number of Gauss-Lobatto-Legendre points in the z-direction
-  int ngllx; ///< Number of Gauss-Lobatto-Legendre points in the x-direction
 };
 
 template <> struct element<specfem::dimension::type::dim3> {

--- a/include/enumerations/mesh_entities.hpp
+++ b/include/enumerations/mesh_entities.hpp
@@ -3,6 +3,7 @@
 #include "dimension.hpp"
 #include <algorithm>
 #include <list>
+#include <stdexcept>
 
 /**
  * @namespace specfem::mesh_entity

--- a/include/io/impl/medium_writer.tpp
+++ b/include/io/impl/medium_writer.tpp
@@ -23,8 +23,8 @@ void specfem::io::impl::write_container(
   typename OutputLibrary::File file(output_folder + "/" + output_namespace);
 
   const int nspec = mesh.nspec;
-  const int ngllz = mesh.ngllz;
-  const int ngllx = mesh.ngllx;
+  const int ngllz = mesh.element_grid.ngllz;
+  const int ngllx = mesh.element_grid.ngllx;
 
   int n_written = 0;
 

--- a/include/io/wavefield/writer.tpp
+++ b/include/io/wavefield/writer.tpp
@@ -24,8 +24,8 @@ void specfem::io::wavefield_writer<OutputLibrary>::initialize(
   using MappingView =
       Kokkos::View<int ***, Kokkos::LayoutLeft, Kokkos::HostSpace>;
 
-  const int ngllz = mesh.ngllz;
-  const int ngllx = mesh.ngllx;
+  const int ngllz = mesh.element_grid.ngllz;
+  const int ngllx = mesh.element_grid.ngllx;
   // const int nspec = mesh.points.nspec;
 
   typename OutputLibrary::Group base_group =

--- a/include/kokkos_kernels/impl/compute_mass_matrix.tpp
+++ b/include/kokkos_kernels/impl/compute_mass_matrix.tpp
@@ -45,7 +45,7 @@ void specfem::kokkos_kernels::impl::compute_mass_matrix(
     return;
 
   // Get the element grid (ngllx, ngllz)
-  const auto element_grid = assembly.mesh.get_element_grid();
+  const auto &element_grid = assembly.mesh.element_grid;
 
   // Check if the number of GLL points in the mesh elements matches the template
   // parameter NGLL

--- a/include/kokkos_kernels/impl/compute_material_derivatives.tpp
+++ b/include/kokkos_kernels/impl/compute_material_derivatives.tpp
@@ -30,7 +30,7 @@ void specfem::kokkos_kernels::impl::compute_material_derivatives(
   const int nelements = elements.extent(0);
 
   // Get the element grid (ngllx, ngllz)
-  const auto element_grid = mesh.get_element_grid();
+  const auto &element_grid = mesh.element_grid;
 
   if (element_grid != NGLL) {
     throw std::runtime_error(

--- a/include/kokkos_kernels/impl/compute_seismogram.tpp
+++ b/include/kokkos_kernels/impl/compute_seismogram.tpp
@@ -33,7 +33,7 @@ void specfem::kokkos_kernels::impl::compute_seismograms(
       assembly.receivers.get_indices_on_device(medium_tag, property_tag);
 
   // Get the element grid (ngllx, ngllz)
-  const auto element_grid = assembly.mesh.get_element_grid();
+  const auto &element_grid = assembly.mesh.element_grid;
 
   // Check if the number of GLL points in the mesh elements matches the template
   // parameter NGLL

--- a/include/kokkos_kernels/impl/compute_source_interaction.tpp
+++ b/include/kokkos_kernels/impl/compute_source_interaction.tpp
@@ -33,7 +33,7 @@ void specfem::kokkos_kernels::impl::compute_source_interaction(
                                              BoundaryTag, WavefieldType);
 
   // Get the element grid (ngllx, ngllz)
-  const auto element_grid = assembly.mesh.get_element_grid();
+  const auto &element_grid = assembly.mesh.element_grid;
 
   // Check if the number of GLL points in the mesh elements matches the template
   // parameter NGLL

--- a/include/kokkos_kernels/impl/compute_stiffness_interaction.tpp
+++ b/include/kokkos_kernels/impl/compute_stiffness_interaction.tpp
@@ -44,7 +44,7 @@ int specfem::kokkos_kernels::impl::compute_stiffness_interaction(
   const int nelements = elements.extent(0);
 
   // Get the element grid information (ngll, ngllx, ngllz, order)
-  const auto element_grid = assembly.mesh.get_element_grid();
+  const auto &element_grid = assembly.mesh.element_grid;
 
   // Return if there are no elements matching the tag combination
   if (nelements == 0)

--- a/src/algorithms/dim2/locate_point.cpp
+++ b/src/algorithms/dim2/locate_point.cpp
@@ -18,7 +18,7 @@ specfem::algorithms::locate_point(
   if (mesh.adjacency_graph_empty()) {
     return specfem::algorithms::locate_point_impl::locate_point_core(
         coordinates, mesh.h_coord, mesh.h_index_mapping,
-        mesh.h_control_node_coord, mesh.ngnod, mesh.ngllx);
+        mesh.h_control_node_coord, mesh.ngnod, mesh.element_grid.ngllx);
   } else {
     return specfem::algorithms::locate_point_impl::locate_point_core(
         mesh.graph(), coordinates, mesh.h_coord, mesh.h_control_node_coord,

--- a/src/periodic_tasks/plot_wavefield.cpp
+++ b/src/periodic_tasks/plot_wavefield.cpp
@@ -53,7 +53,8 @@ specfem::periodic_tasks::plot_wavefield::plot_wavefield(
     : assembly(assembly), wavefield(wavefield), wavefield_type(wavefield_type),
       plotter(time_interval), output_format(output_format),
       output_folder(output_folder), nspec(assembly.mesh.nspec),
-      ngllx(assembly.mesh.ngllx), ngllz(assembly.mesh.ngllz), mpi(mpi) {
+      ngllx(assembly.mesh.element_grid.ngllx),
+      ngllz(assembly.mesh.element_grid.ngllz), mpi(mpi) {
   std::ostringstream message;
   message
       << "Display section is not enabled, since SPECFEM++ was built without "
@@ -106,7 +107,8 @@ specfem::periodic_tasks::plot_wavefield::plot_wavefield(
     : assembly(assembly), wavefield(wavefield), wavefield_type(wavefield_type),
       plotter(time_interval), output_format(output_format),
       output_folder(output_folder), nspec(assembly.mesh.nspec),
-      ngllx(assembly.mesh.ngllx), ngllz(assembly.mesh.ngllz), mpi(mpi) {};
+      ngllx(assembly.mesh.element_grid.ngllx),
+      ngllz(assembly.mesh.element_grid.ngllz), mpi(mpi) {};
 
 // Sigmoid function centered at 0.0
 double specfem::periodic_tasks::plot_wavefield::sigmoid(double x) {
@@ -163,8 +165,8 @@ specfem::periodic_tasks::plot_wavefield::map_materials_with_color() {
 
   const auto &coordinates = assembly.mesh.h_coord;
   const int nspec = assembly.mesh.nspec;
-  const int ngllx = assembly.mesh.ngllx;
-  const int ngllz = assembly.mesh.ngllz;
+  const int ngllx = assembly.mesh.element_grid.ngllx;
+  const int ngllz = assembly.mesh.element_grid.ngllz;
 
   const int cell_points = 4;
 

--- a/tests/unit-tests/assembly/compute_wavefield/generate_data.hpp
+++ b/tests/unit-tests/assembly/compute_wavefield/generate_data.hpp
@@ -16,8 +16,8 @@ void generate_data(
 
   auto field = assembly.fields.template get_simulation_field<type>();
 
-  const int ngllx = assembly.mesh.ngllx;
-  const int ngllz = assembly.mesh.ngllz;
+  const int ngllx = assembly.mesh.element_grid.ngllx;
+  const int ngllz = assembly.mesh.element_grid.ngllz;
 
   const auto elements =
       assembly.element_types.get_elements_on_host(medium, property);

--- a/tests/unit-tests/assembly/compute_wavefield/test_helper.hpp
+++ b/tests/unit-tests/assembly/compute_wavefield/test_helper.hpp
@@ -36,8 +36,8 @@ public:
         specfem::wavefield::wavefield<specfem::dimension::type::dim2,
                                       component>::num_components();
 
-    const int ngllz = assembly.mesh.ngllz;
-    const int ngllx = assembly.mesh.ngllx;
+    const int ngllz = assembly.mesh.element_grid.ngllz;
+    const int ngllx = assembly.mesh.element_grid.ngllx;
 
     for (int iz = 0; iz < ngllz; iz++) {
       for (int ix = 0; ix < ngllx; ix++) {
@@ -86,8 +86,8 @@ public:
         specfem::dimension::type::dim2,
         specfem::wavefield::type::pressure>::num_components();
 
-    const int ngllz = assembly.mesh.ngllz;
-    const int ngllx = assembly.mesh.ngllx;
+    const int ngllz = assembly.mesh.element_grid.ngllz;
+    const int ngllx = assembly.mesh.element_grid.ngllx;
 
     using PointProperties =
         specfem::point::properties<specfem::dimension::type::dim2,
@@ -153,8 +153,8 @@ public:
         specfem::wavefield::wavefield<specfem::dimension::type::dim2,
                                       component>::num_components();
 
-    const int ngllz = assembly.mesh.ngllz;
-    const int ngllx = assembly.mesh.ngllx;
+    const int ngllz = assembly.mesh.element_grid.ngllz;
+    const int ngllx = assembly.mesh.element_grid.ngllx;
 
     using PointProperties = specfem::point::properties<
         specfem::dimension::type::dim2, specfem::element::medium_tag::acoustic,
@@ -217,8 +217,8 @@ public:
         specfem::dimension::type::dim2,
         specfem::wavefield::type::pressure>::num_components();
 
-    const int ngllz = assembly.mesh.ngllz;
-    const int ngllx = assembly.mesh.ngllx;
+    const int ngllz = assembly.mesh.element_grid.ngllz;
+    const int ngllx = assembly.mesh.element_grid.ngllx;
 
     using PointProperties = specfem::point::properties<
         specfem::dimension::type::dim2, specfem::element::medium_tag::acoustic,

--- a/tests/unit-tests/assembly/kernels/kernels.cpp
+++ b/tests/unit-tests/assembly/kernels/kernels.cpp
@@ -32,7 +32,7 @@ set_kernel_value(
 
   specfem::execution::ChunkedDomainIterator policy(
       ParallelConfig<using_simd, Kokkos::DefaultHostExecutionSpace>(), elements,
-      assembly.mesh.get_element_grid());
+      assembly.mesh.element_grid);
 
   specfem::execution::for_all(
       "set_to_value", policy,
@@ -63,7 +63,7 @@ check_kernel_value(
 
   specfem::execution::ChunkedDomainIterator policy(
       ParallelConfig<using_simd, Kokkos::DefaultHostExecutionSpace>(), elements,
-      assembly.mesh.get_element_grid());
+      assembly.mesh.element_grid);
 
   // Iterate over the elements
   specfem::execution::for_all(
@@ -120,7 +120,7 @@ add_value(const ViewType elements,
 
   specfem::execution::ChunkedDomainIterator policy(
       ParallelConfig<using_simd, Kokkos::DefaultHostExecutionSpace>(), elements,
-      assembly.mesh.get_element_grid());
+      assembly.mesh.element_grid);
 
   // Iterate over the elements
   specfem::execution::for_all(
@@ -154,7 +154,7 @@ set_kernel_value(
 
   specfem::execution::ChunkedDomainIterator policy(
       ParallelConfig<using_simd, Kokkos::DefaultExecutionSpace>(), elements,
-      assembly.mesh.get_element_grid());
+      assembly.mesh.element_grid);
 
   // Iterate over the elements
   specfem::execution::for_all(
@@ -181,7 +181,7 @@ check_kernel_value(
   constexpr auto dimension = specfem::dimension::type::dim2;
 
   const int nspec = assembly.mesh.nspec;
-  const int ngll = assembly.mesh.ngllx;
+  const int ngll = assembly.mesh.element_grid.ngllx;
   const auto &kernels = assembly.kernels;
 
   using PointType = specfem::point::kernels<specfem::dimension::type::dim2,
@@ -192,7 +192,7 @@ check_kernel_value(
 
   specfem::execution::ChunkedDomainIterator policy(
       ParallelConfig<using_simd, Kokkos::DefaultExecutionSpace>(), elements,
-      assembly.mesh.get_element_grid());
+      assembly.mesh.element_grid);
   // Iterate over the elements
   specfem::execution::for_all(
       "check_to_value", policy,
@@ -217,7 +217,7 @@ check_kernel_value(
 
   specfem::execution::ChunkedDomainIterator host_policy(
       ParallelConfig<using_simd, Kokkos::DefaultHostExecutionSpace>(),
-      host_elements, assembly.mesh.get_element_grid());
+      host_elements, assembly.mesh.element_grid);
 
   // Iterate over the elements
   specfem::execution::for_all(
@@ -273,7 +273,7 @@ add_value(const ViewType elements,
                                             MediumTag, PropertyTag, using_simd>;
   specfem::execution::ChunkedDomainIterator policy(
       ParallelConfig<using_simd, Kokkos::DefaultExecutionSpace>(), elements,
-      assembly.mesh.get_element_grid());
+      assembly.mesh.element_grid);
 
   // Iterate over the elements
   specfem::execution::for_all(

--- a/tests/unit-tests/assembly/properties/properties.cpp
+++ b/tests/unit-tests/assembly/properties/properties.cpp
@@ -37,7 +37,7 @@ set_property_value(
 
   specfem::execution::ChunkedDomainIterator policy(
       ParallelConfig<using_simd, Kokkos::DefaultHostExecutionSpace>(), elements,
-      assembly.mesh.get_element_grid());
+      assembly.mesh.element_grid);
 
   specfem::execution::for_all(
       "set_to_value", policy,
@@ -68,7 +68,7 @@ check_property_value(
 
   specfem::execution::ChunkedDomainIterator policy(
       ParallelConfig<using_simd, Kokkos::DefaultHostExecutionSpace>(), elements,
-      assembly.mesh.get_element_grid());
+      assembly.mesh.element_grid);
 
   specfem::execution::for_all(
       "set_to_value", policy,
@@ -124,7 +124,7 @@ check_property_value(
   constexpr auto dimension = specfem::dimension::type::dim2;
 
   const int nspec = assembly.mesh.nspec;
-  const int ngll = assembly.mesh.ngllx;
+  const int ngll = assembly.mesh.element_grid.ngllx;
   const auto &properties = assembly.properties;
 
   using PointType =
@@ -136,7 +136,7 @@ check_property_value(
 
   specfem::execution::ChunkedDomainIterator policy(
       ParallelConfig<using_simd, Kokkos::DefaultExecutionSpace>(), elements,
-      assembly.mesh.get_element_grid());
+      assembly.mesh.element_grid);
 
   specfem::execution::for_all(
       "set_to_value", policy,
@@ -159,7 +159,7 @@ check_property_value(
       Kokkos::DefaultHostExecutionSpace(), elements);
   specfem::execution::ChunkedDomainIterator host_policy(
       ParallelConfig<using_simd, Kokkos::DefaultHostExecutionSpace>(),
-      host_elements, assembly.mesh.get_element_grid());
+      host_elements, assembly.mesh.element_grid);
 
   specfem::execution::for_all(
       "set_to_value", host_policy,
@@ -208,7 +208,7 @@ void check_compute_to_mesh(
 
   specfem::execution::ChunkedDomainIterator policy(
       ParallelConfig<false, Kokkos::DefaultHostExecutionSpace>(), elements,
-      assembly.mesh.get_element_grid());
+      assembly.mesh.element_grid);
 
   specfem::execution::for_all(
       "set_to_value", policy,

--- a/tests/unit-tests/assembly/sources/sources.cpp
+++ b/tests/unit-tests/assembly/sources/sources.cpp
@@ -17,8 +17,8 @@ void check_store(
     specfem::assembly::assembly<specfem::dimension::type::dim2> &assembly) {
 
   specfem::assembly::sources<DimensionTag> &sources = assembly.sources;
-  const int ngllz = assembly.mesh.ngllz;
-  const int ngllx = assembly.mesh.ngllx;
+  const int ngllz = assembly.mesh.element_grid.ngllz;
+  const int ngllx = assembly.mesh.element_grid.ngllx;
 
   // the structured binding ([element_indices, source_indices]) is not
   // supported by the intel compiler
@@ -91,8 +91,8 @@ void check_load(
     specfem::assembly::assembly<specfem::dimension::type::dim2> &assembly) {
 
   specfem::assembly::sources<DimensionTag> &sources = assembly.sources;
-  const int ngllz = assembly.mesh.ngllz;
-  const int ngllx = assembly.mesh.ngllx;
+  const int ngllz = assembly.mesh.element_grid.ngllz;
+  const int ngllx = assembly.mesh.element_grid.ngllx;
 
   const auto elements_and_sources = sources.get_sources_on_device(
       MediumTag, PropertyTag, BoundaryTag, WavefieldType);
@@ -198,8 +198,8 @@ void check_assembly_source_construction(
         specfem::sources::source<specfem::dimension::type::dim2> > > &sources,
     specfem::assembly::assembly<specfem::dimension::type::dim2> &assembly) {
 
-  const int ngllz = assembly.mesh.ngllz;
-  const int ngllx = assembly.mesh.ngllx;
+  const int ngllz = assembly.mesh.element_grid.ngllz;
+  const int ngllx = assembly.mesh.element_grid.ngllx;
 
   constexpr auto components =
       specfem::element::attributes<DimensionTag, MediumTag>::components;
@@ -224,8 +224,9 @@ void check_assembly_source_construction(
 
     Kokkos::View<type_real ***, Kokkos::LayoutRight,
                  Kokkos::DefaultHostExecutionSpace>
-        source_array("source_array", components, assembly.mesh.ngllz,
-                     assembly.mesh.ngllx);
+        source_array("source_array", components,
+                     assembly.mesh.element_grid.ngllz,
+                     assembly.mesh.element_grid.ngllx);
 
     specfem::assembly::compute_source_array(
         source, assembly.mesh, assembly.jacobian_matrix, source_array);

--- a/tests/unit-tests/assembly_mesh/index/compute_tests.cpp
+++ b/tests/unit-tests/assembly_mesh/index/compute_tests.cpp
@@ -93,8 +93,8 @@ TEST(ASSEMBLY_MESH, compute_ibool) {
   const auto h_coord = compute_mesh.h_coord;
 
   const int nspec = compute_mesh.nspec;
-  const int ngllz = compute_mesh.ngllz;
-  const int ngllx = compute_mesh.ngllx;
+  const int ngllz = compute_mesh.element_grid.ngllz;
+  const int ngllx = compute_mesh.element_grid.ngllx;
 
   type_real nglob;
   Kokkos::parallel_reduce(

--- a/tests/unit-tests/assembly_mesh/jacobian_matrix/compute_jacobian_matrix_tests.cpp
+++ b/tests/unit-tests/assembly_mesh/jacobian_matrix/compute_jacobian_matrix_tests.cpp
@@ -83,8 +83,8 @@ TEST(ASSEMBLY_MESH, compute_jacobian_matrix) {
       jacobian_matrix(compute_mesh);
 
   const int nspec = compute_mesh.nspec;
-  const int ngllz = compute_mesh.ngllz;
-  const int ngllx = compute_mesh.ngllx;
+  const int ngllz = compute_mesh.element_grid.ngllz;
+  const int ngllx = compute_mesh.element_grid.ngllx;
 
   specfem::testing::array3d<double, Kokkos::LayoutRight> xix_ref(
       test_config.xix_file, nspec, ngllz, ngllx);

--- a/tests/unit-tests/policies/policies.cpp
+++ b/tests/unit-tests/policies/policies.cpp
@@ -133,8 +133,7 @@ execute_chunk_element_policy(const int nspec, const int ngllz,
 
   constexpr auto dimension = specfem::dimension::type::dim2;
 
-  const specfem::mesh_entity::element<dimension> element_grid(ngllx, ngllz,
-                                                              ngllx);
+  const specfem::mesh_entity::element<dimension> element_grid(ngllz, ngllx);
 
   Kokkos::View<int *, Kokkos::DefaultExecutionSpace> elements("elements",
                                                               nspec);


### PR DESCRIPTION
## Description

Fat refactor. 

Removes the values of `ngll`, `ngllx`, `ngllz`, from the mesh and uses element grid instead to contain values.

`mesh.ngll{z,x}` was used in a lot of places, meaning that this is touching a lot of files.

## Issue Number

Updates #1191 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [x] I ran the code through pre-commit to check style
- [x] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [x] I have added labels to the PR (see right hand side of the PR page)
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
