### PR TITLE
`gmshlayerbuilder` boundary conditions

### DIFF
--- a/scripts/gmshlayerbuilder/README.md
+++ b/scripts/gmshlayerbuilder/README.md
@@ -1,6 +1,7 @@
 # `gmshlayerbuilder`
 
 Converts a topography file (used by the internal mesher) into a set of output files to be read in by `meshfem2D`.
+A list of options is provided with the `-h` flag.
 
 > All commands are assumed to be run in the `scripts` directory.
 
@@ -29,6 +30,16 @@ The output can be viewed with the inclusion of a `--plot` flag. `matplotlib` mus
 ```sh
 python gmshlayerbuilder gmshlayerbuilder/test_topo.dat ../results/gmsh_demo/ --plot
 ```
+
+## Setting boundaries
+
+Boundary conditions can be set on the top, bottom, left, and right sides of the domain using `--top`, `--bottom`, `--left`, and `--right` respectively. The available conditions are `neumann`, `acoustic_free_surface`, and `absorbing`. Default is `neumann` for all sides.
+
+```sh
+python gmshlayerbuilder gmshlayerbuilder/test_topo.dat ../results/gmsh_demo/ --top acoustic_free_surface
+```
+
+Note that `gmshlayerbuilder` is not aware of the material, so make sure that you do not set an incompatible boundary condition to the material (`acoustic free surface` for elastic materials).
 
 ## Development Notes
 

--- a/scripts/gmshlayerbuilder/__main__.py
+++ b/scripts/gmshlayerbuilder/__main__.py
@@ -43,30 +43,30 @@ def get_parser():
     parser.add_argument(
         "--top",
         choices=BOUNDARY_TYPES,
-        help=f"Boundary type on the top (defaults to {BOUNDARY_TYPES[0]})",
+        help="Boundary type on the top (defaults to neumann)",
         dest="bdry_top",
-        default=BOUNDARY_TYPES[0],
+        default="neumann",
     )
     parser.add_argument(
         "--bottom",
         choices=BOUNDARY_TYPES,
-        help=f"Boundary type on the bottom (defaults to {BOUNDARY_TYPES[0]})",
+        help="Boundary type on the bottom (defaults to neumann)",
         dest="bdry_bottom",
-        default=BOUNDARY_TYPES[0],
+        default="neumann",
     )
     parser.add_argument(
         "--left",
         choices=BOUNDARY_TYPES,
-        help=f"Boundary type on the left (defaults to {BOUNDARY_TYPES[0]})",
+        help="Boundary type on the left (defaults to neumann)",
         dest="bdry_left",
-        default=BOUNDARY_TYPES[0],
+        default="neumann",
     )
     parser.add_argument(
         "--right",
         choices=BOUNDARY_TYPES,
-        help=f"Boundary type on the right (defaults to {BOUNDARY_TYPES[0]})",
+        help="Boundary type on the right (defaults to neumann)",
         dest="bdry_right",
-        default=BOUNDARY_TYPES[0],
+        default="neumann",
     )
     return parser
 

--- a/scripts/gmshlayerbuilder/__main__.py
+++ b/scripts/gmshlayerbuilder/__main__.py
@@ -12,6 +12,7 @@ except ImportError:
     import _gmsh2meshfem  # noqa: F401
 
 
+BOUNDARY_TYPES = ["neumann", "acoustic_free_surface", "absorbing"]
 def get_parser():
     parser = ArgumentParser(
         prog="gmshLayerBuilder",
@@ -36,6 +37,35 @@ def get_parser():
         help="Shows a plot of the mesh using matplotlib.",
         dest="should_plot",
     )
+
+    parser.add_argument(
+        "--top",
+        choices=BOUNDARY_TYPES,
+        help="Boundary type on the top (defaults to neumann)",
+        dest="bdry_top",
+        default=BOUNDARY_TYPES[0]
+    )
+    parser.add_argument(
+        "--bottom",
+        choices=BOUNDARY_TYPES,
+        help="Boundary type on the bottom (defaults to neumann)",
+        dest="bdry_bottom",
+        default=BOUNDARY_TYPES[0]
+    )
+    parser.add_argument(
+        "--left",
+        choices=BOUNDARY_TYPES,
+        help="Boundary type on the left (defaults to neumann)",
+        dest="bdry_left",
+        default=BOUNDARY_TYPES[0]
+    )
+    parser.add_argument(
+        "--right",
+        choices=BOUNDARY_TYPES,
+        help="Boundary type on the right (defaults to neumann)",
+        dest="bdry_right",
+        default=BOUNDARY_TYPES[0]
+    )
     return parser
 
 
@@ -44,6 +74,8 @@ def run2D():
     import _gmsh2meshfem.topo_import
 
     args = get_parser().parse_args()
+
+
     builder = _gmsh2meshfem.topo_import.builder_from_topo_file(
         args.topo_file
     )

--- a/scripts/gmshlayerbuilder/__main__.py
+++ b/scripts/gmshlayerbuilder/__main__.py
@@ -12,7 +12,7 @@ except ImportError:
     import _gmsh2meshfem  # noqa: F401
 
 
-BOUNDARY_TYPES = ["neumann", "acoustic_free_surface", "absorbing"]
+from _gmsh2meshfem.topo_import.layer_builder.layeredbuilder import BOUNDARY_TYPES
 
 
 def get_parser():
@@ -43,28 +43,28 @@ def get_parser():
     parser.add_argument(
         "--top",
         choices=BOUNDARY_TYPES,
-        help="Boundary type on the top (defaults to neumann)",
+        help=f"Boundary type on the top (defaults to {BOUNDARY_TYPES[0]})",
         dest="bdry_top",
         default=BOUNDARY_TYPES[0],
     )
     parser.add_argument(
         "--bottom",
         choices=BOUNDARY_TYPES,
-        help="Boundary type on the bottom (defaults to neumann)",
+        help=f"Boundary type on the bottom (defaults to {BOUNDARY_TYPES[0]})",
         dest="bdry_bottom",
         default=BOUNDARY_TYPES[0],
     )
     parser.add_argument(
         "--left",
         choices=BOUNDARY_TYPES,
-        help="Boundary type on the left (defaults to neumann)",
+        help=f"Boundary type on the left (defaults to {BOUNDARY_TYPES[0]})",
         dest="bdry_left",
         default=BOUNDARY_TYPES[0],
     )
     parser.add_argument(
         "--right",
         choices=BOUNDARY_TYPES,
-        help="Boundary type on the right (defaults to neumann)",
+        help=f"Boundary type on the right (defaults to {BOUNDARY_TYPES[0]})",
         dest="bdry_right",
         default=BOUNDARY_TYPES[0],
     )

--- a/scripts/gmshlayerbuilder/__main__.py
+++ b/scripts/gmshlayerbuilder/__main__.py
@@ -13,6 +13,8 @@ except ImportError:
 
 
 BOUNDARY_TYPES = ["neumann", "acoustic_free_surface", "absorbing"]
