### PR TITLE
Compute coupled interfaces from the adjacency graph

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,6 +337,7 @@ add_library(
         src/mesh/dim3/generate_database/tags/tags.cpp
 
         src/mesh/dim3/meshfem3d/adjacency_graph/assert_symmetry.cpp
+        src/mesh/dim3/meshfem3d/mesh.cpp
 )
 
 target_link_libraries(

--- a/include/mesh/dim3/meshfem3d/materials/materials.hpp
+++ b/include/mesh/dim3/meshfem3d/materials/materials.hpp
@@ -326,6 +326,33 @@ public:
     return material_container.n_materials - 1;
   }
 
+  /**
+   * @brief Get the medium and property types for a given element index
+   *
+   * Returns a tuple containing the medium and property tags associated with
+   * the material specification for the specified element index.
+   *
+   * @param index Element index to query
+   * @return Tuple of (medium_tag, property_tag) for the element's material
+   *
+   * @code
+   * // Get material type for element 42
+   * auto [medium, property] = materials.get_material_type(42);
+   *
+   * // Use in conditional logic
+   * if (medium == specfem::element::medium_tag::elastic &&
+   *     property == specfem::element::property_tag::isotropic) {
+   *     // Handle elastic isotropic case
+   * }
+   * @endcode
+   */
+  std::tuple<specfem::element::medium_tag, specfem::element::property_tag>
+  get_material_type(const int index) const {
+    const auto &material_specification = this->material_index_mapping[index];
+    return std::make_tuple(material_specification.type,
+                           material_specification.property);
+  }
+
   /** @} */ // End Material Access Interface
 }; // End Materials<dim3> specialization
 } // namespace specfem::mesh::meshfem3d

