### PR TITLE
1170 Part 2 - 3D specialization for chunk_elements

### DIFF
--- a/include/algorithms/divergence.hpp
+++ b/include/algorithms/divergence.hpp
@@ -40,9 +40,11 @@ namespace algorithms {
 template <
     typename ChunkIndexType, typename VectorFieldType, typename WeightsType,
     typename QuadratureType, typename CallableType,
-    std::enable_if_t<VectorFieldType::accessor_type ==
-                         specfem::data_access::AccessorType::chunk_element,
-                     int> = 0>
+    std::enable_if_t<
+        VectorFieldType::accessor_type ==
+                specfem::data_access::AccessorType::chunk_element &&
+            VectorFieldType::dimension_tag == specfem::dimension::type::dim2,
+        int> = 0>
 KOKKOS_FUNCTION void divergence(
     const ChunkIndexType &chunk_index,
     const specfem::assembly::jacobian_matrix<specfem::dimension::type::dim2>

--- a/include/algorithms/gradient.hpp
+++ b/include/algorithms/gradient.hpp
@@ -33,12 +33,13 @@ namespace algorithms {
  * specfem::datatype::TensorPointViewType<type_real, 2, ViewType::components>)
  * @endcode
  */
-template <
-    typename ChunkIndexType, typename ViewType, typename QuadratureType,
-    typename CallbackFunctor,
-    std::enable_if_t<ViewType::accessor_type ==
-                         specfem::data_access::AccessorType::chunk_element,
-                     int> = 0>
+template <typename ChunkIndexType, typename ViewType, typename QuadratureType,
+          typename CallbackFunctor,
+          std::enable_if_t<
+              ViewType::accessor_type ==
+                      specfem::data_access::AccessorType::chunk_element &&
+                  ViewType::dimension_tag == specfem::dimension::type::dim2,
+              int> = 0>
 KOKKOS_FORCEINLINE_FUNCTION void gradient(
     const ChunkIndexType &chunk_index,
     const specfem::assembly::jacobian_matrix<specfem::dimension::type::dim2>
@@ -133,12 +134,13 @@ KOKKOS_FORCEINLINE_FUNCTION void gradient(
  * ViewType::components>)
  * @endcode
  */
-template <
-    typename ChunkIndexType, typename ViewType, typename QuadratureType,
-    typename CallbackFunctor,
-    std::enable_if_t<ViewType::value_type::accessor_type ==
-                         specfem::data_access::AccessorType::chunk_element,
-                     int> = 0>
+template <typename ChunkIndexType, typename ViewType, typename QuadratureType,
+          typename CallbackFunctor,
+          std::enable_if_t<
+              ViewType::value_type::accessor_type ==
+                      specfem::data_access::AccessorType::chunk_element &&
+                  ViewType::dimension_tag == specfem::dimension::type::dim2,
+              int> = 0>
 KOKKOS_FORCEINLINE_FUNCTION void gradient(
     const ChunkIndexType &chunk_index,
     const specfem::assembly::jacobian_matrix<specfem::dimension::type::dim2>

--- a/include/datatypes/chunk_element_view.hpp
+++ b/include/datatypes/chunk_element_view.hpp
@@ -2,6 +2,7 @@
 
 #include "enumerations/interface.hpp"
 #include "impl/chunk_element_subview.hpp"
+#include "point_view.hpp"
 #include "simd.hpp"
 #include <Kokkos_Core.hpp>
 
@@ -33,6 +34,7 @@ template <typename T, specfem::dimension::type DimensionTag,
           typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged> >
 struct ScalarChunkViewType;
 
+/* 2D specialization */
 template <typename T, int NumberOfElements, int NumberOfGLLPoints, bool UseSIMD,
           typename MemorySpace, typename MemoryTraits>
 struct ScalarChunkViewType<T, specfem::dimension::type::dim2, NumberOfElements,
@@ -56,8 +58,10 @@ struct ScalarChunkViewType<T, specfem::dimension::type::dim2, NumberOfElements,
   using value_type = typename type::value_type; ///< Value type used to store
                                                 ///< the elements of the array
   using base_type = T;                          ///< Base type of the array
+  constexpr static auto dimension_tag =
+      specfem::dimension::type::dim2; ///< Dimension tag
   using index_type =
-      typename specfem::point::index<specfem::dimension::type::dim2,
+      typename specfem::point::index<dimension_tag,
                                      UseSIMD>; ///< index type for accessing at
                                                ///< GLL level
   constexpr static bool using_simd = UseSIMD;  ///< Use SIMD datatypes for the
@@ -123,8 +127,101 @@ struct ScalarChunkViewType<T, specfem::dimension::type::dim2, NumberOfElements,
   }
 };
 
+/* 3D specialization */
+template <typename T, int NumberOfElements, int NumberOfGLLPoints, bool UseSIMD,
+          typename MemorySpace, typename MemoryTraits>
+struct ScalarChunkViewType<T, specfem::dimension::type::dim3, NumberOfElements,
+                           NumberOfGLLPoints, UseSIMD, MemorySpace,
+                           MemoryTraits>
+    : public Kokkos::View<typename specfem::datatype::simd<T, UseSIMD>::datatype
+                              [NumberOfElements][NumberOfGLLPoints]
+                              [NumberOfGLLPoints][NumberOfGLLPoints],
+                          MemorySpace, MemoryTraits> {
+  /**
+   * @name Typedefs
+   *
+   */
+  ///@{
+  using simd = specfem::datatype::simd<T, UseSIMD>; ///< SIMD data type
+  using type = Kokkos::View<
+      typename simd::datatype[NumberOfElements][NumberOfGLLPoints]
+                             [NumberOfGLLPoints][NumberOfGLLPoints],
+      MemorySpace, MemoryTraits>; ///< Underlying data type used to
+                                  ///< store values
+  using value_type = typename type::value_type; ///< Value type used to store
+                                                ///< the elements of the array
+  using base_type = T;                          ///< Base type of the array
+  constexpr static auto dimension_tag =
+      specfem::dimension::type::dim2; ///< Dimension tag
+  using index_type =
+      typename specfem::point::index<dimension_tag,
+                                     UseSIMD>; ///< index type for accessing at
+                                               ///< GLL level
+  constexpr static bool using_simd = UseSIMD;  ///< Use SIMD datatypes for the
+                                               ///< array. If false,
+                                               ///< std::is_same<value_type,
+                                               ///< base_type>::value is true
+  ///@}
+
+  /**
+   * @name Compile time constants
+   *
+   */
+  ///@{
+  constexpr static auto accessor_type =
+      specfem::data_access::AccessorType::chunk_element; ///< Accessor type for
+                                                         ///< identifying the
+                                                         ///< class
+
+  constexpr static int nelements = NumberOfElements; ///< Number of elements in
+                                                     ///< the chunk
+  constexpr static int ngll = NumberOfGLLPoints; ///< Number of GLL points in
+                                                 ///< each element
+  ///@}
+
+  /**
+   * @name Constructors and assignment operators
+   *
+   */
+  ///@{
+  /**
+   * @brief Default constructor
+   */
+  KOKKOS_FUNCTION
+  ScalarChunkViewType() = default;
+
+  /**
+   * @brief Construct a new ScalarChunkViewType object within
+   * ScratchMemorySpace.
+   * Allocates an unmanaged view within ScratchMemorySpace. Useful for
+   * generating scratch views.
+   *
+   * @tparam ScratchMemorySpace Memory space of the view
+   * @param scratch_memory_space Memory space of the view
+   */
+  template <typename ScratchMemorySpace>
+  KOKKOS_FUNCTION
+  ScalarChunkViewType(const ScratchMemorySpace &scratch_memory_space)
+      : Kokkos::View<value_type[NumberOfElements][NumberOfGLLPoints]
+                               [NumberOfGLLPoints][NumberOfGLLPoints],
+                     MemorySpace, MemoryTraits>(scratch_memory_space) {}
+  ///@}
+
+  using type::operator();
+
+  /**
+   * @brief Get scalar value by a point index.
+   *
+   * @param index Point index
+   */
+  KOKKOS_INLINE_FUNCTION
+  constexpr value_type &operator()(index_type index) {
+    return (*this)(index.ispec, index.iz, index.iy, index.ix);
+  }
+};
+
 /**
- * @brief Datatype used to vector values within chunk of elements. Data is
+ * @brief 2D Datatype used to vector values within chunk of elements. Data is
  * stored within a Kokkos view located in the memory space specified by
  * MemorySpace.
  *
@@ -144,6 +241,7 @@ template <
     typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged> >
 struct VectorChunkViewType;
 
+/* 2D specialization */
 template <typename T, int NumberOfElements, int NumberOfGLLPoints,
           int Components, bool UseSIMD, typename MemorySpace,
           typename MemoryTraits>
@@ -168,14 +266,19 @@ struct VectorChunkViewType<T, specfem::dimension::type::dim2, NumberOfElements,
   using value_type = typename type::value_type; ///< Value type used to store
                                                 ///< the elements of the array
   using base_type = T;                          ///< Base type of the array
+  constexpr static auto dimension_tag =
+      specfem::dimension::type::dim2; ///< Dimension tag
   using index_type =
-      typename specfem::point::index<specfem::dimension::type::dim2,
+      typename specfem::point::index<dimension_tag,
                                      UseSIMD>; ///< index type for accessing at
                                                ///< GLL level
-  constexpr static bool using_simd = UseSIMD;  ///< Use SIMD datatypes for the
-                                               ///< array. If false,
-                                               ///< std::is_same<value_type,
-                                               ///< base_type>::value is true
+  using point_view_type =
+      VectorPointViewType<T, Components, UseSIMD>; ///< Point view type for
+                                                   ///< component access
+  constexpr static bool using_simd = UseSIMD; ///< Use SIMD datatypes for the
+                                              ///< array. If false,
+                                              ///< std::is_same<value_type,
+                                              ///< base_type>::value is true
   ///@}
 
   /**
@@ -248,6 +351,118 @@ struct VectorChunkViewType<T, specfem::dimension::type::dim2, NumberOfElements,
   }
 };
 
+/* 3D specialization */
+template <typename T, int NumberOfElements, int NumberOfGLLPoints,
+          int Components, bool UseSIMD, typename MemorySpace,
+          typename MemoryTraits>
+struct VectorChunkViewType<T, specfem::dimension::type::dim3, NumberOfElements,
+                           NumberOfGLLPoints, Components, UseSIMD, MemorySpace,
+                           MemoryTraits>
+    : public Kokkos::View<
+          typename specfem::datatype::simd<T, UseSIMD>::datatype
+              [NumberOfElements][NumberOfGLLPoints][NumberOfGLLPoints]
+              [NumberOfGLLPoints][Components],
+          MemorySpace, MemoryTraits> {
+  /**
+   * @name Typedefs
+   *
+   */
+  ///@{
+  using simd = specfem::datatype::simd<T, UseSIMD>; ///< SIMD data type
+  using type = Kokkos::View<
+      typename simd::datatype[NumberOfElements][NumberOfGLLPoints]
+                             [NumberOfGLLPoints][NumberOfGLLPoints][Components],
+      MemorySpace, MemoryTraits>; ///< Underlying data type used to
+                                  ///< store values
+  using value_type = typename type::value_type; ///< Value type used to store
+                                                ///< the elements of the array
+  using base_type = T;                          ///< Base type of the array
+  constexpr static auto dimension_tag =
+      specfem::dimension::type::dim3; ///< Dimension tag
+  using index_type =
+      typename specfem::point::index<dimension_tag,
+                                     UseSIMD>; ///< index type for accessing at
+                                               ///< GLL level
+  using point_view_type =
+      VectorPointViewType<T, Components, UseSIMD>; ///< Point view type for
+                                                   ///< component access
+  constexpr static bool using_simd = UseSIMD; ///< Use SIMD datatypes for the
+                                              ///< array. If false,
+                                              ///< std::is_same<value_type,
+                                              ///< base_type>::value is true
+  ///@}
+
+  /**
+   * @name Compile time constants
+   *
+   */
+  ///@{
+  constexpr static auto accessor_type =
+      specfem::data_access::AccessorType::chunk_element; ///< Accessor type for
+                                                         ///< identifying the
+                                                         ///< class
+  constexpr static int nelements = NumberOfElements; ///< Number of elements in
+                                                     ///< the chunk
+  constexpr static int ngll = NumberOfGLLPoints; ///< Number of GLL points in
+                                                 ///< each element
+  constexpr static int components = Components;  ///< Number of vector values at
+                                                 ///< each GLL point
+  ///@}
+
+  /**
+   * @name Constructors and assignment operators
+   *
+   */
+  ///@{
+  /**
+   * @brief Default constructor
+   */
+  KOKKOS_FUNCTION
+  VectorChunkViewType() = default;
+
+  /**
+   * @brief Construct a new VectorChunkViewType object within
+   * ScratchMemorySpace.
+   * Allocates an unmanaged view within ScratchMemorySpace. Useful for
+   * generating scratch views.
+   *
+   * @tparam ScratchMemorySpace Memory space of the view
+   * @param scratch_memory_space Memory space of the view
+   */
+  template <typename ScratchMemorySpace>
+  KOKKOS_FUNCTION
+  VectorChunkViewType(const ScratchMemorySpace &scratch_memory_space)
+      : Kokkos::View<
+            value_type[NumberOfElements][NumberOfGLLPoints][NumberOfGLLPoints]
+                      [NumberOfGLLPoints][Components],
+            MemorySpace, MemoryTraits>(scratch_memory_space) {}
+  ///@}
+
+  using type::operator();
+
+  /**
+   * @brief Get vector component by a point index and vector indices.
+   *
+   * @param index Point index
+   * @param icomp Component index
+   */
+  KOKKOS_INLINE_FUNCTION
+  constexpr value_type &operator()(const index_type &index, const int &icomp) {
+    return (*this)(index.ispec, index.iz, index.iy, index.ix, icomp);
+  }
+
+  /**
+   * @brief Get vector subview by a point index.
+   *
+   * @param index Point index
+   */
+  KOKKOS_INLINE_FUNCTION
+  impl::VectorChunkSubview<VectorChunkViewType>
+  operator()(const index_type &index) {
+    return { *this, index };
+  }
+};
+
 /**
  * @brief Datatype used to tensor values within chunk of elements. Data is
  * stored within a Kokkos view located in the memory space specified by
@@ -271,6 +486,7 @@ template <typename T, specfem::dimension::type DimensionTag,
           typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged> >
 struct TensorChunkViewType;
 
+/* 2D specialization */
 template <typename T, int NumberOfElements, int NumberOfGLLPoints,
           int Components, int NumberOfDimensions, bool UseSIMD,
           typename MemorySpace, typename MemoryTraits>
@@ -296,14 +512,19 @@ struct TensorChunkViewType<T, specfem::dimension::type::dim2, NumberOfElements,
   using value_type = typename type::value_type; ///< Value type used to store
                                                 ///< the elements of the array
   using base_type = T;                          ///< Base type of the array
+  constexpr static auto dimension_tag =
+      specfem::dimension::type::dim2; ///< Dimension tag
   using index_type =
-      typename specfem::point::index<specfem::dimension::type::dim2,
-                                     UseSIMD>; ///< index type for accessing at
-                                               ///< GLL level
-  constexpr static bool using_simd = UseSIMD;  ///< Use SIMD datatypes for the
-                                               ///< array. If false,
-                                               ///< std::is_same<value_type,
-                                               ///< base_type>::value is true
+      typename specfem::point::index<dimension_tag, UseSIMD>; ///< index type
+                                                              ///< for accessing
+                                                              ///< at GLL level
+  using point_view_type = TensorPointViewType<T, Components, NumberOfDimensions,
+                                              UseSIMD>; ///< Point view type for
+                                                        ///< component access
+  constexpr static bool using_simd = UseSIMD; ///< Use SIMD datatypes for the
+                                              ///< array. If false,
+                                              ///< std::is_same<value_type,
+                                              ///< base_type>::value is true
   ///@}
 
   /**
@@ -374,6 +595,129 @@ struct TensorChunkViewType<T, specfem::dimension::type::dim2, NumberOfElements,
   constexpr value_type &operator()(const index_type &index, const int &icomp,
                                    const int &idim) {
     return (*this)(index.ispec, index.iz, index.ix, icomp, idim);
+  }
+
+  /**
+   * @brief Get tensor subview by a point index.
+   *
+   * @param index Point index
+   */
+  KOKKOS_INLINE_FUNCTION
+  impl::TensorChunkSubview<TensorChunkViewType>
+  operator()(const index_type &index) {
+    return { *this, index };
+  }
+};
+
+/* 3D specialization */
+template <typename T, int NumberOfElements, int NumberOfGLLPoints,
+          int Components, int NumberOfDimensions, bool UseSIMD,
+          typename MemorySpace, typename MemoryTraits>
+struct TensorChunkViewType<T, specfem::dimension::type::dim3, NumberOfElements,
+                           NumberOfGLLPoints, Components, NumberOfDimensions,
+                           UseSIMD, MemorySpace, MemoryTraits>
+    : public Kokkos::View<
+          typename specfem::datatype::simd<T, UseSIMD>::datatype
+              [NumberOfElements][NumberOfGLLPoints][NumberOfGLLPoints]
+              [NumberOfGLLPoints][Components][NumberOfDimensions],
+          MemorySpace, MemoryTraits> {
+  /**
+   * @name Typedefs
+   *
+   */
+  ///@{
+  using simd = specfem::datatype::simd<T, UseSIMD>; ///< SIMD data type
+  using type = typename Kokkos::View<
+      typename simd::datatype[NumberOfElements][NumberOfGLLPoints]
+                             [NumberOfGLLPoints][NumberOfGLLPoints][Components]
+                             [NumberOfDimensions],
+      MemorySpace, MemoryTraits>; ///< Underlying data type used to store values
+  using value_type = typename type::value_type; ///< Value type used to store
+                                                ///< the elements of the array
+  using base_type = T;                          ///< Base type of the array
+  constexpr static auto dimension_tag =
+      specfem::dimension::type::dim3; ///< Dimension tag
+  using index_type =
+      typename specfem::point::index<dimension_tag, UseSIMD>; ///< index type
+                                                              ///< for accessing
+                                                              ///< at GLL level
+  using point_view_type = TensorPointViewType<T, Components, NumberOfDimensions,
+                                              UseSIMD>; ///< Point view type for
+                                                        ///< component access
+  constexpr static bool using_simd = UseSIMD; ///< Use SIMD datatypes for the
+                                              ///< array. If false,
+                                              ///< std::is_same<value_type,
+                                              ///< base_type>::value is true
+  ///@}
+
+  /**
+   * @name Compile time constants
+   *
+   */
+  ///@{
+  constexpr static auto accessor_type =
+      specfem::data_access::AccessorType::chunk_element; ///< Accessor type for
+                                                         ///< identifying the
+                                                         ///< class
+
+  constexpr static int nelements = NumberOfElements; ///< Number of elements in
+                                                     ///< the chunk
+  constexpr static int ngll = NumberOfGLLPoints; ///< Number of GLL points in
+                                                 ///< each element
+  constexpr static int components = Components;  ///< Number of tensor values at
+                                                 ///< each GLL point
+  constexpr static int dimensions =
+      NumberOfDimensions; ///< Number of dimensions
+                          ///< of the tensor values
+  ///@}
+
+  /**
+   * @name Constructors and assignment operators
+   *
+   */
+  ///@{
+
+  /**
+   * @brief Default constructor
+   *
+   */
+  KOKKOS_FUNCTION
+  TensorChunkViewType() = default;
+
+  /**
+   * @brief Construct a new TensorChunkViewType object within
+   * ScratchMemorySpace.
+   * Allocates an unmanaged view within ScratchMemorySpace. Useful for
+   * generating scratch views.
+   *
+   * @tparam ScratchMemorySpace Memory space of the view
+   * @param scratch_memory_space Memory space of the view
+   */
+  template <typename ScratchMemorySpace,
+            typename std::enable_if<
+                std::is_same<MemorySpace, ScratchMemorySpace>::value,
+                bool>::type = true>
+  KOKKOS_FUNCTION
+  TensorChunkViewType(const ScratchMemorySpace &scratch_memory_space)
+      : Kokkos::View<
+            value_type[NumberOfElements][NumberOfGLLPoints][NumberOfGLLPoints]
+                      [NumberOfGLLPoints][Components][NumberOfDimensions],
+            MemorySpace, MemoryTraits>(scratch_memory_space) {}
+  ///@}
+
+  using type::operator();
+
+  /**
+   * @brief Get tensor component by a point index and tensor indices.
+   *
+   * @param index Point index
+   * @param icomp Component index
+   * @param idim Dimension index
+   */
+  KOKKOS_INLINE_FUNCTION
+  constexpr value_type &operator()(const index_type &index, const int &icomp,
+                                   const int &idim) {
+    return (*this)(index.ispec, index.iz, index.iy, index.ix, icomp, idim);
   }
 
   /**

--- a/include/datatypes/impl/chunk_element_subview.hpp
+++ b/include/datatypes/impl/chunk_element_subview.hpp
@@ -32,6 +32,7 @@ template <typename ViewType> struct VectorChunkSubview {
    * @param view Reference to the parent view
    * @param index Reference to the index within the parent view
    */
+  KOKKOS_FUNCTION
   VectorChunkSubview(ViewType &view, const index_type &index)
       : view(view), index(index) {}
 
@@ -170,6 +171,7 @@ template <typename ViewType> struct TensorChunkSubview {
    * @param view Reference to the parent view
    * @param index Reference to the index within the parent view
    */
+  KOKKOS_FUNCTION
   TensorChunkSubview(ViewType &view, const index_type &index)
       : view(view), index(index) {}
 

--- a/include/datatypes/impl/chunk_element_subview.hpp
+++ b/include/datatypes/impl/chunk_element_subview.hpp
@@ -19,9 +19,7 @@ template <typename ViewType> struct VectorChunkSubview {
   /// Index type from the parent view
   using index_type = typename ViewType::index_type;
   /// Point view type for component access
-  using point_view_type =
-      VectorPointViewType<typename ViewType::base_type, ViewType::components,
-                          ViewType::using_simd>;
+  using point_view_type = typename ViewType::point_view_type;
 
   /// Reference to the parent view
   ViewType &view;
@@ -42,7 +40,6 @@ template <typename ViewType> struct VectorChunkSubview {
    *
    * Specialized for 2D case, providing element access with proper indexing.
    *
-   * @tparam D Dimension tag, defaulted to the index type's dimension tag
    * @param icomp Component index to access
    * @return Reference to the component value
    */
@@ -51,6 +48,21 @@ template <typename ViewType> struct VectorChunkSubview {
       typename std::enable_if_t<D == specfem::dimension::type::dim2, int> = 0>
   KOKKOS_INLINE_FUNCTION constexpr auto &operator()(const int &icomp) {
     return view(index.ispec, index.iz, index.ix, icomp);
+  }
+
+  /**
+   * @brief Access a specific component of the vector (non-const)
+   *
+   * Specialized for 3D case, providing element access with proper indexing.
+   *
+   * @param icomp Component index to access
+   * @return Reference to the component value
+   */
+  template <
+      specfem::dimension::type D = index_type::dimension_tag,
+      typename std::enable_if_t<D == specfem::dimension::type::dim3, int> = 0>
+  KOKKOS_INLINE_FUNCTION constexpr auto &operator()(const int &icomp) {
+    return view(index.ispec, index.iz, index.iy, index.ix, icomp);
   }
 
   /**
@@ -67,6 +79,22 @@ template <typename ViewType> struct VectorChunkSubview {
       typename std::enable_if_t<D == specfem::dimension::type::dim2, int> = 0>
   KOKKOS_INLINE_FUNCTION constexpr auto operator()(const int &icomp) const {
     return view(index.ispec, index.iz, index.ix, icomp);
+  }
+
+  /**
+   * @brief Access a specific component of the vector (const)
+   *
+   * Specialized for 3D case, providing const element access with proper
+   * indexing.
+   *
+   * @param icomp Component index to access
+   * @return Value of the component
+   */
+  template <
+      specfem::dimension::type D = index_type::dimension_tag,
+      typename std::enable_if_t<D == specfem::dimension::type::dim3, int> = 0>
+  KOKKOS_INLINE_FUNCTION constexpr auto operator()(const int &icomp) const {
+    return view(index.ispec, index.iz, index.iy, index.ix, icomp);
   }
 
   /**
@@ -99,9 +127,7 @@ template <typename ViewType> struct TensorChunkSubview {
   /// Index type from the parent view
   using index_type = typename ViewType::index_type;
   /// Point view type for tensor component access
-  using point_view_type =
-      TensorPointViewType<typename ViewType::base_type, ViewType::components,
-                          ViewType::dimensions, ViewType::using_simd>;
+  using point_view_type = typename ViewType::point_view_type;
 
   /// Reference to the parent view
   ViewType &view;
@@ -165,12 +191,28 @@ template <typename ViewType> struct TensorChunkSubview {
   }
 
   /**
+   * @brief Access a specific tensor component (non-const)
+   *
+   * Specialized for 3D case, providing element access with proper indexing.
+   *
+   * @param icomp Component index
+   * @param idim Dimension index
+   * @return Reference to the tensor component
+   */
+  template <
+      specfem::dimension::type D = index_type::dimension_tag,
+      typename std::enable_if_t<D == specfem::dimension::type::dim3, int> = 0>
+  KOKKOS_INLINE_FUNCTION constexpr auto &operator()(const int &icomp,
+                                                    const int &idim) {
+    return view(index.ispec, index.iz, index.iy, index.ix, icomp, idim);
+  }
+
+  /**
    * @brief Access a specific tensor component (const)
    *
    * Specialized for 2D case, providing const element access with proper
    * indexing.
    *
-   * @tparam D Dimension tag, defaulted to the index type's dimension tag
    * @param icomp Component index
    * @param idim Dimension index
    * @return Value of the tensor component
@@ -181,6 +223,24 @@ template <typename ViewType> struct TensorChunkSubview {
   KOKKOS_INLINE_FUNCTION constexpr auto operator()(const int &icomp,
                                                    const int &idim) const {
     return view(index.ispec, index.iz, index.ix, icomp, idim);
+  }
+
+  /**
+   * @brief Access a specific tensor component (const)
+   *
+   * Specialized for 3D case, providing const element access with proper
+   * indexing.
+   *
+   * @param icomp Component index
+   * @param idim Dimension index
+   * @return Value of the tensor component
+   */
+  template <
+      specfem::dimension::type D = index_type::dimension_tag,
+      typename std::enable_if_t<D == specfem::dimension::type::dim3, int> = 0>
+  KOKKOS_INLINE_FUNCTION constexpr auto operator()(const int &icomp,
+                                                   const int &idim) const {
+    return view(index.ispec, index.iz, index.iy, index.ix, icomp, idim);
   }
 
   /**


### PR DESCRIPTION
## Description

- Add dimension check for gradient and divergence
- Add 3D specialization for chunk elements.

## Issue Number

Adds to #1170

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