+
+
 def get_parser():
     parser = ArgumentParser(
         prog="gmshLayerBuilder",
@@ -43,28 +45,28 @@ def get_parser():
         choices=BOUNDARY_TYPES,
         help="Boundary type on the top (defaults to neumann)",
         dest="bdry_top",
-        default=BOUNDARY_TYPES[0]
+        default=BOUNDARY_TYPES[0],
     )
     parser.add_argument(
         "--bottom",
         choices=BOUNDARY_TYPES,
         help="Boundary type on the bottom (defaults to neumann)",
         dest="bdry_bottom",
-        default=BOUNDARY_TYPES[0]
+        default=BOUNDARY_TYPES[0],
     )
     parser.add_argument(
         "--left",
         choices=BOUNDARY_TYPES,
         help="Boundary type on the left (defaults to neumann)",
         dest="bdry_left",
-        default=BOUNDARY_TYPES[0]
+        default=BOUNDARY_TYPES[0],
     )
     parser.add_argument(
         "--right",
         choices=BOUNDARY_TYPES,
         help="Boundary type on the right (defaults to neumann)",
         dest="bdry_right",
-        default=BOUNDARY_TYPES[0]
+        default=BOUNDARY_TYPES[0],
     )
     return parser
 
@@ -75,9 +77,12 @@ def run2D():
 
     args = get_parser().parse_args()
 
-
     builder = _gmsh2meshfem.topo_import.builder_from_topo_file(
-        args.topo_file
+        args.topo_file,
+        set_bottom_boundary=args.bdry_bottom,
+        set_top_boundary=args.bdry_top,
+        set_left_boundary=args.bdry_left,
+        set_right_boundary=args.bdry_right,
     )
 
     model = builder.create_model()

--- a/scripts/gmshlayerbuilder/_gmsh2meshfem/dim2/exporter.py
+++ b/scripts/gmshlayerbuilder/_gmsh2meshfem/dim2/exporter.py
@@ -161,14 +161,10 @@ class Exporter:
             nnodes = nodes_arr.shape[0]
             f.write(str(nnodes) + "\n")
 
-            # always write in 3 values. Technically,
-            # nodes_arr should be 3 as well, but we do this
-            # just for sanity
-            nodes_dim = nodes_arr.shape[1]
-            pts = np.zeros((3,))
+            assert nodes_arr.shape[1] == 2, "2d exporter received 3d points!"
+
             for inod in range(nnodes):
-                pts[:nodes_dim] = nodes_arr[inod, :]
-                f.write(f"{pts[0]:.10f} {pts[1]:.10f} {pts[2]:.10f}\n")
+                f.write(f"{nodes_arr[inod, 0]:.10f} {nodes_arr[inod, 1]:.10f}\n")
 
         nelem = self.model.elements.shape[0]
 

--- a/scripts/gmshlayerbuilder/_gmsh2meshfem/dim2/exporter.py
+++ b/scripts/gmshlayerbuilder/_gmsh2meshfem/dim2/exporter.py
@@ -3,6 +3,11 @@ import os
 
 import numpy as np
 
+from _gmsh2meshfem.dim2.model.physical_group import (
+    NullPhysicalGroup,
+    PhysicalGroupBase,
+)
+
 from .model import Model
 from .model.edges import EdgeType
 
@@ -43,6 +48,9 @@ class Exporter:
 
     model: Model
 
