### PR TITLE
1169 Part 4 - add index operators to chunk element view types

### DIFF
--- a/core/specfem/assembly/compute_source_array/dim2/compute_source_array.tpp
+++ b/core/specfem/assembly/compute_source_array/dim2/compute_source_array.tpp
@@ -20,7 +20,7 @@ void specfem::assembly::compute_source_array(
     SourceArrayViewType &source_array) {
 
   // Ensure source_array is a 3D view
-  static_assert(SourceArrayViewType::rank == 3, "Source array must be in rank 3.");
+  static_assert(SourceArrayViewType::rank() == 3, "Source array must be in rank 3.");
 
   switch (source->get_source_type()) {
   case specfem::sources::source_type::vector_source: {

--- a/core/specfem/assembly/compute_source_array/dim3/compute_source_array.tpp
+++ b/core/specfem/assembly/compute_source_array/dim3/compute_source_array.tpp
@@ -20,7 +20,7 @@ void specfem::assembly::compute_source_array(
     SourceArrayViewType &source_array) {
 
   // Ensure source_array is a 4D view
-  static_assert(SourceArrayViewType::rank == 4, "Source array must be in rank 4.");
+  static_assert(SourceArrayViewType::rank() == 4, "Source array must be in rank 4.");
 
 
   switch (source->get_source_type()) {

--- a/core/specfem/point/coordinates.hpp
+++ b/core/specfem/point/coordinates.hpp
@@ -79,7 +79,7 @@ template <> struct local_coordinates<specfem::dimension::type::dim2> {
   template <typename ViewType>
   KOKKOS_FUNCTION local_coordinates(const int &ispec, const ViewType &coords)
       : ispec(ispec), xi(coords[0]), gamma(coords[1]) {
-    static_assert(ViewType::rank == 1, "ViewType must be rank 1");
+    static_assert(ViewType::rank() == 1, "ViewType must be rank 1");
     static_assert(ViewType::static_extent(0) == 2,
                   "ViewType must have extent 2 for 2D coordinates");
   }
@@ -117,7 +117,7 @@ template <> struct global_coordinates<specfem::dimension::type::dim2> {
   template <typename ViewType>
   KOKKOS_FUNCTION global_coordinates(const ViewType &coords)
       : x(coords[0]), z(coords[1]) {
-    static_assert(ViewType::rank == 1, "ViewType must be rank 1");
+    static_assert(ViewType::rank() == 1, "ViewType must be rank 1");
     static_assert(ViewType::static_extent(0) == 2,
                   "ViewType must have extent 2 for 2D coordinates");
   }
@@ -165,7 +165,7 @@ template <> struct local_coordinates<specfem::dimension::type::dim3> {
   template <typename ViewType>
   KOKKOS_FUNCTION local_coordinates(const int &ispec, const ViewType &coords)
       : ispec(ispec), xi(coords[0]), eta(coords[1]), gamma(coords[2]) {
-    static_assert(ViewType::rank == 1, "ViewType must be rank 1");
+    static_assert(ViewType::rank() == 1, "ViewType must be rank 1");
     static_assert(ViewType::static_extent(0) == 3,
                   "ViewType must have extent 3 for 3D coordinates");
   }
@@ -206,7 +206,7 @@ template <> struct global_coordinates<specfem::dimension::type::dim3> {
   template <typename ViewType>
   KOKKOS_FUNCTION global_coordinates(const ViewType &coords)
       : x(coords[0]), y(coords[1]), z(coords[2]) {
-    static_assert(ViewType::rank == 1, "ViewType must be rank 1");
+    static_assert(ViewType::rank() == 1, "ViewType must be rank 1");
     static_assert(ViewType::static_extent(0) == 3,
                   "ViewType must have extent 3 for 3D coordinates");
   }

--- a/core/specfem/point/impl/field.hpp
+++ b/core/specfem/point/impl/field.hpp
@@ -252,6 +252,20 @@ public:
   }
 
   /**
+   * @brief Multiplication assignment operator.
+   *
+   * Multiply by a constant value and assign the result to this field.
+   *
+   * @param other The factor to be multiplied with
+   * @return reference to this field after multiplication
+   */
+  KOKKOS_FORCEINLINE_FUNCTION constexpr auto &
+  operator*=(const typename value_type::value_type &other) {
+    this->m_data *= other;
+    return *this;
+  }
+
+  /**
    * @brief Output a string representation of the field components.
    *
    * Outputs the values of all field components to the specified output stream.

--- a/core/specfem/point/impl/field.hpp
+++ b/core/specfem/point/impl/field.hpp
@@ -252,7 +252,7 @@ public:
   }
 
   /**
-   * @brief Multiplication assignment operator.
+   * @brief Multiplication assignment operator with constant value.
    *
    * Multiply by a constant value and assign the result to this field.
    *

--- a/include/datatypes/chunk_element_view.hpp
+++ b/include/datatypes/chunk_element_view.hpp
@@ -2,7 +2,6 @@
 
 #include "enumerations/dimension.hpp"
 #include "impl/chunk_element_subview.hpp"
-#include "point_view.hpp"
 #include "simd.hpp"
 #include <Kokkos_Core.hpp>
 
@@ -246,8 +245,7 @@ struct VectorChunkViewType<T, specfem::dimension::type::dim2, NumberOfElements,
    * @param index Point index
    */
   KOKKOS_INLINE_FUNCTION
-  impl::VectorChunkSubview2D<
-      type, VectorPointViewType<base_type, components, UseSIMD>, index_type>
+  impl::VectorChunkSubview<VectorChunkViewType>
   operator()(const index_type &index) {
     return { *this, index };
   }
@@ -389,9 +387,7 @@ struct TensorChunkViewType<T, specfem::dimension::type::dim2, NumberOfElements,
    * @param index Point index
    */
   KOKKOS_INLINE_FUNCTION
-  impl::TensorChunkSubview2D<
-      type, TensorPointViewType<base_type, components, dimensions, UseSIMD>,
-      index_type>
+  impl::TensorChunkSubview<TensorChunkViewType>
   operator()(const index_type &index) {
     return { *this, index };
   }

--- a/include/datatypes/chunk_element_view.hpp
+++ b/include/datatypes/chunk_element_view.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "enumerations/dimension.hpp"
+#include "impl/chunk_element_subview.hpp"
+#include "point_view.hpp"
 #include "simd.hpp"
 #include <Kokkos_Core.hpp>
 
@@ -54,10 +57,14 @@ struct ScalarChunkViewType<T, specfem::dimension::type::dim2, NumberOfElements,
   using value_type = typename type::value_type; ///< Value type used to store
                                                 ///< the elements of the array
   using base_type = T;                          ///< Base type of the array
-  constexpr static bool using_simd = UseSIMD;   ///< Use SIMD datatypes for the
-                                                ///< array. If false,
-                                                ///< std::is_same<value_type,
-                                                ///< base_type>::value is true
+  using index_type =
+      typename specfem::point::index<specfem::dimension::type::dim2,
+                                     UseSIMD>; ///< index type for accessing at
+                                               ///< GLL level
+  constexpr static bool using_simd = UseSIMD;  ///< Use SIMD datatypes for the
+                                               ///< array. If false,
+                                               ///< std::is_same<value_type,
+                                               ///< base_type>::value is true
   ///@}
 
   /**
@@ -65,6 +72,11 @@ struct ScalarChunkViewType<T, specfem::dimension::type::dim2, NumberOfElements,
    *
    */
   ///@{
+  constexpr static auto accessor_type =
+      specfem::data_access::AccessorType::chunk_element; ///< Accessor type for
+                                                         ///< identifying the
+                                                         ///< class
+
   constexpr static int nelements = NumberOfElements; ///< Number of elements in
                                                      ///< the chunk
   constexpr static int ngll = NumberOfGLLPoints; ///< Number of GLL points in
@@ -107,8 +119,8 @@ struct ScalarChunkViewType<T, specfem::dimension::type::dim2, NumberOfElements,
    *
    * @param index Point index
    */
-  KOKKOS_INLINE_FUNCTION value_type &operator()(
-      specfem::point::index<specfem::dimension::type::dim2, UseSIMD> index) {
+  KOKKOS_INLINE_FUNCTION
+  constexpr value_type &operator()(index_type index) {
     return (*this)(index.ispec, index.iz, index.ix);
   }
 };
@@ -158,10 +170,14 @@ struct VectorChunkViewType<T, specfem::dimension::type::dim2, NumberOfElements,
   using value_type = typename type::value_type; ///< Value type used to store
                                                 ///< the elements of the array
   using base_type = T;                          ///< Base type of the array
-  constexpr static bool using_simd = UseSIMD;   ///< Use SIMD datatypes for the
-                                                ///< array. If false,
-                                                ///< std::is_same<value_type,
-                                                ///< base_type>::value is true
+  using index_type =
+      typename specfem::point::index<specfem::dimension::type::dim2,
+                                     UseSIMD>; ///< index type for accessing at
+                                               ///< GLL level
+  constexpr static bool using_simd = UseSIMD;  ///< Use SIMD datatypes for the
+                                               ///< array. If false,
+                                               ///< std::is_same<value_type,
+                                               ///< base_type>::value is true
   ///@}
 
   /**
@@ -169,6 +185,10 @@ struct VectorChunkViewType<T, specfem::dimension::type::dim2, NumberOfElements,
    *
    */
   ///@{
+  constexpr static auto accessor_type =
+      specfem::data_access::AccessorType::chunk_element; ///< Accessor type for
+                                                         ///< identifying the
+                                                         ///< class
   constexpr static int nelements = NumberOfElements; ///< Number of elements in
                                                      ///< the chunk
   constexpr static int ngll = NumberOfGLLPoints; ///< Number of GLL points in
@@ -210,14 +230,26 @@ struct VectorChunkViewType<T, specfem::dimension::type::dim2, NumberOfElements,
   using type::operator();
 
   /**
+   * @brief Get vector component by a point index and vector indices.
+   *
+   * @param index Point index
+   * @param icomp Component index
+   */
+  KOKKOS_INLINE_FUNCTION
+  constexpr value_type &operator()(const index_type &index, const int &icomp) {
+    return (*this)(index.ispec, index.iz, index.ix, icomp);
+  }
+
+  /**
    * @brief Get vector subview by a point index.
    *
    * @param index Point index
    */
   KOKKOS_INLINE_FUNCTION
-  auto operator()(
-      specfem::point::index<specfem::dimension::type::dim2, UseSIMD> index) {
-    return Kokkos::subview(*this, index.ispec, index.iz, index.ix, Kokkos::ALL);
+  impl::VectorChunkSubview2D<
+      type, VectorPointViewType<base_type, components, UseSIMD>, index_type>
+  operator()(const index_type &index) {
+    return { *this, index };
   }
 };
 
@@ -269,10 +301,14 @@ struct TensorChunkViewType<T, specfem::dimension::type::dim2, NumberOfElements,
   using value_type = typename type::value_type; ///< Value type used to store
                                                 ///< the elements of the array
   using base_type = T;                          ///< Base type of the array
-  constexpr static bool using_simd = UseSIMD;   ///< Use SIMD datatypes for the
-                                                ///< array. If false,
-                                                ///< std::is_same<value_type,
-                                                ///< base_type>::value is true
+  using index_type =
+      typename specfem::point::index<specfem::dimension::type::dim2,
+                                     UseSIMD>; ///< index type for accessing at
+                                               ///< GLL level
+  constexpr static bool using_simd = UseSIMD;  ///< Use SIMD datatypes for the
+                                               ///< array. If false,
+                                               ///< std::is_same<value_type,
+                                               ///< base_type>::value is true
   ///@}
 
   /**
@@ -280,6 +316,11 @@ struct TensorChunkViewType<T, specfem::dimension::type::dim2, NumberOfElements,
    *
    */
   ///@{
+  constexpr static auto accessor_type =
+      specfem::data_access::AccessorType::chunk_element; ///< Accessor type for
+                                                         ///< identifying the
+                                                         ///< class
+
   constexpr static int nelements = NumberOfElements; ///< Number of elements in
                                                      ///< the chunk
   constexpr static int ngll = NumberOfGLLPoints; ///< Number of GLL points in
@@ -330,14 +371,29 @@ struct TensorChunkViewType<T, specfem::dimension::type::dim2, NumberOfElements,
   using type::operator();
 
   /**
-   * @brief Get vector subview by a point index.
+   * @brief Get tensor component by a point index and tensor indices.
+   *
+   * @param index Point index
+   * @param icomp Component index
+   * @param idim Dimension index
+   */
+  KOKKOS_INLINE_FUNCTION
+  constexpr value_type &operator()(const index_type &index, const int &icomp,
+                                   const int &idim) {
+    return (*this)(index.ispec, index.iz, index.ix, icomp, idim);
+  }
+
+  /**
+   * @brief Get tensor subview by a point index.
    *
    * @param index Point index
    */
-  KOKKOS_INLINE_FUNCTION auto operator()(
-      specfem::point::index<specfem::dimension::type::dim2, UseSIMD> index) {
-    return Kokkos::subview(*this, index.ispec, index.iz, index.ix, Kokkos::ALL,
-                           Kokkos::ALL);
+  KOKKOS_INLINE_FUNCTION
+  impl::TensorChunkSubview2D<
+      type, TensorPointViewType<base_type, components, dimensions, UseSIMD>,
+      index_type>
+  operator()(const index_type &index) {
+    return { *this, index };
   }
 };
 

--- a/include/datatypes/impl/chunk_element_subview.hpp
+++ b/include/datatypes/impl/chunk_element_subview.hpp
@@ -1,72 +1,200 @@
 #pragma once
 
+#include "datatypes/point_view.hpp"
 #include "enumerations/dimension.hpp"
 #include <Kokkos_Core.hpp>
 
 namespace specfem::datatype::impl {
 
-template <typename ViewType, typename PointViewType, typename IndexType>
-struct VectorChunkSubview2D {
-  ViewType &view;
-  const IndexType &index;
+/**
+ * @brief Subview for accessing vector components within a chunk element
+ *
+ * This class provides a convenient interface for accessing vector data
+ * components at a specific index within a larger multi-dimensional view.
+ * It simplifies operations by abstracting the full indexing requirements.
+ *
+ * @tparam ViewType The type of the parent view this subview accesses
+ */
+template <typename ViewType> struct VectorChunkSubview {
+  /// Index type from the parent view
+  using index_type = typename ViewType::index_type;
+  /// Point view type for component access
+  using point_view_type =
+      VectorPointViewType<typename ViewType::base_type, ViewType::components,
+                          ViewType::using_simd>;
 
-  VectorChunkSubview2D(ViewType &view, const IndexType &index)
+  /// Reference to the parent view
+  ViewType &view;
+  /// Reference to the index within the parent view
+  const index_type &index;
+
+  /**
+   * @brief Construct a new Vector Chunk Subview
+   *
+   * @param view Reference to the parent view
+   * @param index Reference to the index within the parent view
+   */
+  VectorChunkSubview(ViewType &view, const index_type &index)
       : view(view), index(index) {}
 
-  KOKKOS_INLINE_FUNCTION
-  constexpr auto &operator()(const int &icomp) {
+  /**
+   * @brief Access a specific component of the vector (non-const)
+   *
+   * Specialized for 2D case, providing element access with proper indexing.
+   *
+   * @tparam D Dimension tag, defaulted to the index type's dimension tag
+   * @param icomp Component index to access
+   * @return Reference to the component value
+   */
+  template <
+      specfem::dimension::type D = index_type::dimension_tag,
+      typename std::enable_if_t<D == specfem::dimension::type::dim2, int> = 0>
+  KOKKOS_INLINE_FUNCTION constexpr auto &operator()(const int &icomp) {
     return view(index.ispec, index.iz, index.ix, icomp);
   }
 
-  KOKKOS_INLINE_FUNCTION
-  constexpr auto operator()(const int &icomp) const {
+  /**
+   * @brief Access a specific component of the vector (const)
+   *
+   * Specialized for 2D case, providing const element access with proper
+   * indexing.
+   *
+   * @param icomp Component index to access
+   * @return Value of the component
+   */
+  template <
+      specfem::dimension::type D = index_type::dimension_tag,
+      typename std::enable_if_t<D == specfem::dimension::type::dim2, int> = 0>
+  KOKKOS_INLINE_FUNCTION constexpr auto operator()(const int &icomp) const {
     return view(index.ispec, index.iz, index.ix, icomp);
   }
 
+  /**
+   * @brief Assignment operator from another point view
+   *
+   * Copies all components from the source point view to this subview.
+   *
+   * @param other Source point view to copy from
+   * @return Reference to this subview after assignment
+   */
   KOKKOS_INLINE_FUNCTION
-  auto &operator=(const PointViewType &other) {
-    for (int icomp = 0; icomp < PointViewType::components; ++icomp) {
+  auto &operator=(const point_view_type &other) {
+    for (int icomp = 0; icomp < point_view_type::components; ++icomp) {
       (*this)(icomp) = other(icomp);
     }
     return *this;
   }
 };
 
-template <typename ViewType, typename PointViewType, typename IndexType>
-struct TensorChunkSubview2D {
-  ViewType &view;
-  const IndexType &index;
+/**
+ * @brief Subview for accessing tensor components within a chunk element
+ *
+ * This class provides a convenient interface for accessing tensor data
+ * at a specific index within a larger multi-dimensional view.
+ * It handles the proper indexing based on the dimensionality of the problem.
+ *
+ * @tparam ViewType The type of the parent view this subview accesses
+ */
+template <typename ViewType> struct TensorChunkSubview {
+  /// Index type from the parent view
+  using index_type = typename ViewType::index_type;
+  /// Point view type for tensor component access
+  using point_view_type =
+      TensorPointViewType<typename ViewType::base_type, ViewType::components,
+                          ViewType::dimensions, ViewType::using_simd>;
 
+  /// Reference to the parent view
+  ViewType &view;
+  /// Reference to the index within the parent view
+  const index_type &index;
+
+  /**
+   * @brief Get the rank of the tensor
+   *
+   * @return Rank of the tensor (always 2 for this implementation)
+   */
   KOKKOS_INLINE_FUNCTION
   constexpr static std::size_t rank() { return 2; }
 
+  /**
+   * @brief Get the extent of a dimension
+   *
+   * @param i Dimension index
+   * @return Size of the dimension
+   */
   KOKKOS_INLINE_FUNCTION
   constexpr std::size_t extent(const size_t &i) const {
     return view.extent(i + 3);
   }
 
+  /**
+   * @brief Get the static extent of a dimension
+   *
+   * @param i Dimension index
+   * @return Static size of the dimension
+   */
   KOKKOS_INLINE_FUNCTION
   constexpr static std::size_t static_extent(const size_t &i) {
     return ViewType::static_extent(i + 3);
   }
 
-  TensorChunkSubview2D(ViewType &view, const IndexType &index)
+  /**
+   * @brief Construct a new Tensor Chunk Subview
+   *
+   * @param view Reference to the parent view
+   * @param index Reference to the index within the parent view
+   */
+  TensorChunkSubview(ViewType &view, const index_type &index)
       : view(view), index(index) {}
 
-  KOKKOS_INLINE_FUNCTION
-  constexpr auto &operator()(const int &icomp, const int &idim) {
+  /**
+   * @brief Access a specific tensor component (non-const)
+   *
+   * Specialized for 2D case, providing element access with proper indexing.
+   *
+   * @param icomp Component index
+   * @param idim Dimension index
+   * @return Reference to the tensor component
+   */
+  template <
+      specfem::dimension::type D = index_type::dimension_tag,
+      typename std::enable_if_t<D == specfem::dimension::type::dim2, int> = 0>
+  KOKKOS_INLINE_FUNCTION constexpr auto &operator()(const int &icomp,
+                                                    const int &idim) {
     return view(index.ispec, index.iz, index.ix, icomp, idim);
   }
 
-  KOKKOS_INLINE_FUNCTION
-  constexpr auto operator()(const int &icomp, const int &idim) const {
+  /**
+   * @brief Access a specific tensor component (const)
+   *
+   * Specialized for 2D case, providing const element access with proper
+   * indexing.
+   *
+   * @tparam D Dimension tag, defaulted to the index type's dimension tag
+   * @param icomp Component index
+   * @param idim Dimension index
+   * @return Value of the tensor component
+   */
+  template <
+      specfem::dimension::type D = index_type::dimension_tag,
+      typename std::enable_if_t<D == specfem::dimension::type::dim2, int> = 0>
+  KOKKOS_INLINE_FUNCTION constexpr auto operator()(const int &icomp,
+                                                   const int &idim) const {
     return view(index.ispec, index.iz, index.ix, icomp, idim);
   }
 
+  /**
+   * @brief Assignment operator from another point view
+   *
+   * Copies all tensor components from the source point view to this subview.
+   *
+   * @param other Source point view to copy from
+   * @return Reference to this subview after assignment
+   */
   KOKKOS_INLINE_FUNCTION
-  auto &operator=(const PointViewType &other) {
-    for (int icomp = 0; icomp < PointViewType::components; ++icomp) {
-      for (int idim = 0; idim < PointViewType::dimensions; ++idim) {
+  auto &operator=(const point_view_type &other) {
+    for (int icomp = 0; icomp < point_view_type::components; ++icomp) {
+      for (int idim = 0; idim < point_view_type::dimensions; ++idim) {
         (*this)(icomp, idim) = other(icomp, idim);
       }
     }

--- a/include/datatypes/impl/chunk_element_subview.hpp
+++ b/include/datatypes/impl/chunk_element_subview.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "enumerations/dimension.hpp"
+#include <Kokkos_Core.hpp>
+
+namespace specfem::datatype::impl {
+
+template <typename ViewType, typename PointViewType, typename IndexType>
+struct VectorChunkSubview2D {
+  ViewType &view;
+  const IndexType &index;
+
+  VectorChunkSubview2D(ViewType &view, const IndexType &index)
+      : view(view), index(index) {}
+
+  KOKKOS_INLINE_FUNCTION
+  constexpr auto &operator()(const int &icomp) {
+    return view(index.ispec, index.iz, index.ix, icomp);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  auto &operator=(const PointViewType &other) {
+    for (int icomp = 0; icomp < PointViewType::components; ++icomp) {
+      (*this)(icomp) = other(icomp);
+    }
+    return *this;
+  }
+};
+
+template <typename ViewType, typename PointViewType, typename IndexType>
+struct TensorChunkSubview2D {
+  ViewType &view;
+  const IndexType &index;
+
+  TensorChunkSubview2D(ViewType &view, const IndexType &index)
+      : view(view), index(index) {}
+
+  KOKKOS_INLINE_FUNCTION
+  constexpr auto &operator()(const int &icomp, const int &idim) {
+    return view(index.ispec, index.iz, index.ix, icomp, idim);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  auto &operator=(const PointViewType &other) {
+    for (int icomp = 0; icomp < PointViewType::components; ++icomp) {
+      for (int idim = 0; idim < PointViewType::dimensions; ++idim) {
+        (*this)(icomp, idim) = other(icomp, idim);
+      }
+    }
+    return *this;
+  }
+};
+
+} // namespace specfem::datatype::impl

--- a/include/datatypes/impl/chunk_element_subview.hpp
+++ b/include/datatypes/impl/chunk_element_subview.hpp
@@ -19,6 +19,11 @@ struct VectorChunkSubview2D {
   }
 
   KOKKOS_INLINE_FUNCTION
+  constexpr auto operator()(const int &icomp) const {
+    return view(index.ispec, index.iz, index.ix, icomp);
+  }
+
+  KOKKOS_INLINE_FUNCTION
   auto &operator=(const PointViewType &other) {
     for (int icomp = 0; icomp < PointViewType::components; ++icomp) {
       (*this)(icomp) = other(icomp);
@@ -32,11 +37,29 @@ struct TensorChunkSubview2D {
   ViewType &view;
   const IndexType &index;
 
+  KOKKOS_INLINE_FUNCTION
+  constexpr static std::size_t rank() { return 2; }
+
+  KOKKOS_INLINE_FUNCTION
+  constexpr std::size_t extent(const size_t &i) const {
+    return view.extent(i + 3);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  constexpr static std::size_t static_extent(const size_t &i) {
+    return ViewType::static_extent(i + 3);
+  }
+
   TensorChunkSubview2D(ViewType &view, const IndexType &index)
       : view(view), index(index) {}
 
   KOKKOS_INLINE_FUNCTION
   constexpr auto &operator()(const int &icomp, const int &idim) {
+    return view(index.ispec, index.iz, index.ix, icomp, idim);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  constexpr auto operator()(const int &icomp, const int &idim) const {
     return view(index.ispec, index.iz, index.ix, icomp, idim);
   }
 

--- a/include/datatypes/point_view.hpp
+++ b/include/datatypes/point_view.hpp
@@ -27,7 +27,6 @@ struct VectorPointViewType
    *
    */
   ///@{
-  using self_type = VectorPointViewType<T, Components, UseSIMD>;
   using base_type = impl::RegisterArray<
       typename specfem::datatype::simd<T, UseSIMD>::datatype,
       Kokkos::extents<std::size_t, Components>,
@@ -59,8 +58,9 @@ struct VectorPointViewType
 
   using base_type::base_type;
 
-  KOKKOS_INLINE_FUNCTION value_type operator*(const self_type &other) const {
-    constexpr int N = self_type::components;
+  KOKKOS_INLINE_FUNCTION value_type
+  operator*(const VectorPointViewType &other) const {
+    constexpr int N = VectorPointViewType::components;
     value_type result{ 0.0 };
 
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)

--- a/include/datatypes/point_view.hpp
+++ b/include/datatypes/point_view.hpp
@@ -56,8 +56,8 @@ struct VectorPointViewType
    *
    */
   ///@{
-
   using base_type::base_type;
+  ///@}
 
   KOKKOS_INLINE_FUNCTION value_type operator*(const self_type &other) const {
     constexpr int N = self_type::components;
@@ -71,7 +71,19 @@ struct VectorPointViewType
     }
     return result;
   }
-  ///@}
+
+  KOKKOS_FORCEINLINE_FUNCTION constexpr auto &
+  operator*=(const value_type &other) {
+    constexpr int N = self_type::components;
+
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+#pragma unroll
+#endif
+    for (int i = 0; i < N; ++i) {
+      (*this)(i) *= other;
+    }
+    return *this;
+  }
 };
 
 /**

--- a/include/datatypes/point_view.hpp
+++ b/include/datatypes/point_view.hpp
@@ -27,7 +27,6 @@ struct VectorPointViewType
    *
    */
   ///@{
-  using self_type = VectorPointViewType<T, Components, UseSIMD>;
   using base_type = impl::RegisterArray<
       typename specfem::datatype::simd<T, UseSIMD>::datatype,
       Kokkos::extents<std::size_t, Components>,
@@ -59,8 +58,9 @@ struct VectorPointViewType
   using base_type::base_type;
   ///@}
 
-  KOKKOS_INLINE_FUNCTION value_type operator*(const self_type &other) const {
-    constexpr int N = self_type::components;
+  KOKKOS_INLINE_FUNCTION value_type
+  operator*(const VectorPointViewType &other) const {
+    constexpr int N = VectorPointViewType::components;
     value_type result{ 0.0 };
 
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
@@ -74,7 +74,7 @@ struct VectorPointViewType
 
   KOKKOS_FORCEINLINE_FUNCTION constexpr auto &
   operator*=(const value_type &other) {
-    constexpr int N = self_type::components;
+    constexpr int N = VectorPointViewType::components;
 
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
 #pragma unroll

--- a/include/kokkos_kernels/impl/compute_mass_matrix.tpp
+++ b/include/kokkos_kernels/impl/compute_mass_matrix.tpp
@@ -112,9 +112,7 @@ void specfem::kokkos_kernels::impl::compute_mass_matrix(
         PointMassType mass_matrix =
             specfem::medium::mass_matrix_component(point_property);
 
-        for (int icomp = 0; icomp < components; icomp++) {
-          mass_matrix(icomp) *= wgll(ix) * wgll(iz) * jacobian;
-        }
+        mass_matrix *= wgll(ix) * wgll(iz) * jacobian;
 
         PointBoundaryType point_boundary;
         specfem::assembly::load_on_device(index, boundaries, point_boundary);

--- a/include/kokkos_kernels/impl/compute_stiffness_interaction.tpp
+++ b/include/kokkos_kernels/impl/compute_stiffness_interaction.tpp
@@ -77,9 +77,6 @@ int specfem::kokkos_kernels::impl::compute_stiffness_interaction(
   using parallel_config = specfem::parallel_config::default_chunk_config<
       dimension, simd, Kokkos::DefaultExecutionSpace>;
 
-  constexpr int components =
-      specfem::element::attributes<dimension, medium_tag>::components;
-
   using ChunkElementFieldType = specfem::chunk_element::displacement<
         parallel_config::chunk_size, ngll, dimension, medium_tag, using_simd>;
   using ChunkStressIntegrandType = specfem::chunk_element::stress_integrand<
@@ -185,11 +182,7 @@ int specfem::kokkos_kernels::impl::compute_stiffness_interaction(
                 const auto &local_index = iterator_index.get_local_index();
                 PointAccelerationType acceleration(result);
 
-                for (int icomponent = 0; icomponent < components;
-                     ++icomponent) {
-                  acceleration(icomponent) *=
-                      static_cast<type_real>(-1.0);
-                }
+                acceleration *= static_cast<type_real>(-1.0);
 
                 PointPropertyType point_property;
                 specfem::assembly::load_on_device(index, properties,

--- a/include/kokkos_kernels/impl/compute_stiffness_interaction.tpp
+++ b/include/kokkos_kernels/impl/compute_stiffness_interaction.tpp
@@ -152,7 +152,7 @@ int specfem::kokkos_kernels::impl::compute_stiffness_interaction(
               [&](const auto &iterator_index,
                   const typename PointFieldDerivativesType::value_type &du) {
                 const auto &index = iterator_index.get_index();
-                const int &ielement = iterator_index.get_policy_index();
+                const auto &local_index = iterator_index.get_local_index();
                 PointJacobianMatrixType point_jacobian_matrix;
                 specfem::assembly::load_on_device(index, jacobian_matrix,
                                                   point_jacobian_matrix);
@@ -173,15 +173,7 @@ int specfem::kokkos_kernels::impl::compute_stiffness_interaction(
                 specfem::medium::compute_cosserat_stress(
                     point_property, point_displacement, point_stress);
 
-                const auto F = point_stress * point_jacobian_matrix;
-
-                for (int icomponent = 0; icomponent < components;
-                     ++icomponent) {
-                  for (int idim = 0; idim < num_dimensions; ++idim) {
-                    stress_integrand.F(ielement, index.iz, index.ix, icomponent,
-                                       idim) = F(icomponent, idim);
-                  }
-                }
+                stress_integrand.F(local_index) = point_stress * point_jacobian_matrix;
               });
 
           team.team_barrier();

--- a/include/kokkos_kernels/impl/compute_stiffness_interaction.tpp
+++ b/include/kokkos_kernels/impl/compute_stiffness_interaction.tpp
@@ -79,8 +79,6 @@ int specfem::kokkos_kernels::impl::compute_stiffness_interaction(
 
   constexpr int components =
       specfem::element::attributes<dimension, medium_tag>::components;
-  constexpr int num_dimensions =
-      specfem::element::attributes<dimension, medium_tag>::dimension;
 
   using ChunkElementFieldType = specfem::chunk_element::displacement<
         parallel_config::chunk_size, ngll, dimension, medium_tag, using_simd>;
@@ -184,7 +182,7 @@ int specfem::kokkos_kernels::impl::compute_stiffness_interaction(
               [&](const auto &iterator_index,
                   const typename PointAccelerationType::value_type &result) {
                 const auto &index = iterator_index.get_index();
-                const auto &ielement = iterator_index.get_policy_index();
+                const auto &local_index = iterator_index.get_local_index();
                 PointAccelerationType acceleration(result);
 
                 for (int icomponent = 0; icomponent < components;
@@ -220,8 +218,7 @@ int specfem::kokkos_kernels::impl::compute_stiffness_interaction(
                 // Compute the couple stress from the stress integrand
                 specfem::medium::compute_couple_stress(
                     point_jacobian_matrix, point_property, factor,
-                    Kokkos::subview(stress_integrand.F, ielement, index.iz,
-                                    index.ix, Kokkos::ALL, Kokkos::ALL),
+                    stress_integrand.F(local_index),
                     acceleration);
 
                 // Apply boundary conditions

--- a/include/medium/compute_cosserat_couple_stress.hpp
+++ b/include/medium/compute_cosserat_couple_stress.hpp
@@ -55,7 +55,7 @@ assert_types(const std::integral_constant<bool, true>) {
 
   // Check the PointStressIntegrandViewType, which is a kokkos view for its
   //  extent
-  static_assert(PointStressIntegrandViewType::rank == 2,
+  static_assert(PointStressIntegrandViewType::rank() == 2,
                 "PointStressIntegrandViewType must be a 2D view");
   static_assert(
       PointStressIntegrandViewType::static_extent(0) ==


### PR DESCRIPTION
## Description

- Add `get_local_index()` method for PointIndex.
- Replace ViewType::rank with ViewType::rank()
- Add () operator for chunk element view
- Add * operator to `RegisterArray`
- Add *= operator to `VectorPointViewType` and `point::field`
- Update `kokkos_kernels` with new implementation

Point-wise operations are not implemented because I don't think it makes sense to pre-define all possible operations
e.g.
```cpp
for (int icomp = 0; icomp < PointAccelerationType::components;
             ++icomp) {
          acceleration(icomp) *= mass_inverse(icomp);
        }

for (int icomp = 0; icomp < PointMassType::components;
             ++icomp) {
          mass(icomp) = static_cast<type_real>(1.0) / mass(icomp);
        }
```
plus there are many possible combinations between `point::field`, `VectorPointViewType` and `RegisterArray` and I can't figure out a clean way to fit all circumstances.

## Issue Number

Closes #1169

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
