### PR TITLE
Added adjacency graph computation for MESHFEM3D

### DIFF
--- a/fortran/meshfem3d/meshfem3D/CMakeLists.txt
+++ b/fortran/meshfem3d/meshfem3D/CMakeLists.txt
@@ -36,6 +36,7 @@ set(MESHFEM3D_MESH_MODULE
     save_databases.F90
     store_boundaries.f90
     store_coords.f90
+    adjacency_graph.f90
 )
 
 if (ADIOS)

--- a/fortran/meshfem3d/meshfem3D/adjacency_graph.f90
+++ b/fortran/meshfem3d/meshfem3D/adjacency_graph.f90
@@ -1,0 +1,360 @@
+
+module adjacency_graph
+   implicit none
+
+contains
+
+   subroutine compute_adjacency_graph(nglob)
+      use constants_meshfem, only: NCORNERS, NGLLX_M, NGLLY_M, NGLLZ_M
+      use meshfem_par, only: ibool, adjacency_matrix, nspec, NPROC
+
+      implicit none
+
+      integer :: i, ier
+      integer, allocatable :: elmnts_bis(:)
+        integer :: ispec
+        integer :: nglob
+
+      if (NPROC > 1) then
+         write(*,*) 'Adjacency graph computation is only implemented for NPROC = 1'
+         stop "Adjacency graph computation error"
+      end if
+
+      allocate(elmnts_bis(0:NCORNERS*nspec-1),stat=ier)
+      allocate(adjacency_matrix(0:nspec-1, 0:nspec-1),stat=ier)
+
+      adjacency_matrix(:,:) = 0
+
+      do ispec = 0, nspec-1
+         elmnts_bis(ispec * NCORNERS + 0) = ibool(1,1,1,ispec)
+         elmnts_bis(ispec * NCORNERS + 1) = ibool(NGLLX_M,1,1,ispec)
+         elmnts_bis(ispec * NCORNERS + 2) = ibool(NGLLX_M,NGLLY_M,1,ispec)
+         elmnts_bis(ispec * NCORNERS + 3) = ibool(1,NGLLY_M,1,ispec)
+         elmnts_bis(ispec * NCORNERS + 4) = ibool(1,1,NGLLZ_M,ispec)
+         elmnts_bis(ispec * NCORNERS + 5) = ibool(NGLLX_M,1,NGLLZ_M,ispec)
+         elmnts_bis(ispec * NCORNERS + 6) = ibool(NGLLX_M,NGLLY_M,NGLLZ_M,ispec)
+         elmnts_bis(ispec * NCORNERS + 7) = ibool(1,NGLLY_M,NGLLZ_M,ispec)
+      end do
+
+      call build_adjacency_graph(elmnts_bis, nglob)
+
+   end subroutine compute_adjacency_graph
+
+   subroutine build_adjacency_graph(elmnts_bis, nglob)
+
+      use constants_meshfem, only: NCORNERS, MAX_NEIGHBORS
+      use meshfem_par, only: adjacency_matrix, nspec
+      implicit none
+
+      integer :: i, j, element, element1, element2
+      integer :: current_node
+      integer :: num_shared
+      integer :: corner_id1, corner_id2
+      integer :: edge_id1, edge_id2
+      integer :: face_id1, face_id2
+      integer :: shared_nodes(0:NCORNERS-1)
+
+
+      integer, intent(in) :: nglob
+      integer, intent(in) :: elmnts_bis(0:NCORNERS*nspec-1)
+      integer, allocatable :: nelements_for_each_node(:)
+      integer, allocatable :: elements_for_each_node(:,:)
+
+      if (.not. allocated(nelements_for_each_node)) allocate(nelements_for_each_node(0:nglob-1))
+      if (.not. allocated(elements_for_each_node)) allocate(elements_for_each_node(0:nglob-1, 0:MAX_NEIGHBORS-1))
+
+      nelements_for_each_node(:) = 0
+      elements_for_each_node(:,:) = -1
+
+      do i = 0, NCORNERS*nspec-1
+         element = i / NCORNERS
+         elements_for_each_node(elmnts_bis(i), nelements_for_each_node(elmnts_bis(i))) = element
+         nelements_for_each_node(elmnts_bis(i)) = nelements_for_each_node(elmnts_bis(i)) + 1
+      end do
+
+      do current_node = 0, nglob - 1
+         do i = 0, nelements_for_each_node(current_node) - 1
+            element1 = elements_for_each_node(current_node, i)
+            do j = i + 1, nelements_for_each_node(current_node) - 1
+               element2 = elements_for_each_node(current_node, j)
+               ! get shared nodes between element1 and element2
+               call get_shared_nodes(elmnts_bis, element1, element2, shared_nodes, num_shared)
+
+               if (num_shared == 0) cycle
+
+               if (num_shared == 1) then
+                  ! Only a corner node is shared
+                  call get_corner_id(element1, shared_nodes(0), corner_id1)
+                  call get_corner_id(element2, shared_nodes(0), corner_id2)
+                  adjacency_matrix(element1, element2) = corner_id1
+                  adjacency_matrix(element2, element1) = corner_id2
+
+
+               else if (num_shared == 2) then
+                  ! An edge is shared
+                  call get_edge_id(element1, shared_nodes(0), shared_nodes(1), edge_id1)
+                  call get_edge_id(element2, shared_nodes(0), shared_nodes(1), edge_id2)
+                  if (adjacency_matrix(element1, element2) == 0) then
+                     adjacency_matrix(element1, element2) = edge_id1
+                     adjacency_matrix(element2, element1) = edge_id2
+                  else
+                     ! Edge already recorded, do nothing
+                  end if
+               else if (num_shared == 4) then
+                  ! A face is shared
+                  call get_face_id(element1, shared_nodes(0), shared_nodes(1), shared_nodes(2), shared_nodes(3), face_id1)
+                  call get_face_id(element2, shared_nodes(0), shared_nodes(1), shared_nodes(2), shared_nodes(3), face_id2)
+                  if (adjacency_matrix(element1, element2) == 0) then
+                     adjacency_matrix(element1, element2) = face_id1
+                     adjacency_matrix(element2, element1) = face_id2
+                  else
+                     ! Face already recorded, do nothing
+                  end if
+               else
+                  ! More than 4 nodes shared - should not happen in a valid mesh
+                  write(*,*) 'Error: Wrong number of shared nodes between elements ', element1, ' and ', element2, ': ', num_shared
+                  stop "Invalid mesh: wrong number of shared nodes"
+               end if
+            end do
+         end do
+      end do
+
+   end subroutine build_adjacency_graph
+
+   subroutine get_shared_nodes(elmnts_bis, element1, element2, shared_nodes, num_shared)
+        use constants_meshfem, only: NCORNERS
+        use meshfem_par, only: nspec
+      implicit none
+      integer, intent(in) :: elmnts_bis(0:NCORNERS*nspec-1)
+      integer, intent(in) :: element1, element2
+      integer, intent(out) :: shared_nodes(0:NCORNERS-1)
+      integer, intent(out) :: num_shared
+
+      integer :: i, j
+      num_shared = 0
+      shared_nodes(:) = -1
+      do i = 0, NCORNERS-1
+         do j = 0, NCORNERS-1
+            if (elmnts_bis(element1 * NCORNERS + i) == elmnts_bis(element2 * NCORNERS + j)) then
+               shared_nodes(num_shared) = elmnts_bis(element1 * NCORNERS + i)
+               num_shared = num_shared + 1
+            end if
+         end do
+      end do
+   end subroutine get_shared_nodes
+
+   subroutine get_corner_id(element, node, corner_id)
+      use constants_meshfem, only: NGLLX_M, NGLLY_M, NGLLZ_M
+      use meshfem_par, only: ibool
+      implicit none
+
+      integer, intent(in) :: element, node
+      integer, intent(out) :: corner_id
+
+      ! Corner IDs are 19 - 26
+      ! bottom_front_left = 19,  ///< Bottom-front-left corner of the element
+      ! bottom_front_right = 20, ///< Bottom-front-right corner of the element
+      ! bottom_back_left = 21,   ///< Bottom-back-left corner of the element
+      ! bottom_back_right = 22,  ///< Bottom-back-right corner of the element
+      ! top_front_left = 23,     ///< Top-front-left corner of the element
+      ! top_front_right = 24,    ///< Top-front-right corner of the element
+      ! top_back_left = 25,      ///< Top-back-left corner of the element
+      ! top_back_right = 26      ///< Top-back-right corner of the element
+
+      if (ibool(1,1,1,element) == node) then
+         corner_id = 19
+      else if (ibool(NGLLX_M,1,1,element) == node) then
+         corner_id = 20
+      else if (ibool(1,NGLLY_M,1,element) == node) then
+         corner_id = 21
+      else if (ibool(NGLLX_M,NGLLY_M,1,element) == node) then
+         corner_id = 22
+      else if (ibool(1,1,NGLLZ_M,element) == node) then
+         corner_id = 23
+      else if (ibool(NGLLX_M,1,NGLLZ_M,element) == node) then
+         corner_id = 24
+      else if (ibool(1,NGLLY_M,NGLLZ_M,element) == node) then
+         corner_id = 25
+      else if (ibool(NGLLX_M,NGLLY_M,NGLLZ_M,element) == node) then
+         corner_id = 26
+      else
+         write(*,*) 'Error: Node ', node, ' is not a corner of element ', element
+         stop "Invalid corner node"
+      end if
+   end subroutine get_corner_id
+
+   subroutine get_edge_id(element, node1, node2, edge_id)
+    use constants_meshfem, only: NGLLX_M, NGLLY_M, NGLLZ_M
+    use meshfem_par, only: ibool
+      implicit none
+
+      integer, intent(in) :: element, node1, node2
+      integer, intent(out) :: edge_id
+
+      ! Edge IDs are 7 - 18
+      !   bottom_left = 7,         ///< Bottom-left edge of the element
+      !   bottom_right = 8,        ///< Bottom-right edge of the element
+      !   top_right = 9,           ///< Top-right edge of the element
+      !   top_left = 10,           ///< Top-left edge of the element
+      !   front_bottom = 11,       ///< Front-bottom edge of the element
+      !   front_top = 12,          ///< Front-top edge of the element
+      !   front_left = 13,         ///< Front-left edge of the element
+      !   front_right = 14,        ///< Front-right edge of the element
+      !   back_bottom = 15,        ///< Back-bottom edge of the element
+      !   back_top = 16,           ///< Back-top edge of the element
+      !   back_left = 17,          ///< Back-left edge of the element
+      !   back_right = 18,         ///< Back-right edge of the element
+
+      ! get nodes for each edge
+      integer :: bottom_face, top_face, front_face, back_face, left_face, right_face
+      integer, dimension(0:1) :: bottom_left_nodes, bottom_right_nodes, top_right_nodes, top_left_nodes, &
+         front_bottom_nodes, front_top_nodes, front_left_nodes, front_right_nodes, &
+         back_bottom_nodes, back_top_nodes, back_left_nodes, back_right_nodes
+
+      bottom_face = 1
+      top_face = NGLLZ_M
+      front_face = 1
+      back_face = NGLLY_M
+      left_face = 1
+      right_face = NGLLX_M
+
+      bottom_left_nodes = [ibool(left_face, front_face, bottom_face, element), &
+         ibool(left_face, back_face, bottom_face, element)]
+      bottom_right_nodes = [ibool(right_face, front_face, bottom_face, element), &
+         ibool(right_face, back_face, bottom_face, element)]
+      top_right_nodes = [ibool(right_face, front_face, top_face, element), &
+         ibool(right_face, back_face, top_face, element)]
+      top_left_nodes = [ibool(left_face, front_face, top_face, element), &
+         ibool(left_face, back_face, top_face, element)]
+      front_bottom_nodes = [ibool(left_face, front_face, bottom_face, element), &
+         ibool(right_face, front_face, bottom_face, element)]
+      front_top_nodes = [ibool(left_face, front_face, top_face, element), &
+         ibool(right_face, front_face, top_face, element)]
+      front_left_nodes = [ibool(left_face, front_face, bottom_face, element), &
+         ibool(left_face, front_face, top_face, element)]
+      front_right_nodes = [ibool(right_face, front_face, bottom_face, element), &
+         ibool(right_face, front_face, top_face, element)]
+      back_bottom_nodes = [ibool(left_face, back_face, bottom_face, element), &
+         ibool(right_face, back_face, bottom_face, element)]
+      back_top_nodes = [ibool(left_face, back_face, top_face, element), &
+         ibool(right_face, back_face, top_face, element)]
+      back_left_nodes = [ibool(left_face, back_face, bottom_face, element), &
+         ibool(left_face, back_face, top_face, element)]
+      back_right_nodes = [ibool(right_face, back_face, bottom_face, element), &
+         ibool(right_face, back_face, top_face, element)]
+
+      if ((node1 == bottom_left_nodes(0) .and. node2 == bottom_left_nodes(1)) .or. &
+         (node1 == bottom_left_nodes(1) .and. node2 == bottom_left_nodes(0))) then
+         edge_id = 7
+      else if ((node1 == bottom_right_nodes(0) .and. node2 == bottom_right_nodes(1)) .or. &
+         (node1 == bottom_right_nodes(1) .and. node2 == bottom_right_nodes(0))) then
+         edge_id = 8
+      else if ((node1 == top_right_nodes(0) .and. node2 == top_right_nodes(1)) .or. &
+         (node1 == top_right_nodes(1) .and. node2 == top_right_nodes(0))) then
+         edge_id = 9
+      else if ((node1 == top_left_nodes(0) .and. node2 == top_left_nodes(1)) .or. &
+         (node1 == top_left_nodes(1) .and. node2 == top_left_nodes(0))) then
+         edge_id = 10
+      else if ((node1 == front_bottom_nodes(0) .and. node2 == front_bottom_nodes(1)) .or. &
+         (node1 == front_bottom_nodes(1) .and. node2 == front_bottom_nodes(0))) then
+         edge_id = 11
+      else if ((node1 == front_top_nodes(0) .and. node2 == front_top_nodes(1)) .or. &
+         (node1 == front_top_nodes(1) .and. node2 == front_top_nodes(0))) then
+         edge_id = 12
+      else if ((node1 == front_left_nodes(0) .and. node2 == front_left_nodes(1)) .or. &
+         (node1 == front_left_nodes(1) .and. node2 == front_left_nodes(0))) then
+         edge_id = 13
+      else if ((node1 == front_right_nodes(0) .and. node2 == front_right_nodes(1)) .or. &
+         (node1 == front_right_nodes(1) .and. node2 == front_right_nodes(0))) then
+         edge_id = 14
+      else if ((node1 == back_bottom_nodes(0) .and. node2 == back_bottom_nodes(1)) .or. &
+         (node1 == back_bottom_nodes(1) .and. node2 == back_bottom_nodes(0))) then
+         edge_id = 15
+      else if ((node1 == back_top_nodes(0) .and. node2 == back_top_nodes(1)) .or. &
+         (node1 == back_top_nodes(1) .and. node2 == back_top_nodes(0))) then
+         edge_id = 16
+      else if ((node1 == back_left_nodes(0) .and. node2 == back_left_nodes(1)) .or. &
+         (node1 == back_left_nodes(1) .and. node2 == back_left_nodes(0))) then
+         edge_id = 17
+      else if ((node1 == back_right_nodes(0) .and. node2 == back_right_nodes(1)) .or. &
+         (node1 == back_right_nodes(1) .and. node2 == back_right_nodes(0))) then
+         edge_id = 18
+      else
+         write(*,*) 'Error: Nodes ', node1, ' and ', node2, ' do not form an edge of element ', element
+         stop "Invalid edge nodes"
+      end if
+
+   end subroutine get_edge_id
+
+   subroutine get_face_id(element, node1, node2, node3, node4, face_id)
+      use constants_meshfem, only: NGLLX_M, NGLLY_M, NGLLZ_M
+      use meshfem_par, only: ibool
+      implicit none
+
+      integer, intent(in) :: element
+      integer, intent(in) :: node1, node2, node3, node4
+      integer, intent(out) :: face_id
+
+      ! Face IDs are 1 - 6
+      !   bottom = 1,       ///< Bottom face of the element
+      !   right = 2,        ///< Right face of the element
+      !   top = 3,          ///< Top face of the element
+      !   left = 4,         ///< Left face of the element
+      !   front = 5,        ///< Front face of the element
+      !   back = 6          ///< Back face of the element
+
+      integer :: bottom_face, top_face, front_face, back_face, left_face, right_face
+      integer, dimension(4) :: bottom_face_nodes, right_face_nodes, top_face_nodes, left_face_nodes, &
+         front_face_nodes, back_face_nodes
+
+      bottom_face = 1
+      top_face = NGLLZ_M
+      front_face = 1
+      back_face = NGLLY_M
+      left_face = 1
+      right_face = NGLLX_M
+
+      bottom_face_nodes = [ibool(left_face, front_face, bottom_face, element), &
+         ibool(right_face, front_face, bottom_face, element), &
+         ibool(right_face, back_face, bottom_face, element), &
+         ibool(left_face, back_face, bottom_face, element)]
+      right_face_nodes = [ibool(right_face, front_face, bottom_face, element), &
+         ibool(right_face, back_face, bottom_face, element), &
+         ibool(right_face, back_face, top_face, element), &
+         ibool(right_face, front_face, top_face, element)]
+      top_face_nodes = [ibool(left_face, front_face, top_face, element), &
+         ibool(right_face, front_face, top_face, element), &
+         ibool(right_face, back_face, top_face, element), &
+         ibool(left_face, back_face, top_face, element)]
+      left_face_nodes = [ibool(left_face, front_face, bottom_face, element), &
+         ibool(left_face, back_face, bottom_face, element), &
+         ibool(left_face, back_face, top_face, element), &
+         ibool(left_face, front_face, top_face, element)]
+      front_face_nodes = [ibool(left_face, front_face, bottom_face, element), &
+         ibool(right_face, front_face, bottom_face, element), &
+         ibool(right_face, front_face, top_face, element), &
+         ibool(left_face, front_face, top_face, element)]
+      back_face_nodes = [ibool(left_face, back_face, bottom_face, element), &
+         ibool(right_face, back_face, bottom_face, element), &
+         ibool(right_face, back_face, top_face, element), &
+         ibool(left_face, back_face, top_face, element)]
+
+      if (all(merge([node1, node2, node3, node4] == bottom_face_nodes(:), .true., .false.))) then
+         face_id = 1
+      else if (all(merge([node1, node2, node3, node4] == right_face_nodes(:), .true., .false.))) then
+         face_id = 2
+      else if (all(merge([node1, node2, node3, node4] == top_face_nodes(:), .true., .false.))) then
+         face_id = 3
+      else if (all(merge([node1, node2, node3, node4] == left_face_nodes(:), .true., .false.))) then
+         face_id = 4
+      else if (all(merge([node1, node2, node3, node4] == front_face_nodes(:), .true., .false.))) then
+         face_id = 5
+      else if (all(merge([node1, node2, node3, node4] == back_face_nodes(:), .true., .false.))) then
+         face_id = 6
+      else
+         write(*,*) 'Error: Nodes ', node1, node2, node3, node4, ' do not form a face of element ', element
+         stop "Invalid face nodes"
+      end if
+
+   end subroutine get_face_id
+end module adjacency_graph