+    acoustic_free_surface_physical_group: PhysicalGroupBase
+    absorbing_surface_physical_group: PhysicalGroupBase
+
     def __init__(
         self,
         model: Model,
@@ -52,11 +60,13 @@ class Exporter:
         materials_file: str = "materials",
         free_surface_file: str = "free_surface",
         axial_elements_file: str | None = None,
-        absorbing_surface_file: str | None = None,
+        absorbing_surface_file: str | None = "absorbing_surface",
         acoustic_forcing_surface_file: str | None = None,
         absorbing_cpml_file: str | None = None,
         tangential_detection_curve_file: str | None = None,
         nonconforming_adjacencies_file: str | None = None,
+        acoustic_free_surface_physical_group: str | None = "acoustic_free_surface",
+        absorbing_surface_physical_group: str | None = "absorbing",
     ):
         """Initialize an Exporter2D object to write `model` to files for meshfem.
 
@@ -80,7 +90,7 @@ class Exporter:
                 for no export. Defaults to None.
             absorbing_surface_file (str | None, optional): name of the file
                 (path relative to `destination_folder`), or None
-                for no export. Defaults to None.
+                for no export. Defaults to "absorbing_surface".
             acoustic_forcing_surface_file (str | None, optional): name of
                 the file (path relative to `destination_folder`),
                 or None for no export. Defaults to None.
@@ -124,9 +134,20 @@ class Exporter:
             if nonconforming_adjacencies_file is None
             else PurePath(nonconforming_adjacencies_file)
         )
+        self.acoustic_free_surface_physical_group = (
+            NullPhysicalGroup("_NULL_AFS_")
+            if acoustic_free_surface_physical_group is None
+            or acoustic_free_surface_physical_group not in self.model.physical_groups
+            else self.model.physical_groups[acoustic_free_surface_physical_group]
+        )
+        self.absorbing_surface_physical_group = (
+            NullPhysicalGroup("_NULL_ABS_")
+            if absorbing_surface_physical_group is None
+            or absorbing_surface_physical_group not in self.model.physical_groups
+            else self.model.physical_groups[absorbing_surface_physical_group]
+        )
 
     def export_mesh(self):
-
         if not self.destination_folder.exists():
             self.destination_folder.mkdir()
 
@@ -138,7 +159,7 @@ class Exporter:
 
             # header is number of lines (1 line per node)
             nnodes = nodes_arr.shape[0]
-            f.write(str(nnodes))
+            f.write(str(nnodes) + "\n")
 
             # always write in 3 values. Technically,
             # nodes_arr should be 3 as well, but we do this
@@ -147,7 +168,7 @@ class Exporter:
             pts = np.zeros((3,))
             for inod in range(nnodes):
                 pts[:nodes_dim] = nodes_arr[inod, :]
-                f.write(f"\n {pts[0]:.10f} {pts[1]:.10f} {pts[2]:.10f}")
+                f.write(f"{pts[0]:.10f} {pts[1]:.10f} {pts[2]:.10f}\n")
 
         nelem = self.model.elements.shape[0]
 
@@ -157,9 +178,9 @@ class Exporter:
         with (self.destination_folder / self.mesh_file).open("w") as f:
             elem_arr = self.model.elements
 
-            f.write(str(nelem))
+            f.write(str(nelem) + "\n")
             for ielem in range(nelem):
-                f.write("\n " + " ".join(f"{k + 1:d}" for k in elem_arr[ielem, :]))
+                f.write(" ".join(f"{k + 1:d}" for k in elem_arr[ielem, :]) + "\n")
 
         # =========================
         # materials
@@ -171,16 +192,38 @@ class Exporter:
         # free surface
         # =========================
         with (self.destination_folder / self.free_surface_file).open("w") as f:
-            # NotImplemented
-            f.write(str(0))
+            elements, edgetypes = (
+                self.acoustic_free_surface_physical_group.get_all_edges()
+            )
+
+            f.write(str(elements.shape[0]) + "\n")
+
+            # we're not handling corner cases. Make sure this is fine.
+            # (or just let it go until something breaks and you find this comment)
+
+            for elem, edgetype in zip(elements, edgetypes):
+                node_indices = self.model.elements[
+                    elem, EdgeType.QUA_9_node_indices_on_type(edgetype)[::2]
+                ]
+                f.write(f"{elem} 2 {node_indices[0]} {node_indices[1]}\n")
 
         # =========================
         # absorbing bdries (if needed)
         # =========================
         if self.absorbing_surface_file is not None:
             with (self.destination_folder / self.absorbing_surface_file).open("w") as f:
-                # NotImplemented
-                f.write(str(0))
+                elements, edgetypes = (
+                    self.absorbing_surface_physical_group.get_all_edges()
+                )
+                f.write(str(elements.shape[0]) + "\n")
+
+                for elem, edgetype in zip(elements, edgetypes):
+                    node_indices = self.model.elements[
+                        elem, EdgeType.QUA_9_node_indices_on_type(edgetype)[::2]
+                    ]
+                    f.write(
+                        f"{elem} 2 {node_indices[0]} {node_indices[1]} {edgetype}\n"
+                    )
 
         # =========================
         # acoustic forcing (if needed)

--- a/scripts/gmshlayerbuilder/_gmsh2meshfem/dim2/exporter.py
+++ b/scripts/gmshlayerbuilder/_gmsh2meshfem/dim2/exporter.py
@@ -222,7 +222,7 @@ class Exporter:
                         elem, EdgeType.QUA_9_node_indices_on_type(edgetype)[::2]
                     ]
                     f.write(
-                        f"{elem} 2 {node_indices[0]} {node_indices[1]} {edgetype}\n"
+                        f"{elem} 2 {node_indices[0]} {node_indices[1]} {edgetype + 1}\n"
                     )
 
         # =========================
@@ -261,7 +261,7 @@ class Exporter:
                 "w"
             ) as f:
                 num_pairs = self.model.nonconforming_interfaces.edges_a.shape[0]
-                f.write(str(num_pairs * 2))
+                f.write(str(num_pairs * 2) + "\n")
 
                 for ispec_a, ispec_b, edge_a, edge_b in zip(
                     self.model.nonconforming_interfaces.elements_a,
@@ -270,12 +270,12 @@ class Exporter:
                     self.model.nonconforming_interfaces.edges_b,
                 ):
                     f.write(
-                        f"\n{ispec_a + 1:d} {ispec_b + 1:d} "
+                        f"{ispec_a + 1:d} {ispec_b + 1:d} "
                         f"{NONCONFORMING_CONNECTION_TYPE:d} "
-                        f"{model_edge_to_meshfem_edge(edge_a):d}"
+                        f"{model_edge_to_meshfem_edge(edge_a):d}\n"
                     )
                     f.write(
-                        f"\n{ispec_b + 1:d} {ispec_a + 1:d} "
+                        f"{ispec_b + 1:d} {ispec_a + 1:d} "
                         f"{NONCONFORMING_CONNECTION_TYPE:d} "
-                        f"{model_edge_to_meshfem_edge(edge_b):d}"
+                        f"{model_edge_to_meshfem_edge(edge_b):d}\n"
                     )

--- a/scripts/gmshlayerbuilder/_gmsh2meshfem/dim2/model/edges.py
+++ b/scripts/gmshlayerbuilder/_gmsh2meshfem/dim2/model/edges.py
@@ -9,6 +9,7 @@ from _gmsh2meshfem.dim2.binary_detect_N3 import maxfind_coefs_a, maxfind_coefs_b
 
 
 class EdgeType(IntEnum):
+    # this indexing is 1 less than the meshfem indexing. Keep that in mind.
     BOTTOM = 0
     RIGHT = 1
     TOP = 2

--- a/scripts/gmshlayerbuilder/_gmsh2meshfem/dim2/model/edges.py
+++ b/scripts/gmshlayerbuilder/_gmsh2meshfem/dim2/model/edges.py
@@ -3,6 +3,7 @@ from dataclasses import replace as dataclass_replace
 from enum import IntEnum
 
 import numpy as np
+from numpy.typing import NDArray
 
 from _gmsh2meshfem.dim2.binary_detect_N3 import maxfind_coefs_a, maxfind_coefs_b, L
 
@@ -201,3 +202,24 @@ def vectorized_bbox_calc(node_coord_matrix: np.ndarray) -> np.ndarray:
     np.minimum(ret[..., :2], node_coord_matrix[..., 0, :], ret[..., :2])
     np.minimum(ret[..., :2], node_coord_matrix[..., 2, :], ret[..., :2])
     return ret
+
+
+def unique_edges(
+    elements_arr: NDArray[np.uint64], edge_type_arr: NDArray[np.uint8]
+) -> tuple[NDArray[np.uint64], NDArray[np.uint8]]:
+    """Finds the unique edges among the values passed in.
+
+    In the future, consider modeling this off of np.unique.
+
+    Args:
+        elements_arr (NDArray[np.uint64]): element indices
+        edge_type_arr (NDArray[np.uint8]): edge types
+
+    Returns:
+        tuple[NDArray[np.uint64], NDArray[np.uint8]]: the shortened and sorted unique edges.
+    """
+    uniques = np.unique(
+        np.stack([elements_arr, edge_type_arr], axis=-1, dtype=elements_arr.dtype),
+        axis=0,
+    )
+    return uniques[:, 0], np.astype(uniques[:, 1], np.uint8)

--- a/scripts/gmshlayerbuilder/_gmsh2meshfem/dim2/model/model.py
+++ b/scripts/gmshlayerbuilder/_gmsh2meshfem/dim2/model/model.py
@@ -1,17 +1,28 @@
 from dataclasses import dataclass, field
 from dataclasses import replace as dataclass_replace
+from typing import Iterable
 
 import numpy as np
 from _gmsh2meshfem.gmsh_dep import GmshContext
 
 from .boundary import BoundarySpec
 from .edges import ConformingInterfaces
-from .index_mapping import IndexMapping
+from .index_mapping import IndexMapping, JoinedIndexMapping
 from .nonconforming_interfaces import (
     NonconformingInterfaces,
 )
+from .physical_group import (
+    NullPhysicalGroup,
+    PhysicalGroup,
+    UnionPhysicalGroup,
+    physical_group_from_name,
+)
 from .plotter import plot_model
 
+
+# TODO: consider using some sort of joint node and element index mapping container during
+# construction, which would simplify the process. In particular, `element_nodes`
+# needs to be shared around a lot.
 @dataclass
 class Model:
     """Result generated from LayeredBuilder. This does not need gmsh to be initialized."""
@@ -27,10 +38,10 @@ class Model:
     nonconforming_interfaces: NonconformingInterfaces = field(
         default_factory=NonconformingInterfaces
     )
+    physical_groups: dict[str, PhysicalGroup] = field(default_factory=dict)
 
     def plot(self):
-        """Displays, using matplotlib, the mesh corresponding to this model.
-        """
+        """Displays, using matplotlib, the mesh corresponding to this model."""
         plot_model(self.nodes, self.elements)
 
     @staticmethod
@@ -40,7 +51,7 @@ class Model:
         """
         nodemap1 = model1._node_gmshtag_to_index_mapping
         nodemap2 = model2._node_gmshtag_to_index_mapping
