### PR TITLE
Helpers for tests: field load_on_host + coupled_interface to_string()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,7 @@ add_library(
         src/enumerations/wavefield.cpp
         src/enumerations/connections.cpp
         src/enumerations/mesh_entities.cpp
+        src/enumerations/coupled_interface.cpp
 )
 
 target_link_libraries(

--- a/core/specfem/assembly/fields/data_access.hpp
+++ b/core/specfem/assembly/fields/data_access.hpp
@@ -8,5 +8,6 @@
 #include "dim2/add_on_device.hpp"
 #include "dim2/atomic_add_on_device.hpp"
 #include "dim2/load_on_device.hpp"
+#include "dim2/load_on_host.hpp"
 #include "dim2/store_on_device.hpp"
 #include "dim2/store_on_host.hpp"

--- a/core/specfem/assembly/fields/dim2/load_on_host.hpp
+++ b/core/specfem/assembly/fields/dim2/load_on_host.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+#include "impl/load_access_functions.hpp"
+#include "specfem/assembly/fields.hpp"
+#include "specfem/assembly/fields/impl/check_accessor_compatibility.hpp"
+#include "specfem/assembly/fields/impl/load_access_functions.hpp"
+#include "specfem/data_access.hpp"
+#include <Kokkos_Core.hpp>
+#include <type_traits>
+namespace specfem::assembly {
+
+namespace fields_impl {
+template <typename IndexType, typename ContainerType, typename... AccessorTypes,
+          typename std::enable_if_t<
+              ((specfem::data_access::is_assembly_index<IndexType>::value) &&
+               (specfem::data_access::is_field<AccessorTypes>::value && ...)),
+              int> = 0>
+KOKKOS_FORCEINLINE_FUNCTION void load_on_host(const IndexType &index,
+                                              const ContainerType &field,
+                                              AccessorTypes &...accessors) {
+
+  constexpr static auto MediumTag =
+      std::tuple_element_t<0, std::tuple<AccessorTypes...> >::medium_tag;
+
+  // Check that all accessors have the same medium tag
+  fields_impl::check_accessor_compatibility<AccessorTypes...>();
+
+  const auto &current_field = field.template get_field<MediumTag>();
+
+  fields_impl::load_after_field_access<false>(index, current_field,
+                                              accessors...);
+
+  return;
+}
+
+template <typename IndexType, typename ContainerType, typename... AccessorTypes,
+          typename std::enable_if_t<
+              ((specfem::data_access::is_index_type<IndexType>::value) &&
+               (specfem::data_access::is_point<IndexType>::value ||
+                specfem::data_access::is_chunk_element<IndexType>::value ||
+                specfem::data_access::is_chunk_edge<IndexType>::value) &&
+               (specfem::data_access::is_field<AccessorTypes>::value && ...)),
+              int> = 0>
+KOKKOS_FORCEINLINE_FUNCTION void load_on_host(const IndexType &index,
+                                              const ContainerType &field,
+                                              AccessorTypes &...accessors) {
+
+  constexpr static auto MediumTag =
+      std::tuple_element_t<0, std::tuple<AccessorTypes...> >::medium_tag;
+
+  // Check that all accessors have the same medium tag
+  fields_impl::check_accessor_compatibility<AccessorTypes...>();
+
+  using simd_accessor_type =
+      std::integral_constant<bool, IndexType::using_simd>;
+  simulation_field_impl::load_after_simd_dispatch<false>(
+      simd_accessor_type(), index, field, accessors...);
+  return;
+}
+} // namespace fields_impl
+
+/**
+ * @brief Loads field data on the device at the specified index into the given
+ * accessors.
+ *
+ * @ingroup FieldDataAccess
+ *
+ * @tparam IndexType The type of the index (assembly index, point, or chunk
+ * element).
+ * @tparam ContainerType The type of the container holding the field data.
+ * @tparam AccessorTypes The types of the accessors used to access the field
+ * data.
+ *
+ * @param index The index specifying the location or entity for field access.
+ * @param field The container holding the field data.
+ * @param accessors One or more accessor objects specifying how to access the
+ * field data.
+ */
+template <
+    typename IndexType, typename ContainerType, typename... AccessorTypes,
+    typename std::enable_if_t<
+        (specfem::data_access::is_field<AccessorTypes>::value && ...), int> = 0>
+KOKKOS_FORCEINLINE_FUNCTION void load_on_host(const IndexType &index,
+                                              const ContainerType &field,
+                                              AccessorTypes &...accessors) {
+  fields_impl::load_on_host(index, field, accessors...);
+  return;
+}
+} // namespace specfem::assembly

--- a/include/enumerations/coupled_interface.hpp
+++ b/include/enumerations/coupled_interface.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "enumerations/connections.hpp"
 #include "enumerations/dimension.hpp"
 #include "enumerations/medium.hpp"
 
@@ -263,5 +264,7 @@ struct attributes<specfem::dimension::type::dim2,
                                    specfem::element::medium_tag::elastic_psv,
                                    false>;
 };
+
+std::string to_string(const interface_tag &interface_tag);
 
 } // namespace specfem::interface

--- a/include/enumerations/coupled_interface.hpp
+++ b/include/enumerations/coupled_interface.hpp
@@ -16,9 +16,7 @@
 
 #pragma once
 
-#include "enumerations/connections.hpp"
-#include "enumerations/dimension.hpp"
-#include "enumerations/medium.hpp"
+#include "enumerations/interface.hpp
 
 /**
  * @brief Forward declarations for point field types

--- a/include/enumerations/coupled_interface.hpp
+++ b/include/enumerations/coupled_interface.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "enumerations/interface.hpp
+#include "enumerations/interface.hpp"
 
 /**
  * @brief Forward declarations for point field types

--- a/src/enumerations/coupled_interface.cpp
+++ b/src/enumerations/coupled_interface.cpp
@@ -1,0 +1,22 @@
+#include "enumerations/coupled_interface.hpp"
+
+namespace specfem::interface {
+std::string to_string(const interface_tag &interface_tag) {
+
+  std::string interface_string;
+
+  switch (interface_tag) {
+  case specfem::interface::interface_tag::acoustic_elastic:
+    interface_string = "acoustic_elastic";
+    break;
+  case specfem::interface::interface_tag::elastic_acoustic:
+    interface_string = "elastic_acoustic";
+    break;
+  default:
+    interface_string = "unknown";
+    break;
+  }
+
+  return interface_string;
+}
+} // namespace specfem::interface


### PR DESCRIPTION
## Description

Please describe the changes/features in this pull request.

- adds `load_on_host` for field accessors. This is useful for when manipulating things in host space, with `std::cout`, etc. This is basically a copy-paste of `load_on_device`, with the `on_device` bool template parameters set to `false`.
- adds `specfem::interface::to_string(interface_tag)` to make logs easier

## Issue Number

If there is an issue created for these changes, link it here

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
