### PR TITLE
1170 Part 1 - Replace field_without_accessor with get_data() for chunk_element

### DIFF
--- a/core/specfem/chunk_element/impl/field.hpp
+++ b/core/specfem/chunk_element/impl/field.hpp
@@ -7,141 +7,6 @@
 
 namespace specfem::chunk_element::impl {
 
-/**
- * @brief Accessor-agnostic field implementation for chunk-based element data.
- *
- * This class provides a accessor-agnostic implementation for chunk-based
- * element data, primarily used when making unified references to different
- * field types. See the code example below :
- *
- * @code{.cpp}
- * // Example usage of field_without_accessor
- * const specfem::wavefield::type wavefield_type = ...;
- * const auto field = [&]() {
- *   if (wavefield_type == specfem::wavefield::type::displacement) {
- *     return displacement_field.field_without_accessor();
- *   } else if (wavefield_type == specfem::wavefield::type::velocity) {
- *     return velocity_field.field_without_accessor();
- *   } else if (wavefield_type == specfem::wavefield::type::acceleration) {
- *     return acceleration_field.field_without_accessor();
- *   } else {
- *     throw std::runtime_error("Unsupported wavefield type");
- *   }
- * }();
- * @endcode
- *
- * @note Note that this class is used internally and external references to it
- *       should be made using @c auto keyword.
- *
- * @tparam ChunkSize Number of elements processed together in a chunk
- * @tparam NGLL Number of Gauss-Lobatto-Legendre points per spatial dimension
- * @tparam DimensionTag Spatial dimension (dim2 or dim3) of the field
- * @tparam MediumTag Medium type (acoustic, elastic, poroelastic, etc.)
- * @tparam UseSIMD Whether to enable SIMD vectorization for performance
- * @tparam ValueType The underlying data storage type for field values
- */
-template <int ChunkSize, int NGLL, specfem::dimension::type DimensionTag,
-          specfem::element::medium_tag MediumTag, bool UseSIMD,
-          typename ValueType>
-class field_without_accessor {
-public:
-  /// @brief Number of field components based on dimension and medium type
-  constexpr static int components =
-      specfem::element::attributes<DimensionTag, MediumTag>::components;
-
-  /// @brief Number of elements in the chunk
-  constexpr static int nelements = ChunkSize;
-
-  /// @brief Number of Gauss-Lobatto-Legendre points per spatial dimension
-  constexpr static int ngll = NGLL;
-
-  /// @brief Medium tag identifying the physical medium type
-  constexpr static auto medium_tag = MediumTag;
-
-  /// @brief Type alias for the underlying data storage
-  using value_type = ValueType;
-
-  /// @brief SIMD type for vectorized operations
-  using simd = specfem::datatype::simd<type_real, UseSIMD>;
-
-private:
-  /// @brief Internal storage for chunk field data
-  value_type m_data;
-
-public:
-  /**
-   * @brief Default constructor - creates field with uninitialized data.
-   */
-  KOKKOS_FORCEINLINE_FUNCTION field_without_accessor() = default;
-
-  /**
-   * @brief Construct field from existing data storage.
-   *
-   * Initializes the chunk field accessor with pre-allocated data storage.
-   * This is typically used when wrapping existing Kokkos views or other
-   * data structures.
-   *
-   * @param data_in The data storage object to wrap
-   */
-  KOKKOS_FORCEINLINE_FUNCTION
-  field_without_accessor(const value_type &data_in) : m_data(data_in) {}
-
-  /**
-   * @brief Multi-dimensional index operator for accessing field components.
-   *
-   * Provides access to individual field values using multi-dimensional
-   * indexing. The exact indexing scheme depends on the ValueType
-   * implementation, but typically follows the pattern: (element_id,
-   * gll_indices..., component_id).
-   *
-   * @tparam Indices Parameter pack for multi-dimensional indices
-   * @param indices The indices specifying the location and component to access
-   * @return Reference to the field value at the specified location
-   *
-   * @code{.cpp}
-   * // For 2D fields: (element, i_gll, j_gll, component)
-   * auto value = field(ielem, i, j, icomp);
-   * field(ielem, i, j, icomp) = new_value;
-   *
-   * // For 3D fields: (element, i_gll, j_gll, k_gll, component)
-   * auto value = field(ielem, i, j, k, icomp);
-   * @endcode
-   */
-  template <typename... Indices>
-  KOKKOS_FORCEINLINE_FUNCTION typename value_type::value_type &
-  operator()(Indices... indices) const {
-    return m_data(indices...);
-  }
-};
-
-/**
- * @brief Type trait helper for removing accessor attributes from field types.
- *
- * This template metafunction provides a type alias that maps from the full
- * field type (with accessor interface) to the lightweight
- * field_without_accessor type. It is used for type transformations when the
- * accessor interface overhead is not needed.
- *
- * @tparam ChunkSize Number of elements processed together in a chunk
- * @tparam NGLL Number of Gauss-Lobatto-Legendre points per spatial dimension
- * @tparam DimensionTag Spatial dimension (dim2 or dim3) of the field
- * @tparam MediumTag Medium type (acoustic, elastic, poroelastic, etc.)
- * @tparam UseSIMD Whether to enable SIMD vectorization
- * @tparam ValueType The underlying data storage type
- *
- * @see field_without_accessor for the resulting type
- *
- */
-template <int ChunkSize, int NGLL, specfem::dimension::type DimensionTag,
-          specfem::element::medium_tag MediumTag, bool UseSIMD,
-          typename ValueType>
-class remove_accessor_attribute {
-public:
-  /// @brief Type alias for the field without accessor interface
-  using type = field_without_accessor<ChunkSize, NGLL, DimensionTag, MediumTag,
-                                      UseSIMD, ValueType>;
-};
-
 // clang-format off
 /**
  * @brief Chunk element field accessor for storing field values at all
@@ -176,7 +41,6 @@ public:
  * @tparam DataClass     Data class type for access control and memory traits.
  * @tparam UseSIMD       Whether to enable SIMD vectorization for performance.
  *
- * @see remove_accessor_attribute for type trait to strip accessor attributes.
  */
 // clang-format on
 template <int ChunkSize, int NGLL, specfem::dimension::type DimensionTag,
@@ -306,34 +170,11 @@ public:
   constexpr static std::size_t shmem_size() { return value_type::shmem_size(); }
 
   /**
-   * @brief Strip accessor attributes and return a @c field_without_accessor
-   * type.
+   * @brief Access internal field data storage.
    *
-   * This method provides a way to a unified field type that does not
-   * include the accessor interface. It is useful when you need to reference
-   * field of different types.
-   *
-   * @code{.cpp}
-   * // Example usage of field_without_accessor
-   * const specfem::wavefield::type wavefield_type = ...;
-   * const auto field = [&]() {
-   *   if (wavefield_type == specfem::wavefield::type::displacement) {
-   *     return displacement_field.field_without_accessor();
-   *   } else if (wavefield_type == specfem::wavefield::type::velocity) {
-   *     return velocity_field.field_without_accessor();
-   *   } else if (wavefield_type == specfem::wavefield::type::acceleration) {
-   *     return acceleration_field.field_without_accessor();
-   *   } else {
-   *     throw std::runtime_error("Unsupported wavefield type");
-   *   }
-   * }();
-   * @endcode
-   *
-   * @return A field_without_accessor type with the same data storage
+   * @return const reference to the internal value_type storing field components
    */
-  KOKKOS_INLINE_FUNCTION const value_type &field_without_accessor() const {
-    return m_data;
-  }
+  KOKKOS_INLINE_FUNCTION const value_type &get_data() const { return m_data; }
 };
 
 } // namespace specfem::chunk_element::impl

