### PR TITLE
Updated the links in the readme and the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 [![Documentation Status](https://readthedocs.org/projects/specfem2d-kokkos/badge/?version=latest)](https://specfem2d-kokkos.readthedocs.io/en/latest/?badge=latest)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
-![NVIDIA Build](https://jenkins.princeton.edu/buildStatus/icon?job=SpecFEM_KOKKOS%2FNVIDIA_Compiler_Checks&build=last&subject=NVIDIA%20Build)
-![GCC Build](https://jenkins.princeton.edu/buildStatus/icon?job=SpecFEM_KOKKOS%2FGNU+Compiler&build=last&subject=GCC%20Build)
-![IntelLLVM Build](https://jenkins.princeton.edu/buildStatus/icon?job=SpecFEM_KOKKOS%2FIntel_Compiler_Checks&build=last&subject=IntelLLVM%20Build)
-
 
 ## About
 
@@ -21,21 +17,32 @@ SPECFEM++ is a complete re-write of SPECFEM suite of packages (SPECFEM2D, SPECFE
 ## Documentation
 
 
-The online documentation for SPECFEM++ is located [here](https://specfem2d-kokkos.readthedocs.io/en/latest/index.html#)
+The online documentation for SPECFEM++ is located
+[here](https://specfem2d-kokkos.readthedocs.io/en/latest/index.html#)
 
 ## Getting Started with SPECFEM++
 
-Follow the [Getting Started Guide](https://specfem2d-kokkos.readthedocs.io/en/latest/getting_started/index.html) to install SPECFEM++ on your system and run the solver.
+Follow the [Getting Started
+Guide](https://specfem2d-kokkos.readthedocs.io/en/latest/sections/getting_started/index.html)
+to install SPECFEM++ on your system and run the solver.
 
 ## Examples
 
-We recommend starting with the [cookbook examples](https://specfem2d-kokkos.readthedocs.io/en/latest/cookbooks/index.html) to learn how to customize the solver for your use case.
+We recommend starting with the [cookbook
+examples](https://specfem2d-kokkos.readthedocs.io/en/latest/sections/cookbooks/index.html)
+to learn how to customize the solver for your use case.
 
 ## Contributing to SPECFEM++
 
-SPECFEM is a community project that lives by the participation of its members — i.e., including you! It is our goal to build an inclusive and participatory community so we are happy that you are interested in participating! Please see [this page](https://specfem2d-kokkos.readthedocs.io/en/latest/developer_documentation/index.html) for developer documentation.
+SPECFEM is a community project that lives by the participation of its members —
+i.e., including you! It is our goal to build an inclusive and participatory
+community so we are happy that you are interested in participating! Please see
+[this
+page](https://specfem2d-kokkos.readthedocs.io/en/latest/sections/developer_documentation/contributing.html)
+for developer documentation.
 
-In particular you should follow the git development workflow and pre-commit style checks when contributing to SPECEFM.
+In particular you should follow the git development workflow and pre-commit
+style checks when contributing to SPECFEM++.
 
 ## License
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,15 +5,6 @@
 SPECFEM++ - A modular and portable spectral-element code for seismic wave propagation
 =====================================================================================
 
-.. image:: https://jenkins.princeton.edu/buildStatus/icon?job=SpecFEM_KOKKOS%2FGNU+Compiler&build=last&subject=GCC%20Build
-    :alt: GCC Build
-
-.. image:: https://jenkins.princeton.edu/buildStatus/icon?job=SpecFEM_KOKKOS%2FIntel_Compiler_Checks&build=last&subject=IntelLLVM%20Build
-    :alt: IntelLLVM Build
-
-.. image:: https://jenkins.princeton.edu/buildStatus/icon?job=SpecFEM_KOKKOS%2FNVIDIA_Compiler_Checks&build=last&subject=NVIDIA%20Build
-   :alt: NVIDIA Build
-
 .. image:: https://img.shields.io/badge/License-GPLv3-blue.svg
     :target: https://github.com/PrincetonUniversity/SPECFEMPP/blob/main/LICENSE
     :alt: License
@@ -268,6 +259,7 @@ Contribution
     :maxdepth: 1
     :hidden:
 
+    sections/developer_documentation/contributing
     sections/developer_documentation/style
     sections/developer_documentation/git_workflow
     sections/developer_documentation/build_requirements

--- a/docs/sections/api/specfem/point/properties/dim2/elastic_isotropic.rst
+++ b/docs/sections/api/specfem/point/properties/dim2/elastic_isotropic.rst
@@ -3,7 +3,7 @@
 2D Elastic Isotropic
 ====================
 
-.. doxygengroup:: specfem_point_properties_dim2_elastic_isotropic
+.. doxygengroup:: specfem_point_properties_elastic_isotropic
     :members:
     :private-members:
     :content-only:

--- a/docs/sections/cookbooks/dim2/CUBIT/index.rst
+++ b/docs/sections/cookbooks/dim2/CUBIT/index.rst
@@ -202,6 +202,7 @@ Finally, we can run the solver using the following command.
 To create an animated gif of the wavefield evolution, you can use ImageMagick (if available):
 
 .. code-block:: bash
+
     magick OUTPUT_FILES/display/wavefield*.png -trim +repage -delay 10 -loop 0 wavefield.gif
 
 The output animated gif will show the wavefield evolution over time. We can see that the P-wave is impinging on the cavity diffracting/reflecting along the edge, and a little later the S-wave doing the same with the addition of S-to-P reflections.

--- a/docs/sections/developer_documentation/build_requirements.rst
+++ b/docs/sections/developer_documentation/build_requirements.rst
@@ -1,7 +1,8 @@
 Build system requirements
 ==========================
 
-This section covers compilation checks required so that SPECFEM++ is able to run across all architectures.
+This section covers compilation checks required so that SPECFEM++ is able to run
+across all architectures.
 
 .. note::
 

--- a/docs/sections/developer_documentation/contributing.rst
+++ b/docs/sections/developer_documentation/contributing.rst
@@ -1,0 +1,40 @@
+.. _contributing:
+
+Contributing to SPECFEM++
+=========================
+
+
+The easiest way to contribute is by starting to `fork the repository
+<https://github.com/PrincetonUniversity/SPECFEMPP/fork>`_, make and commit
+changes, and `create a pull request
+<https://github.com/PrincetonUniversity/SPECFEMPP/compare>`_ from your updated
+fork to the ``devel`` branch of the `SPECFEM++ repository
+<https://github.com/PrincetonUniversity/SPECFEMPP>`_.
+
+
+That being said, we do have some basic guidelines for contributing.
+
+Style guidelines
+----------------
+
+To ensure that the code is consistent and follows best practices, the code style
+is *automatically* enforced using pre-commit hooks, which are configured in the
+`.pre-commit-config.yaml` file in the root of the repository. More about this in
+the :ref:`style` documentation.
+
+
+Github Issues and pull requests handling
+----------------------------------------
+
+This includes guidelines for managing GitHub issues and pull requests, which is
+described in the :ref:`git-workflow` documentation, which goes over the
+branching model and the process for making contributions.
+
+
+*For maintainers*: Continuous integration (CI)
+----------------------------------------------
+
+This includes guidelines for the continuous integration (CI) process, which is
+described in the :ref:`tests` documentation. The CI process ensures that the
+code is tested and validated before it is merged into the ``main`` or ``devel``
+branches.

--- a/docs/sections/developer_documentation/git_workflow.rst
+++ b/docs/sections/developer_documentation/git_workflow.rst
@@ -1,3 +1,5 @@
+.. _git-workflow:
+
 Git development workflow
 ========================
 


### PR DESCRIPTION
## Description

A few links in the readme were broken, including one to the main "Contributing page which does not exist anymore.

- Added contributing document, which links and briefly describes the subsections of Contribution sections
- removed links to jenkins build stats from the README.md
- removed links to jenking from the docs.

## Issue Number

#1199 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [x] I ran the code through pre-commit to check style
- [x] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [x] I have added labels to the PR (see right hand side of the PR page)
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