-        nodemapu = IndexMapping.join(
+        nodemapu = JoinedIndexMapping(
             nodemap1,
             nodemap2,
         )
@@ -48,8 +59,8 @@ class Model:
         nodes[nodemapu.apply(nodemap1.original_tag_list)] = model1.nodes
         nodes[nodemapu.apply(nodemap2.original_tag_list)] = model2.nodes
 
-        elem1_remapped = nodemapu.apply(nodemap1.invert(model1.elements))
-        elem2_remapped = nodemapu.apply(nodemap2.invert(model2.elements))
+        elem1_remapped = nodemapu.left_to_joined.apply(model1.elements)
+        elem2_remapped = nodemapu.right_to_joined.apply(model2.elements)
 
         # equate elements if they have same nodes
         elemu, elemu_inds, elemu_inv = np.unique(
@@ -59,21 +70,30 @@ class Model:
             return_counts=False,
             axis=0,
         )
-        elem_ind_remap = IndexMapping(elemu_inds)
+        num_elems1 = elem1_remapped.shape[0]
+        num_elems2 = elem2_remapped.shape[0]
+        elem_left_map = IndexMapping(np.arange(num_elems1))
+        elem_right_map = IndexMapping(num_elems1 + np.arange(num_elems2))
+        elem_ind_remap = JoinedIndexMapping(elem_left_map, elem_right_map)
 
         # remap element ids in bdspec
-        bdspec1 = dataclass_replace(
-            model1.boundaries,
-            element_inds=elem_ind_remap.apply(model1.boundaries.element_inds),
-        )
-        num_elems1 = elem1_remapped.shape[0]
-        bdspec2 = dataclass_replace(
-            model2.boundaries,
-            element_inds=elem_ind_remap.apply(
-                model2.boundaries.element_inds + num_elems1
-            ),
-        )
+        bdspec1 = model1.boundaries.remapped_elements(elem_ind_remap.left_to_joined)
+        bdspec2 = model2.boundaries.remapped_elements(elem_ind_remap.right_to_joined)
         combined_bdries = BoundarySpec.union(bdspec1, bdspec2)
+
+        # remap element and node ids in physical groups
+        combined_physical_groups = {}
+        for name in model1.physical_groups.keys() | model2.physical_groups.keys():
+            pg1 = model1.physical_groups.get(name, NullPhysicalGroup(name))
+            pg2 = model2.physical_groups.get(name, NullPhysicalGroup(name))
+
+            pg1.remap_nodes(nodemapu.left_to_joined)
+            pg2.remap_nodes(nodemapu.right_to_joined)
+            pg1.remap_elements(elem_ind_remap.left_to_joined)
+            pg2.remap_elements(elem_ind_remap.right_to_joined)
+
+            combined_physical_groups[name] = UnionPhysicalGroup(name, pg1, pg2)
+
         # remap element ids in materials
         elem_materials = np.full(elemu.shape[0], 0, dtype=np.uint8)
         elem_materials[elemu_inv[:num_elems1]] = model1.materials
@@ -117,10 +137,15 @@ class Model:
                 elemu_inv[num_elems1:],
             ),
             nonconforming_interfaces=ncis,
+            physical_groups=combined_physical_groups,
         )
 
     @staticmethod
-    def from_meshed_surface(surface: list[int] | int, gmsh: GmshContext) -> "Model":
+    def from_meshed_surface(
+        surface: list[int] | int,
+        gmsh: GmshContext,
+        physical_group_captures: Iterable[str] | None = None,
+    ) -> "Model":
         """Given an initialized mesh in gmsh, constructs a Model
         that stores the data of a surface or collection of
         surfaces with the given tag(s). The resulting Model is
@@ -129,6 +154,7 @@ class Model:
         Args:
             surface (list[int] | int): gmsh surface tag(s)
             gmsh (GmshContext): the gmsh handshake to secure active environment.
+            physical_group_captures (list[str] | None): a list of the physical groups to store.
         """
         if isinstance(surface, list):
             if len(surface) == 0:
@@ -206,6 +232,18 @@ class Model:
                 [(2, surface)], oriented=False, recursive=False
             )
 
+            physical_groups: dict[str, PhysicalGroup] = {}
+            for name in (
+                [] if physical_group_captures is None else physical_group_captures
+            ):
+                physical_groups[name] = physical_group_from_name(
+                    gmsh,
+                    node_indexing.invert(element_nodes),
+                    node_indexing,
+                    node_locs,
+                    name,
+                )
+
             return Model(
                 nodes=node_locs,
                 elements=element_nodes,
@@ -215,15 +253,20 @@ class Model:
                     [tag for dim, tag in boundary_entities if dim == 1],
                     node_indexing.invert(element_nodes),
                     node_indexing,
-                    node_locs
+                    node_locs,
                 ),
                 _node_gmshtag_to_index_mapping=node_indexing,
                 conforming_interfaces=ConformingInterfaces.from_element_node_matrix(
                     element_nodes
                 ),
+                physical_groups=physical_groups,
             )
         else:
             return Model.union(
-                Model.from_meshed_surface(surface[0], gmsh),
-                Model.from_meshed_surface(surface[1:], gmsh),
+                Model.from_meshed_surface(
+                    surface[0], gmsh, physical_group_captures=physical_group_captures
+                ),
+                Model.from_meshed_surface(
+                    surface[1:], gmsh, physical_group_captures=physical_group_captures
+                ),
             )

--- a/scripts/gmshlayerbuilder/_gmsh2meshfem/dim2/model/physical_group.py
+++ b/scripts/gmshlayerbuilder/_gmsh2meshfem/dim2/model/physical_group.py
@@ -1,17 +1,109 @@
+import copy
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import override
 
 import numpy as np
-
 from _gmsh2meshfem.gmsh_dep import GmshContext
 
 from .boundary import BoundarySpec
+from .edges import edges_of_all_elements, unique_edges
 from .index_mapping import IndexMapping
 
 
-class PhysicalGroupImpl(ABC):
-    dim: int
+@dataclass(frozen=True)
+class PhysicalGroupBase(ABC):
+    """Base class for physical groups, which are named collections of gmsh entities.
+    PhysicalGroup classes are expected to persist after closing the gmsh context, but are
+    permitted to use them during construction.
+    """
+
     name: str
