### PR TITLE
1169 Part 3 - dimensionalize chunk element view and add () operator for point index

### DIFF
--- a/core/specfem/chunk_element/stress_integrand.hpp
+++ b/core/specfem/chunk_element/stress_integrand.hpp
@@ -65,8 +65,8 @@ public:
   using simd = specfem::datatype::simd<type_real, UseSIMD>; ///< SIMD type.
 
   using ViewType = specfem::datatype::TensorChunkViewType<
-      type_real, NumberElements, NGLL, components, num_dimensions, UseSIMD,
-      MemorySpace,
+      type_real, DimensionTag, NumberElements, NGLL, components, num_dimensions,
+      UseSIMD, MemorySpace,
       MemoryTraits>; ///< Underlying view used to store data.
   ///@}
 

--- a/core/specfem/data_access/accessor/chunk_element.hpp
+++ b/core/specfem/data_access/accessor/chunk_element.hpp
@@ -22,20 +22,18 @@ struct Accessor<specfem::data_access::AccessorType::chunk_element, DataClass,
 
   template <typename T, int nelements, int ngll>
   using scalar_type =
-
-      Kokkos::View<typename simd<T>::datatype[nelements][ngll][ngll],
-                   Kokkos::DefaultExecutionSpace::scratch_memory_space,
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+      specfem::datatype::ScalarChunkViewType<T, DimensionTag, nelements, ngll,
+                                             UseSIMD>;
 
   template <typename T, int nelements, int ngll, int components>
   using vector_type =
-      specfem::datatype::VectorChunkViewType<T, nelements, ngll, components,
-                                             UseSIMD>;
+      specfem::datatype::VectorChunkViewType<T, DimensionTag, nelements, ngll,
+                                             components, UseSIMD>;
 
   template <typename T, int nelements, int ngll, int components, int dimension>
   using tensor_type =
-      specfem::datatype::TensorChunkViewType<T, nelements, ngll, components,
-                                             dimension, UseSIMD>;
+      specfem::datatype::TensorChunkViewType<T, DimensionTag, nelements, ngll,
+                                             components, dimension, UseSIMD>;
 };
 
 template <typename T, typename = void>

