### PR TITLE
1169 Part 5 - Finalize operators and update all kokkos_kernels to new implementation

### DIFF
--- a/core/specfem/point/impl/field.hpp
+++ b/core/specfem/point/impl/field.hpp
@@ -252,6 +252,20 @@ public:
   }
 
   /**
+   * @brief Multiplication assignment operator.
+   *
+   * Multiply by a constant value and assign the result to this field.
+   *
+   * @param other The factor to be multiplied with
+   * @return reference to this field after multiplication
+   */
+  KOKKOS_FORCEINLINE_FUNCTION constexpr auto &
+  operator*=(const typename value_type::value_type &other) {
+    this->m_data *= other;
+    return *this;
+  }
+
+  /**
    * @brief Output a string representation of the field components.
    *
    * Outputs the values of all field components to the specified output stream.

--- a/include/datatypes/point_view.hpp
+++ b/include/datatypes/point_view.hpp
@@ -56,8 +56,8 @@ struct VectorPointViewType
    *
    */
   ///@{
-
   using base_type::base_type;
+  ///@}
 
   KOKKOS_INLINE_FUNCTION value_type operator*(const self_type &other) const {
     constexpr int N = self_type::components;
@@ -71,7 +71,19 @@ struct VectorPointViewType
     }
     return result;
   }
-  ///@}
+
+  KOKKOS_FORCEINLINE_FUNCTION constexpr auto &
+  operator*=(const value_type &other) {
+    constexpr int N = self_type::components;
+
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+#pragma unroll
+#endif
+    for (int i = 0; i < N; ++i) {
+      (*this)(i) *= other;
+    }
+    return *this;
+  }
 };
 
 /**

--- a/include/kokkos_kernels/impl/compute_stiffness_interaction.tpp
+++ b/include/kokkos_kernels/impl/compute_stiffness_interaction.tpp
@@ -77,9 +77,6 @@ int specfem::kokkos_kernels::impl::compute_stiffness_interaction(
   using parallel_config = specfem::parallel_config::default_chunk_config<
       dimension, simd, Kokkos::DefaultExecutionSpace>;
 
-  constexpr int components =
-      specfem::element::attributes<dimension, medium_tag>::components;
-
   using ChunkElementFieldType = specfem::chunk_element::displacement<
         parallel_config::chunk_size, ngll, dimension, medium_tag, using_simd>;
   using ChunkStressIntegrandType = specfem::chunk_element::stress_integrand<
@@ -185,11 +182,7 @@ int specfem::kokkos_kernels::impl::compute_stiffness_interaction(
                 const auto &local_index = iterator_index.get_local_index();
                 PointAccelerationType acceleration(result);
 
-                for (int icomponent = 0; icomponent < components;
-                     ++icomponent) {
-                  acceleration(icomponent) *=
-                      static_cast<type_real>(-1.0);
-                }
+                acceleration *= static_cast<type_real>(-1.0);
 
                 PointPropertyType point_property;
                 specfem::assembly::load_on_device(index, properties,


### PR DESCRIPTION
## Description

- Add *= operator to `VectorPointViewType` and `point::field`
- Update `kokkos_kernels`

Point-wise operations are not implemented e.g.
```cpp
for (int icomp = 0; icomp < PointAccelerationType::components;
             ++icomp) {
          acceleration(icomp) *= mass_inverse(icomp);
        }
``` and
```cpp
for (int icomp = 0; icomp < PointMassType::components;
             ++icomp) {
          mass(icomp) = static_cast<type_real>(1.0) / mass(icomp);
        }
```
because there are too many possible combinations between `point::field`, `VectorPointViewType` and `RegisterArray` and I can't figure out a clean way to fit all circumstances.

## Issue Number

Closes #1169

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