--- a/fortran/meshfem3d/meshfem3D/constants_meshfem3D.h
+++ b/fortran/meshfem3d/meshfem3D/constants_meshfem3D.h
@@ -64,3 +64,6 @@
   integer, parameter :: NGLOB_DOUBLING_SUPERBRICK = 67
   integer, parameter :: NSPEC_SUPERBRICK_1L = 28
   integer, parameter :: NGLOB_SUPERBRICK_1L = 58
+
+  integer, parameter :: MAX_NEIGHBORS = 300
+  integer, parameter :: NCORNERS = 8

--- a/fortran/meshfem3d/meshfem3D/create_meshfem_mesh.f90
+++ b/fortran/meshfem3d/meshfem3D/create_meshfem_mesh.f90
@@ -86,6 +86,8 @@ end module create_meshfem_par
   !! setting up wavefield discontinuity interface
   use shared_parameters, only: IS_WAVEFIELD_DISCONTINUITY
 
+  use adjacency_graph, only: compute_adjacency_graph
+
   implicit none
 
   ! local parameters
@@ -129,6 +131,9 @@ end module create_meshfem_par
 
   ! determine cavity
   call cmm_determine_cavity(nglob)
+
+  ! Build the adjacency graph
+  call compute_adjacency_graph(nglob)
 
   ! CPML initialization
   call create_CPML_regions(nspec,nglob,nodes_coords)

