### PR TITLE
[Fix] Performance issues with adjacency matrix implementation

### DIFF
--- a/include/mesh/dim2/adjacency_graph/adjacency_graph.hpp
+++ b/include/mesh/dim2/adjacency_graph/adjacency_graph.hpp
@@ -95,7 +95,13 @@ public:
    *
    * @return Mutable reference to the Boost adjacency_list graph
    */
-  Graph &graph() { return *p_graph_; }
+  Graph &graph() {
+    if (!p_graph_) {
+      p_graph_ = std::make_shared<Graph>();
+      throw std::runtime_error("Graph wasn't initialized during mesh reader");
+    }
+    return *p_graph_;
+  }
 
   /**
    * @brief Get const reference to the underlying graph
@@ -105,7 +111,12 @@ public:
    *
    * @return Const reference to the Boost adjacency_list graph
    */
-  const Graph &graph() const { return *p_graph_; }
+  const Graph &graph() const {
+    if (!p_graph_) {
+      throw std::runtime_error("Graph wasn't initialized during mesh reader");
+    }
+    return *p_graph_;
+  }
 
   // TODO(Rohit: ADJ_GRAPH_DEFAULT)
   // Graph should never be empty after it is made as default
@@ -117,7 +128,9 @@ public:
    *
    * @return true if the graph has no vertices, false otherwise
    */
-  bool empty() const { return boost::num_vertices(*p_graph_) == 0; }
+  bool empty() const {
+    return p_graph_ == nullptr || boost::num_vertices(*p_graph_) == 0;
+  }
 
   /**
    * @brief Assert that the adjacency graph is symmetric

--- a/include/mesh/dim2/adjacency_graph/adjacency_graph.hpp
+++ b/include/mesh/dim2/adjacency_graph/adjacency_graph.hpp
@@ -2,6 +2,7 @@
 
 #include "enumerations/interface.hpp"
 #include <boost/graph/adjacency_list.hpp>
+#include <memory>
 
 namespace specfem::mesh {
 
@@ -66,7 +67,7 @@ private:
                             boost::no_property, EdgeProperties>;
 
   /** @brief The underlying Boost graph storing adjacency relationships */
-  Graph graph_;
+  std::shared_ptr<Graph> p_graph_;
 
 public:
   /**
@@ -84,7 +85,7 @@ public:
    *
    * @param nspec Number of spectral elements in the mesh
    */
-  adjacency_graph(const int nspec) : graph_(nspec) {}
+  adjacency_graph(const int nspec) : p_graph_(std::make_shared<Graph>(nspec)) {}
 
   /**
    * @brief Get mutable reference to the underlying graph
@@ -94,7 +95,7 @@ public:
    *
    * @return Mutable reference to the Boost adjacency_list graph
    */
-  Graph &graph() { return graph_; }
+  Graph &graph() { return *p_graph_; }
 
   /**
    * @brief Get const reference to the underlying graph
@@ -104,7 +105,7 @@ public:
    *
    * @return Const reference to the Boost adjacency_list graph
    */
-  const Graph &graph() const { return graph_; }
+  const Graph &graph() const { return *p_graph_; }
 
   // TODO(Rohit: ADJ_GRAPH_DEFAULT)
   // Graph should never be empty after it is made as default
@@ -116,7 +117,7 @@ public:
    *
    * @return true if the graph has no vertices, false otherwise
    */
-  bool empty() const { return boost::num_vertices(graph_) == 0; }
+  bool empty() const { return boost::num_vertices(*p_graph_) == 0; }
 
   /**
    * @brief Assert that the adjacency graph is symmetric

--- a/include/mesh/dim2/adjacency_graph/adjacency_graph.hpp
+++ b/include/mesh/dim2/adjacency_graph/adjacency_graph.hpp
@@ -75,7 +75,7 @@ public:
    *
    * Creates an empty adjacency graph with no vertices or edges.
    */