--- a/core/specfem/chunk_element/impl/field.hpp
+++ b/core/specfem/chunk_element/impl/field.hpp
@@ -61,12 +61,6 @@ public:
   /// @brief Type alias for the underlying data storage
   using value_type = ValueType;
 
-  /// @brief Flag indicating this is a chunk-based view type
-  constexpr static bool isChunkViewType = true;
-
-  /// @brief Flag indicating this supports scalar view operations
-  constexpr static bool isScalarViewType = true;
-
   /// @brief SIMD type for vectorized operations
   using simd = specfem::datatype::simd<type_real, UseSIMD>;
 
@@ -223,12 +217,6 @@ public:
   /// @brief Medium tag identifying the physical medium type
   constexpr static auto medium_tag = MediumTag;
 
-  /// @brief Flag indicating this is a chunk-based view type
-  constexpr static bool isChunkViewType = true;
-
-  /// @brief Flag indicating this supports scalar view operations
-  constexpr static bool isScalarViewType = true;
-
 private:
   /// @brief Internal storage for chunk field data
   value_type m_data;
@@ -343,10 +331,8 @@ public:
    *
    * @return A field_without_accessor type with the same data storage
    */
-  KOKKOS_INLINE_FUNCTION const typename remove_accessor_attribute<
-      ChunkSize, NGLL, DimensionTag, MediumTag, UseSIMD, value_type>::type
-  field_without_accessor() const {
-    return { m_data };
+  KOKKOS_INLINE_FUNCTION const value_type &field_without_accessor() const {
+    return m_data;
   }
 };
 

