### PR TITLE
Fix bug in chunk element subview extent() for 3D

### DIFF
--- a/include/datatypes/impl/chunk_element_subview.hpp
+++ b/include/datatypes/impl/chunk_element_subview.hpp
@@ -149,9 +149,18 @@ template <typename ViewType> struct TensorChunkSubview {
    * @param i Dimension index
    * @return Size of the dimension
    */
-  KOKKOS_INLINE_FUNCTION
-  constexpr std::size_t extent(const size_t &i) const {
+  template <
+      specfem::dimension::type D = index_type::dimension_tag,
+      typename std::enable_if_t<D == specfem::dimension::type::dim2, int> = 0>
+  KOKKOS_INLINE_FUNCTION constexpr std::size_t extent(const size_t &i) const {
     return view.extent(i + 3);
+  }
+
+  template <
+      specfem::dimension::type D = index_type::dimension_tag,
+      typename std::enable_if_t<D == specfem::dimension::type::dim3, int> = 0>
+  KOKKOS_INLINE_FUNCTION constexpr std::size_t extent(const size_t &i) const {
+    return view.extent(i + 4);
   }
 
   /**
@@ -160,9 +169,20 @@ template <typename ViewType> struct TensorChunkSubview {
    * @param i Dimension index
    * @return Static size of the dimension
    */
-  KOKKOS_INLINE_FUNCTION
-  constexpr static std::size_t static_extent(const size_t &i) {
+  template <
+      specfem::dimension::type D = index_type::dimension_tag,
+      typename std::enable_if_t<D == specfem::dimension::type::dim2, int> = 0>
+  KOKKOS_INLINE_FUNCTION constexpr static std::size_t
+  static_extent(const size_t &i) {
     return ViewType::static_extent(i + 3);
+  }
+
+  template <
+      specfem::dimension::type D = index_type::dimension_tag,
+      typename std::enable_if_t<D == specfem::dimension::type::dim3, int> = 0>
+  KOKKOS_INLINE_FUNCTION constexpr static std::size_t
+  static_extent(const size_t &i) {
+    return ViewType::static_extent(i + 4);
   }
 
   /**


### PR DESCRIPTION
For `chunk_element_subview`, `extent(0)` should correspond to `icomp` and `extent(1)` should correspond to `idim`. Current `extent()` function only applies to dim2.