--- a/include/mesh/dim3/meshfem3d/mesh.hpp
+++ b/include/mesh/dim3/meshfem3d/mesh.hpp
@@ -58,6 +58,11 @@ template <specfem::dimension::type DimensionTag> struct mesh;
  */
 template <> struct mesh<specfem::dimension::type::dim3> {
 
+  /**
+   * @brief Number of spectral elements in the mesh
+   *
+   */
+
   int nspec;
   /**
    * @brief Control node geometric data container

--- a/include/mesh/dim3/meshfem3d/mesh.hpp
+++ b/include/mesh/dim3/meshfem3d/mesh.hpp
@@ -100,6 +100,8 @@ template <> struct mesh<specfem::dimension::type::dim3> {
   specfem::mesh::meshfem3d::adjacency_graph<specfem::dimension::type::dim3>
       adjacency_graph;
 
+  void setup_coupled_interfaces();
+
   /**
    * @brief Default constructor
    *

--- a/include/mesh/dim3/meshfem3d/mesh.hpp
+++ b/include/mesh/dim3/meshfem3d/mesh.hpp
@@ -62,8 +62,8 @@ template <> struct mesh<specfem::dimension::type::dim3> {
    * @brief Number of spectral elements in the mesh
    *
    */
-
   int nspec;
+
   /**
    * @brief Control node geometric data container
    *

--- a/include/mesh/dim3/meshfem3d/mesh.hpp
+++ b/include/mesh/dim3/meshfem3d/mesh.hpp
@@ -97,9 +97,27 @@ template <> struct mesh<specfem::dimension::type::dim3> {
   specfem::mesh::meshfem3d::AbsorbingBoundaries<specfem::dimension::type::dim3>
       absorbing_boundaries;
 
+  /**
+   * @brief Element adjacency graph
+   *
+   * Represents the connectivity relationships between spectral elements in
+   * the mesh.
+   *
+   * @see specfem::mesh::meshfem3d::adjacency_graph
+   */
   specfem::mesh::meshfem3d::adjacency_graph<specfem::dimension::type::dim3>
       adjacency_graph;
 
+  /**
+   * @brief Setup coupled interfaces in the mesh
+   *
+   * Coupled interfaces are essential for multi-domain simulations where
+   * different materials or physical models interact at shared boundaries.
+   *
+   * @note This function should be called after the mesh has been fully
+   * initialized and all components (control nodes, materials, boundaries)
+   * have been populated from MESHFEM3D database files.
+   */
   void setup_coupled_interfaces();
 
   /**

--- a/src/io/mesh/impl/fortran/dim3/meshfem3d/mesh.cpp
+++ b/src/io/mesh/impl/fortran/dim3/meshfem3d/mesh.cpp
@@ -64,5 +64,7 @@ specfem::io::meshfem3d::read_3d_mesh(const std::string &mesh_parameters_file,
 
   param_stream.close();
 
+  mesh.setup_coupled_interfaces();
+
   return mesh;
 }

--- a/src/mesh/dim3/meshfem3d/adjacency_graph/assert_symmetry.cpp
+++ b/src/mesh/dim3/meshfem3d/adjacency_graph/assert_symmetry.cpp
@@ -10,11 +10,26 @@ void specfem::mesh::meshfem3d::adjacency_graph<
   for (const auto &edge : boost::make_iterator_range(boost::edges(g))) {
     const auto source = boost::source(edge, g);
     const auto target = boost::target(edge, g);
-    if (!boost::edge(target, source, g).second) {
+    const auto &edge_props = g[edge];
+    const auto target_edge =
+        boost::edge(target, source, g); // Check for reverse edge
+    if (!target_edge.second) {
+      // Reverse edge does not exist, graph is not symmetric
       std::ostringstream message;
       message << "Adjacency graph is not symmetric: edge from " << source
               << " to " << target << " exists, but not from " << target
               << " to " << source;
+      throw std::runtime_error(message.str());
+    }
+    const auto &target_edge_props = g[target_edge.first];
+    if (edge_props.connection != target_edge_props.connection) {
+      // Connection types do not match, graph is not symmetric
+      std::ostringstream message;
+      message << "Adjacency graph is not symmetric: edge from " << source
+              << " to " << target << " has connection type "
+              << specfem::connections::to_string(edge_props.connection)
+              << ", but reverse edge has connection type "
+              << specfem::connections::to_string(target_edge_props.connection);
       throw std::runtime_error(message.str());
     }
   }

--- a/src/mesh/dim3/meshfem3d/mesh.cpp
+++ b/src/mesh/dim3/meshfem3d/mesh.cpp
@@ -1,0 +1,33 @@
+#include "mesh/mesh.hpp"
+
+void specfem::mesh::meshfem3d::mesh<
+    specfem::dimension::type::dim3>::setup_coupled_interfaces() {
+  if (this->adjacency_graph.empty()) {
+    return;
+  }
+
+  auto &graph = this->adjacency_graph.graph();
+  auto &materials = this->materials;
+
+  for (const auto v : boost::make_iterator_range(boost::vertices(graph))) {
+    for (const auto e :
+         boost::make_iterator_range(boost::out_edges(v, graph))) {
+      const auto target = boost::target(e, graph);
+      auto &edge_props = graph[e];
+
+      const auto [self_medium, self_property] = materials.get_material_type(v);
+      const auto [neighbor_medium, neighbor_property] =
+          materials.get_material_type(target);
+      if ((self_medium != neighbor_medium) &&
+          (edge_props.connection ==
+           specfem::connections::type::strongly_conforming)) {
+        // Change strongly conforming to weakly conforming if media differ
+        edge_props.connection = specfem::connections::type::weakly_conforming;
+      }
+    }
+  }
+
+  this->adjacency_graph.assert_symmetry();
+
+  return;
+}


### PR DESCRIPTION
## Description

This PR implements routines to mark coupled interfaces in 3D mesh. The edges belonging to an interface are marked as weakly conforming if the `medium_tag` of element on either side is different. 
## Issue Number

If there is an issue created for these changes, link it here

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