--- a/include/algorithms/divergence.hpp
+++ b/include/algorithms/divergence.hpp
@@ -37,9 +37,12 @@ namespace algorithms {
  * specfem::datatype::VectorPointViewType<type_real, ViewType::components>)
  * @endcode
  */
-template <typename ChunkIndexType, typename VectorFieldType,
-          typename WeightsType, typename QuadratureType, typename CallableType,
-          std::enable_if_t<(VectorFieldType::isChunkViewType), int> = 0>
+template <
+    typename ChunkIndexType, typename VectorFieldType, typename WeightsType,
+    typename QuadratureType, typename CallableType,
+    std::enable_if_t<VectorFieldType::accessor_type ==
+                         specfem::data_access::AccessorType::chunk_element,
+                     int> = 0>
 KOKKOS_FUNCTION void divergence(
     const ChunkIndexType &chunk_index,
     const specfem::assembly::jacobian_matrix<specfem::dimension::type::dim2>

--- a/include/algorithms/gradient.hpp
+++ b/include/algorithms/gradient.hpp
@@ -3,6 +3,7 @@
 #include "execution/for_each_level.hpp"
 #include "kokkos_abstractions.h"
 #include "specfem/assembly.hpp"
+#include "specfem/data_access.hpp"
 #include "specfem/point.hpp"
 #include <Kokkos_Core.hpp>
 
@@ -33,11 +34,10 @@ namespace algorithms {
  * specfem::datatype::TensorPointViewType<type_real, 2, ViewType::components>)
  * @endcode
  */
-template <
-    typename ChunkIndexType, typename ViewType, typename QuadratureType,
-    typename CallbackFunctor,
-    std::enable_if_t<specfem::data_access::is_chunk_element<ViewType>::value
-                     int> = 0>
+template <typename ChunkIndexType, typename ViewType, typename QuadratureType,
+          typename CallbackFunctor,
+          std::enable_if_t<
+              specfem::data_access::is_chunk_element<ViewType>::value, int> = 0>
 KOKKOS_FORCEINLINE_FUNCTION void gradient(
     const ChunkIndexType &chunk_index,
     const specfem::assembly::jacobian_matrix<specfem::dimension::type::dim2>
@@ -132,11 +132,10 @@ KOKKOS_FORCEINLINE_FUNCTION void gradient(
  * ViewType::components>)
  * @endcode
  */
-template <
-    typename ChunkIndexType, typename ViewType, typename QuadratureType,
-    typename CallbackFunctor,
-    std::enable_if_t<specfem::data_access::is_chunk_element<ViewType>::value
-                     int> = 0>
+template <typename ChunkIndexType, typename ViewType, typename QuadratureType,
+          typename CallbackFunctor,
+          std::enable_if_t<
+              specfem::data_access::is_chunk_element<ViewType>::value, int> = 0>
 KOKKOS_FORCEINLINE_FUNCTION void gradient(
     const ChunkIndexType &chunk_index,
     const specfem::assembly::jacobian_matrix<specfem::dimension::type::dim2>

--- a/include/algorithms/gradient.hpp
+++ b/include/algorithms/gradient.hpp
@@ -36,8 +36,7 @@ namespace algorithms {
 template <
     typename ChunkIndexType, typename ViewType, typename QuadratureType,
     typename CallbackFunctor,
-    std::enable_if_t<ViewType::accessor_type ==
-                         specfem::data_access::AccessorType::chunk_element,
+    std::enable_if_t<specfem::data_access::is_chunk_element<ViewType>::value
                      int> = 0>
 KOKKOS_FORCEINLINE_FUNCTION void gradient(
     const ChunkIndexType &chunk_index,

--- a/include/algorithms/gradient.hpp
+++ b/include/algorithms/gradient.hpp
@@ -135,8 +135,7 @@ KOKKOS_FORCEINLINE_FUNCTION void gradient(
 template <
     typename ChunkIndexType, typename ViewType, typename QuadratureType,
     typename CallbackFunctor,
-    std::enable_if_t<ViewType::value_type::accessor_type ==
-                         specfem::data_access::AccessorType::chunk_element,
+    std::enable_if_t<specfem::data_access::is_chunk_element<ViewType>::value
                      int> = 0>
 KOKKOS_FORCEINLINE_FUNCTION void gradient(
     const ChunkIndexType &chunk_index,

--- a/include/algorithms/gradient.hpp
+++ b/include/algorithms/gradient.hpp
@@ -33,9 +33,12 @@ namespace algorithms {
  * specfem::datatype::TensorPointViewType<type_real, 2, ViewType::components>)
  * @endcode
  */
-template <typename ChunkIndexType, typename ViewType, typename QuadratureType,
-          typename CallbackFunctor,
-          std::enable_if_t<ViewType::isChunkViewType, int> = 0>
+template <
+    typename ChunkIndexType, typename ViewType, typename QuadratureType,
+    typename CallbackFunctor,
+    std::enable_if_t<ViewType::accessor_type ==
+                         specfem::data_access::AccessorType::chunk_element,
+                     int> = 0>
 KOKKOS_FORCEINLINE_FUNCTION void gradient(
     const ChunkIndexType &chunk_index,
     const specfem::assembly::jacobian_matrix<specfem::dimension::type::dim2>
@@ -53,9 +56,6 @@ KOKKOS_FORCEINLINE_FUNCTION void gradient(
                                              using_simd>;
 
   using datatype = typename ViewType::simd::datatype;
-
-  static_assert(ViewType::isScalarViewType,
-                "ViewType must be a scalar field view type");
 
   static_assert(
       std::is_invocable_v<CallbackFunctor,
@@ -133,9 +133,12 @@ KOKKOS_FORCEINLINE_FUNCTION void gradient(
  * ViewType::components>)
  * @endcode
  */
-template <typename ChunkIndexType, typename ViewType, typename QuadratureType,
-          typename CallbackFunctor,
-          std::enable_if_t<ViewType::isChunkViewType, int> = 0>
+template <
+    typename ChunkIndexType, typename ViewType, typename QuadratureType,
+    typename CallbackFunctor,
+    std::enable_if_t<ViewType::value_type::accessor_type ==
+                         specfem::data_access::AccessorType::chunk_element,
+                     int> = 0>
 KOKKOS_FORCEINLINE_FUNCTION void gradient(
     const ChunkIndexType &chunk_index,
     const specfem::assembly::jacobian_matrix<specfem::dimension::type::dim2>
@@ -151,9 +154,6 @@ KOKKOS_FORCEINLINE_FUNCTION void gradient(
   using TensorPointViewType =
       specfem::datatype::TensorPointViewType<type_real, components, dimension,
                                              using_simd>;
-
-  static_assert(ViewType::isScalarViewType,
-                "ViewType must be a scalar field view type");
 
   using datatype = typename ViewType::simd::datatype;
 

--- a/include/datatypes/chunk_element_view.hpp
+++ b/include/datatypes/chunk_element_view.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "enumerations/dimension.hpp"
+#include "enumerations/interface.hpp"
 #include "impl/chunk_element_subview.hpp"
 #include "simd.hpp"
 #include <Kokkos_Core.hpp>
@@ -80,7 +80,6 @@ struct ScalarChunkViewType<T, specfem::dimension::type::dim2, NumberOfElements,
                                                      ///< the chunk
   constexpr static int ngll = NumberOfGLLPoints; ///< Number of GLL points in
                                                  ///< each element
-  constexpr static bool isChunkViewType = true;
   ///@}
 
   /**
@@ -194,8 +193,6 @@ struct VectorChunkViewType<T, specfem::dimension::type::dim2, NumberOfElements,
                                                  ///< each element
   constexpr static int components = Components;  ///< Number of vector values at
                                                  ///< each GLL point
-  constexpr static bool isChunkViewType = true;
-  constexpr static bool isScalarViewType = true;
   ///@}
 
   /**
@@ -328,8 +325,6 @@ struct TensorChunkViewType<T, specfem::dimension::type::dim2, NumberOfElements,
   constexpr static int dimensions =
       NumberOfDimensions; ///< Number of dimensions
                           ///< of the tensor values
-  constexpr static bool isChunkViewType = true;
-  constexpr static bool isScalarViewType = false;
   ///@}
 
   /**

--- a/include/medium/compute_wavefield.hpp
+++ b/include/medium/compute_wavefield.hpp
@@ -76,13 +76,11 @@ KOKKOS_INLINE_FUNCTION auto compute_wavefield(
                     specfem::dimension::type::dim2,
                 "AccelerationFieldType dimension tag must be dim2");
 
-  static_assert(DisplacementFieldType::accessor_type ==
-                        specfem::data_access::AccessorType::chunk_element &&
-                    VelocityFieldType::accessor_type ==
-                        specfem::data_access::AccessorType::chunk_element &&
-                    AccelerationFieldType::accessor_type ==
-                        specfem::data_access::AccessorType::chunk_element,
-                "All field types must be chunk view types");
+  static_assert(
+      specfem::data_access::is_chunk_element<DisplacementFieldType>::value &&
+          specfem::data_access::is_chunk_element<VelocityFieldType>::value &&
+          specfem::data_access::is_chunk_element<AccelerationFieldType>::value,
+      "All field types must be chunk view types");
 
   using dimension_dispatch =
       std::integral_constant<specfem::dimension::type,
@@ -97,7 +95,7 @@ KOKKOS_INLINE_FUNCTION auto compute_wavefield(
                          displacement, velocity, acceleration,
                          wavefield_component, wavefield_on_entire_grid);
   return;
-} // compute_wavefield
+} // git pull
 
 } // namespace medium
 } // namespace specfem

--- a/include/medium/compute_wavefield.hpp
+++ b/include/medium/compute_wavefield.hpp
@@ -76,9 +76,12 @@ KOKKOS_INLINE_FUNCTION auto compute_wavefield(
                     specfem::dimension::type::dim2,
                 "AccelerationFieldType dimension tag must be dim2");
 
-  static_assert(DisplacementFieldType::isChunkViewType &&
-                    VelocityFieldType::isChunkViewType &&
-                    AccelerationFieldType::isChunkViewType,
+  static_assert(DisplacementFieldType::accessor_type ==
+                        specfem::data_access::AccessorType::chunk_element &&
+                    VelocityFieldType::accessor_type ==
+                        specfem::data_access::AccessorType::chunk_element &&
+                    AccelerationFieldType::accessor_type ==
+                        specfem::data_access::AccessorType::chunk_element,
                 "All field types must be chunk view types");
 
   using dimension_dispatch =

--- a/include/medium/dim2/acoustic/isotropic/wavefield.hpp
+++ b/include/medium/dim2/acoustic/isotropic/wavefield.hpp
@@ -42,13 +42,13 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
 
   const auto &active_field = [&]() {
     if (wavefield_type == specfem::wavefield::type::displacement) {
-      return displacement.field_without_accessor();
+      return displacement.get_data();
     } else if (wavefield_type == specfem::wavefield::type::velocity) {
-      return velocity.field_without_accessor();
+      return velocity.get_data();
     } else if (wavefield_type == specfem::wavefield::type::acceleration) {
-      return acceleration.field_without_accessor();
+      return acceleration.get_data();
     } else if (wavefield_type == specfem::wavefield::type::pressure) {
-      return acceleration.field_without_accessor();
+      return acceleration.get_data();
     } else {
       KOKKOS_ABORT_WITH_LOCATION(
           "Unsupported wavefield component for 2D acoustic isotropic media.");

--- a/include/medium/dim2/elastic/anisotropic/wavefield.hpp
+++ b/include/medium/dim2/elastic/anisotropic/wavefield.hpp
@@ -39,13 +39,13 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
 
   const auto &active_field = [&]() {
     if (wavefield_type == specfem::wavefield::type::displacement) {
-      return displacement.field_without_accessor();
+      return displacement.get_data();
     } else if (wavefield_type == specfem::wavefield::type::velocity) {
-      return velocity.field_without_accessor();
+      return velocity.get_data();
     } else if (wavefield_type == specfem::wavefield::type::acceleration) {
-      return acceleration.field_without_accessor();
+      return acceleration.get_data();
     } else if (wavefield_type == specfem::wavefield::type::pressure) {
-      return displacement.field_without_accessor();
+      return displacement.get_data();
     } else {
       KOKKOS_ABORT_WITH_LOCATION("Unsupported wavefield component for 2D "
                                  "elastic anisotropic P-SV media.");
@@ -142,13 +142,13 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
 
   const auto &active_field = [&]() {
     if (wavefield_type == specfem::wavefield::type::displacement) {
-      return displacement.field_without_accessor();
+      return displacement.get_data();
     } else if (wavefield_type == specfem::wavefield::type::velocity) {
-      return velocity.field_without_accessor();
+      return velocity.get_data();
     } else if (wavefield_type == specfem::wavefield::type::acceleration) {
-      return acceleration.field_without_accessor();
+      return acceleration.get_data();
     } else if (wavefield_type == specfem::wavefield::type::pressure) {
-      return displacement.field_without_accessor();
+      return displacement.get_data();
     } else {
       KOKKOS_ABORT_WITH_LOCATION("Unsupported wavefield component for 2D "
                                  "elastic anisotropic SH media.");

--- a/include/medium/dim2/elastic/isotropic/wavefield.hpp
+++ b/include/medium/dim2/elastic/isotropic/wavefield.hpp
@@ -40,13 +40,13 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
 
   const auto &active_field = [&]() {
     if (wavefield_type == specfem::wavefield::type::displacement) {
-      return displacement.field_without_accessor();
+      return displacement.get_data();
     } else if (wavefield_type == specfem::wavefield::type::velocity) {
-      return velocity.field_without_accessor();
+      return velocity.get_data();
     } else if (wavefield_type == specfem::wavefield::type::acceleration) {
-      return acceleration.field_without_accessor();
+      return acceleration.get_data();
     } else if (wavefield_type == specfem::wavefield::type::pressure) {
-      return displacement.field_without_accessor();
+      return displacement.get_data();
     } else {
       KOKKOS_ABORT_WITH_LOCATION("Unsupported wavefield component for 2D "
                                  "elastic isotropic P-SV media.");
@@ -130,11 +130,11 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
 
   const auto &active_field = [&]() {
     if (wavefield_type == specfem::wavefield::type::displacement) {
-      return displacement.field_without_accessor();
+      return displacement.get_data();
     } else if (wavefield_type == specfem::wavefield::type::velocity) {
-      return velocity.field_without_accessor();
+      return velocity.get_data();
     } else if (wavefield_type == specfem::wavefield::type::acceleration) {
-      return acceleration.field_without_accessor();
+      return acceleration.get_data();
     } else {
       KOKKOS_ABORT_WITH_LOCATION(
           "Unsupported wavefield component for 2D elastic isotropic SH media.");

--- a/include/medium/dim2/elastic/isotropic_cosserat/wavefield.hpp
+++ b/include/medium/dim2/elastic/isotropic_cosserat/wavefield.hpp
@@ -42,19 +42,19 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
 
   const auto &active_field = [&]() {
     if (wavefield_type == specfem::wavefield::type::displacement) {
-      return displacement.field_without_accessor();
+      return displacement.get_data();
     } else if (wavefield_type == specfem::wavefield::type::velocity) {
-      return velocity.field_without_accessor();
+      return velocity.get_data();
     } else if (wavefield_type == specfem::wavefield::type::acceleration) {
-      return acceleration.field_without_accessor();
+      return acceleration.get_data();
     } else if (wavefield_type == specfem::wavefield::type::pressure) {
-      return displacement.field_without_accessor();
+      return displacement.get_data();
     } else if (wavefield_type == specfem::wavefield::type::rotation) {
-      return displacement.field_without_accessor();
+      return displacement.get_data();
     } else if (wavefield_type == specfem::wavefield::type::intrinsic_rotation) {
-      return displacement.field_without_accessor();
+      return displacement.get_data();
     } else if (wavefield_type == specfem::wavefield::type::curl) {
-      return displacement.field_without_accessor();
+      return displacement.get_data();
     } else {
       KOKKOS_ABORT_WITH_LOCATION("Unsupported wavefield component for 2D "
                                  "elastic isotropic Cosserat P-SV-T media");

--- a/include/medium/dim2/poroelastic/isotropic/wavefield.hpp
+++ b/include/medium/dim2/poroelastic/isotropic/wavefield.hpp
@@ -40,13 +40,13 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
 
   const auto &active_field = [&]() {
     if (wavefield_type == specfem::wavefield::type::displacement) {
-      return displacement.field_without_accessor();
+      return displacement.get_data();
     } else if (wavefield_type == specfem::wavefield::type::velocity) {
-      return velocity.field_without_accessor();
+      return velocity.get_data();
     } else if (wavefield_type == specfem::wavefield::type::acceleration) {
-      return acceleration.field_without_accessor();
+      return acceleration.get_data();
     } else if (wavefield_type == specfem::wavefield::type::pressure) {
-      return displacement.field_without_accessor();
+      return displacement.get_data();
     } else {
       KOKKOS_ABORT_WITH_LOCATION("Unsupported wavefield component for 2D "
                                  "poroelastic isotropic media.");


### PR DESCRIPTION
## Description

All the properties that are needed from `field_without_accessor` are actually now provided from the underlying `m_data` which is of type `VectorChunkViewType`, so now returning `m_data` would serve the purpose of `field_without_accessor`.

- Switch to `accessor_type` for type checking in `algorithms::gradient` and `algorithms::divergence`.
- Remove all `isXxxChunkViewType` properties.
- Replace `field_without_accessor` with `get_data()` for `chunk_element`.

## Issue Number

Adds to #1170

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