--- a/fortran/meshfem3d/meshfem3D/meshfem3D_par.f90
+++ b/fortran/meshfem3d/meshfem3D/meshfem3D_par.f90
@@ -67,6 +67,9 @@ module meshfem_par
   ! for loop on all the slices
   integer, dimension(:,:), allocatable :: addressing
 
+  ! Adjacency matrix
+  integer, dimension(:,:), allocatable :: adjacency_matrix
+
   ! addressing for all the slices
   integer, dimension(:), allocatable :: iproc_xi_slice,iproc_eta_slice
   integer :: iproc_xi_current,iproc_eta_current

--- a/include/enumerations/dim3/mesh_entities.hpp
+++ b/include/enumerations/dim3/mesh_entities.hpp
@@ -39,14 +39,7 @@ namespace dim3 {
  *  1 -------- 2
  * @endcode
  *
- * Face numbering (1-6):
- * - bottom (1): z-negative face
- * - right (2): x-positive face
- * - top (3): z-positive face
- * - left (4): x-negative face
- * - front (5): y-positive face
- * - back (6): y-negative face
- *
+ * Face numbering (1-6): Element boundary surfaces
  * Edge numbering (7-18): Connects adjacent faces
  * Corner numbering (19-26): Element vertices
  */

--- a/src/io/mesh/impl/fortran/dim3/meshfem3d/mesh.cpp
+++ b/src/io/mesh/impl/fortran/dim3/meshfem3d/mesh.cpp
@@ -1,4 +1,5 @@
 #include "mesh/mesh.hpp"
+#include "io/fortranio/interface.hpp"
 #include "io/interface.hpp"
 #include "io/mesh/impl/fortran/dim3/meshfem3d/read_absorbing_boundaries.hpp"
 #include "io/mesh/impl/fortran/dim3/meshfem3d/read_control_nodes.hpp"


### PR DESCRIPTION
## Description

Adds routines to compute adjancecy graph in MESHFEM3D. Neighboring elements are found using n-common nodes approach, where if elements can share single, 2, or 4 nodes (relating to corner, edge and face adjacencies)

## Issue Number

If there is an issue created for these changes, link it here

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
