### PR TITLE
1169 Part 5 - Update get_policy_index() and field methods

### DIFF
--- a/core/specfem/assembly/fields/dim2/impl/atomic_add_access_functions.hpp
+++ b/core/specfem/assembly/fields/dim2/impl/atomic_add_access_functions.hpp
@@ -33,8 +33,7 @@ atomic_add_after_simd_dispatch(const std::false_type, const IndexType &index,
 
   const auto &current_field = field.template get_field<MediumTag>();
 
-  const int iglob = field.template get_iglob<on_device>(index.ispec, index.iz,
-                                                        index.ix, MediumTag);
+  const int iglob = field.template get_iglob<on_device>(index, MediumTag);
 
   constexpr static int ncomponents = specfem::element::attributes<
       std::tuple_element_t<0, std::tuple<AccessorTypes...> >::dimension_tag,
@@ -77,10 +76,10 @@ atomic_add_after_simd_dispatch(const std::true_type, const IndexType &index,
 
   int iglob[simd_size];
   for (int lane = 0; lane < simd_size; ++lane) {
-    iglob[lane] = index.mask(lane)
-                      ? field.template get_iglob<on_device>(
-                            index.ispec + lane, index.iz, index.ix, MediumTag)
-                      : field.nglob + 1;
+    iglob[lane] =
+        index.mask(lane)
+            ? field.template get_iglob<on_device>(index, lane, MediumTag)
+            : field.nglob + 1;
   }
 
   const auto &current_field = field.template get_field<MediumTag>();

--- a/core/specfem/assembly/fields/dim2/impl/load_access_functions.hpp
+++ b/core/specfem/assembly/fields/dim2/impl/load_access_functions.hpp
@@ -35,8 +35,7 @@ load_after_simd_dispatch(const std::false_type, const IndexType &index,
 
   const auto current_field = field.template get_field<MediumTag>();
 
-  const int iglob = field.template get_iglob<on_device>(index.ispec, index.iz,
-                                                        index.ix, MediumTag);
+  const int iglob = field.template get_iglob<on_device>(index, MediumTag);
 
   constexpr static int ncomponents = specfem::element::attributes<
       std::tuple_element_t<0, std::tuple<AccessorTypes...> >::dimension_tag,
@@ -80,10 +79,10 @@ load_after_simd_dispatch(const std::true_type, const IndexType &index,
 
   int iglob[simd_size];
   for (int lane = 0; lane < simd_size; ++lane) {
-    iglob[lane] = index.mask(lane)
-                      ? field.template get_iglob<on_device>(
-                            index.ispec + lane, index.iz, index.ix, MediumTag)
-                      : field.nglob + 1;
+    iglob[lane] =
+        index.mask(lane)
+            ? field.template get_iglob<on_device>(index, lane, MediumTag)
+            : field.nglob + 1;
   }
 
   const auto &current_field = field.template get_field<MediumTag>();
@@ -138,8 +137,8 @@ load_after_simd_dispatch(const std::false_type, const IndexType &index,
         const auto ielement = iterator_index.get_policy_index();
         const auto point_index = iterator_index.get_index();
 
-        const int iglob = field.template get_iglob<on_device>(
-            point_index.ispec, point_index.iz, point_index.ix, MediumTag);
+        const int iglob =
+            field.template get_iglob<on_device>(point_index, MediumTag);
 
         for (int icomp = 0; icomp < ncomponents; ++icomp) {
           (specfem::assembly::fields_impl::base_load_accessor<

--- a/core/specfem/assembly/fields/dim2/impl/store_access_functions.hpp
+++ b/core/specfem/assembly/fields/dim2/impl/store_access_functions.hpp
@@ -33,8 +33,7 @@ store_after_simd_dispatch(const std::false_type, const IndexType &index,
 
   const auto current_field = field.template get_field<MediumTag>();
 
-  const int iglob = field.template get_iglob<on_device>(index.ispec, index.iz,
-                                                        index.ix, MediumTag);
+  const int iglob = field.template get_iglob<on_device>(index, MediumTag);
 
   constexpr static int ncomponents = specfem::element::attributes<
       std::tuple_element_t<0, std::tuple<AccessorTypes...> >::dimension_tag,
@@ -77,10 +76,10 @@ store_after_simd_dispatch(const std::true_type, const IndexType &index,
 
   int iglob[simd_size];
   for (int lane = 0; lane < simd_size; ++lane) {
-    iglob[lane] = index.mask(lane)
-                      ? field.template get_iglob<on_device>(
-                            index.ispec + lane, index.iz, index.ix, MediumTag)
-                      : field.nglob + 1;
+    iglob[lane] =
+        index.mask(lane)
+            ? field.template get_iglob<on_device>(index, lane, MediumTag)
+            : field.nglob + 1;
   }
 
   const auto &current_field = field.template get_field<MediumTag>();

--- a/core/specfem/assembly/fields/dim2/simulation_field.hpp
+++ b/core/specfem/assembly/fields/dim2/simulation_field.hpp
@@ -175,6 +175,29 @@ public:
     return -1;
   }
 
+  /**
+   * @brief Returns the assembled index given element index.
+   *
+   */
+  template <bool on_device>
+  KOKKOS_INLINE_FUNCTION constexpr int get_iglob(
+      const specfem::point::index<specfem::dimension::type::dim2, false> &index,
+      const specfem::element::medium_tag MediumTag) const {
+    return get_iglob<on_device>(index.ispec, index.iz, index.ix, MediumTag);
+  }
+
+  /**
+   * @brief Returns the assembled index given element index.
+   *
+   */
+  template <bool on_device>
+  KOKKOS_INLINE_FUNCTION constexpr int get_iglob(
+      const specfem::point::index<specfem::dimension::type::dim2, true> &index,
+      const int &lane, const specfem::element::medium_tag MediumTag) const {
+    return get_iglob<on_device>(index.ispec + lane, index.iz, index.ix,
+                                MediumTag);
+  }
+
   int nglob = 0; ///< Number of global degrees of freedom
   int nspec;     ///< Number of spectral elements
   int ngllz;     ///< Number of quadrature points in z direction

--- a/core/specfem/assembly/receivers/dim2/receivers.hpp
+++ b/core/specfem/assembly/receivers/dim2/receivers.hpp
@@ -206,7 +206,7 @@ load_on_device(const ChunkIndexType &chunk_index,
       [&](const typename ChunkIndexType::iterator_type::index_type
               &iterator_index) {
         const auto index = iterator_index.get_index();
-        const int ielement = iterator_index.get_policy_index();
+        const int ielement = iterator_index.get_local_index().ispec;
         const int irec = index.imap;
 
 #ifndef NDEBUG
@@ -257,7 +257,7 @@ store_on_device(const ChunkIndexType &chunk_index,
       [&](const typename ChunkIndexType::iterator_type::index_type
               &iterator_index) {
         const auto index = iterator_index.get_index();
-        const int ielement = iterator_index.get_policy_index();
+        const int ielement = iterator_index.get_local_index().ispec;
         const int irec = index.imap;
 
 #ifndef NDEBUG

--- a/core/specfem/assembly/receivers/dim3/receivers.hpp
+++ b/core/specfem/assembly/receivers/dim3/receivers.hpp
@@ -219,7 +219,7 @@ load_on_device(const ChunkIndexType &chunk_index,
       [&](const typename ChunkIndexType::iterator_type::index_type
               &iterator_index) {
         const auto index = iterator_index.get_index();
-        const int ielement = iterator_index.get_policy_index();
+        const int ielement = iterator_index.get_local_index().ispec;
         const int irec = index.imap;
 
 #ifndef NDEBUG
@@ -276,7 +276,7 @@ store_on_device(const ChunkIndexType &chunk_index,
       [&](const typename ChunkIndexType::iterator_type::index_type
               &iterator_index) {
         const auto index = iterator_index.get_index();
-        const int ielement = iterator_index.get_policy_index();
+        const int ielement = iterator_index.get_local_index().ispec;
         const int irec = index.imap;
 
 #ifndef NDEBUG

--- a/core/specfem/chunk_element/impl/field.hpp
+++ b/core/specfem/chunk_element/impl/field.hpp
@@ -289,13 +289,15 @@ public:
     return m_data(indices...);
   }
 
+  template <typename IndexType, typename std::enable_if_t<specfem::data_access::is_index_type<IndexType>::value && specfem::data_access::is_point_type<IndexType>::value, int= 0>>
   KOKKOS_FORCEINLINE_FUNCTION auto &
-  operator()(const specfem::point::index<dimension_tag, using_simd> &index) {
+  operator()(const IndexType &index) {
     return m_data(index);
   }
 
+  template <typename IndexType, typename std::enable_if_t<specfem::data_access::is_index_type<IndexType>::value && specfem::data_access::is_point_type<IndexType>::value, int= 0>>
   KOKKOS_FORCEINLINE_FUNCTION typename value_type::value_type &
-  operator()(const specfem::point::index<dimension_tag, using_simd> &index,
+  operator()(const IndexType &index,
              const int &icomp) {
     return m_data(index, icomp);
   }

--- a/core/specfem/chunk_element/impl/field.hpp
+++ b/core/specfem/chunk_element/impl/field.hpp
@@ -289,16 +289,22 @@ public:
     return m_data(indices...);
   }
 
-  template <typename IndexType, typename std::enable_if_t<specfem::data_access::is_index_type<IndexType>::value && specfem::data_access::is_point_type<IndexType>::value, int= 0>>
-  KOKKOS_FORCEINLINE_FUNCTION auto &
-  operator()(const IndexType &index) {
+  template <typename IndexType,
+            typename std::enable_if_t<
+                specfem::data_access::is_index_type<IndexType>::value &&
+                    specfem::data_access::is_point<IndexType>::value,
+                int> = 0>
+  KOKKOS_FORCEINLINE_FUNCTION auto &operator()(const IndexType &index) {
     return m_data(index);
   }
 
-  template <typename IndexType, typename std::enable_if_t<specfem::data_access::is_index_type<IndexType>::value && specfem::data_access::is_point_type<IndexType>::value, int= 0>>
+  template <typename IndexType,
+            typename std::enable_if_t<
+                specfem::data_access::is_index_type<IndexType>::value &&
+                    specfem::data_access::is_point<IndexType>::value,
+                int> = 0>
   KOKKOS_FORCEINLINE_FUNCTION typename value_type::value_type &
-  operator()(const IndexType &index,
-             const int &icomp) {
+  operator()(const IndexType &index, const int &icomp) {
     return m_data(index, icomp);
   }
 

--- a/core/specfem/chunk_element/impl/field.hpp
+++ b/core/specfem/chunk_element/impl/field.hpp
@@ -210,11 +210,15 @@ public:
 
   /// @brief SIMD type for vectorized operations
   using simd = typename base_type::template simd<type_real>;
+  constexpr static auto using_simd = UseSIMD;
 
   /// @brief Vector type for storing chunk field data with optimized layout
   using value_type =
       typename base_type::template vector_type<type_real, nelements, ngll,
                                                components>;
+
+  /// @brief Dimension tag identifying the physical medium type
+  constexpr static auto dimension_tag = DimensionTag;
 
   /// @brief Medium tag identifying the physical medium type
   constexpr static auto medium_tag = MediumTag;
@@ -283,6 +287,17 @@ public:
   KOKKOS_FORCEINLINE_FUNCTION typename value_type::value_type &
   operator()(Indices... indices) const {
     return m_data(indices...);
+  }
+
+  KOKKOS_FORCEINLINE_FUNCTION auto &
+  operator()(const specfem::point::index<dimension_tag, using_simd> &index) {
+    return m_data(index);
+  }
+
+  KOKKOS_FORCEINLINE_FUNCTION typename value_type::value_type &
+  operator()(const specfem::point::index<dimension_tag, using_simd> &index,
+             const int &icomp) {
+    return m_data(index, icomp);
   }
 
   /**

--- a/include/algorithms/divergence.hpp
+++ b/include/algorithms/divergence.hpp
@@ -72,7 +72,7 @@ KOKKOS_FUNCTION void divergence(
       chunk_index.get_iterator(),
       [&](const typename ChunkIndexType::iterator_type::index_type
               &iterator_index) {
-        const auto ielement = iterator_index.get_policy_index();
+        const auto ielement = iterator_index.get_local_index().ispec;
         const auto index = iterator_index.get_index();
         const int iz = index.iz;
         const int ix = index.ix;

--- a/include/algorithms/gradient.hpp
+++ b/include/algorithms/gradient.hpp
@@ -70,7 +70,7 @@ KOKKOS_FORCEINLINE_FUNCTION void gradient(
       chunk_index.get_iterator(),
       [&](const typename ChunkIndexType::iterator_type::index_type
               &iterator_index) {
-        const auto ielement = iterator_index.get_policy_index();
+        const auto ielement = iterator_index.get_local_index().ispec;
         const auto point_index = iterator_index.get_index();
         const int ispec = point_index.ispec;
         const int iz = point_index.iz;
@@ -171,7 +171,7 @@ KOKKOS_FORCEINLINE_FUNCTION void gradient(
       chunk_index.get_iterator(),
       [&](const typename ChunkIndexType::iterator_type::index_type
               &iterator_index) {
-        const auto ielement = iterator_index.get_policy_index();
+        const auto ielement = iterator_index.get_local_index().ispec;
         const auto point_index = iterator_index.get_index();
         const int ispec = point_index.ispec;
         const int iz = point_index.iz;

--- a/include/algorithms/interpolate.hpp
+++ b/include/algorithms/interpolate.hpp
@@ -139,7 +139,7 @@ KOKKOS_FUNCTION void interpolate_function(const ChunkIndex &chunk_index,
       [&](const typename ChunkIndex::iterator_type::index_type
               &iterator_index) {
         const auto index = iterator_index.get_index();
-        const int ielement = iterator_index.get_policy_index();
+        const int ielement = iterator_index.get_local_index().ispec;
 
         for (int icomponent = 0; icomponent < ncomponents; ++icomponent) {
           type_real polynomial_value =

--- a/include/medium/dim2/acoustic/isotropic/wavefield.hpp
+++ b/include/medium/dim2/acoustic/isotropic/wavefield.hpp
@@ -61,7 +61,7 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
         [&](const typename ChunkIndexType::iterator_type::index_type
                 &iterator_index) {
           const auto index = iterator_index.get_index();
-          const int ielement = iterator_index.get_policy_index();
+          const int ielement = iterator_index.get_local_index().ispec;
           wavefield(ielement, index.iz, index.ix, 0) =
               -1.0 * active_field(ielement, index.iz, index.ix, 0);
         });
@@ -76,7 +76,7 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
               &iterator_index,
           const FieldDerivativesType::value_type &du) {
         const auto index = iterator_index.get_index();
-        const int ielement = iterator_index.get_policy_index();
+        const int ielement = iterator_index.get_local_index().ispec;
         PointPropertyType point_property;
 
         specfem::assembly::load_on_device(index, properties, point_property);

--- a/include/medium/dim2/elastic/anisotropic/wavefield.hpp
+++ b/include/medium/dim2/elastic/anisotropic/wavefield.hpp
@@ -61,7 +61,7 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
                 &iterator_index,
             const FieldDerivativesType::value_type &du) {
           const auto index = iterator_index.get_index();
-          const int ielement = iterator_index.get_policy_index();
+          const int ielement = iterator_index.get_local_index().ispec;
           PointPropertyType point_property;
 
           specfem::assembly::load_on_device(index, properties, point_property);
@@ -102,7 +102,7 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
       [&](const typename ChunkIndexType::iterator_type::index_type
               &iterator_index) {
         const auto index = iterator_index.get_index();
-        const int ielement = iterator_index.get_policy_index();
+        const int ielement = iterator_index.get_local_index().ispec;
         wavefield(ielement, index.iz, index.ix, 0) =
             active_field(ielement, index.iz, index.ix, 0);
         wavefield(ielement, index.iz, index.ix, 1) =
@@ -160,7 +160,7 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
       [&](const typename ChunkIndexType::iterator_type::index_type
               &iterator_index) {
         const auto index = iterator_index.get_index();
-        const int ielement = iterator_index.get_policy_index();
+        const int ielement = iterator_index.get_local_index().ispec;
         wavefield(ielement, index.iz, index.ix, 0) =
             active_field(ielement, index.iz, index.ix, 0);
       });

--- a/include/medium/dim2/elastic/isotropic/wavefield.hpp
+++ b/include/medium/dim2/elastic/isotropic/wavefield.hpp
@@ -62,7 +62,7 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
                 &iterator_index,
             const FieldDerivativesType::value_type &du) {
           const auto index = iterator_index.get_index();
-          const int ielement = iterator_index.get_policy_index();
+          const int ielement = iterator_index.get_local_index().ispec;
           PointPropertyType point_property;
 
           specfem::assembly::load_on_device(index, properties, point_property);
@@ -96,7 +96,7 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
       [&](const typename ChunkIndexType::iterator_type::index_type
               &iterator_index) {
         const auto index = iterator_index.get_index();
-        const int ielement = iterator_index.get_policy_index();
+        const int ielement = iterator_index.get_local_index().ispec;
         wavefield(ielement, index.iz, index.ix, 0) =
             active_field(ielement, index.iz, index.ix, 0);
         wavefield(ielement, index.iz, index.ix, 1) =
@@ -146,7 +146,7 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
       [&](const typename ChunkIndexType::iterator_type::index_type
               &iterator_index) {
         const auto index = iterator_index.get_index();
-        const int ielement = iterator_index.get_policy_index();
+        const int ielement = iterator_index.get_local_index().ispec;
         wavefield(ielement, index.iz, index.ix, 0) =
             active_field(ielement, index.iz, index.ix, 0);
       });

--- a/include/medium/dim2/elastic/isotropic_cosserat/wavefield.hpp
+++ b/include/medium/dim2/elastic/isotropic_cosserat/wavefield.hpp
@@ -70,7 +70,7 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
                 &iterator_index,
             const FieldDerivativesType::value_type &du) {
           const auto index = iterator_index.get_index();
-          const int ielement = iterator_index.get_policy_index();
+          const int ielement = iterator_index.get_local_index().ispec;
           PointPropertyType point_property;
 
           specfem::assembly::load_on_device(index, properties, point_property);
@@ -135,7 +135,7 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
         [&](const typename ChunkIndexType::iterator_type::index_type
                 &iterator_index) {
           const auto index = iterator_index.get_index();
-          const int ielement = iterator_index.get_policy_index();
+          const int ielement = iterator_index.get_local_index().ispec;
 
           // The rotational component of the
           wavefield(ielement, index.iz, index.ix, 0) =
@@ -151,7 +151,7 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
                 &iterator_index,
             const FieldDerivativesType::value_type &du) {
           const auto index = iterator_index.get_index();
-          const int ielement = iterator_index.get_policy_index();
+          const int ielement = iterator_index.get_local_index().ispec;
 
           // Here we compute the curl of the displacement field.
           wavefield(ielement, index.iz, index.ix, 0) = du(0, 1) - du(1, 0);
@@ -166,7 +166,7 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
                 &iterator_index,
             const FieldDerivativesType::value_type &du) {
           const auto index = iterator_index.get_index();
-          const int ielement = iterator_index.get_policy_index();
+          const int ielement = iterator_index.get_local_index().ispec;
 
           // Here we compute the intrinsic rotation wavefield from the
           // rotation field and the curl of the displacement field.
@@ -183,7 +183,7 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
       [&](const typename ChunkIndexType::iterator_type::index_type
               &iterator_index) {
         const auto index = iterator_index.get_index();
-        const int ielement = iterator_index.get_policy_index();
+        const int ielement = iterator_index.get_local_index().ispec;
         wavefield(ielement, index.iz, index.ix, 0) =
             active_field(ielement, index.iz, index.ix, 0);
         wavefield(ielement, index.iz, index.ix, 1) =

--- a/include/medium/dim2/poroelastic/isotropic/wavefield.hpp
+++ b/include/medium/dim2/poroelastic/isotropic/wavefield.hpp
@@ -62,7 +62,7 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
                 &iterator_index,
             const FieldDerivativesType::value_type &du) {
           const auto index = iterator_index.get_index();
-          const int ielement = iterator_index.get_policy_index();
+          const int ielement = iterator_index.get_local_index().ispec;
           PointPropertyType point_property;
 
           specfem::assembly::load_on_device(index, properties, point_property);
@@ -84,7 +84,7 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
       [&](const typename ChunkIndexType::iterator_type::index_type
               &iterator_index) {
         const auto index = iterator_index.get_index();
-        const int ielement = iterator_index.get_policy_index();
+        const int ielement = iterator_index.get_local_index().ispec;
         wavefield(ielement, index.iz, index.ix, 0) =
             active_field(ielement, index.iz, index.ix, 0);
         wavefield(ielement, index.iz, index.ix, 1) =


### PR DESCRIPTION
## Description

- Make get_policy_index() for `ChunkElement` and `MappedChunkElement` to be the actual kokkos_index
- Update field.get_iglob() with `point_index` as parameter
- Update `chunk_element::field` operators for `point_index`

## Issue Number

Adds to #1169 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