+
+    @abstractmethod
+    def remap_indices(
+        self,
+        /,
+        node_mapping: IndexMapping | None = None,
+        element_mapping: IndexMapping | None = None,
+    ) -> "PhysicalGroupBase":
+        """Remaps the node and element indices of this physical group. Indices are remapped
+        according to <node/element>_mapping.apply(indices)
+
+        Args:
+            node_mapping (IndexMapping | None, optional): the index mapping that takes the
+                node indices to their new values, or None if the node indices should be kept
+                the same. Defaults to None.
+            element_mapping (IndexMapping | None, optional): the index mapping that takes the
+                element indices to their new values, or None if the element indices should be kept
+                the same. Defaults to None.
+
+        Returns:
+            PhysicalGroupBase: The physical group with remapped values
+        """
+        raise NotImplementedError
+
+    def remap_nodes(self, node_mapping: IndexMapping) -> "PhysicalGroupBase":
+        """If a node reindexing occurs, call this method to apply it to the physical group.
+        Nodes are remapped according to node_mapping.apply(node_indices)
+
+        Args:
+            node_mapping (IndexMapping):
+        """
+        return self.remap_indices(node_mapping=node_mapping)
+
+    def remap_elements(self, element_mapping: IndexMapping) -> "PhysicalGroupBase":
+        """If an element reindexing occurs, call this method to apply it to the physical group.
+        Elements are remapped according to element_mapping.apply(element_indices)
+
+        Args:
+            element_mapping (IndexMapping):
+        """
+        return self.remap_indices(element_mapping=element_mapping)
+
+    @abstractmethod
+    def get_all_points(self, include_from_higher_dim: bool = False) -> np.ndarray:
+        """Recovers all of the points (node indices) from this physical group.
+        When `include_from_higher_dim` is set to true, nodes from edges and elements
+        are included. That is, higher dimensional physical groups are not skipped.
+
+        Args:
+            include_from_higher_dim (bool, optional): whether to pull from higher
+                dimensional groups. Defaults to False.
+
+        Returns:
+            np.ndarray: a shape (N,) array containing node indices.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_all_edges(
+        self, include_from_higher_dim: bool = False
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Recovers all of the edges (element index + EdgeType) from this physical group.
+        When `include_from_higher_dim` is set to true, nodes from elements
+        are included. That is, higher dimensional physical groups are not skipped.
+
+        Args:
+            include_from_higher_dim (bool, optional): whether to pull from higher
+                dimensional groups. Defaults to False.
+
+        Returns:
+            tuple[np.ndarray, np.ndarray]: Two shape (N,) integer arrays. The first stores the
+                element indices, while the second stores the edge types.
+        """
+        raise NotImplementedError
+
+
+@dataclass(frozen=True, init=False)
+class SingleDimensionPhysicalGroup(PhysicalGroupBase):
+    """The bulk of physical groups are stored in these, which perform the main logic of
+    extracting gmsh physical groups.
+
+    A SingleDimensionPhysicalGroup will store elements of only one number of dimensions.
+    """
+
+    dim: int
 
     def __init__(
         self,
@@ -19,7 +111,6 @@ class PhysicalGroupImpl(ABC):
         element_nodes: np.ndarray,
         node_mapping: IndexMapping,
         node_coords: np.ndarray,
-        dim: int,
         name: str | None = None,
         tag: int | None = None,
     ):
@@ -33,7 +124,6 @@ class PhysicalGroupImpl(ABC):
             element_nodes (np.ndarray): the node tags (shape = (N,9)) of all elements.
             node_mapping (IndexMapping): the index mapping of node tags.
             node_coords (np.ndarray): the coordinate array, re-indexed by node_mapping.
-            dim (int): dimension of the element
             name (str | None, optional): identifier of the group. If multiple groups have the same
                 name, then all of them with the correct dimension are taken. This behavior overrides
                 the `tag` argument. If specified, `tag` is not needed.