--- a/include/datatypes/chunk_element_view.hpp
+++ b/include/datatypes/chunk_element_view.hpp
@@ -5,32 +5,6 @@
 
 namespace specfem {
 namespace datatype {
-
-namespace impl {
-/**
- * @brief Helper struct to select the correct chunk view type based on the
- * dimension tag.
- */
-template <specfem::dimension::type DimensionTag> struct BaseDimension;
-
-template <> struct BaseDimension<specfem::dimension::type::dim2> {
-  template <typename T, int NumberOfElements, int NumberOfGLLPoints,
-            bool UseSIMD>
-  using datatype =
-      typename specfem::datatype::simd<T, UseSIMD>::datatype[NumberOfElements]
-                                                            [NumberOfGLLPoints];
-};
-
-template <> struct BaseDimension<specfem::dimension::type::dim3> {
-  template <typename T, int NumberOfElements, int NumberOfGLLPoints,
-            bool UseSIMD>
-  using datatype =
-      typename specfem::datatype::simd<T, UseSIMD>::datatype[NumberOfElements]
-                                                            [NumberOfGLLPoints]
-                                                            [NumberOfGLLPoints];
-};
-} // namespace impl
-
 /**
  * @brief Datatype used to scalar values within chunk of elements. Data is
  * stored within a Kokkos view located in the memory space specified by
@@ -49,10 +23,16 @@ template <typename T, specfem::dimension::type DimensionTag,
           typename MemorySpace =
               Kokkos::DefaultExecutionSpace::scratch_memory_space,
           typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged> >
-struct ScalarChunkViewType
+struct ScalarChunkViewType;
+
+template <typename T, int NumberOfElements, int NumberOfGLLPoints, bool UseSIMD,
+          typename MemorySpace, typename MemoryTraits>
+struct ScalarChunkViewType<T, specfem::dimension::type::dim2, NumberOfElements,
+                           NumberOfGLLPoints, UseSIMD, MemorySpace,
+                           MemoryTraits>
     : public Kokkos::View<
-          typename impl::BaseDimension<DimensionTag>::template datatype<
-              T, UseSIMD, NumberOfElements, NumberOfGLLPoints>,
+          typename specfem::datatype::simd<T, UseSIMD>::datatype
+              [NumberOfElements][NumberOfGLLPoints][NumberOfGLLPoints],
           MemorySpace, MemoryTraits> {
   /**
    * @name Typedefs
@@ -60,11 +40,11 @@ struct ScalarChunkViewType
    */
   ///@{
   using simd = specfem::datatype::simd<T, UseSIMD>; ///< SIMD data type
-  using type = Kokkos::View<
-      typename impl::BaseDimension<DimensionTag>::template datatype<
-          T, UseSIMD, NumberOfElements, NumberOfGLLPoints>,
-      MemorySpace, MemoryTraits>; ///< Underlying data type used to
-                                  ///< store values
+  using type =
+      Kokkos::View<typename specfem::datatype::simd<T, UseSIMD>::datatype
+                       [NumberOfElements][NumberOfGLLPoints][NumberOfGLLPoints],
+                   MemorySpace, MemoryTraits>; ///< Underlying data type used to
+                                               ///< store values
   using value_type = typename type::value_type; ///< Value type used to store
                                                 ///< the elements of the array
   using base_type = T;                          ///< Base type of the array
@@ -110,8 +90,8 @@ struct ScalarChunkViewType
   KOKKOS_FUNCTION
   ScalarChunkViewType(const ScratchMemorySpace &scratch_memory_space)
       : Kokkos::View<
-            typename impl::BaseDimension<DimensionTag>::template datatype<
-                T, UseSIMD, NumberOfElements, NumberOfGLLPoints>,
+            typename specfem::datatype::simd<T, UseSIMD>::datatype
+                [NumberOfElements][NumberOfGLLPoints][NumberOfGLLPoints],
             MemorySpace, MemoryTraits>(scratch_memory_space) {}
   ///@}
 };
@@ -135,7 +115,14 @@ template <
     int NumberOfGLLPoints, int Components, bool UseSIMD = false,
     typename MemorySpace = Kokkos::DefaultExecutionSpace::scratch_memory_space,
     typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged> >
-struct VectorChunkViewType
+struct VectorChunkViewType;
+
+template <typename T, int NumberOfElements, int NumberOfGLLPoints,
+          int Components, bool UseSIMD, typename MemorySpace,
+          typename MemoryTraits>
+struct VectorChunkViewType<T, specfem::dimension::type::dim2, NumberOfElements,
+                           NumberOfGLLPoints, Components, UseSIMD, MemorySpace,
+                           MemoryTraits>
     : public Kokkos::View<typename specfem::datatype::simd<T, UseSIMD>::datatype
                               [NumberOfElements][NumberOfGLLPoints]
                               [NumberOfGLLPoints][Components],
@@ -225,7 +212,14 @@ template <typename T, specfem::dimension::type DimensionTag,
           typename MemorySpace =
               Kokkos::DefaultExecutionSpace::scratch_memory_space,
           typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged> >
-struct TensorChunkViewType
+struct TensorChunkViewType;
+
+template <typename T, int NumberOfElements, int NumberOfGLLPoints,
+          int Components, int NumberOfDimensions, bool UseSIMD,
+          typename MemorySpace, typename MemoryTraits>
+struct TensorChunkViewType<T, specfem::dimension::type::dim2, NumberOfElements,
+                           NumberOfGLLPoints, Components, NumberOfDimensions,
+                           UseSIMD, MemorySpace, MemoryTraits>
     : public Kokkos::View<
           typename specfem::datatype::simd<T, UseSIMD>::datatype
               [NumberOfElements][NumberOfGLLPoints][NumberOfGLLPoints]

--- a/include/kokkos_kernels/impl/compute_seismogram.tpp
+++ b/include/kokkos_kernels/impl/compute_seismogram.tpp
@@ -84,10 +84,8 @@ void specfem::kokkos_kernels::impl::compute_seismograms(
   using ElementQuadratureType = specfem::element::quadrature<
       ngll, dimension, specfem::kokkos::DevScratchSpace,
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, true, false>;
-  using ViewType = Kokkos::View<type_real[ParallelConfig::chunk_size][ngll][ngll][2],
-                               Kokkos::LayoutLeft,
-                               specfem::kokkos::DevScratchSpace,
-                               Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+  using ViewType = specfem::datatype::VectorChunkViewType<
+      type_real, dimension, parallel_config::chunk_size, ngll, 2, using_simd>;
   using ResultsViewType =
       Kokkos::View<type_real[ParallelConfig::chunk_size][2], Kokkos::LayoutLeft,
                    specfem::kokkos::DevScratchSpace,


### PR DESCRIPTION
## Description

- Adds `ScalarChunkViewType`
- Template chunk view type with dimension
- Add () operator that returns a subview

## Issue Number

Adds to #1169 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