-  adjacency_graph() = default;
+  adjacency_graph() : p_graph_(std::make_shared<Graph>(0)) {}
 
   /**
    * @brief Constructor with specified number of spectral elements
@@ -95,12 +95,7 @@ public:
    *
    * @return Mutable reference to the Boost adjacency_list graph
    */
-  Graph &graph() {
-    if (p_graph_ == nullptr) {
-      p_graph_ = std::make_shared<Graph>();
-    }
-    return *p_graph_;
-  }
+  Graph &graph() { return *p_graph_; }
 
   /**
    * @brief Get const reference to the underlying graph
@@ -110,12 +105,7 @@ public:
    *
    * @return Const reference to the Boost adjacency_list graph
    */
-  const Graph &graph() const {
-    if (p_graph_ == nullptr) {
-      p_graph_ = std::make_shared<Graph>();
-    }
-    return *p_graph_;
-  }
+  const Graph &graph() const { return *p_graph_; }
 
   // TODO(Rohit: ADJ_GRAPH_DEFAULT)
   // Graph should never be empty after it is made as default
@@ -127,9 +117,7 @@ public:
    *
    * @return true if the graph has no vertices, false otherwise
    */
-  bool empty() const {
-    return p_graph_ == nullptr || boost::num_vertices(*p_graph_) == 0;
-  }
+  bool empty() const { return (boost::num_vertices(*p_graph_) == 0); }
 
   /**
    * @brief Assert that the adjacency graph is symmetric

--- a/include/mesh/dim2/adjacency_graph/adjacency_graph.hpp
+++ b/include/mesh/dim2/adjacency_graph/adjacency_graph.hpp
@@ -96,9 +96,8 @@ public:
    * @return Mutable reference to the Boost adjacency_list graph
    */
   Graph &graph() {
-    if (!p_graph_) {
+    if (p_graph_ == nullptr) {
       p_graph_ = std::make_shared<Graph>();
-      throw std::runtime_error("Graph wasn't initialized during mesh reader");
     }
     return *p_graph_;
   }
@@ -112,8 +111,8 @@ public:
    * @return Const reference to the Boost adjacency_list graph
    */
   const Graph &graph() const {
-    if (!p_graph_) {
-      throw std::runtime_error("Graph wasn't initialized during mesh reader");
+    if (p_graph_ == nullptr) {
+      p_graph_ = std::make_shared<Graph>();
     }
     return *p_graph_;
   }

--- a/src/mesh/dim2/adjacency_graph/assert_symmetry.cpp
+++ b/src/mesh/dim2/adjacency_graph/assert_symmetry.cpp
@@ -3,6 +3,11 @@
 template <>
 void specfem::mesh::adjacency_graph<
     specfem::dimension::type::dim2>::assert_symmetry() const {
+
+  if (this->empty()) {
+    return; // An empty graph is symmetric
+  }
+
   const auto &g = this->graph();
 
   for (const auto &edge : boost::make_iterator_range(boost::edges(g))) {

--- a/tests/unit-tests/mesh/adjacency_graph/adjacency_graph.cpp
+++ b/tests/unit-tests/mesh/adjacency_graph/adjacency_graph.cpp
@@ -55,8 +55,6 @@ TEST(AdjacencyGraphTest, DefaultConstructor) {
   specfem::mesh::adjacency_graph<specfem::dimension::type::dim2> graph;
 
   EXPECT_TRUE(graph.empty());
-  EXPECT_EQ(boost::num_vertices(graph.graph()), 0);
-  EXPECT_EQ(boost::num_edges(graph.graph()), 0);
 }
 
 /**


### PR DESCRIPTION
## Description

The copy constructor for the adjacency graph is costly because it performs a deep copy. This PR alters the underlying implementation of the adjacency map to store a pointer to the graph, ensuring only one graph exists in the simulation. Any copies then only copy the pointers.

@icui merge this into your branch before running benchmarks. I'll run benchmarks for this branch, and we can compare to see if your implementation causes any regression in performance.  

## Issue Number

If there is an issue created for these changes, link it here

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