@@ -41,7 +131,14 @@ class PhysicalGroupImpl(ABC):
                 If both `name` and `tag` are given, all tags with the given name are chosen, but if
                 `tag` is not among them, an error is thrown.
         """
-        self.dim = dim
+        if not hasattr(self.__class__, "_dim"):
+            e = TypeError(
+                "SingleDimensionPhysicalGroup requires subclasses to have a `_dim` attribute "
+                f"to recover the dimension, but {self.__class__} does not have one."
+            )
+            raise e
+        dim = self.__class__._dim  # pyright: ignore
+        object.__setattr__(self, "dim", dim)
 
         # a name may correspond with multiple tags
         tags = []
@@ -50,13 +147,13 @@ class PhysicalGroupImpl(ABC):
             if tag is None:
                 e = ValueError("`name` or `tag` must be specified!")
                 raise e
-            self.name = gmsh.model.get_physical_name(dim, tag)
+            name = gmsh.model.get_physical_name(dim, tag)
         else:
-            self.name = name
             for _dim, _tag in gmsh.model.get_physical_groups():
                 if _dim == dim and gmsh.model.get_physical_name(_dim, _tag) == name:
                     # found a tag with this identity
                     tags.append(_tag)
+        object.__setattr__(self, "name", name)
 
         if tag is not None and tag not in tags:
             e = ValueError(
@@ -65,7 +162,7 @@ class PhysicalGroupImpl(ABC):
             )
             raise e
 
-        # "tag" no longer needed.
+        # we have our list of tags to pull from; dispose of them after getting all data from gmsh.
 
         entities = []
         for tag in tags:
@@ -86,7 +183,9 @@ class PhysicalGroupImpl(ABC):
         raise NotImplementedError
 
 
-class PhysicalGroup0D(PhysicalGroupImpl):
+@dataclass(frozen=True, init=False)
+class PhysicalGroup0D(SingleDimensionPhysicalGroup):
+    _dim = 0
     nodes: np.ndarray
 
     @override
@@ -111,11 +210,44 @@ class PhysicalGroup0D(PhysicalGroupImpl):
                     )
                 },
             )
-        self.nodes = np.concatenate(nodelists)
+        if nodelists:
+            nodes = np.unique(np.concatenate(nodelists))
+        else:
+            nodes = np.empty((0,), dtype=np.uint64)
+        object.__setattr__(self, "nodes", nodes)
+
+    @override
+    def remap_indices(
+        self,
+        /,
+        node_mapping: IndexMapping | None = None,
+        element_mapping: IndexMapping | None = None,
+    ) -> "PhysicalGroupBase":
+        if node_mapping is None:
+            return self
+        cpy = copy.copy(self)
+        object.__setattr__(cpy, "nodes", node_mapping.apply(self.nodes))
+        return cpy
+
+    @override
+    def get_all_points(self, include_from_higher_dim: bool = False) -> np.ndarray:
+        return self.nodes
+
+    @override
+    def get_all_edges(
+        self, include_from_higher_dim: bool = False
+    ) -> tuple[np.ndarray, np.ndarray]:
+        return np.empty((0,), dtype=np.uint64), np.empty((0,), dtype=np.uint8)
 
 
-class PhysicalGroup1D(PhysicalGroupImpl):
+@dataclass(frozen=True, init=False)
+class PhysicalGroup1D(SingleDimensionPhysicalGroup):
+    _dim = 1
     edges: BoundarySpec
+
+    # consider moving this somewhere else. The information is redundant, and is only stored to keep
+    # Model and PhysicalGroup in a one-way relationship.
+    nodes: np.ndarray
 
     @override
     def _populate(
@@ -128,6 +260,188 @@ class PhysicalGroup1D(PhysicalGroupImpl):
         entity_tags: list[int],
     ):
         assert dim == 1
-        self.edges = BoundarySpec.from_model_entity(
-            gmsh, entity_tags, element_nodes, node_mapping, node_coords
+        object.__setattr__(
+            self,
+            "edges",
+            BoundarySpec.from_model_entity(
+                gmsh, entity_tags, element_nodes, node_mapping, node_coords
+            ),
         )
+        object.__setattr__(
+            self,
+            "nodes",
+            edges_of_all_elements(element_nodes)[
+                self.edges.element_inds, self.edges.element_edges
+            ],
+        )
+
+    @override
+    def remap_indices(
+        self,
+        /,
+        node_mapping: IndexMapping | None = None,
+        element_mapping: IndexMapping | None = None,
+    ) -> "PhysicalGroupBase":
+        if node_mapping is None and element_mapping is None:
+            return self
+
+        cpy = copy.copy(self)
+        if element_mapping is not None:
+            object.__setattr__(
+                cpy, "edges", self.edges.remapped_elements(element_mapping)
+            )
+        if node_mapping is not None:
+            object.__setattr__(cpy, "nodes", node_mapping.apply(self.nodes))
+        return cpy
+
+    @override
+    def get_all_points(self, include_from_higher_dim: bool = False) -> np.ndarray:
+        if include_from_higher_dim:
+            return np.unique(self.nodes)
+        return np.empty((0,), dtype=np.uint64)
+
+    @override
+    def get_all_edges(
+        self, include_from_higher_dim: bool = False
+    ) -> tuple[np.ndarray, np.ndarray]:
+        return unique_edges(self.edges.element_inds, self.edges.element_edges)
+
+
+@dataclass(frozen=True, init=False)
+class NullPhysicalGroup(PhysicalGroupBase):
+    @override
+    def remap_indices(
+        self,
+        /,
+        node_mapping: IndexMapping | None = None,
+        element_mapping: IndexMapping | None = None,
+    ) -> "PhysicalGroupBase":
+        return self
+
+    @override
+    def get_all_points(self, include_from_higher_dim: bool = False) -> np.ndarray:
+        return np.empty((0,), dtype=np.uint64)
+
+    @override
+    def get_all_edges(
+        self, include_from_higher_dim: bool = False
+    ) -> tuple[np.ndarray, np.ndarray]:
+        return np.empty((0,), dtype=np.uint64), np.empty((0,), dtype=np.uint8)
+
+
+@dataclass(frozen=True, init=False)
+class UnionPhysicalGroup(PhysicalGroupBase):
+    physical_groups: list[PhysicalGroupBase]
+
+    def __init__(
+        self, name: str, *groups: PhysicalGroupBase, verify_names: bool = True
+    ):
+        super().__init__(name=name)
+        object.__setattr__(self, "physical_groups", [])
+
+        def add_group(group: PhysicalGroupBase):
+            if verify_names and group.name != name:
+                e = ValueError(
+                    "When constructing UnionPhysicalGroup of name "
+                    f"{name}: encountered different name {group.name}."
+                )
+                raise e
+
+            # expand unions (basedbasedbasedbased). We should have a depth of one
+            if isinstance(group, UnionPhysicalGroup):
+                for subgp in group.physical_groups:
+                    add_group(subgp)
+                return
+
+            # blank. We can skip
+            if isinstance(group, NullPhysicalGroup):
+                return
+
+            self.physical_groups.append(group)
+
+        for group in groups:
+            add_group(group)
+
+    @override
+    def remap_indices(
+        self,
+        /,
+        node_mapping: IndexMapping | None = None,
+        element_mapping: IndexMapping | None = None,
+    ) -> "PhysicalGroupBase":
+        return UnionPhysicalGroup(
+            self.name,
+            *(
+                gp.remap_indices(
+                    node_mapping=node_mapping, element_mapping=element_mapping
+                )
+                for gp in self.physical_groups
+            ),
+            verify_names=False,
+        )
+
+    @override
+    def get_all_points(self, include_from_higher_dim: bool = False) -> np.ndarray:
+        collected = [
+            gp.get_all_points(include_from_higher_dim=include_from_higher_dim)
+            for gp in self.physical_groups
+        ]
+        if collected:
+            return np.unique(np.concatenate(collected))
+        else:
+            return np.empty((0,), dtype=np.uint64)
+
+    @override
+    def get_all_edges(
+        self, include_from_higher_dim: bool = False
+    ) -> tuple[np.ndarray, np.ndarray]:
+        collected_elems = []
+        collected_edgetypes = []
+        for gp in self.physical_groups:
+            elem, edge = gp.get_all_edges(
+                include_from_higher_dim=include_from_higher_dim
+            )
+            collected_elems.append(elem)
+            collected_edgetypes.append(edge)
+
+        if collected_elems:
+            return unique_edges(
+                np.concatenate(collected_elems), np.concatenate(collected_edgetypes)
+            )
+        else:
+            return np.empty((0,), dtype=np.uint64), np.empty((0,), dtype=np.uint8)
+
+
+PhysicalGroup = PhysicalGroupBase
+
+
+def physical_group_from_name(
+    gmsh: GmshContext,
+    element_nodes: np.ndarray,
+    node_mapping: IndexMapping,
+    node_coords: np.ndarray,
+    name: str,
+):
+    """Recovers the elements of a given dimension associated with a physical group tag or name.
+    the gmsh context is only used in generation.
+    `element_nodes` are the un-remapped node indices of each element,
+    in the same order as `element_mapping.original_tag_list`.
+
+    Args:
+        gmsh (GmshContext): gmsh context
+        element_nodes (np.ndarray): the node tags (shape = (N,9)) of all elements.
+        node_mapping (IndexMapping): the index mapping of node tags.
+        node_coords (np.ndarray): the coordinate array, re-indexed by node_mapping.
+        name (str): identifier of the group.
+    """
+
+    # get one group for each dimension
+    pg0d = PhysicalGroup0D(gmsh, element_nodes, node_mapping, node_coords, name=name)
+    pg1d = PhysicalGroup1D(gmsh, element_nodes, node_mapping, node_coords, name=name)
+
+    if len(pg1d.edges.edge_tags) > 0:
+        return pg1d
+    elif len(pg0d.nodes) > 0:
+        return pg0d
+
+    return NullPhysicalGroup(name)

--- a/scripts/gmshlayerbuilder/_gmsh2meshfem/dim2/model/physical_group.py
+++ b/scripts/gmshlayerbuilder/_gmsh2meshfem/dim2/model/physical_group.py
@@ -1,0 +1,133 @@
+from abc import ABC, abstractmethod
+from typing import override
+
+import numpy as np
+
+from _gmsh2meshfem.gmsh_dep import GmshContext
+
+from .boundary import BoundarySpec
+from .index_mapping import IndexMapping
+
+
+class PhysicalGroupImpl(ABC):
+    dim: int
+    name: str
+
+    def __init__(
+        self,
+        gmsh: GmshContext,
+        element_nodes: np.ndarray,
+        node_mapping: IndexMapping,
+        node_coords: np.ndarray,
+        dim: int,
+        name: str | None = None,
+        tag: int | None = None,
+    ):
+        """Recovers the elements of a given dimension associated with a physical group tag or name.
+        the gmsh context is only used in generation.
+        `element_nodes` are the un-remapped node indices of each element,
+        in the same order as `element_mapping.original_tag_list`.
+
+        Args:
+            gmsh (GmshContext): gmsh context
+            element_nodes (np.ndarray): the node tags (shape = (N,9)) of all elements.
+            node_mapping (IndexMapping): the index mapping of node tags.
+            node_coords (np.ndarray): the coordinate array, re-indexed by node_mapping.
+            dim (int): dimension of the element
+            name (str | None, optional): identifier of the group. If multiple groups have the same
+                name, then all of them with the correct dimension are taken. This behavior overrides
+                the `tag` argument. If specified, `tag` is not needed.
+            tag (int | None, optional): identifier of the group. If specified, `name` is not needed.
+                If both `name` and `tag` are given, all tags with the given name are chosen, but if
+                `tag` is not among them, an error is thrown.
+        """
+        self.dim = dim
+
+        # a name may correspond with multiple tags
+        tags = []
+
+        if name is None:
+            if tag is None:
+                e = ValueError("`name` or `tag` must be specified!")
+                raise e
+            self.name = gmsh.model.get_physical_name(dim, tag)
+        else:
+            self.name = name
+            for _dim, _tag in gmsh.model.get_physical_groups():
+                if _dim == dim and gmsh.model.get_physical_name(_dim, _tag) == name:
+                    # found a tag with this identity
+                    tags.append(_tag)
+
+        if tag is not None and tag not in tags:
+            e = ValueError(
+                f"`name` {name} was specified, but given `tag` {tag} (name = "
+                f"{gmsh.model.get_physical_name(dim, tag)}) was not included!"
+            )
+            raise e
+
+        # "tag" no longer needed.
+
+        entities = []
+        for tag in tags:
+            entities.extend(gmsh.model.get_entities_for_physical_group(dim, tag))
+
+        self._populate(gmsh, element_nodes, node_mapping, node_coords, dim, entities)
+
+    @abstractmethod
+    def _populate(
+        self,
+        gmsh: GmshContext,
+        element_nodes: np.ndarray,
+        node_mapping: IndexMapping,
+        node_coords: np.ndarray,
+        dim: int,
+        entity_tags: list[int],
+    ) -> None:
+        raise NotImplementedError
+
+
+class PhysicalGroup0D(PhysicalGroupImpl):
+    nodes: np.ndarray
+
+    @override
+    def _populate(
+        self,
+        gmsh: GmshContext,
+        element_nodes: np.ndarray,
+        node_mapping: IndexMapping,
+        node_coords: np.ndarray,
+        dim: int,
+        entity_tags: list[int],
+    ):
+        assert dim == 0
+        nodelists = []
+        for entity in entity_tags:
+            gmsh.for_element_types_in_entity(
+                dim,
+                entity,
+                mapping={
+                    15: lambda elem_tags, node_tags: nodelists.append(
+                        node_mapping.apply(node_tags)
+                    )
+                },
+            )
+        self.nodes = np.concatenate(nodelists)
+
+
+class PhysicalGroup1D(PhysicalGroupImpl):
+    edges: BoundarySpec
+
+    @override
+    def _populate(
+        self,
+        gmsh: GmshContext,
+        element_nodes: np.ndarray,
+        node_mapping: IndexMapping,
+        node_coords: np.ndarray,
+        dim: int,
+        entity_tags: list[int],
+    ):
+        assert dim == 1
+        self.edges = BoundarySpec.from_model_entity(
+            gmsh, entity_tags, element_nodes, node_mapping, node_coords
+        )

--- a/scripts/gmshlayerbuilder/_gmsh2meshfem/topo_import/layer_builder/layeredbuilder.py
+++ b/scripts/gmshlayerbuilder/_gmsh2meshfem/topo_import/layer_builder/layeredbuilder.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import Literal, get_args as recover_vals
+from typing import Literal
 
 from _gmsh2meshfem.gmsh_dep import GmshContext
 from _gmsh2meshfem.dim2.model import Model
@@ -7,7 +7,7 @@ from _gmsh2meshfem.dim2.model import Model
 from .layer import Layer, LayerBoundary
 
 BoundaryConditionType = Literal["neumann", "acoustic_free_surface", "absorbing"]
-BOUNDARY_TYPES = recover_vals(BoundaryConditionType)
+BOUNDARY_TYPES = ["neumann", "acoustic_free_surface", "absorbing"]
 
 
 class LayeredBuilder:
@@ -34,10 +34,10 @@ class LayeredBuilder:
         self,
         xlow: float,
         xhigh: float,
-        set_left_boundary: BoundaryConditionType = BOUNDARY_TYPES[0],
-        set_right_boundary: BoundaryConditionType = BOUNDARY_TYPES[0],
-        set_top_boundary: BoundaryConditionType = BOUNDARY_TYPES[0],
-        set_bottom_boundary: BoundaryConditionType = BOUNDARY_TYPES[0],
+        set_left_boundary: BoundaryConditionType = "neumann",
+        set_right_boundary: BoundaryConditionType = "neumann",
+        set_top_boundary: BoundaryConditionType = "neumann",
+        set_bottom_boundary: BoundaryConditionType = "neumann",
     ):
         self.xlow = xlow
         self.xhigh = xhigh

--- a/scripts/gmshlayerbuilder/_gmsh2meshfem/topo_import/layer_builder/layeredbuilder.py
+++ b/scripts/gmshlayerbuilder/_gmsh2meshfem/topo_import/layer_builder/layeredbuilder.py
@@ -1,10 +1,13 @@
 import itertools
-from typing import Literal
+from typing import Literal, get_args as recover_vals
 
 from _gmsh2meshfem.gmsh_dep import GmshContext
 from _gmsh2meshfem.dim2.model import Model
 
 from .layer import Layer, LayerBoundary
+
+BoundaryConditionType = Literal["neumann", "acoustic_free_surface", "absorbing"]
+BOUNDARY_TYPES = recover_vals(BoundaryConditionType)
 
 
 class LayeredBuilder:
@@ -18,12 +21,10 @@ class LayeredBuilder:
     boundaries: list[LayerBoundary]
     layers: list[Layer]
 
-    domain_boundary_type_top: Literal["neumann", "acoustic_free_surface", "absorbing"]
-    domain_boundary_type_bottom: Literal[
-        "neumann", "acoustic_free_surface", "absorbing"
-    ]
-    domain_boundary_type_left: Literal["neumann", "acoustic_free_surface", "absorbing"]
-    domain_boundary_type_right: Literal["neumann", "acoustic_free_surface", "absorbing"]
+    domain_boundary_type_top: BoundaryConditionType
+    domain_boundary_type_bottom: BoundaryConditionType
+    domain_boundary_type_left: BoundaryConditionType
+    domain_boundary_type_right: BoundaryConditionType
 
     @property
     def width(self):
@@ -33,18 +34,10 @@ class LayeredBuilder:
         self,
         xlow: float,
         xhigh: float,
-        set_left_boundary: Literal[
-            "neumann", "acoustic_free_surface", "absorbing"
-        ] = "neumann",
-        set_right_boundary: Literal[
-            "neumann", "acoustic_free_surface", "absorbing"
-        ] = "neumann",
-        set_top_boundary: Literal[
-            "neumann", "acoustic_free_surface", "absorbing"
-        ] = "neumann",
-        set_bottom_boundary: Literal[
-            "neumann", "acoustic_free_surface", "absorbing"
-        ] = "neumann",
+        set_left_boundary: BoundaryConditionType = BOUNDARY_TYPES[0],
+        set_right_boundary: BoundaryConditionType = BOUNDARY_TYPES[0],
+        set_top_boundary: BoundaryConditionType = BOUNDARY_TYPES[0],
+        set_bottom_boundary: BoundaryConditionType = BOUNDARY_TYPES[0],
     ):
         self.xlow = xlow
         self.xhigh = xhigh
@@ -78,9 +71,14 @@ class LayeredBuilder:
                 left_walls.append(layer_result.left_wall_index)
                 right_walls.append(layer_result.right_wall_index)
 
-            # physical groups in model space. must sync with geo
+            # physical groups in model space, but our geometry construction is
+            # currently only in geo space. Sync so physical groups can access
+            # entities
             gmsh.model.geo.synchronize()
 
+            # set physical groups for 4 sides. These aren't used by Model,
+            # but may be useful for future implementation.
+            # We will select from these physical groups when setting BCs
             left_tag = gmsh.model.add_physical_group(
                 1, left_walls, name="left_boundary"
             )
@@ -94,15 +92,10 @@ class LayeredBuilder:
                 1, [built_layerbds[-1].curve_copy], name="top_boundary"
             )
 
-            bdry_neumann = []
-            bdry_afs = []
-            bdry_abs = []
+            # append edge tags to these arrays
+            # we will physical group afterwards
+            bdry_by_name = {condition: [] for condition in BOUNDARY_TYPES}
 
-            bdry_by_name = {
-                "neumann": bdry_neumann,
-                "acoustic_free_surface": bdry_afs,
-                "absorbing": bdry_abs,
-            }
             bdry_by_name[self.domain_boundary_type_bottom].extend(
                 gmsh.model.get_entities_for_physical_group(1, bottom_tag)
             )
@@ -115,6 +108,8 @@ class LayeredBuilder:
             bdry_by_name[self.domain_boundary_type_right].extend(
                 gmsh.model.get_entities_for_physical_group(1, right_tag)
             )
+
+            # set physical group
             for name, bdry in bdry_by_name.items():
                 if bdry:
                     gmsh.model.add_physical_group(1, bdry, name=name)

--- a/scripts/gmshlayerbuilder/_gmsh2meshfem/topo_import/topo_reader.py
+++ b/scripts/gmshlayerbuilder/_gmsh2meshfem/topo_import/topo_reader.py
@@ -1,9 +1,12 @@
 from pathlib import Path
-from typing import Literal
 
 from .layer_builder.layer_boundaries import LerpLayerBoundary
 from .layer_builder.layer import Layer
-from .layer_builder.layeredbuilder import LayeredBuilder
+from .layer_builder.layeredbuilder import (
+    LayeredBuilder,
+    BoundaryConditionType,
+    BOUNDARY_TYPES,
+)
 
 
 # processes out comments from topo file
@@ -28,18 +31,10 @@ def _file_get_line(file_input_stream):
 
 def builder_from_topo_file(
     file: Path | str,
-    set_left_boundary: Literal[
-        "neumann", "acoustic_free_surface", "absorbing"
-    ] = "neumann",
-    set_right_boundary: Literal[
-        "neumann", "acoustic_free_surface", "absorbing"
-    ] = "neumann",
-    set_top_boundary: Literal[
-        "neumann", "acoustic_free_surface", "absorbing"
-    ] = "neumann",
-    set_bottom_boundary: Literal[
-        "neumann", "acoustic_free_surface", "absorbing"
-    ] = "neumann",
+    set_left_boundary: BoundaryConditionType = BOUNDARY_TYPES[0],
+    set_right_boundary: BoundaryConditionType = BOUNDARY_TYPES[0],
+    set_top_boundary: BoundaryConditionType = BOUNDARY_TYPES[0],
+    set_bottom_boundary: BoundaryConditionType = BOUNDARY_TYPES[0],
 ) -> LayeredBuilder:
     with Path(file).open("r") as f:
         ninterfaces = int(_file_get_line(f))

--- a/scripts/gmshlayerbuilder/_gmsh2meshfem/topo_import/topo_reader.py
+++ b/scripts/gmshlayerbuilder/_gmsh2meshfem/topo_import/topo_reader.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Literal
 
 from .layer_builder.layer_boundaries import LerpLayerBoundary
 from .layer_builder.layer import Layer
@@ -27,6 +28,18 @@ def _file_get_line(file_input_stream):
 
 def builder_from_topo_file(
     file: Path | str,
+    set_left_boundary: Literal[
+        "neumann", "acoustic_free_surface", "absorbing"
+    ] = "neumann",
+    set_right_boundary: Literal[
+        "neumann", "acoustic_free_surface", "absorbing"
+    ] = "neumann",
+    set_top_boundary: Literal[
+        "neumann", "acoustic_free_surface", "absorbing"
+    ] = "neumann",
+    set_bottom_boundary: Literal[
+        "neumann", "acoustic_free_surface", "absorbing"
+    ] = "neumann",
 ) -> LayeredBuilder:
     with Path(file).open("r") as f:
         ninterfaces = int(_file_get_line(f))
@@ -71,10 +84,17 @@ def builder_from_topo_file(
                 layer_boundaries[ilayer + 1].points
             )
             layer_aspect_ratio = (xmax - xmin) / (zavg_above - zavg_below)
-            nx = max(1,round(nz * layer_aspect_ratio))
-            layers.append(Layer(nx,nz))
+            nx = max(1, round(nz * layer_aspect_ratio))
+            layers.append(Layer(nx, nz))
 
-        builder = LayeredBuilder(xmin, xmax)
+        builder = LayeredBuilder(
+            xmin,
+            xmax,
+            set_bottom_boundary=set_bottom_boundary,
+            set_top_boundary=set_top_boundary,
+            set_left_boundary=set_left_boundary,
+            set_right_boundary=set_right_boundary,
+        )
         builder.layers = layers
         builder.boundaries = layer_boundaries
 

--- a/scripts/gmshlayerbuilder/_gmsh2meshfem/topo_import/topo_reader.py
+++ b/scripts/gmshlayerbuilder/_gmsh2meshfem/topo_import/topo_reader.py
@@ -5,7 +5,6 @@ from .layer_builder.layer import Layer
 from .layer_builder.layeredbuilder import (
     LayeredBuilder,
     BoundaryConditionType,
-    BOUNDARY_TYPES,
 )
 
 
@@ -31,10 +30,10 @@ def _file_get_line(file_input_stream):
 
 def builder_from_topo_file(
     file: Path | str,
-    set_left_boundary: BoundaryConditionType = BOUNDARY_TYPES[0],
-    set_right_boundary: BoundaryConditionType = BOUNDARY_TYPES[0],
-    set_top_boundary: BoundaryConditionType = BOUNDARY_TYPES[0],
-    set_bottom_boundary: BoundaryConditionType = BOUNDARY_TYPES[0],
+    set_left_boundary: BoundaryConditionType = "neumann",
+    set_right_boundary: BoundaryConditionType = "neumann",
+    set_top_boundary: BoundaryConditionType = "neumann",
+    set_bottom_boundary: BoundaryConditionType = "neumann",
 ) -> LayeredBuilder:
     with Path(file).open("r") as f:
         ninterfaces = int(_file_get_line(f))


### PR DESCRIPTION
## Description

- Adds physical group captures to the `gmsh->meshfem` routines, as well as exporting afs and abs boundary conditions.
- `gmshlayerbuilder` now has options for setting top, bottom, left, and right conditions individually.

## Issue Number

closes #1184

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
