### PR TITLE
Assembly mesh construction using MESHFEM3D mesh

### DIFF
--- a/core/specfem/assembly/assembly/dim3/assembly.hpp
+++ b/core/specfem/assembly/assembly/dim3/assembly.hpp
@@ -99,6 +99,8 @@ template <> struct assembly<specfem::dimension::type::dim3> {
       const bool allocate_boundary_values,
       const std::shared_ptr<specfem::io::reader> &property_reader);
 
+  assembly() = default;
+
   /**
    * @brief Maps the component of wavefield on the entire spectral element grid
    *

--- a/core/specfem/assembly/jacobian_matrix.hpp
+++ b/core/specfem/assembly/jacobian_matrix.hpp
@@ -18,4 +18,5 @@ template <specfem::dimension::type DimensionTag> struct jacobian_matrix;
 // Data access functions
 #include "jacobian_matrix/dim3/load_on_device.hpp"
 #include "jacobian_matrix/dim3/load_on_host.hpp"
+#include "jacobian_matrix/dim3/store_on_device.hpp"
 #include "jacobian_matrix/dim3/store_on_host.hpp"

--- a/core/specfem/assembly/jacobian_matrix/dim3/jacobian_matrix.cpp
+++ b/core/specfem/assembly/jacobian_matrix/dim3/jacobian_matrix.cpp
@@ -1,5 +1,6 @@
 #include "specfem/assembly/jacobian_matrix.hpp"
 #include "mesh/mesh.hpp"
+#include "specfem/jacobian.hpp"
 
 specfem::assembly::jacobian_matrix<specfem::dimension::type::dim3>::
     jacobian_matrix(
@@ -147,4 +148,89 @@ specfem::assembly::jacobian_matrix<
       found);
 
   return std::make_tuple(found, small_jacobian);
+}
+
+specfem::assembly::jacobian_matrix<specfem::dimension::type::dim3>::
+    jacobian_matrix(const specfem::assembly::mesh<dimension_tag> &assembly_mesh)
+    : nspec(assembly_mesh.nspec), ngllx(assembly_mesh.element_grid.ngllx),
+      nglly(assembly_mesh.element_grid.nglly),
+      ngllz(assembly_mesh.element_grid.ngllz),
+      xix("specfem::assembly::jacobian_matrix::xix", assembly_mesh.nspec,
+          assembly_mesh.element_grid.ngllz, assembly_mesh.element_grid.nglly,
+          assembly_mesh.element_grid.ngllx),
+      xiy("specfem::assembly::jacobian_matrix::xiy", assembly_mesh.nspec,
+          assembly_mesh.element_grid.ngllz, assembly_mesh.element_grid.nglly,
+          assembly_mesh.element_grid.ngllx),
+      xiz("specfem::assembly::jacobian_matrix::xiz", assembly_mesh.nspec,
+          assembly_mesh.element_grid.ngllz, assembly_mesh.element_grid.nglly,
+          assembly_mesh.element_grid.ngllx),
+      etax("specfem::assembly::jacobian_matrix::etax", assembly_mesh.nspec,
+           assembly_mesh.element_grid.ngllz, assembly_mesh.element_grid.nglly,
+           assembly_mesh.element_grid.ngllx),
+      etay("specfem::assembly::jacobian_matrix::etay", assembly_mesh.nspec,
+           assembly_mesh.element_grid.ngllz, assembly_mesh.element_grid.nglly,
+           assembly_mesh.element_grid.ngllx),
+      etaz("specfem::assembly::jacobian_matrix::etaz", assembly_mesh.nspec,
+           assembly_mesh.element_grid.ngllz, assembly_mesh.element_grid.nglly,
+           assembly_mesh.element_grid.ngllx),
+      gammax("specfem::assembly::jacobian_matrix::gammax", assembly_mesh.nspec,
+             assembly_mesh.element_grid.ngllz, assembly_mesh.element_grid.nglly,
+             assembly_mesh.element_grid.ngllx),
+      gammay("specfem::assembly::jacobian_matrix::gammay", assembly_mesh.nspec,
+             assembly_mesh.element_grid.ngllz, assembly_mesh.element_grid.nglly,
+             assembly_mesh.element_grid.ngllx),
+      gammaz("specfem::assembly::jacobian_matrix::gammaz", assembly_mesh.nspec,
+             assembly_mesh.element_grid.ngllz, assembly_mesh.element_grid.nglly,
+             assembly_mesh.element_grid.ngllx),
+      jacobian("specfem::assembly::jacobian_matrix::jacobian",
+               assembly_mesh.nspec, assembly_mesh.element_grid.ngllz,
+               assembly_mesh.element_grid.nglly,
+               assembly_mesh.element_grid.ngllx),
+      h_xix(Kokkos::create_mirror_view(xix)),
+      h_xiy(Kokkos::create_mirror_view(xiy)),
+      h_xiz(Kokkos::create_mirror_view(xiz)),
+      h_etax(Kokkos::create_mirror_view(etax)),
+      h_etay(Kokkos::create_mirror_view(etay)),
+      h_etaz(Kokkos::create_mirror_view(etaz)),
+      h_gammax(Kokkos::create_mirror_view(gammax)),
+      h_gammay(Kokkos::create_mirror_view(gammay)),
+      h_gammaz(Kokkos::create_mirror_view(gammaz)),
+      h_jacobian(Kokkos::create_mirror_view(jacobian)) {
+
+  nspec = assembly_mesh.nspec;
+  ngllx = assembly_mesh.element_grid.ngllx;
+  nglly = assembly_mesh.element_grid.nglly;
+  ngllz = assembly_mesh.element_grid.ngllz;
+  const int ngnod = assembly_mesh.ngnod;
+
+  const auto &shape_derivatives = assembly_mesh.dshape3D;
+  const auto &coordinates = assembly_mesh.control_node_coordinates;
+
+  Kokkos::parallel_for(
+      "specfem::assembly::jacobian_matrix::initialize_from_mesh",
+      Kokkos::MDRangePolicy<Kokkos::Rank<4> >({ 0, 0, 0, 0 },
+                                              { nspec, ngllz, nglly, ngllx }),
+      KOKKOS_LAMBDA(const int ispec, const int iz, const int iy, const int ix) {
+        // compute jacobian matrix
+        const auto jacobian_matrix = specfem::jacobian::compute_jacobian(
+            Kokkos::subview(coordinates, ispec, Kokkos::ALL(), Kokkos::ALL()),
+            Kokkos::subview(shape_derivatives, iz, iy, ix, Kokkos::ALL(),
+                            Kokkos::ALL()));
+
+        specfem::assembly::store_on_device(
+            specfem::point::index<dimension_tag, false>(ispec, iz, iy, ix),
+            jacobian_matrix, *this);
+      });
+
+  Kokkos::deep_copy(h_xix, xix);
+  Kokkos::deep_copy(h_xiy, xiy);
+  Kokkos::deep_copy(h_xiz, xiz);
+  Kokkos::deep_copy(h_etax, etax);
+  Kokkos::deep_copy(h_etay, etay);
+  Kokkos::deep_copy(h_etaz, etaz);
+  Kokkos::deep_copy(h_gammax, gammax);
+  Kokkos::deep_copy(h_gammay, gammay);
+  Kokkos::deep_copy(h_gammaz, gammaz);
+  Kokkos::deep_copy(h_jacobian, jacobian);
+  return;
 }

--- a/core/specfem/assembly/jacobian_matrix/dim3/jacobian_matrix.hpp
+++ b/core/specfem/assembly/jacobian_matrix/dim3/jacobian_matrix.hpp
@@ -52,6 +52,8 @@ struct jacobian_matrix<specfem::dimension::type::dim3>
   jacobian_matrix(
       const specfem::mesh::jacobian_matrix<dimension_tag> &mesh_jacobian);
 
+  jacobian_matrix(const specfem::assembly::mesh<dimension_tag> &assembly_mesh);
+
   void sync_views();
 
   std::tuple<bool, Kokkos::View<bool *, Kokkos::DefaultHostExecutionSpace> >

--- a/core/specfem/assembly/jacobian_matrix/dim3/store_on_device.hpp
+++ b/core/specfem/assembly/jacobian_matrix/dim3/store_on_device.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "enumerations/interface.hpp"
+#include "specfem/data_access.hpp"
+#include <Kokkos_Core.hpp>
+#include <type_traits>
+
+namespace specfem::assembly {
+
+template <
+    typename PointIndexType, typename PointType, typename ContainerType,
+    typename std::enable_if_t<
+        specfem::data_access::is_index_type<PointIndexType>::value &&
+            PointIndexType::dimension_tag == specfem::dimension::type::dim3 &&
+            !PointIndexType::using_simd && !PointType::simd::using_simd &&
+            specfem::data_access::is_jacobian_matrix<ContainerType>::value,
+        int> = 0>
+KOKKOS_FUNCTION void store_on_device(const PointIndexType &index,
+                                     const PointType &point,
+                                     const ContainerType &container) {
+  static_assert(
+      specfem::data_access::CheckCompatibility<PointIndexType, ContainerType,
+                                               PointType>::value,
+      "Incompatible Index, Container, and Point Types.");
+
+  constexpr static bool store_jacobian = PointType::store_jacobian;
+
+  container.xix(index.ispec, index.iz, index.iy, index.ix) = point.xix;
+  container.xiy(index.ispec, index.iz, index.iy, index.ix) = point.xiy;
+  container.xiz(index.ispec, index.iz, index.iy, index.ix) = point.xiz;
+  container.etax(index.ispec, index.iz, index.iy, index.ix) = point.etax;
+  container.etay(index.ispec, index.iz, index.iy, index.ix) = point.etay;
+  container.etaz(index.ispec, index.iz, index.iy, index.ix) = point.etaz;
+  container.gammax(index.ispec, index.iz, index.iy, index.ix) = point.gammax;
+  container.gammay(index.ispec, index.iz, index.iy, index.ix) = point.gammay;
+  container.gammaz(index.ispec, index.iz, index.iy, index.ix) = point.gammaz;
+  if constexpr (store_jacobian) {
+    container.jacobian(index.ispec, index.iz, index.iy, index.ix) =
+        point.jacobian;
+  }
+}
+
+} // namespace specfem::assembly

--- a/core/specfem/assembly/mesh/dim3/impl/control_nodes.hpp
+++ b/core/specfem/assembly/mesh/dim3/impl/control_nodes.hpp
@@ -16,16 +16,25 @@ public:
       Kokkos::View<type_real ***, Kokkos::LayoutLeft,
                    Kokkos::DefaultExecutionSpace>;
 
+  using ControlNodeIndexView =
+      Kokkos::View<int **, Kokkos::LayoutLeft, Kokkos::DefaultExecutionSpace>;
+
   int nspec;
   int ngnod;
 
   ControlNodeCoordinatesView control_node_coordinates;
   ControlNodeCoordinatesView::HostMirror h_control_node_coordinates;
 
+  ControlNodeIndexView control_node_index;
+  ControlNodeIndexView::HostMirror h_control_node_index;
+
   control_nodes() = default;
 
   control_nodes(
       const specfem::mesh::control_nodes<dimension_tag> &control_nodes);
+
+  control_nodes(const specfem::mesh::meshfem3d::ControlNodes<dimension_tag>
+                    &control_nodes);
 };
 
 } // namespace specfem::assembly::mesh_impl

--- a/core/specfem/assembly/mesh/dim3/impl/control_nodes.tpp
+++ b/core/specfem/assembly/mesh/dim3/impl/control_nodes.tpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "control_nodes.hpp"
-#include "mesh/mesh.hpp"
 #include "enumerations/dimension.hpp"
+#include "mesh/mesh.hpp"
 #include <Kokkos_Core.hpp>
 
 specfem::assembly::mesh_impl::control_nodes<specfem::dimension::type::dim3>::
@@ -13,8 +13,6 @@ specfem::assembly::mesh_impl::control_nodes<specfem::dimension::type::dim3>::
                                control_nodes.nspec, control_nodes.ngnod, ndim),
       h_control_node_coordinates(
           Kokkos::create_mirror_view(control_node_coordinates)) {
-
-
 
   Kokkos::parallel_for(
       "specfem::assembly::mesh::control_nodes::copy_to_device",
@@ -29,6 +27,41 @@ specfem::assembly::mesh_impl::control_nodes<specfem::dimension::type::dim3>::
       });
 
   Kokkos::fence();
+  Kokkos::deep_copy(control_node_coordinates, h_control_node_coordinates);
+  return;
+}
+
+specfem::assembly::mesh_impl::control_nodes<specfem::dimension::type::dim3>::
+    control_nodes(const specfem::mesh::meshfem3d::ControlNodes<dimension_tag>
+                      &control_nodes)
+    : nspec(control_nodes.nspec), ngnod(control_nodes.ngnod),
+      control_node_coordinates("specfem::assembly::mesh::control_nodes",
+                               control_nodes.nspec, control_nodes.ngnod, ndim),
+      h_control_node_coordinates(
+          Kokkos::create_mirror_view(control_node_coordinates)) {
+
+  // We use the device by default for better performance.
+
+  using MemorySpace = typename Kokkos::DefaultExecutionSpace::memory_space;
+
+  const auto coordinates = Kokkos::create_mirror_view_and_copy(
+      MemorySpace(), control_nodes.coordinates);
+  h_control_node_index = control_nodes.control_node_index;
+  control_node_index =
+      Kokkos::create_mirror_view_and_copy(MemorySpace(), h_control_node_index);
+
+  Kokkos::parallel_for(
+      "specfem::assembly::mesh::control_nodes::copy_to_device",
+      Kokkos::MDRangePolicy<Kokkos::Rank<2> >(
+          { 0, 0 }, { control_nodes.nspec, control_nodes.ngnod }),
+      KOKKOS_LAMBDA(const int ispec, const int ia) {
+        const int index = control_node_index(ispec, ia);
+        for (int idim = 0; idim < ndim; ++idim)
+          control_node_coordinates(ispec, ia, idim) = coordinates(index, idim);
+      });
+
+  Kokkos::fence();
+
   Kokkos::deep_copy(control_node_coordinates, h_control_node_coordinates);
   return;
 }

--- a/core/specfem/assembly/mesh/dim3/impl/control_nodes.tpp
+++ b/core/specfem/assembly/mesh/dim3/impl/control_nodes.tpp
@@ -5,6 +5,39 @@
 #include "mesh/mesh.hpp"
 #include <Kokkos_Core.hpp>
 
+void initialize_control_nodes(
+    specfem::assembly::mesh_impl::control_nodes<specfem::dimension::type::dim3>
+        &dest,
+    const specfem::mesh::meshfem3d::ControlNodes<specfem::dimension::type::dim3>
+        &src) {
+
+  // We use the device by default for better performance.
+
+  using MemorySpace = typename Kokkos::DefaultExecutionSpace::memory_space;
+
+  const auto coordinates =
+      Kokkos::create_mirror_view_and_copy(MemorySpace(), src.coordinates);
+  dest.h_control_node_index = src.control_node_index;
+  dest.control_node_index = Kokkos::create_mirror_view_and_copy(
+      MemorySpace(), dest.h_control_node_index);
+
+  Kokkos::parallel_for(
+      "specfem::assembly::mesh::control_nodes::copy_to_device",
+      Kokkos::MDRangePolicy<Kokkos::Rank<2> >({ 0, 0 },
+                                              { src.nspec, src.ngnod }),
+      KOKKOS_LAMBDA(const int ispec, const int ia) {
+        const int index = dest.control_node_index(ispec, ia);
+        for (int idim = 0; idim < ndim; ++idim)
+          dest.control_node_coordinates(ispec, ia, idim) =
+              coordinates(index, idim);
+      });
+
+  Kokkos::fence();
+
+  Kokkos::deep_copy(dest.control_node_coordinates, dest.h_control_node_coordinates);
+  return;
+}
+
 specfem::assembly::mesh_impl::control_nodes<specfem::dimension::type::dim3>::
     control_nodes(
         const specfem::mesh::control_nodes<dimension_tag> &control_nodes)
@@ -40,28 +73,5 @@ specfem::assembly::mesh_impl::control_nodes<specfem::dimension::type::dim3>::
       h_control_node_coordinates(
           Kokkos::create_mirror_view(control_node_coordinates)) {
 
-  // We use the device by default for better performance.
-
-  using MemorySpace = typename Kokkos::DefaultExecutionSpace::memory_space;
-
-  const auto coordinates = Kokkos::create_mirror_view_and_copy(
-      MemorySpace(), control_nodes.coordinates);
-  h_control_node_index = control_nodes.control_node_index;
-  control_node_index =
-      Kokkos::create_mirror_view_and_copy(MemorySpace(), h_control_node_index);
-
-  Kokkos::parallel_for(
-      "specfem::assembly::mesh::control_nodes::copy_to_device",
-      Kokkos::MDRangePolicy<Kokkos::Rank<2> >(
-          { 0, 0 }, { control_nodes.nspec, control_nodes.ngnod }),
-      KOKKOS_LAMBDA(const int ispec, const int ia) {
-        const int index = control_node_index(ispec, ia);
-        for (int idim = 0; idim < ndim; ++idim)
-          control_node_coordinates(ispec, ia, idim) = coordinates(index, idim);
-      });
-
-  Kokkos::fence();
-
-  Kokkos::deep_copy(control_node_coordinates, h_control_node_coordinates);
-  return;
+  initialize_control_nodes(*this, control_nodes);
 }

--- a/core/specfem/assembly/mesh/dim3/impl/points.hpp
+++ b/core/specfem/assembly/mesh/dim3/impl/points.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "control_nodes.hpp"
 #include "enumerations/interface.hpp"
 #include "mesh/mesh.hpp"
+#include "shape_functions.hpp"
 #include <Kokkos_Core.hpp>
 
 namespace specfem::assembly::mesh_impl {
@@ -33,9 +35,19 @@ public:
   int nglly; ///< Number of quadrature points in y dimension
   int ngllx; ///< Number of quadrature points in x dimension
 
+  int nglob; ///< Total number of global points
+
   points() = default;
   points(const specfem::mesh::mapping<dimension_tag> &mapping,
          const specfem::mesh::coordinates<dimension_tag> &coordinates);
+
+  points(const int &nspec, const int &ngllz, const int &nglly, const int &ngllx,
+         const specfem::mesh::meshfem3d::adjacency_graph<dimension_tag>
+             &adjacency_graph,
+         const specfem::assembly::mesh_impl::control_nodes<dimension_tag>
+             &control_nodes,
+         const specfem::assembly::mesh_impl::shape_functions<dimension_tag>
+             &shape_functions);
 };
 
 } // namespace specfem::assembly::mesh_impl

--- a/core/specfem/assembly/mesh/dim3/impl/points.tpp
+++ b/core/specfem/assembly/mesh/dim3/impl/points.tpp
@@ -35,3 +35,263 @@ specfem::assembly::mesh_impl::points<specfem::dimension::type::dim3>::points(
   Kokkos::deep_copy(this->coord, this->h_coord);
   Kokkos::deep_copy(this->index_mapping, this->h_index_mapping);
 }
+
+specfem::assembly::mesh_impl::points<specfem::dimension::type::dim3>::points(
+    const int &nspec, const int &ngllz, const int &nglly, const int &ngllx,
+    const specfem::mesh::meshfem3d::adjacency_graph<dimension_tag>
+        &adjacency_graph,
+    const specfem::assembly::mesh_impl::control_nodes<dimension_tag>
+        &control_nodes,
+    const specfem::assembly::mesh_impl::shape_functions<dimension_tag>
+        &shape_functions)
+    : nspec(nspec), ngllz(ngllz), nglly(nglly), ngllx(ngllx),
+      index_mapping("specfem::assembly::mesh::points::index_mapping", nspec,
+                    ngllz, nglly, ngllx),
+      coord("specfem::assembly::mesh::points::coord", nspec, ngllz, nglly,
+            ngllx, ndim),
+      h_index_mapping(Kokkos::create_mirror_view(index_mapping)),
+      h_coord(Kokkos::create_mirror_view(coord)) {
+
+  // Use adjacency graph to set up quadrature point indexing
+  const auto &graph = adjacency_graph.graph();
+
+  constexpr int chunk_size = 1;
+  const int nchunks = nspec / chunk_size + (nspec % chunk_size == 0 ? 0 : 1);
+
+  // Initialize to -1
+  Kokkos::parallel_for(
+      "specfem::assembly::mesh::points::initialize_index_mapping",
+      Kokkos::MDRangePolicy<Kokkos::DefaultHostExecutionSpace,
+                            Kokkos::Rank<4> >({ 0, 0, 0, 0 },
+                                              { nspec, ngllz, nglly, ngllx }),
+      [=](const int ispec, const int iz, const int iy, const int ix) {
+        this->h_index_mapping(ispec, iz, iy, ix) = -1;
+      });
+
+  Kokkos::fence();
+
+  // Set up internal points
+  Kokkos::parallel_for(
+      "specfem::assembly::mesh::points::initialize_internal_indices",
+      Kokkos::MDRangePolicy<Kokkos::DefaultHostExecutionSpace,
+                            Kokkos::Rank<4> >(
+          { 0, 1, 1, 1 }, { nchunks, ngllz - 1, nglly - 1, ngllx - 1 }),
+      [=](const int ichunk, const int iz, const int iy, const int ix) {
+        for (int ielement = 0; ielement < chunk_size; ielement++) {
+          int ispec = ichunk + ielement;
+          if (ispec >= nspec)
+            break;
+          this->h_index_mapping(ispec, iz, iy, ix) =
+              ielement + iz * chunk_size + iy * chunk_size * (ngllz - 2) +
+              ix * chunk_size * (ngllz - 2) * (nglly - 2) +
+              ichunk * chunk_size * (ngllz - 2) * (nglly - 2) * (ngllx - 2);
+        }
+      });
+
+  int ig = nspec * (ngllz - 2) * (nglly - 2) * (ngllx - 2);
+
+  // Filter out strongly conforming connections
+  auto filter = [&graph](const auto &edge) {
+    return graph[edge].connection ==
+           specfem::connections::type::strongly_conforming;
+  };
+
+  // Create a filtered graph view
+  const auto fg = boost::make_filtered_graph(graph, filter);
+
+  const auto mapping = specfem::mesh_entity::element(ngllz, nglly, ngllx);
+
+  // Iterate over all faces
+  for (int ichunk = 0; ichunk < nchunks; ichunk++) {
+    // Iterate over all faces
+    for (auto iface : specfem::mesh_entity::dim3::faces) {
+      const int npoints = mapping.number_of_points_on_orientation(iface);
+      for (auto ipoint = 0; ipoint < npoints; ipoint++) {
+        for (int ielement = 0; ielement < chunk_size; ielement++) {
+          int ispec = ichunk + ielement;
+          if (ispec >= nspec)
+            break;
+          const auto [iz, iy, ix] = mapping.map_coordinates(iface, ipoint);
+          // skip points on edges and corners
+          if (iz == 0 || iz == ngllz - 1 || iy == 0 || iy == nglly - 1 ||
+              ix == 0 || ix == ngllx - 1)
+            continue;
+
+          // Check if already assigned
+          bool previously_assigned = false;
+          for (auto face :
+               boost::make_iterator_range(boost::out_edges(ispec, fg))) {
+            if (fg[face].orientation == iface) {
+              const int jspec = boost::target(face, fg);
+              const auto other_face = boost::edge(jspec, ispec, graph).first;
+              const auto jface = fg[other_face].orientation;
+
+              const auto connections = specfem::connections::connection_mapping(
+                  ngllz, nglly, ngllx,
+                  Kokkos::subview(control_nodes.h_control_node_index, ispec,
+                                  Kokkos::ALL),
+                  Kokkos::subview(control_nodes.h_control_node_index, jspec,
+                                  Kokkos::ALL));
+
+              const auto [mapped_iz, mapped_iy, mapped_ix] =
+                  connections.map_coordinates(iface, jface, iz, iy, ix);
+
+              if (this->h_index_mapping(jspec, mapped_iz, mapped_iy,
+                                        mapped_ix) != -1) {
+                this->h_index_mapping(ispec, iz, iy, ix) =
+                    this->h_index_mapping(jspec, mapped_iz, mapped_iy,
+                                          mapped_ix);
+                previously_assigned = true;
+                break;
+              }
+            }
+          }
+          if (!previously_assigned) {
+            this->h_index_mapping(ispec, iz, iy, ix) = ig;
+            ig++;
+          }
+        }
+      }
+    }
+
+    // Iterate over all edges
+    for (auto iedge : specfem::mesh_entity::dim3::edges) {
+      const int npoints =
+          mapping.number_of_points_on_orientation(iedge);
+      for (int ipoint = 0; ipoint < npoints; ipoint++) {
+        for (int ielement = 0; ielement < chunk_size; ielement++) {
+          int ispec = ichunk + ielement;
+          if (ispec >= nspec)
+            break;
+          const auto [iz, iy, ix] = mapping.map_coordinates(iedge, ipoint);
+          // skip points on corners
+          if ((iz == 0 || iz == ngllz - 1) && (iy == 0 || iy == nglly - 1) &&
+              (ix == 0 || ix == ngllx - 1))
+            continue;
+
+          // Check if already assigned
+          bool previously_assigned = false;
+          for (auto edge :
+               boost::make_iterator_range(boost::out_edges(ispec, fg))) {
+            if (fg[edge].orientation == iedge) {
+              const int jspec = boost::target(edge, fg);
+              const auto other_face = boost::edge(jspec, ispec, graph).first;
+              const auto jedge = fg[other_face].orientation;
+              const auto connections = specfem::connections::connection_mapping(
+                  ngllz, nglly, ngllx,
+                  Kokkos::subview(control_nodes.h_control_node_index, ispec,
+                                  Kokkos::ALL),
+                  Kokkos::subview(control_nodes.h_control_node_index, jspec,
+                                  Kokkos::ALL));
+
+              const auto [mapped_iz, mapped_iy, mapped_ix] =
+                  connections.map_coordinates(iedge, jedge, iz, iy, ix);
+              if (this->h_index_mapping(jspec, mapped_iz, mapped_iy,
+                                        mapped_ix) != -1) {
+                this->h_index_mapping(ispec, iz, iy, ix) =
+                    this->h_index_mapping(jspec, mapped_iz, mapped_iy,
+                                          mapped_ix);
+                previously_assigned = true;
+                break;
+              }
+            }
+          }
+          if (!previously_assigned) {
+            this->h_index_mapping(ispec, iz, iy, ix) = ig;
+            ig++;
+          }
+        }
+      }
+    }
+
+    // Finally we need to treat corner points
+    for (auto icorner : specfem::mesh_entity::dim3::corners) {
+      for (int ielement = 0; ielement < chunk_size; ielement++) {
+        int ispec = ichunk + ielement;
+        if (ispec >= nspec)
+          break;
+        const auto [iz, iy, ix] = mapping.map_coordinates(icorner);
+        // Check if already assigned
+        bool previously_assigned = false;
+        for (auto corner :
+             boost::make_iterator_range(boost::out_edges(ispec, fg))) {
+          if (fg[corner].orientation == icorner) {
+            const int jspec = boost::target(corner, fg);
+            const auto other_face = boost::edge(jspec, ispec, graph).first;
+            const auto jcorner = fg[other_face].orientation;
+            const auto connections = specfem::connections::connection_mapping(
+                ngllz, nglly, ngllx,
+                Kokkos::subview(control_nodes.h_control_node_index, ispec,
+                                Kokkos::ALL),
+                Kokkos::subview(control_nodes.h_control_node_index, jspec,
+                                Kokkos::ALL));
+
+            const auto [mapped_iz, mapped_iy, mapped_ix] =
+                connections.map_coordinates(icorner, jcorner);
+            if (this->h_index_mapping(jspec, mapped_iz, mapped_iy, mapped_ix) !=
+                -1) {
+              this->h_index_mapping(ispec, iz, iy, ix) =
+                  this->h_index_mapping(jspec, mapped_iz, mapped_iy, mapped_ix);
+              previously_assigned = true;
+              break;
+            }
+          }
+        }
+        if (!previously_assigned) {
+          this->h_index_mapping(ispec, iz, iy, ix) = ig;
+          ig++;
+        }
+      }
+    }
+  }
+
+  this->nglob = ig;
+
+  // Make sure all points have been assigned
+  Kokkos::parallel_for(
+      "specfem::assembly::mesh::points::check_all_points_assigned",
+      Kokkos::MDRangePolicy<Kokkos::DefaultHostExecutionSpace,
+                            Kokkos::Rank<4> >({ 0, 0, 0, 0 },
+                                              { nspec, ngllz, nglly, ngllx }),
+      [=](const int ispec, const int iz, const int iy, const int ix) {
+        if (this->h_index_mapping(ispec, iz, iy, ix) == -1) {
+          std::stringstream ss;
+          ss << "Point not assigned for element " << ispec << " at (" << iz
+             << ", " << iy << ", " << ix << ").";
+          throw std::runtime_error(ss.str());
+        }
+      });
+
+  Kokkos::fence();
+
+  Kokkos::deep_copy(this->index_mapping, this->h_index_mapping);
+
+  this->coord = CoordViewType("specfem::assembly::mesh::points::coord", nspec,
+                              ngllz, nglly, ngllx, ndim);
+  this->h_coord = Kokkos::create_mirror_view(this->coord);
+
+  const int ngnod = control_nodes.ngnod;
+
+  Kokkos::parallel_for(
+      "specfem::assembly::mesh::points::initialize_coordinates",
+      Kokkos::MDRangePolicy<Kokkos::Rank<4> >({ 0, 0, 0, 0 },
+                                              { nspec, ngllz, nglly, ngllx }),
+      KOKKOS_LAMBDA(const int ispec, const int iz, const int iy, const int ix) {
+        for (int ia = 0; ia < ngnod; ia++) {
+          this->coord(ispec, iz, iy, ix, 0) +=
+              shape_functions.shape3D(iz, iy, ix, ia) *
+              control_nodes.control_node_coordinates(ispec, ia, 0);
+          this->coord(ispec, iz, iy, ix, 1) +=
+              shape_functions.shape3D(iz, iy, ix, ia) *
+              control_nodes.control_node_coordinates(ispec, ia, 1);
+          this->coord(ispec, iz, iy, ix, 2) +=
+              shape_functions.shape3D(iz, iy, ix, ia) *
+              control_nodes.control_node_coordinates(ispec, ia, 2);
+        }
+      });
+
+  Kokkos::fence();
+  Kokkos::deep_copy(this->h_coord, this->coord);
+
+  return;
+}

--- a/core/specfem/assembly/mesh/dim3/impl/points.tpp
+++ b/core/specfem/assembly/mesh/dim3/impl/points.tpp
@@ -327,7 +327,7 @@ specfem::assembly::mesh_impl::points<specfem::dimension::type::dim3>::points(
 
   const int ngnod = control_nodes.ngnod;
 
-  initialize_coordinates(nspec, ngllz, nglly, ngllx, ngnod, this->h_coord,
+  initialize_coordinates(nspec, ngllz, nglly, ngllx, ngnod, this->coord,
                          shape_functions.shape3D,
                          control_nodes.control_node_coordinates);
 

--- a/core/specfem/assembly/mesh/dim3/impl/shape_functions.hpp
+++ b/core/specfem/assembly/mesh/dim3/impl/shape_functions.hpp
@@ -46,6 +46,14 @@ public:
 
   shape_functions() = default;
 
+  shape_functions(const int ngllz, const int nglly, const int ngllx,
+                  const int ngnod,
+                  const specfem::assembly::mesh_impl::quadrature<
+                      specfem::dimension::type::dim3> &quadrature,
+                  const specfem::assembly::mesh_impl::control_nodes<
+                      specfem::dimension::type::dim3>
+                      control_nodes);
+
   ShapeFunctionViewType shape3D;                 ///< Shape functions
   DShapeFunctionViewType dshape3D;               ///< Shape function
                                                  ///< derivatives

--- a/core/specfem/assembly/mesh/dim3/impl/shape_functions.tpp
+++ b/core/specfem/assembly/mesh/dim3/impl/shape_functions.tpp
@@ -52,3 +52,49 @@ specfem::assembly::mesh_impl::shape_functions<specfem::dimension::type::dim3>::
 
   return;
 }
+
+specfem::assembly::mesh_impl::shape_functions<specfem::dimension::type::dim3>::
+    shape_functions(const int ngllz, const int nglly, const int ngllx,
+                    const int ngnod,
+                    const specfem::assembly::mesh_impl::quadrature<
+                        specfem::dimension::type::dim3> &quadrature,
+                    const specfem::assembly::mesh_impl::control_nodes<
+                        specfem::dimension::type::dim3>
+                        control_nodes)
+    : ngllz(ngllz), nglly(nglly), ngllx(ngllx), ngnod(control_nodes.ngnod),
+      shape3D("specfem::assembly::shape_functions::shape3D", ngllz, nglly,
+              ngllx, ngnod),
+      dshape3D("specfem::assembly::shape_functions::dshape3D", ngllz, nglly,
+               ngllx, ndim, ngnod),
+      h_shape3D(Kokkos::create_mirror_view(shape3D)),
+      h_dshape3D(Kokkos::create_mirror_view(dshape3D)) {
+
+  const auto xi = quadrature.xi;
+
+  Kokkos::parallel_for(
+      "specfem::assembly::mesh::shape_functions::initialize_shape_functions",
+      Kokkos::MDRangePolicy<Kokkos::DefaultHostExecutionSpace,
+                            Kokkos::Rank<3> >({ 0, 0, 0 },
+                                              { ngllz, nglly, ngllx }),
+      [=](const int iz, const int iy, const int ix) {
+        type_real xil = xi(ix);
+        type_real etal = xi(iy);
+        type_real zetal = xi(iz);
+        const auto shape_function =
+            specfem::shape_function::shape_function(xil, etal, zetal, ngnod);
+        const auto shape_function_derivatives =
+            specfem::shape_function::shape_function_derivatives(xil, etal,
+                                                                zetal, ngnod);
+        for (int in = 0; in < ngnod; in++) {
+          h_shape3D(iz, iy, ix, in) = shape_function[in];
+          h_dshape3D(iz, iy, ix, 0, in) = shape_function_derivatives[0][in];
+          h_dshape3D(iz, iy, ix, 1, in) = shape_function_derivatives[1][in];
+          h_dshape3D(iz, iy, ix, 2, in) = shape_function_derivatives[2][in];
+        }
+      });
+
+  Kokkos::deep_copy(shape3D, h_shape3D);
+  Kokkos::deep_copy(dshape3D, h_dshape3D);
+
+  return;
+}

--- a/core/specfem/assembly/mesh/dim3/impl/shape_functions.tpp
+++ b/core/specfem/assembly/mesh/dim3/impl/shape_functions.tpp
@@ -69,7 +69,7 @@ specfem::assembly::mesh_impl::shape_functions<specfem::dimension::type::dim3>::
       h_shape3D(Kokkos::create_mirror_view(shape3D)),
       h_dshape3D(Kokkos::create_mirror_view(dshape3D)) {
 
-  const auto xi = quadrature.xi;
+  const auto xi = quadrature.h_xi;
 
   Kokkos::parallel_for(
       "specfem::assembly::mesh::shape_functions::initialize_shape_functions",

--- a/core/specfem/assembly/mesh/dim3/mesh.hpp
+++ b/core/specfem/assembly/mesh/dim3/mesh.hpp
@@ -46,6 +46,14 @@ public:
        const specfem::mesh::mapping<dimension_tag> &mapping,
        const specfem::mesh::control_nodes<dimension_tag> &control_nodes,
        const specfem::quadrature::quadratures &quadrature);
+
+  mesh(const int nspec, const int ngnod, const int ngllz, const int nglly,
+       const int ngllx,
+       const specfem::mesh::meshfem3d::adjacency_graph<dimension_tag>
+           &adjacency_graph,
+       const specfem::mesh::meshfem3d::ControlNodes<dimension_tag>
+           &control_nodes,
+       const specfem::quadrature::quadratures &quadrature);
 };
 
 } // namespace specfem::assembly

--- a/core/specfem/assembly/mesh/dim3/mesh.tpp
+++ b/core/specfem/assembly/mesh/dim3/mesh.tpp
@@ -21,3 +21,43 @@ specfem::assembly::mesh<specfem::dimension::type::dim3>::mesh(
       specfem::assembly::mesh_impl::shape_functions<dimension_tag>(
           quadrature.gll.get_hxi(), quadrature.gll.get_hxi(),
           quadrature.gll.get_hxi(), parameters.ngllz, parameters.ngnod) {}
+
+specfem::assembly::mesh<specfem::dimension::type::dim3>::mesh(
+    const int nspec, const int ngnod, const int ngllz, const int nglly,
+    const int ngllx,
+    const specfem::mesh::meshfem3d::adjacency_graph<dimension_tag>
+        &adjacency_graph,
+    const specfem::mesh::meshfem3d::ControlNodes<dimension_tag> &control_nodes,
+    const specfem::quadrature::quadratures &quadrature)
+    : nspec(nspec), element_grid(ngllz, nglly, ngllx), ngnod(ngnod) {
+  // Initialize base classes
+  static_cast<specfem::assembly::mesh_impl::control_nodes<dimension_tag> &>(
+      *this) = { control_nodes };
+  static_cast<specfem::assembly::mesh_impl::quadrature<dimension_tag> &>(
+      *this) = { quadrature };
+  static_cast<specfem::assembly::mesh_impl::shape_functions<dimension_tag> &>(
+      *this) = {
+    ngllz,
+    nglly,
+    ngllx,
+    ngnod,
+    static_cast<
+        const specfem::assembly::mesh_impl::quadrature<dimension_tag> &>(*this),
+    static_cast<const specfem::assembly::mesh_impl::control_nodes<dimension_tag>
+                    &>(*this)
+  };
+  static_cast<specfem::assembly::mesh_impl::points<dimension_tag> &>(*this) = {
+    nspec,
+    ngllz,
+    nglly,
+    ngllx,
+    adjacency_graph,
+    static_cast<const specfem::assembly::mesh_impl::control_nodes<dimension_tag>
+                    &>(*this),
+    static_cast<
+        const specfem::assembly::mesh_impl::shape_functions<dimension_tag> &>(
+        *this)
+  };
+
+  return;
+}

--- a/core/specfem/jacobian/dim3/jacobian.hpp
+++ b/core/specfem/jacobian/dim3/jacobian.hpp
@@ -61,4 +61,39 @@ compute_jacobian(
     const int ngnod, const type_real xi, const type_real eta,
     const type_real gamma);
 
+template <typename CoordinateView, typename ShapeDerivativesView>
+KOKKOS_FUNCTION
+    specfem::point::jacobian_matrix<specfem::dimension::type::dim3, true, false>
+    compute_jacobian(const CoordinateView coordinates,
+                     const ShapeDerivativesView shape_derivatives) {
+  const int ngnod = coordinates.extent(0);
+  type_real xxi = 0.0, yxi = 0.0, zxi = 0.0;
+  type_real xeta = 0.0, yeta = 0.0, zeta = 0.0;
+  type_real xgamma = 0.0, ygamma = 0.0, zgamma = 0.0;
+  for (int in = 0; in < ngnod; in++) {
+    xxi += shape_derivatives(0, in) * coordinates(in, 0);
+    yxi += shape_derivatives(0, in) * coordinates(in, 1);
+    zxi += shape_derivatives(0, in) * coordinates(in, 2);
+    xeta += shape_derivatives(1, in) * coordinates(in, 0);
+    yeta += shape_derivatives(1, in) * coordinates(in, 1);
+    zeta += shape_derivatives(1, in) * coordinates(in, 2);
+    xgamma += shape_derivatives(2, in) * coordinates(in, 0);
+    ygamma += shape_derivatives(2, in) * coordinates(in, 1);
+    zgamma += shape_derivatives(2, in) * coordinates(in, 2);
+  }
+  auto jacobian = xxi * (yeta * zgamma - ygamma * zeta) -
+                  xeta * (yxi * zgamma - ygamma * zxi) +
+                  xgamma * (yxi * zeta - yeta * zxi);
+  const type_real xix = (yeta * zgamma - ygamma * zeta) / jacobian;
+  const type_real xiy = (xgamma * zeta - xeta * zgamma) / jacobian;
+  const type_real xiz = (xeta * ygamma - xgamma * yeta) / jacobian;
+  const type_real etax = (ygamma * zxi - yxi * zgamma) / jacobian;
+  const type_real etay = (xxi * zgamma - xgamma * zxi) / jacobian;
+  const type_real etaz = (xgamma * yxi - xxi * ygamma) / jacobian;
+  const type_real gammax = (yxi * zeta - yeta * zxi) / jacobian;
+  const type_real gammay = (xeta * zxi - xxi * zeta) / jacobian;
+  const type_real gammaz = (xxi * yeta - xeta * yxi) / jacobian;
+  return { xix, xiy, xiz, etax, etay, etaz, gammax, gammay, gammaz, jacobian };
+}
+
 } // namespace specfem::jacobian

--- a/core/specfem/point/jacobian_matrix.hpp
+++ b/core/specfem/point/jacobian_matrix.hpp
@@ -3,6 +3,7 @@
 #include "enumerations/interface.hpp"
 #include "specfem/data_access.hpp"
 #include "specfem_setup.hpp"
+#include "utilities/utilities.hpp"
 #include <Kokkos_Core.hpp>
 
 namespace specfem {
@@ -118,6 +119,14 @@ public:
   // operator*
   KOKKOS_FUNCTION jacobian_matrix operator*(const type_real &rhs) {
     return { xix * rhs, gammax * rhs, xiz * rhs, gammaz * rhs };
+  }
+
+  // operator==
+  KOKKOS_FUNCTION bool operator==(const jacobian_matrix &rhs) const {
+    return (specfem::utilities::is_close(this->xix, rhs.xix)) &&
+           (specfem::utilities::is_close(this->gammax, rhs.gammax)) &&
+           (specfem::utilities::is_close(this->xiz, rhs.xiz)) &&
+           (specfem::utilities::is_close(this->gammaz, rhs.gammaz));
   }
 };
 
@@ -264,6 +273,19 @@ public:
     return { xix * rhs,    etax * rhs, gammax * rhs, xiy * rhs,   etay * rhs,
              gammay * rhs, xiz * rhs,  etaz * rhs,   gammaz * rhs };
   }
+
+  // operator==
+  KOKKOS_FUNCTION bool operator==(const jacobian_matrix &rhs) const {
+    return (specfem::utilities::is_close(this->xix, rhs.xix)) &&
+           (specfem::utilities::is_close(this->etax, rhs.etax)) &&
+           (specfem::utilities::is_close(this->gammax, rhs.gammax)) &&
+           (specfem::utilities::is_close(this->xiy, rhs.xiy)) &&
+           (specfem::utilities::is_close(this->etay, rhs.etay)) &&
+           (specfem::utilities::is_close(this->gammay, rhs.gammay)) &&
+           (specfem::utilities::is_close(this->xiz, rhs.xiz)) &&
+           (specfem::utilities::is_close(this->etaz, rhs.etaz)) &&
+           (specfem::utilities::is_close(this->gammaz, rhs.gammaz));
+  }
 };
 
 // operator*
@@ -391,6 +413,11 @@ public:
   specfem::datatype::VectorPointViewType<type_real, 2, UseSIMD>
   compute_normal(const specfem::mesh_entity::dim2::type &type) const;
   ///@}
+
+  KOKKOS_FUNCTION bool operator==(const jacobian_matrix &rhs) const {
+    return (static_cast<base_type>(*this) == static_cast<base_type>(rhs)) &&
+           (specfem::utilities::is_close(this->jacobian, rhs.jacobian));
+  }
 
 private:
   specfem::datatype::VectorPointViewType<type_real, 2, UseSIMD>
@@ -525,6 +552,12 @@ public:
 
   // operator*
   KOKKOS_FUNCTION jacobian_matrix operator*(const type_real &rhs) = delete;
+
+  // operator==
+  KOKKOS_FUNCTION bool operator==(const jacobian_matrix &rhs) const {
+    return (static_cast<base_type>(*this) == static_cast<base_type>(rhs)) &&
+           (specfem::utilities::is_close(this->jacobian, rhs.jacobian));
+  }
 
   /**
    * @name Member functions

--- a/include/enumerations/dim3/mesh_entities.hpp
+++ b/include/enumerations/dim3/mesh_entities.hpp
@@ -466,4 +466,66 @@ edges_of_face(const specfem::mesh_entity::dim3::type &face);
  */
 std::array<specfem::mesh_entity::dim3::type, 4>
 corners_of_face(const specfem::mesh_entity::dim3::type &face);
+
+/**
+ * @brief Returns the faces that meet at a given corner
+ *
+ * @param corner The corner mesh entity type
+ * @return std::list<specfem::mesh_entity::dim3::type> List of face types
+ * connected at the corner
+ *
+ * For each corner of a hexahedral element, this function returns the three
+ * faces that converge at that corner. The faces are returned in a consistent
+ * order.
+ *
+ * @throws std::runtime_error if the input is not a valid corner type
+ *
+ * @code
+ * auto faces = faces_of_corner(type::bottom_front_left);
+ * // Returns the three faces meeting at bottom_front_left corner
+ * @endcode
+ */
+std::list<specfem::mesh_entity::dim3::type>
+faces_of_corner(const specfem::mesh_entity::dim3::type &corner);
+
+/**
+ * @brief Returns the edges that meet at a given corner
+ *
+ * @param corner The corner mesh entity type
+ * @return std::list<specfem::mesh_entity::dim3::type> List of edge types that
+ * meet at the corner
+ *
+ * For each corner of a hexahedral element, this function returns the three
+ * edges that converge at that corner. The edges are returned in a consistent
+ * order.
+ *
+ * @throws std::runtime_error if the input is not a valid corner type
+ *
+ * @code
+ * auto edges = edges_of_corner(type::bottom_front_left);
+ * // Returns the three edges meeting at bottom_front_left corner
+ * @endcode
+ */
+std::list<specfem::mesh_entity::dim3::type>
+edges_of_corner(const specfem::mesh_entity::dim3::type &corner);
+
+/**
+ * @brief Returns the faces that are connected by a given edge
+ *
+ * @param edge The edge mesh entity type
+ * @return std::list<specfem::mesh_entity::dim3::type> List of face types
+ * connected by the edge
+ *
+ * For each edge of a hexahedral element, this function returns the two faces
+ * that meet at that edge. The faces are returned in a consistent order.
+ *
+ * @throws std::runtime_error if the input is not a valid edge type
+ *
+ * @code
+ * auto faces = faces_of_edge(type::bottom_left);
+ * // Returns faces that share the bottom_left edge
+ * @endcode
+ */
+std::list<specfem::mesh_entity::dim3::type>
+faces_of_edge(const specfem::mesh_entity::dim3::type &edge);
 } // namespace specfem::mesh_entity

--- a/include/enumerations/dim3/mesh_entities.hpp
+++ b/include/enumerations/dim3/mesh_entities.hpp
@@ -96,8 +96,9 @@ const std::string to_string(const specfem::mesh_entity::dim3::type &entity);
  * - front: y-positive boundary
  * - back: y-negative boundary
  */
-const std::list<type> faces = { type::bottom, type::right, type::top,
-                                type::left,   type::front, type::back };
+const std::list<specfem::mesh_entity::dim3::type> faces = {
+  type::bottom, type::right, type::top, type::left, type::front, type::back
+};
 
 /**
  * @brief List of all edge types in a hexahedral element
@@ -112,7 +113,7 @@ const std::list<type> faces = { type::bottom, type::right, type::top,
  * - Front vertical edges: front_bottom, front_top, front_left, front_right
  * - Back vertical edges: back_bottom, back_top, back_left, back_right
  */
-const std::list<type> edges = {
+const std::list<specfem::mesh_entity::dim3::type> edges = {
   type::bottom_left,  type::bottom_right, type::top_right,  type::top_left,
   type::front_bottom, type::front_top,    type::front_left, type::front_right,
   type::back_bottom,  type::back_top,     type::back_left,  type::back_right
@@ -132,7 +133,7 @@ const std::list<type> edges = {
  * - Top corners (z-positive): top_front_left, top_front_right,
  *   top_back_left, top_back_right
  */
-const std::list<type> corners = {
+const std::list<specfem::mesh_entity::dim3::type> corners = {
   type::bottom_front_left, type::bottom_front_right, type::bottom_back_left,
   type::bottom_back_right, type::top_front_left,     type::top_front_right,
   type::top_back_left,     type::top_back_right

--- a/src/enumerations/dim3/mesh_entities.cpp
+++ b/src/enumerations/dim3/mesh_entities.cpp
@@ -590,3 +590,140 @@ specfem::mesh_entity::corners_of_face(
     throw std::runtime_error("Invalid face type");
   }
 }
+
+std::list<specfem::mesh_entity::dim3::type>
+specfem::mesh_entity::faces_of_corner(
+    const specfem::mesh_entity::dim3::type &corner) {
+
+  if (!specfem::mesh_entity::contains(specfem::mesh_entity::dim3::corners,
+                                      corner)) {
+    throw std::runtime_error("The argument is not a corner");
+  }
+
+  switch (corner) {
+  case specfem::mesh_entity::dim3::type::bottom_front_left:
+    return { specfem::mesh_entity::dim3::type::bottom,
+             specfem::mesh_entity::dim3::type::front,
+             specfem::mesh_entity::dim3::type::left };
+  case specfem::mesh_entity::dim3::type::bottom_front_right:
+    return { specfem::mesh_entity::dim3::type::bottom,
+             specfem::mesh_entity::dim3::type::front,
+             specfem::mesh_entity::dim3::type::right };
+  case specfem::mesh_entity::dim3::type::bottom_back_left:
+    return { specfem::mesh_entity::dim3::type::bottom,
+             specfem::mesh_entity::dim3::type::back,
+             specfem::mesh_entity::dim3::type::left };
+  case specfem::mesh_entity::dim3::type::bottom_back_right:
+    return { specfem::mesh_entity::dim3::type::bottom,
+             specfem::mesh_entity::dim3::type::back,
+             specfem::mesh_entity::dim3::type::right };
+  case specfem::mesh_entity::dim3::type::top_front_left:
+    return { specfem::mesh_entity::dim3::type::top,
+             specfem::mesh_entity::dim3::type::front,
+             specfem::mesh_entity::dim3::type::left };
+  case specfem::mesh_entity::dim3::type::top_front_right:
+    return { specfem::mesh_entity::dim3::type::top,
+             specfem::mesh_entity::dim3::type::front,
+             specfem::mesh_entity::dim3::type::right };
+  case specfem::mesh_entity::dim3::type::top_back_left:
+    return { specfem::mesh_entity::dim3::type::top,
+             specfem::mesh_entity::dim3::type::back,
+             specfem::mesh_entity::dim3::type::left };
+  case specfem::mesh_entity::dim3::type::top_back_right:
+    return { specfem::mesh_entity::dim3::type::top,
+             specfem::mesh_entity::dim3::type::back,
+             specfem::mesh_entity::dim3::type::right };
+  default:
+    throw std::runtime_error("Invalid corner type");
+  }
+}
+
+std::list<specfem::mesh_entity::dim3::type>
+specfem::mesh_entity::edges_of_corner(
+    const specfem::mesh_entity::dim3::type &corner) {
+  switch (corner) {
+  case specfem::mesh_entity::dim3::type::bottom_front_left:
+    return { specfem::mesh_entity::dim3::type::bottom_left,
+             specfem::mesh_entity::dim3::type::front_left,
+             specfem::mesh_entity::dim3::type::front_bottom };
+  case specfem::mesh_entity::dim3::type::bottom_front_right:
+    return { specfem::mesh_entity::dim3::type::bottom_right,
+             specfem::mesh_entity::dim3::type::front_right,
+             specfem::mesh_entity::dim3::type::front_bottom };
+  case specfem::mesh_entity::dim3::type::bottom_back_left:
+    return { specfem::mesh_entity::dim3::type::bottom_left,
+             specfem::mesh_entity::dim3::type::back_left,
+             specfem::mesh_entity::dim3::type::back_bottom };
+  case specfem::mesh_entity::dim3::type::bottom_back_right:
+    return { specfem::mesh_entity::dim3::type::bottom_right,
+             specfem::mesh_entity::dim3::type::back_right,
+             specfem::mesh_entity::dim3::type::back_bottom };
+  case specfem::mesh_entity::dim3::type::top_front_left:
+    return { specfem::mesh_entity::dim3::type::top_left,
+             specfem::mesh_entity::dim3::type::front_left,
+             specfem::mesh_entity::dim3::type::front_top };
+  case specfem::mesh_entity::dim3::type::top_front_right:
+    return { specfem::mesh_entity::dim3::type::top_right,
+             specfem::mesh_entity::dim3::type::front_right,
+             specfem::mesh_entity::dim3::type::front_top };
+  case specfem::mesh_entity::dim3::type::top_back_left:
+    return { specfem::mesh_entity::dim3::type::top_left,
+             specfem::mesh_entity::dim3::type::back_left,
+             specfem::mesh_entity::dim3::type::back_top };
+  case specfem::mesh_entity::dim3::type::top_back_right:
+    return { specfem::mesh_entity::dim3::type::top_right,
+             specfem::mesh_entity::dim3::type::back_right,
+             specfem::mesh_entity::dim3::type::back_top };
+  default:
+    throw std::runtime_error("Invalid corner type");
+  }
+}
+
+std::list<specfem::mesh_entity::dim3::type> specfem::mesh_entity::faces_of_edge(
+    const specfem::mesh_entity::dim3::type &edge) {
+  if (!specfem::mesh_entity::contains(specfem::mesh_entity::dim3::edges,
+                                      edge)) {
+    throw std::runtime_error("The argument is not an edge");
+  }
+
+  switch (edge) {
+  case specfem::mesh_entity::dim3::type::bottom_left:
+    return { specfem::mesh_entity::dim3::type::bottom,
+             specfem::mesh_entity::dim3::type::left };
+  case specfem::mesh_entity::dim3::type::bottom_right:
+    return { specfem::mesh_entity::dim3::type::bottom,
+             specfem::mesh_entity::dim3::type::right };
+  case specfem::mesh_entity::dim3::type::top_left:
+    return { specfem::mesh_entity::dim3::type::top,
+             specfem::mesh_entity::dim3::type::left };
+  case specfem::mesh_entity::dim3::type::top_right:
+    return { specfem::mesh_entity::dim3::type::top,
+             specfem::mesh_entity::dim3::type::right };
+  case specfem::mesh_entity::dim3::type::front_bottom:
+    return { specfem::mesh_entity::dim3::type::bottom,
+             specfem::mesh_entity::dim3::type::front };
+  case specfem::mesh_entity::dim3::type::front_top:
+    return { specfem::mesh_entity::dim3::type::top,
+             specfem::mesh_entity::dim3::type::front };
+  case specfem::mesh_entity::dim3::type::front_left:
+    return { specfem::mesh_entity::dim3::type::left,
+             specfem::mesh_entity::dim3::type::front };
+  case specfem::mesh_entity::dim3::type::front_right:
+    return { specfem::mesh_entity::dim3::type::right,
+             specfem::mesh_entity::dim3::type::front };
+  case specfem::mesh_entity::dim3::type::back_bottom:
+    return { specfem::mesh_entity::dim3::type::bottom,
+             specfem::mesh_entity::dim3::type::back };
+  case specfem::mesh_entity::dim3::type::back_top:
+    return { specfem::mesh_entity::dim3::type::top,
+             specfem::mesh_entity::dim3::type::back };
+  case specfem::mesh_entity::dim3::type::back_left:
+    return { specfem::mesh_entity::dim3::type::left,
+             specfem::mesh_entity::dim3::type::back };
+  case specfem::mesh_entity::dim3::type::back_right:
+    return { specfem::mesh_entity::dim3::type::right,
+             specfem::mesh_entity::dim3::type::back };
+  default:
+    throw std::runtime_error("Invalid edge type");
+  }
+}

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -454,6 +454,7 @@ add_executable(
   assembly/dim3/mesh/shape_functions.cpp
   assembly/dim3/mesh/points.cpp
   assembly/dim3/mesh/control_nodes.cpp
+  assembly/dim3/jacobian_matrix/jacobian_matrix.cpp
 )
 
 target_compile_definitions(assembly_tests PRIVATE TEST_OUTPUT_DIR=${TEST_OUTPUT_DIR})

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -449,6 +449,11 @@ add_executable(
   assembly/compute_source_array/dim2/compute_source_array_from_vector.cpp
   assembly/compute_source_array/dim2/compute_source_array_from_tensor.cpp
   assembly/compute_source_array/dim3/compute_source_array_from_vector.cpp
+
+  # New dim3 tests
+  assembly/dim3/mesh/shape_functions.cpp
+  assembly/dim3/mesh/points.hpp
+  assembly/dim3/mesh/control_nodes.cpp
 )
 
 target_compile_definitions(assembly_tests PRIVATE TEST_OUTPUT_DIR=${TEST_OUTPUT_DIR})
@@ -465,9 +470,13 @@ target_link_libraries(
   kokkos_environment
   yaml-cpp
   utilities
+  enumerations
+  shape_functions
+  quadrature
   boost
   -lpthread -lm
   gtest_main
+  ${BOOST_LIBS}
 )
 
 add_executable(

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -452,7 +452,7 @@ add_executable(
 
   # New dim3 tests
   assembly/dim3/mesh/shape_functions.cpp
-  assembly/dim3/mesh/points.hpp
+  assembly/dim3/mesh/points.cpp
   assembly/dim3/mesh/control_nodes.cpp
 )
 

--- a/tests/unit-tests/assembly/dim3/.gitignore
+++ b/tests/unit-tests/assembly/dim3/.gitignore
@@ -1,0 +1,2 @@
+
+!test_fixture.hpp

--- a/tests/unit-tests/assembly/dim3/jacobian_matrix/jacobian_matrix.cpp
+++ b/tests/unit-tests/assembly/dim3/jacobian_matrix/jacobian_matrix.cpp
@@ -181,20 +181,29 @@ struct ExpectedJacobian3D {
 
 using namespace specfem::assembly_test;
 
+//
+// Ground truth data for Jacobian matrix tests in 3D
+// How should you add new test cases?
+// The goal is to test elements where you might think Jacobian computation
+// could be wrong. For example, elements with high aspect ratio, distorted
+// elements, etc.
+// The first tests check jacobian for a simple EightNodeElastic element, where
+// we expect the jacobian to be very uniform across all GLL points.
+// Future tests should check more complex elements.
 static const std::unordered_map<std::string, ExpectedJacobian3D>
     expected_jacobians_3d = { { "EightNodeElastic",
                                 { { 5, 5, 5, 8 }, // Total GLL points: ngllx,
                                                   // nglly, ngllz, nelements
                                   { { 0,
                                       8,
-                                      { { 0.0, 50000.0, 50000.0 },
-                                        { 50000.0, 50000.0, 0.0 },
-                                        { 50000.0, 0.0, 0.0 },
-                                        { 0.0, 0.0, 50000.0 },
-                                        { 0.0, 50000.0, 50000.0 },
-                                        { 50000.0, 50000.0, 0.0 },
-                                        { 50000.0, 0.0, 0.0 },
-                                        { 0.0, 0.0, 0.0 } } } } } } };
+                                      { { 0.0, 0.0, -60000.0 },
+                                        { 50000.0, 0.0, -60000.0 },
+                                        { 50000.0, 40000.0, -60000.0 },
+                                        { 0.0, 40000.0, -60000.0 },
+                                        { 0.0, 0.0, -30000.0 },
+                                        { 50000.0, 0.0, -30000.0 },
+                                        { 50000.0, 40000.0, -30000.0 },
+                                        { 0.0, 40000.0, -30000.0 } } } } } } };
 
 TEST_P(Assembly3DTest, JacobianMatrix) {
   const auto &param_name = GetParam();

--- a/tests/unit-tests/assembly/dim3/jacobian_matrix/jacobian_matrix.cpp
+++ b/tests/unit-tests/assembly/dim3/jacobian_matrix/jacobian_matrix.cpp
@@ -22,9 +22,6 @@
  * hexahedral elements in physical space, allowing for accurate integration and
  * differentiation operations.
  *
- * @note Recent commits (cc3a5571, efd2e72c) implemented constructor-based
- * initialization and fixed test validation routines for improved robustness.
- *
  * @see specfem::assembly::jacobian_matrix
  * @see specfem::jacobian::compute_jacobian
  * @see ExpectedJacobian3D for test data structures
@@ -89,7 +86,7 @@ namespace specfem::assembly_test {
  * using tensor products of 1D GLL quadrature points. This structure stores
  * the total configuration for the entire mesh.
  */
-struct TotalGLLPoints {
+struct GridExtents {
   int ngllx;     ///< Number of GLL points in x direction
   int nglly;     ///< Number of GLL points in y direction
   int ngllz;     ///< Number of GLL points in z direction
@@ -103,7 +100,7 @@ struct TotalGLLPoints {
    * @param ngllz Number of GLL points in z direction
    * @param nelements Total number of spectral elements
    */
-  TotalGLLPoints(int ngllx, int nglly, int ngllz, int nelements)
+  GridExtents(int ngllx, int nglly, int ngllz, int nelements)
       : ngllx(ngllx), nglly(nglly), ngllz(ngllz), nelements(nelements) {}
 };
 
@@ -207,7 +204,7 @@ struct ExpectedJacobian3D {
   constexpr static specfem::dimension::type dimension =
       specfem::dimension::type::dim3; ///< Compile-time dimension specification
 
-  TotalGLLPoints total_gll_points; ///< GLL discretization parameters
+  GridExtents total_gll_points;    ///< GLL discretization parameters
   std::vector<Element3D> elements; ///< Collection of test elements
 
   /**
@@ -216,7 +213,7 @@ struct ExpectedJacobian3D {
    * @param total_gll_points GLL point configuration for the mesh
    * @param elements Initializer list of Element3D test cases
    */
-  ExpectedJacobian3D(TotalGLLPoints total_gll_points,
+  ExpectedJacobian3D(GridExtents total_gll_points,
                      const std::initializer_list<Element3D> &elements)
       : total_gll_points(total_gll_points), elements(elements) {}
 

--- a/tests/unit-tests/assembly/dim3/jacobian_matrix/jacobian_matrix.cpp
+++ b/tests/unit-tests/assembly/dim3/jacobian_matrix/jacobian_matrix.cpp
@@ -1,0 +1,212 @@
+#include "../test_fixture.hpp"
+#include "enumerations/interface.hpp"
+#include "quadrature/interface.hpp"
+#include "specfem/assembly.hpp"
+#include "specfem/jacobian.hpp"
+#include "specfem/point.hpp"
+#include "gtest/gtest.h"
+#include <Kokkos_Core.hpp>
+#include <array>
+#include <unordered_map>
+#include <vector>
+
+#define CHECK_VIEW_ALLOCATION(view, nspec, ngllz, nglly, ngllx)                \
+  ASSERT_TRUE(view.extent(0) == nspec)                                         \
+      << "View extent 0 mismatch. Expected: " << nspec                         \
+      << ", Got: " << view.extent(0) << std::endl;                             \
+  ASSERT_TRUE(view.extent(1) == ngllz)                                         \
+      << "View extent 1 mismatch. Expected: " << ngllz                         \
+      << ", Got: " << view.extent(1) << std::endl;                             \
+  ASSERT_TRUE(view.extent(2) == nglly)                                         \
+      << "View extent 2 mismatch. Expected: " << nglly                         \
+      << ", Got: " << view.extent(2) << std::endl;                             \
+  ASSERT_TRUE(view.extent(3) == ngllx)                                         \
+      << "View extent 3 mismatch. Expected: " << ngllx                         \
+      << ", Got: " << view.extent(3) << std::endl;
+
+namespace specfem::assembly_test {
+
+struct TotalGLLPoints {
+  int ngllx;     ///< Number of GLL points in x direction
+  int nglly;     ///< Number of GLL points in y direction
+  int ngllz;     ///< Number of GLL points in z direction
+  int nelements; ///< Total number of elements in the mesh
+
+  TotalGLLPoints(int ngllx, int nglly, int ngllz, int nelements)
+      : ngllx(ngllx), nglly(nglly), ngllz(ngllz), nelements(nelements) {}
+};
+
+struct Element3D {
+  int element_id;
+  int control_nodes_per_element;
+
+private:
+  std::vector<std::array<type_real, 3> > _coordinates;
+
+public:
+  Element3D(int element_id, int control_nodes_per_element,
+            const std::initializer_list<std::array<type_real, 3> > &coords)
+      : element_id(element_id),
+        control_nodes_per_element(control_nodes_per_element),
+        _coordinates(coords) {
+    int i = 0;
+    for (const auto &coord : coords) {
+      _coordinates[i] = coord;
+      ++i;
+    }
+  }
+
+  const Kokkos::View<
+      specfem::point::global_coordinates<specfem::dimension::type::dim3> *,
+      Kokkos::HostSpace>
+  coordinates() const {
+    const int npoints = static_cast<int>(_coordinates.size());
+    Kokkos::View<
+        specfem::point::global_coordinates<specfem::dimension::type::dim3> *,
+        Kokkos::HostSpace>
+        coord_view("coord_view", npoints);
+    for (int i = 0; i < npoints; ++i) {
+      coord_view(i) = { _coordinates[i][0], _coordinates[i][1],
+                        _coordinates[i][2] };
+    }
+    return coord_view;
+  }
+};
+
+struct ExpectedJacobian3D {
+  constexpr static specfem::dimension::type dimension =
+      specfem::dimension::type::dim3;
+  TotalGLLPoints total_gll_points;
+  std::vector<Element3D> elements;
+
+  ExpectedJacobian3D(TotalGLLPoints total_gll_points,
+                     const std::initializer_list<Element3D> &elements)
+      : total_gll_points(total_gll_points), elements(elements) {}
+
+  void check(const specfem::assembly::jacobian_matrix<dimension>
+                 &jacobian_matrix) const {
+    ASSERT_EQ(jacobian_matrix.nspec, total_gll_points.nelements)
+        << "Total number of elements mismatch. "
+        << "Expected: " << total_gll_points.nelements << ", "
+        << "Got: " << jacobian_matrix.nspec << std::endl;
+    ASSERT_EQ(jacobian_matrix.ngllx, total_gll_points.ngllx)
+        << "Total number of GLL points in x direction mismatch. "
+        << "Expected: " << total_gll_points.ngllx << ", "
+        << "Got: " << jacobian_matrix.ngllx << std::endl;
+    ASSERT_EQ(jacobian_matrix.nglly, total_gll_points.nglly)
+        << "Total number of GLL points in y direction mismatch. "
+        << "Expected: " << total_gll_points.nglly << ", "
+        << "Got: " << jacobian_matrix.nglly << std::endl;
+    ASSERT_EQ(jacobian_matrix.ngllz, total_gll_points.ngllz)
+        << "Total number of GLL points in z direction mismatch. "
+        << "Expected: " << total_gll_points.ngllz << ", "
+        << "Got: " << jacobian_matrix.ngllz << std::endl;
+
+    // Check that views are allocated
+    const int nspec = jacobian_matrix.nspec;
+    const int ngllx = jacobian_matrix.ngllx;
+    const int nglly = jacobian_matrix.nglly;
+    const int ngllz = jacobian_matrix.ngllz;
+
+    // Gernerate quadrature
+    const auto quadrature = []() {
+      specfem::quadrature::gll::gll gll{};
+      return specfem::quadrature::quadratures(gll);
+    }();
+
+    CHECK_VIEW_ALLOCATION(jacobian_matrix.h_xix, nspec, ngllz, nglly, ngllx);
+    CHECK_VIEW_ALLOCATION(jacobian_matrix.h_xiy, nspec, ngllz, nglly, ngllx);
+    CHECK_VIEW_ALLOCATION(jacobian_matrix.h_xiz, nspec, ngllz, nglly, ngllx);
+    CHECK_VIEW_ALLOCATION(jacobian_matrix.h_etax, nspec, ngllz, nglly, ngllx);
+    CHECK_VIEW_ALLOCATION(jacobian_matrix.h_etay, nspec, ngllz, nglly, ngllx);
+    CHECK_VIEW_ALLOCATION(jacobian_matrix.h_etaz, nspec, ngllz, nglly, ngllx);
+    CHECK_VIEW_ALLOCATION(jacobian_matrix.h_gammax, nspec, ngllz, nglly, ngllx);
+    CHECK_VIEW_ALLOCATION(jacobian_matrix.h_gammay, nspec, ngllz, nglly, ngllx);
+    CHECK_VIEW_ALLOCATION(jacobian_matrix.h_gammaz, nspec, ngllz, nglly, ngllx);
+    CHECK_VIEW_ALLOCATION(jacobian_matrix.h_jacobian, nspec, ngllz, nglly,
+                          ngllx);
+
+    CHECK_VIEW_ALLOCATION(jacobian_matrix.xix, nspec, ngllz, nglly, ngllx);
+    CHECK_VIEW_ALLOCATION(jacobian_matrix.xiy, nspec, ngllz, nglly, ngllx);
+    CHECK_VIEW_ALLOCATION(jacobian_matrix.xiz, nspec, ngllz, nglly, ngllx);
+    CHECK_VIEW_ALLOCATION(jacobian_matrix.etax, nspec, ngllz, nglly, ngllx);
+    CHECK_VIEW_ALLOCATION(jacobian_matrix.etay, nspec, ngllz, nglly, ngllx);
+    CHECK_VIEW_ALLOCATION(jacobian_matrix.etaz, nspec, ngllz, nglly, ngllx);
+    CHECK_VIEW_ALLOCATION(jacobian_matrix.gammax, nspec, ngllz, nglly, ngllx);
+    CHECK_VIEW_ALLOCATION(jacobian_matrix.gammay, nspec, ngllz, nglly, ngllx);
+    CHECK_VIEW_ALLOCATION(jacobian_matrix.gammaz, nspec, ngllz, nglly, ngllx);
+
+    const auto xi = quadrature.gll.get_hxi();
+
+    for (const auto &element : elements) {
+      const int ispec = element.element_id;
+      const auto expected_coord = element.coordinates();
+      for (int iz = 0; iz < ngllz; ++iz) {
+        for (int iy = 0; iy < nglly; ++iy) {
+          for (int ix = 0; ix < ngllx; ++ix) {
+            const type_real xil = xi(ix);
+            const type_real etal = xi(iy);
+            const type_real zetal = xi(iz);
+
+            const auto expected_jacobian = specfem::jacobian::compute_jacobian(
+                expected_coord, element.control_nodes_per_element, xil, etal,
+                zetal);
+
+            const type_real tol = 1e-6;
+
+            const auto point_jacobian = [&]()
+                -> specfem::point::jacobian_matrix<dimension, true, false> {
+              specfem::point::jacobian_matrix<dimension, true, false>
+                  point_jacobian;
+              specfem::assembly::load_on_host(
+                  specfem::point::index<dimension, false>(ispec, iz, iy, ix),
+                  jacobian_matrix, point_jacobian);
+              return point_jacobian;
+            }();
+
+            EXPECT_TRUE(expected_jacobian == point_jacobian)
+                << "Jacobian matrix mismatch at element " << ispec
+                << ", GLL point (" << ix << ", " << iy << ", " << iz << ").";
+          }
+        }
+      }
+    }
+
+    SUCCEED()
+        << "Jacobian matrix check passed for all elements and GLL points.";
+  }
+};
+
+} // namespace specfem::assembly_test
+
+using namespace specfem::assembly_test;
+
+static const std::unordered_map<std::string, ExpectedJacobian3D>
+    expected_jacobians_3d = { { "EightNodeElastic",
+                                { { 5, 5, 5, 8 }, // Total GLL points: ngllx,
+                                                  // nglly, ngllz, nelements
+                                  { { 0,
+                                      8,
+                                      { { 0.0, 50000.0, 50000.0 },
+                                        { 50000.0, 50000.0, 0.0 },
+                                        { 50000.0, 0.0, 0.0 },
+                                        { 0.0, 0.0, 50000.0 },
+                                        { 0.0, 50000.0, 50000.0 },
+                                        { 50000.0, 50000.0, 0.0 },
+                                        { 50000.0, 0.0, 0.0 },
+                                        { 0.0, 0.0, 0.0 } } } } } } };
+
+TEST_P(Assembly3DTest, JacobianMatrix) {
+  const auto &param_name = GetParam();
+
+  if (expected_jacobians_3d.find(param_name) == expected_jacobians_3d.end()) {
+    GTEST_SKIP() << "No expected jacobian matrix data available for test case '"
+                 << param_name << "'.";
+    return;
+  }
+
+  const auto &assembly = getAssembly();
+  const auto &jacobian_matrix = assembly.jacobian_matrix;
+  const auto &expected_jacobian = expected_jacobians_3d.at(param_name);
+  expected_jacobian.check(jacobian_matrix);
+}

--- a/tests/unit-tests/assembly/dim3/jacobian_matrix/jacobian_matrix.cpp
+++ b/tests/unit-tests/assembly/dim3/jacobian_matrix/jacobian_matrix.cpp
@@ -1,3 +1,35 @@
+/**
+ * @file jacobian_matrix.cpp
+ * @brief Unit tests for 3D Jacobian matrix computation in spectral element
+ * assembly.
+ *
+ * This file contains comprehensive tests for validating the Jacobian matrix
+ * computation in 3D spectral element methods. The Jacobian matrix represents
+ * the transformation between reference coordinates \f$(\xi, \eta, \gamma)\f$
+ * and physical coordinates
+ * \f$(x, y, z)\f$ for hexahedral spectral elements.
+ *
+ * @details The tests verify:
+ * - Correct allocation and dimensioning of Jacobian matrix storage
+ * - Accurate computation of partial derivatives (\f$\xi_x, \xi_y, \xi_z\f$,
+ * etc.)
+ * - Proper Jacobian determinant calculation
+ * - Consistency between host and device memory layouts
+ * - Validation against analytical solutions for simple element geometries
+ *
+ * The Jacobian transformation is fundamental to spectral element methods as it
+ * enables the mapping from the reference element \f$[-1,1]^3\f$ to arbitrary
+ * hexahedral elements in physical space, allowing for accurate integration and
+ * differentiation operations.
+ *
+ * @note Recent commits (cc3a5571, efd2e72c) implemented constructor-based
+ * initialization and fixed test validation routines for improved robustness.
+ *
+ * @see specfem::assembly::jacobian_matrix
+ * @see specfem::jacobian::compute_jacobian
+ * @see ExpectedJacobian3D for test data structures
+ */
+
 #include "../test_fixture.hpp"
 #include "enumerations/interface.hpp"
 #include "quadrature/interface.hpp"
@@ -10,6 +42,26 @@
 #include <unordered_map>
 #include <vector>
 
+/**
+ * @brief Macro for validating Kokkos View allocation with expected dimensions.
+ *
+ * This macro performs comprehensive dimension checking for 4D Kokkos Views used
+ * in Jacobian matrix storage. It validates that each dimension matches the
+ * expected values for spectral element discretization:
+ * - Extent 0: Number of spectral elements (nspec)
+ * - Extent 1: Number of GLL points in z direction (ngllz)
+ * - Extent 2: Number of GLL points in y direction (nglly)
+ * - Extent 3: Number of GLL points in x direction (ngllx)
+ *
+ * @param view The Kokkos View to validate
+ * @param nspec Expected number of spectral elements
+ * @param ngllz Expected number of GLL points in z direction
+ * @param nglly Expected number of GLL points in y direction
+ * @param ngllx Expected number of GLL points in x direction
+ *
+ * @note The macro provides detailed error messages indicating which dimension
+ *       failed validation and the expected vs. actual values.
+ */
 #define CHECK_VIEW_ALLOCATION(view, nspec, ngllz, nglly, ngllx)                \
   ASSERT_TRUE(view.extent(0) == nspec)                                         \
       << "View extent 0 mismatch. Expected: " << nspec                         \
@@ -26,24 +78,71 @@
 
 namespace specfem::assembly_test {
 
+/**
+ * @brief Container for total GLL point configuration in 3D spectral elements.
+ *
+ * This structure encapsulates the discretization parameters that define the
+ * number of Gauss-Lobatto-Legendre (GLL) quadrature points in each spatial
+ * dimension for a 3D spectral element mesh.
+ *
+ * @details In spectral element methods, each hexahedral element is discretized
+ * using tensor products of 1D GLL quadrature points. This structure stores
+ * the total configuration for the entire mesh.
+ */
 struct TotalGLLPoints {
   int ngllx;     ///< Number of GLL points in x direction
   int nglly;     ///< Number of GLL points in y direction
   int ngllz;     ///< Number of GLL points in z direction
   int nelements; ///< Total number of elements in the mesh
 
+  /**
+   * @brief Constructor for GLL point configuration.
+   *
+   * @param ngllx Number of GLL points in x direction
+   * @param nglly Number of GLL points in y direction
+   * @param ngllz Number of GLL points in z direction
+   * @param nelements Total number of spectral elements
+   */
   TotalGLLPoints(int ngllx, int nglly, int ngllz, int nelements)
       : ngllx(ngllx), nglly(nglly), ngllz(ngllz), nelements(nelements) {}
 };
 
+/**
+ * @brief Test fixture for a single 3D hexahedral spectral element.
+ *
+ * This class represents a single hexahedral spectral element with its geometric
+ * properties and control node coordinates. It provides functionality to convert
+ * coordinate data into Kokkos Views compatible with SPECFEM++ data structures.
+ *
+ * @details The element stores:
+ * - Element identifier for test organization
+ * - Number of control nodes (typically 8 for hexahedral elements)
+ * - 3D coordinates of all control nodes in physical space
+ *
+ * The coordinate transformation follows the standard hexahedral element
+ * ordering convention used in SPECFEM++ for consistent geometric
+ * representation.
+ */
 struct Element3D {
-  int element_id;
-  int control_nodes_per_element;
+  int element_id;                ///< Unique identifier for the element
+  int control_nodes_per_element; ///< Number of control nodes (typically 8 for
+                                 ///< hex elements)
 
 private:
-  std::vector<std::array<type_real, 3> > _coordinates;
+  std::vector<std::array<type_real, 3> > _coordinates; ///< Private storage for
+                                                       ///< 3D coordinates
 
 public:
+  /**
+   * @brief Constructor for 3D spectral element.
+   *
+   * @param element_id Unique identifier for this element
+   * @param control_nodes_per_element Number of control nodes (typically 8)
+   * @param coords Initializer list of 3D coordinate arrays {x, y, z}
+   *
+   * @note The coordinate ordering should follow the standard hexahedral
+   *       element convention used in SPECFEM++.
+   */
   Element3D(int element_id, int control_nodes_per_element,
             const std::initializer_list<std::array<type_real, 3> > &coords)
       : element_id(element_id),
@@ -56,6 +155,18 @@ public:
     }
   }
 
+  /**
+   * @brief Convert stored coordinates to Kokkos View format.
+   *
+   * This method transforms the internally stored coordinate data into a
+   * Kokkos HostSpace View that is compatible with SPECFEM++ Jacobian
+   * computation routines.
+   *
+   * @return Kokkos View containing global coordinates for all control nodes
+   *
+   * @note The returned view uses HostSpace memory and contains
+   *       specfem::point::global_coordinates data structures.
+   */
   const Kokkos::View<
       specfem::point::global_coordinates<specfem::dimension::type::dim3> *,
       Kokkos::HostSpace>
@@ -73,18 +184,72 @@ public:
   }
 };
 
+/**
+ * @brief Expected results container for 3D Jacobian matrix validation.
+ *
+ * This structure encapsulates the expected configuration and validation logic
+ * for testing 3D Jacobian matrix computations. It stores reference element
+ * geometries and provides comprehensive validation against computed results.
+ *
+ * @details The validator performs multi-level verification:
+ * 1. **Dimensional consistency**: Validates mesh parameters (nspec, ngll*)
+ * 2. **Memory allocation**: Ensures all Kokkos Views are properly allocated
+ * 3. **Mathematical accuracy**: Compares computed vs. analytical Jacobian
+ * values
+ * 4. **Point-wise validation**: Tests every GLL quadrature point in every
+ * element
+ *
+ * The validation process uses analytical Jacobian computation via
+ * specfem::jacobian::compute_jacobian() and compares results at each
+ * GLL point with a specified tolerance.
+ */
 struct ExpectedJacobian3D {
   constexpr static specfem::dimension::type dimension =
-      specfem::dimension::type::dim3;
-  TotalGLLPoints total_gll_points;
-  std::vector<Element3D> elements;
+      specfem::dimension::type::dim3; ///< Compile-time dimension specification
 
+  TotalGLLPoints total_gll_points; ///< GLL discretization parameters
+  std::vector<Element3D> elements; ///< Collection of test elements
+
+  /**
+   * @brief Constructor for expected Jacobian validation data.
+   *
+   * @param total_gll_points GLL point configuration for the mesh
+   * @param elements Initializer list of Element3D test cases
+   */
   ExpectedJacobian3D(TotalGLLPoints total_gll_points,
                      const std::initializer_list<Element3D> &elements)
       : total_gll_points(total_gll_points), elements(elements) {}
 
+  /**
+   * @brief Comprehensive validation of computed Jacobian matrix.
+   *
+   * This method performs exhaustive testing of the Jacobian matrix computation
+   * including dimensional verification, memory allocation checks, and
+   * point-wise mathematical validation against analytical solutions.
+   *
+   * @param jacobian_matrix The computed Jacobian matrix to validate
+   *
+   * @details Validation steps:
+   * 1. **Parameter Validation**: Checks nspec, ngllx, nglly, ngllz consistency
+   * 2. **Memory Layout Validation**: Verifies all device and host View
+   * allocations
+   * 3. **Quadrature Setup**: Initializes GLL quadrature points for integration
+   * 4. **Point-wise Comparison**: For each element and GLL point:
+   *    - Computes analytical Jacobian using reference implementation
+   *    - Extracts computed values from jacobian_matrix
+   *    - Performs tolerance-based comparison (1e-6 default)
+   *
+   * @note The validation uses specfem::assembly::load_on_host() to extract
+   *       point-specific Jacobian data and
+   * specfem::jacobian::compute_jacobian() for analytical reference values.
+   *
+   * @throws AssertionError if any validation step fails, with detailed
+   *         error messages indicating the failure location and expected vs.
+   * actual values.
+   */
   void check(const specfem::assembly::jacobian_matrix<dimension>
                  &jacobian_matrix) const {
+    // Validate mesh configuration parameters
     ASSERT_EQ(jacobian_matrix.nspec, total_gll_points.nelements)
         << "Total number of elements mismatch. "
         << "Expected: " << total_gll_points.nelements << ", "
@@ -102,18 +267,19 @@ struct ExpectedJacobian3D {
         << "Expected: " << total_gll_points.ngllz << ", "
         << "Got: " << jacobian_matrix.ngllz << std::endl;
 
-    // Check that views are allocated
+    // Extract dimensions for validation
     const int nspec = jacobian_matrix.nspec;
     const int ngllx = jacobian_matrix.ngllx;
     const int nglly = jacobian_matrix.nglly;
     const int ngllz = jacobian_matrix.ngllz;
 
-    // Gernerate quadrature
+    // Initialize GLL quadrature for coordinate transformations
     const auto quadrature = []() {
       specfem::quadrature::gll::gll gll{};
       return specfem::quadrature::quadratures(gll);
     }();
 
+    // Validate host mirror View allocations for partial derivatives
     CHECK_VIEW_ALLOCATION(jacobian_matrix.h_xix, nspec, ngllz, nglly, ngllx);
     CHECK_VIEW_ALLOCATION(jacobian_matrix.h_xiy, nspec, ngllz, nglly, ngllx);
     CHECK_VIEW_ALLOCATION(jacobian_matrix.h_xiz, nspec, ngllz, nglly, ngllx);
@@ -126,6 +292,7 @@ struct ExpectedJacobian3D {
     CHECK_VIEW_ALLOCATION(jacobian_matrix.h_jacobian, nspec, ngllz, nglly,
                           ngllx);
 
+    // Validate device View allocations for partial derivatives
     CHECK_VIEW_ALLOCATION(jacobian_matrix.xix, nspec, ngllz, nglly, ngllx);
     CHECK_VIEW_ALLOCATION(jacobian_matrix.xiy, nspec, ngllz, nglly, ngllx);
     CHECK_VIEW_ALLOCATION(jacobian_matrix.xiz, nspec, ngllz, nglly, ngllx);
@@ -136,24 +303,32 @@ struct ExpectedJacobian3D {
     CHECK_VIEW_ALLOCATION(jacobian_matrix.gammay, nspec, ngllz, nglly, ngllx);
     CHECK_VIEW_ALLOCATION(jacobian_matrix.gammaz, nspec, ngllz, nglly, ngllx);
 
+    // Extract GLL quadrature points for coordinate transformation
     const auto xi = quadrature.gll.get_hxi();
 
+    // Point-wise Jacobian validation for all elements and GLL points
     for (const auto &element : elements) {
       const int ispec = element.element_id;
       const auto expected_coord = element.coordinates();
+
+      // Iterate through all GLL points in 3D (z, y, x order)
       for (int iz = 0; iz < ngllz; ++iz) {
         for (int iy = 0; iy < nglly; ++iy) {
           for (int ix = 0; ix < ngllx; ++ix) {
+            // Extract reference coordinates for this GLL point
             const type_real xil = xi(ix);
             const type_real etal = xi(iy);
             const type_real zetal = xi(iz);
 
+            // Compute analytical Jacobian matrix using reference implementation
             const auto expected_jacobian = specfem::jacobian::compute_jacobian(
                 expected_coord, element.control_nodes_per_element, xil, etal,
                 zetal);
 
+            // Set numerical tolerance for floating-point comparison
             const type_real tol = 1e-6;
 
+            // Extract computed Jacobian data from assembly structure
             const auto point_jacobian = [&]()
                 -> specfem::point::jacobian_matrix<dimension, true, false> {
               specfem::point::jacobian_matrix<dimension, true, false>
@@ -164,6 +339,7 @@ struct ExpectedJacobian3D {
               return point_jacobian;
             }();
 
+            // Perform tolerance-based comparison of Jacobian matrices
             EXPECT_TRUE(expected_jacobian == point_jacobian)
                 << "Jacobian matrix mismatch at element " << ispec
                 << ", GLL point (" << ix << ", " << iy << ", " << iz << ").";
@@ -181,30 +357,83 @@ struct ExpectedJacobian3D {
 
 using namespace specfem::assembly_test;
 
-//
-// Ground truth data for Jacobian matrix tests in 3D
-// How should you add new test cases?
-// The goal is to test elements where you might think Jacobian computation
-// could be wrong. For example, elements with high aspect ratio, distorted
-// elements, etc.
-// The first tests check jacobian for a simple EightNodeElastic element, where
-// we expect the jacobian to be very uniform across all GLL points.
-// Future tests should check more complex elements.
+/**
+ * @brief Ground truth test data for 3D Jacobian matrix validation.
+ *
+ * This section defines reference test cases with known geometric configurations
+ * and expected Jacobian matrix behavior. Each test case represents a specific
+ * element geometry that exercises different aspects of the Jacobian
+ * computation.
+ *
+ * @details Current test cases:
+ * - **EightNodeElastic**: Standard hexahedral element with uniform geometry
+ *   - Configuration: 5×5×5 GLL points, 8 spectral elements
+ *   - Geometry: Regular rectangular parallelepiped (50000×40000×30000 units)
+ *   - Purpose: Validates basic Jacobian computation for well-conditioned
+ * elements
+ *   - Expected behavior: Uniform Jacobian across all GLL points due to regular
+ * geometry
+ *
+ * @note When adding new test cases, focus on geometries that might reveal
+ *       computational issues:
+ *       - High aspect ratio elements
+ *       - Severely distorted or skewed elements
+ *       - Elements with curved boundaries
+ *       - Near-degenerate configurations
+ *
+ * @warning The coordinate ordering must follow SPECFEM++ hexahedral element
+ *          conventions for consistent geometric representation.
+ */
 static const std::unordered_map<std::string, ExpectedJacobian3D>
-    expected_jacobians_3d = { { "EightNodeElastic",
-                                { { 5, 5, 5, 8 }, // Total GLL points: ngllx,
-                                                  // nglly, ngllz, nelements
-                                  { { 0,
-                                      8,
-                                      { { 0.0, 0.0, -60000.0 },
-                                        { 50000.0, 0.0, -60000.0 },
-                                        { 50000.0, 40000.0, -60000.0 },
-                                        { 0.0, 40000.0, -60000.0 },
-                                        { 0.0, 0.0, -30000.0 },
-                                        { 50000.0, 0.0, -30000.0 },
-                                        { 50000.0, 40000.0, -30000.0 },
-                                        { 0.0, 40000.0, -30000.0 } } } } } } };
+    expected_jacobians_3d = {
+      { "EightNodeElastic",
+        { { 5, 5, 5, 8 }, // GLL configuration: ngllx, nglly, ngllz, nelements
+          { { 0,          // Element ID
+              8,          // Control nodes per element (hexahedral)
+              {
+                  // Control node coordinates {x, y, z} in SPECFEM++ ordering
+                  { 0.0, 0.0, -60000.0 },         // Node 0: bottom-front-left
+                  { 50000.0, 0.0, -60000.0 },     // Node 1: bottom-front-right
+                  { 50000.0, 40000.0, -60000.0 }, // Node 2: bottom-back-right
+                  { 0.0, 40000.0, -60000.0 },     // Node 3: bottom-back-left
+                  { 0.0, 0.0, -30000.0 },         // Node 4: top-front-left
+                  { 50000.0, 0.0, -30000.0 },     // Node 5: top-front-right
+                  { 50000.0, 40000.0, -30000.0 }, // Node 6: top-back-right
+                  { 0.0, 40000.0, -30000.0 }      // Node 7: top-back-left
+              } } } } }
+    };
 
+/**
+ * @brief Parameterized test for 3D Jacobian matrix computation validation.
+ *
+ * This test validates the Jacobian matrix computation for 3D spectral elements
+ * using parameterized test cases. Each test case represents a different
+ * geometric configuration and validates both the structural integrity and
+ * mathematical accuracy of the computed Jacobian matrices.
+ *
+ * @details Test execution flow:
+ * 1. **Parameter Retrieval**: Gets test case name from parameterized test
+ * framework
+ * 2. **Data Validation**: Ensures expected results exist for the test case
+ * 3. **Assembly Access**: Retrieves computed Jacobian matrix from test assembly
+ * 4. **Comprehensive Validation**: Delegates to ExpectedJacobian3D::check()
+ * for:
+ *    - Dimensional consistency verification
+ *    - Memory allocation validation
+ *    - Point-wise mathematical accuracy testing
+ *
+ * @note The test uses GoogleTest's parameterized testing framework, allowing
+ *       multiple geometric configurations to be tested with the same validation
+ * logic.
+ *
+ * @param param_name Test case identifier (e.g., "EightNodeElastic")
+ *
+ * @warning If no expected data exists for a test case, the test is skipped
+ *          with an appropriate message rather than failing.
+ *
+ * @see Assembly3DTest for test fixture implementation
+ * @see expected_jacobians_3d for available test case configurations
+ */
 TEST_P(Assembly3DTest, JacobianMatrix) {
   const auto &param_name = GetParam();
 

--- a/tests/unit-tests/assembly/dim3/mesh/control_nodes.cpp
+++ b/tests/unit-tests/assembly/dim3/mesh/control_nodes.cpp
@@ -139,7 +139,7 @@ static const std::unordered_map<std::string, ExpectedControlNodes3D>
     expected_control_nodes_map = {
       { "EightNodeElastic",
         ExpectedControlNodes3D(
-            TotalControlNodes(125, 8),
+            TotalControlNodes(8, 8),
             { // Domain corner
               ControlNode3D(0.0, 0.0, 0.0, 4, 4, 4),
               // Shared nodes

--- a/tests/unit-tests/assembly/dim3/mesh/control_nodes.cpp
+++ b/tests/unit-tests/assembly/dim3/mesh/control_nodes.cpp
@@ -1,0 +1,164 @@
+#include "../test_fixture.hpp"
+#include "enumerations/interface.hpp"
+#include "specfem/assembly.hpp"
+#include "utilities/utilities.hpp"
+#include <gtest/gtest.h>
+#include <vector>
+
+namespace specfem::assembly_test {
+
+struct TotalControlNodes {
+  int nnodes_per_element; ///< Number of control nodes per element
+  int nelements;          ///< Total number of elements in the mesh
+  TotalControlNodes(int nnodes_per_element, int nelements)
+      : nnodes_per_element(nnodes_per_element), nelements(nelements) {}
+};
+
+struct ControlNode3D {
+  type_real x, y, z;
+  int id;
+  int element_id;
+  int local_id;
+  ControlNode3D(type_real x, type_real y, type_real z, int id, int element_id,
+                int local_id)
+      : x(x), y(y), z(z), id(id), element_id(element_id), local_id(local_id) {}
+};
+
+struct ExpectedControlNodes3D {
+  constexpr static specfem::dimension::type dimension =
+      specfem::dimension::type::dim3;
+  TotalControlNodes total_control_nodes;
+  std::vector<ControlNode3D> nodes;
+
+  ExpectedControlNodes3D(TotalControlNodes total_control_nodes,
+                         const std::initializer_list<ControlNode3D> nodes)
+      : total_control_nodes(total_control_nodes), nodes(nodes) {}
+
+  void check(const specfem::assembly::mesh_impl::control_nodes<dimension>
+                 &control_nodes) const {
+    ASSERT_EQ(control_nodes.nspec, total_control_nodes.nelements)
+        << "Total number of elements mismatch. "
+        << "Expected: " << total_control_nodes.nelements << ", "
+        << "Got: " << control_nodes.nspec << std::endl;
+    ASSERT_EQ(control_nodes.ngnod, total_control_nodes.nnodes_per_element)
+        << "Total number of control nodes per element mismatch. "
+        << "Expected: " << total_control_nodes.nnodes_per_element << ", "
+        << "Got: " << control_nodes.ngnod << std::endl;
+
+    // Make sure all views are allocated
+    ASSERT_TRUE(control_nodes.control_node_index.extent(0) ==
+                control_nodes.nspec)
+        << "Control node index extent 0 mismatch.";
+    ASSERT_TRUE(control_nodes.control_node_index.extent(1) ==
+                control_nodes.ngnod)
+        << "Control node index extent 1 mismatch.";
+    ASSERT_TRUE(control_nodes.control_node_coordinates.extent(0) ==
+                control_nodes.nspec)
+        << "Control node coordinates extent 0 mismatch.";
+    ASSERT_TRUE(control_nodes.control_node_coordinates.extent(1) ==
+                control_nodes.ngnod)
+        << "Control node coordinates extent 1 mismatch.";
+    ASSERT_TRUE(control_nodes.control_node_coordinates.extent(2) == 3)
+        << "Control node coordinates extent 2 mismatch.";
+
+    ASSERT_TRUE(control_nodes.h_control_node_index.extent(0) ==
+                control_nodes.nspec)
+        << "Control node index extent 0 mismatch.";
+    ASSERT_TRUE(control_nodes.h_control_node_index.extent(1) ==
+                control_nodes.ngnod)
+        << "Control node index extent 1 mismatch.";
+    ASSERT_TRUE(control_nodes.h_control_node_coordinates.extent(0) ==
+                control_nodes.nspec)
+        << "Control node coordinates extent 0 mismatch.";
+    ASSERT_TRUE(control_nodes.h_control_node_coordinates.extent(1) ==
+                control_nodes.ngnod)
+        << "Control node coordinates extent 1 mismatch.";
+    ASSERT_TRUE(control_nodes.h_control_node_coordinates.extent(2) == 3)
+        << "Control node coordinates extent 2 mismatch.";
+
+    for (const auto &expected_node : nodes) {
+      const int id = expected_node.id;
+
+      if (id < 0 || id >= control_nodes.ngnod * control_nodes.nspec) {
+        FAIL() << "Expected control node ID " << id << " is out of range."
+               << std::endl;
+
+        return;
+      }
+
+      EXPECT_EQ(control_nodes.h_control_node_index(expected_node.element_id,
+                                                   expected_node.local_id),
+                id)
+          << "Control node ID mismatch for element " << expected_node.element_id
+          << " local node " << expected_node.local_id << ". "
+          << "Expected: " << expected_node.id << ", "
+          << "Got: "
+          << control_nodes.h_control_node_index(expected_node.element_id,
+                                                expected_node.local_id)
+          << std::endl;
+
+      if (!specfem::utilities::is_close(
+              control_nodes.h_control_node_coordinates(
+                  expected_node.element_id, expected_node.local_id, 0),
+              expected_node.x) ||
+          !specfem::utilities::is_close(
+              control_nodes.h_control_node_coordinates(
+                  expected_node.element_id, expected_node.local_id, 1),
+              expected_node.y) ||
+          !specfem::utilities::is_close(
+              control_nodes.h_control_node_coordinates(
+                  expected_node.element_id, expected_node.local_id, 2),
+              expected_node.z)) {
+        FAIL() << "Control node ID " << id << " coordinates do not match. "
+               << "Expected: (" << expected_node.x << ", " << expected_node.y
+               << ", " << expected_node.z << "), "
+               << "Got: ("
+               << control_nodes.h_control_node_coordinates(
+                      expected_node.element_id, expected_node.local_id, 0)
+               << ", "
+               << control_nodes.h_control_node_coordinates(
+                      expected_node.element_id, expected_node.local_id, 1)
+               << ", "
+               << control_nodes.h_control_node_coordinates(
+                      expected_node.element_id, expected_node.local_id, 2)
+               << ")" << std::endl;
+      }
+
+      SUCCEED() << "All expected control nodes are present and correct."
+                << std::endl;
+    }
+  }
+};
+
+} // namespace specfem::assembly_test
+
+using namespace specfem::assembly_test;
+
+// Expected control nodes for specific test cases
+static const std::unordered_map<std::string, ExpectedControlNodes3D>
+    expected_control_nodes_map = {
+      { "EightNodeElastic",
+        ExpectedControlNodes3D(
+            TotalControlNodes(125, 8),
+            { // Domain corner
+              ControlNode3D(0.0, 0.0, 0.0, 4, 4, 4),
+              // Shared nodes
+              ControlNode3D(50000.0, 40000.0, -30000.0, 62, 0, 6),
+              ControlNode3D(50000.0, 40000.0, -30000.0, 62, 2, 5) }) }
+    };
+
+TEST_P(Assembly3DTest, ControlNodes) {
+  const auto &param_name = GetParam();
+  if (expected_control_nodes_map.find(param_name) ==
+      expected_control_nodes_map.end()) {
+    GTEST_SKIP() << "No expected control nodes defined for parameter: "
+                 << param_name;
+    return;
+  }
+
+  const auto &assembly = getAssembly();
+  const auto &control_nodes = assembly.mesh;
+  const auto &expected_nodes = expected_control_nodes_map.at(param_name);
+
+  expected_nodes.check(control_nodes);
+}

--- a/tests/unit-tests/assembly/dim3/mesh/points.hpp
+++ b/tests/unit-tests/assembly/dim3/mesh/points.hpp
@@ -1,0 +1,162 @@
+#include "../test_fixture.hpp"
+#include "MPI_environment.hpp"
+#include "enumerations/connections.hpp"
+#include "enumerations/interface.hpp"
+#include "enumerations/mesh_entity.hpp"
+#include "io/interface.hpp"
+#include "mesh/mesh.hpp"
+#include "specfem/assembly.hpp"
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/filtered_graph.hpp>
+#include <gtest/gtest.h>
+
+namespace specfem::assembly_test {
+
+struct TotalQuadraturePoints {
+  int nelements;
+  int ngllz;
+  int nglly;
+  int ngllx;
+  int npoints;
+  TotalQuadraturePoints(int nelements, int ngllz, int nglly, int ngllx,
+                        int npoints)
+      : nelements(nelements), ngllz(ngllz), nglly(nglly), ngllx(ngllx),
+        npoints(npoints) {}
+};
+
+struct ExpectedMapping {
+  constexpr static specfem::dimension::type dimension =
+      specfem::dimension::type::dim3;
+  TotalQuadraturePoints total_quadrature_points;
+  std::string database_file;
+
+  ExpectedMapping(TotalQuadraturePoints total_quadrature_points,
+                  const std::string &database_file)
+      : total_quadrature_points(total_quadrature_points),
+        database_file(database_file) {}
+
+  void
+  check(const specfem::assembly::mesh_impl::points<dimension> &points) const {
+
+    // Get the mesh
+    const auto expected_mesh = specfem::io::meshfem3d::read_3d_mesh(
+        database_file, MPIEnvironment::get_mpi());
+
+    ASSERT_EQ(points.nspec, total_quadrature_points.nelements)
+        << "Number of spectral elements mismatch. "
+        << "Expected: " << total_quadrature_points.nelements << ", "
+        << "Got: " << points.nspec << std::endl;
+    ASSERT_EQ(points.ngllz, total_quadrature_points.ngllz)
+        << "Number of GLL points in z-direction mismatch. "
+        << "Expected: " << total_quadrature_points.ngllz << ", "
+        << "Got: " << points.ngllz << std::endl;
+    ASSERT_EQ(points.nglly, total_quadrature_points.nglly)
+        << "Number of GLL points in y-direction mismatch. "
+        << "Expected: " << total_quadrature_points.nglly << ", "
+        << "Got: " << points.nglly << std::endl;
+    ASSERT_EQ(points.ngllx, total_quadrature_points.ngllx)
+        << "Number of GLL points in x-direction mismatch. "
+        << "Expected: " << total_quadrature_points.ngllx << ", "
+        << "Got: " << points.ngllx << std::endl;
+    ASSERT_EQ(points.nglob, total_quadrature_points.npoints)
+        << "Total number of global points mismatch. "
+        << "Expected: " << total_quadrature_points.npoints << ", "
+        << "Got: " << points.nglob << std::endl;
+
+    // Check that views are allocated correctly
+    ASSERT_TRUE(points.index_mapping.extent(0) == points.nspec)
+        << "Index mapping extent 0 mismatch.";
+    ASSERT_TRUE(points.index_mapping.extent(1) == points.ngllz)
+        << "Index mapping extent 1 mismatch.";
+    ASSERT_TRUE(points.index_mapping.extent(2) == points.nglly)
+        << "Index mapping extent 2 mismatch.";
+    ASSERT_TRUE(points.index_mapping.extent(3) == points.ngllx)
+        << "Index mapping extent 3 mismatch.";
+    ASSERT_TRUE(points.coord.extent(0) == points.nspec)
+        << "Coordinate view extent 0 mismatch.";
+    ASSERT_TRUE(points.coord.extent(1) == points.ngllz)
+        << "Coordinate view extent 1 mismatch.";
+    ASSERT_TRUE(points.coord.extent(2) == points.nglly)
+        << "Coordinate view extent 2 mismatch.";
+    ASSERT_TRUE(points.coord.extent(3) == points.ngllx)
+        << "Coordinate view extent 3 mismatch.";
+    ASSERT_TRUE(points.coord.extent(4) == 3)
+        << "Coordinate view extent 4 mismatch.";
+
+    const auto &adjacency_graph = expected_mesh.adjacency_graph;
+    const auto &graph = adjacency_graph.graph();
+
+    // Filter out strongly conforming connections
+    auto filter = [&graph](const auto &edge) {
+      return graph[edge].connection ==
+             specfem::connections::type::strongly_conforming;
+    };
+
+    // Create a filtered graph view
+    const auto fg = boost::make_filtered_graph(graph, filter);
+
+    // Validate index mapping and coordinates against expected mesh
+    for (int e = 0; e < points.nspec; e++) {
+      for (const auto edge :
+           boost::make_iterator_range(boost::out_edges(e, fg))) {
+        const int neighbor = boost::target(edge, graph);
+        const auto orientation1 = fg[edge].orientation;
+        const auto other_edge = boost::edge(neighbor, e, graph).first;
+        const auto orientation2 = fg[other_edge].orientation;
+
+        const auto connections = specfem::connections::connection_mapping(
+            points.ngllz, points.nglly, points.ngllx,
+            Kokkos::subview(expected_mesh.control_nodes.h_control_node_index, e,
+                            Kokkos::ALL),
+            Kokkos::subview(expected_mesh.control_nodes.h_control_node_index,
+                            neighbor, Kokkos::ALL));
+
+        const int npoints =
+            mapping.number_of_points_on_orientation(orientation1);
+        for (int p = 0; p < npoints; p++) {
+          const auto [iz, iy, ix] = mapping.map_coordinates(orientation1, p);
+          const auto [mapped_iz, mapped_iy, mapped_ix] =
+              connections.map_coordinates(orientation1, orientation2, iz, iy,
+                                          ix);
+          const int global_index_1 = points.h_index_mapping(e, iz, iy, ix);
+          const int global_index_2 =
+              points.h_index_mapping(neighbor, mapped_iz, mapped_iy, mapped_ix);
+          ASSERT_EQ(global_index_1, global_index_2)
+              << "Global index mismatch between element " << e
+              << " and neighbor " << neighbor << " at point " << p
+              << " on orientation " << orientation1 << ". "
+              << "Expected: " << global_index_2 << ", "
+              << "Got: " << global_index_1 << std::endl;
+        }
+      }
+    }
+
+    SUCCEED() << "All points mapping and coordinates are correct." << std::endl;
+    return;
+  }
+};
+
+} // namespace specfem::assembly_test
+
+usiong namespace specfem::assembly_test;
+
+const std::unordered_map<std::string, ExpectedMapping> expected_mappings = {
+  { "EightNodeElastic",
+    ExpectedMapping(TotalQuadraturePoints(8, 5, 5, 5, 1000),
+                    "dim3/mesh/EightNodeElastic/database.bin") }
+};
+
+TEST_P(Assembly3DTest, Points) {
+  const auto &param_name = GetParam();
+  if (expected_mappings.find(param_name) == expected_mappings.end()) {
+    GTEST_SKIP() << "No expected mapping defined for test case: " << param_name
+                 << std::endl;
+    return;
+  }
+  const auto &assembly = getAssembly();
+  const auto &points = assembly.mesh;
+
+  const auto &expected_mapping = expected_mappings.at(param_name);
+
+  expected_mapping.check(points);
+}

--- a/tests/unit-tests/assembly/dim3/mesh/shape_functions.cpp
+++ b/tests/unit-tests/assembly/dim3/mesh/shape_functions.cpp
@@ -1,0 +1,145 @@
+#include "specfem/shape_functions.hpp"
+#include "../test_fixture.hpp"
+#include "enumerations/interface.hpp"
+#include "quadrature/interface.hpp"
+#include "specfem/assembly.hpp"
+#include "utilities/utilities.hpp"
+#include <gtest/gtest.h>
+#include <vector>
+
+namespace specfem::assembly_test {
+
+struct ShapeFunction3D {
+  constexpr static specfem::dimension::type dimension =
+      specfem::dimension::type::dim3;
+  int ngllz;              ///< Number of GLL points in z-direction
+  int nglly;              ///< Number of GLL points in y-direction
+  int ngllx;              ///< Number of GLL points in x-direction
+  int nnodes_per_element; ///< Number of control nodes per element
+
+  ShapeFunction3D(int ngllz, int nglly, int ngllx, int nnodes_per_element)
+      : ngllz(ngllz), nglly(nglly), ngllx(ngllx),
+        nnodes_per_element(nnodes_per_element) {}
+
+  void check(const specfem::assembly::mesh_impl::shape_functions<dimension>
+                 &shape_functions) const {
+
+    // Gernerate quadrature
+    const auto quadrature = []() {
+      specfem::quadrature::gll::gll gll{};
+      return specfem::quadrature::quadratures(gll);
+    }();
+
+    ASSERT_EQ(shape_functions.ngllz, ngllz)
+        << "Number of GLL points in z-direction mismatch. "
+        << "Expected: " << ngllz << ", "
+        << "Got: " << shape_functions.ngllz << std::endl;
+    ASSERT_EQ(shape_functions.nglly, nglly)
+        << "Number of GLL points in y-direction mismatch. "
+        << "Expected: " << nglly << ", "
+        << "Got: " << shape_functions.nglly << std::endl;
+    ASSERT_EQ(shape_functions.ngllx, ngllx)
+        << "Number of GLL points in x-direction mismatch. "
+        << "Expected: " << ngllx << ", "
+        << "Got: " << shape_functions.ngllx << std::endl;
+    ASSERT_EQ(shape_functions.ngnod, nnodes_per_element)
+        << "Number of control nodes per element mismatch. "
+        << "Expected: " << nnodes_per_element << ", "
+        << "Got: " << shape_functions.ngnod << std::endl;
+
+    // Check if the shape function views are allocated correctly
+    ASSERT_TRUE(shape_functions.shape3D.extent(0) == ngllz)
+        << "Shape function extent 0 mismatch.";
+    ASSERT_TRUE(shape_functions.shape3D.extent(1) == nglly)
+        << "Shape function extent 1 mismatch.";
+    ASSERT_TRUE(shape_functions.shape3D.extent(2) == ngllx)
+        << "Shape function extent 2 mismatch.";
+    ASSERT_TRUE(shape_functions.shape3D.extent(3) == nnodes_per_element)
+        << "Shape function extent 3 mismatch.";
+    ASSERT_TRUE(shape_functions.dshape3D.extent(0) == ngllz)
+        << "Shape function derivative extent 0 mismatch.";
+    ASSERT_TRUE(shape_functions.dshape3D.extent(1) == nglly)
+        << "Shape function derivative extent 1 mismatch.";
+    ASSERT_TRUE(shape_functions.dshape3D.extent(2) == ngllx)
+        << "Shape function derivative extent 2 mismatch.";
+    ASSERT_TRUE(shape_functions.dshape3D.extent(3) == 3)
+        << "Shape function derivative extent 3 mismatch.";
+    ASSERT_TRUE(shape_functions.dshape3D.extent(4) == nnodes_per_element)
+        << "Shape function derivative extent 4 mismatch.";
+
+    const auto xi = quadrature.gll.get_hxi();
+    for (int iz = 0; iz < ngllz; iz++) {
+      for (int iy = 0; iy < nglly; iy++) {
+        for (int ix = 0; ix < ngllx; ix++) {
+          type_real xil = xi(ix);
+          type_real etal = xi(iy);
+          type_real zetal = xi(iz);
+
+          const auto expected_shape_function =
+              specfem::shape_function::shape_function(xil, etal, zetal,
+                                                      nnodes_per_element);
+
+          for (int in = 0; in < nnodes_per_element; in++) {
+            if (!specfem::utilities::is_close(
+                    shape_functions.h_shape3D(iz, iy, ix, in),
+                    expected_shape_function[in])) {
+              FAIL() << "Shape function value mismatch at (" << iz << ", " << iy
+                     << ", " << ix << ") for node " << in << ". "
+                     << "Expected: " << expected_shape_function[in] << ", "
+                     << "Got: " << shape_functions.h_shape3D(iz, iy, ix, in)
+                     << std::endl;
+            }
+            return;
+          }
+
+          const auto expected_shape_function_derivatives =
+              specfem::shape_function::shape_function_derivatives(
+                  xil, etal, zetal, nnodes_per_element);
+
+          for (int in = 0; in < nnodes_per_element; in++) {
+            for (int dim = 0; dim < 3; dim++) {
+              if (!specfem::utilities::is_close(
+                      shape_functions.h_dshape3D(iz, iy, ix, dim, in),
+                      expected_shape_function_derivatives[dim][in])) {
+                FAIL() << "Shape function derivative mismatch at (" << iz
+                       << ", " << iy << ", " << ix << ") for node " << in
+                       << " in dimension " << dim << ". "
+                       << "Expected: "
+                       << expected_shape_function_derivatives[dim][in] << ", "
+                       << "Got: "
+                       << shape_functions.h_dshape3D(iz, iy, ix, dim, in)
+                       << std::endl;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+};
+} // namespace specfem::assembly_test
+
+using namespace specfem::assembly_test;
+
+const static std::unordered_map<std::string,
+                                specfem::assembly_test::ShapeFunction3D>
+    expected_shape_functions_map = { { "EightNodeElastic",
+                                       specfem::assembly_test::ShapeFunction3D(
+                                           5, 5, 5, 8) } };
+
+TEST_P(Assembly3DTest, ShapeFunctions) {
+  const auto &param_name = GetParam();
+  if (expected_shape_functions_map.find(param_name) ==
+      expected_shape_functions_map.end()) {
+    GTEST_SKIP() << "No expected shape function data found for parameter: "
+                 << param_name;
+    return;
+  }
+
+  const auto &expected_shape_functions =
+      expected_shape_functions_map.at(param_name);
+  const auto &assembly = getAssembly();
+  const auto &shape_functions = assembly.mesh;
+
+  expected_shape_functions.check(shape_functions);
+}

--- a/tests/unit-tests/assembly/dim3/test_fixture.hpp
+++ b/tests/unit-tests/assembly/dim3/test_fixture.hpp
@@ -31,6 +31,7 @@ struct Assembly3D {
       nspec,     ngnod, 5, 5, 5, mesh.adjacency_graph, mesh.control_nodes,
       quadrature
     };
+    assembly.jacobian_matrix = { assembly.mesh };
   }
 };
 } // namespace specfem::test_configuration

--- a/tests/unit-tests/assembly/dim3/test_fixture.hpp
+++ b/tests/unit-tests/assembly/dim3/test_fixture.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "MPI_environment.hpp"
+#include "enumerations/interface.hpp"
+#include "io/interface.hpp"
+#include "mesh/dim3/meshfem3d/mesh.hpp"
+#include "specfem/assembly.hpp"
+#include <gtest/gtest.h>
+#include <string>
+
+namespace specfem::test_configuration {
+struct Assembly3D {
+  constexpr static specfem::dimension::type dimension =
+      specfem::dimension::type::dim3;
+  specfem::assembly::assembly<dimension> assembly;
+
+  Assembly3D() = default;
+
+  Assembly3D(const std::string &database_file, const specfem::MPI::MPI *mpi) {
+    const auto mesh = specfem::io::meshfem3d::read_3d_mesh(database_file, mpi);
+
+    const int nspec = mesh.nspec;
+    const int ngnod = mesh.control_nodes.ngnod;
+
+    const auto quadrature = []() {
+      specfem::quadrature::gll::gll gll{};
+      return specfem::quadrature::quadratures(gll);
+    }();
+
+    assembly.mesh = {
+      nspec,     ngnod, 5, 5, 5, mesh.adjacency_graph, mesh.control_nodes,
+      quadrature
+    };
+  }
+};
+} // namespace specfem::test_configuration
+
+// Setup a fixture for parameterized tests
+class Assembly3DTest : public ::testing::TestWithParam<std::string> {
+protected:
+  constexpr static specfem::dimension::type dimension =
+      specfem::dimension::type::dim3;
+  specfem::test_configuration::Assembly3D assembly;
+
+  Assembly3DTest() = default;
+
+  void SetUp() override {
+    const auto &folder = GetParam();
+    const std::string database_file = "data/dim3/" + folder + "/database.bin";
+    // Initialize MPI (assuming MPIEnvironment is defined elsewhere)
+    specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
+    assembly = specfem::test_configuration::Assembly3D(database_file, mpi);
+  }
+  void TearDown() override {
+    // Any cleanup needed for each test
+  }
+
+  ~Assembly3DTest() override = default;
+
+  // Accessor for the assembly
+  const auto &getAssembly() const { return assembly.assembly; }
+};

--- a/tests/unit-tests/assembly/runner.cpp
+++ b/tests/unit-tests/assembly/runner.cpp
@@ -1,6 +1,10 @@
 #include "../Kokkos_Environment.hpp"
 #include "../MPI_environment.hpp"
+#include "dim3/test_fixture.hpp"
 #include "gtest/gtest.h"
+
+INSTANTIATE_TEST_SUITE_P(Assembly3DTests, Assembly3DTest,
+                         ::testing::Values("EightNodeElastic"));
 
 int main(int argc, char *argv[]) {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
## Description

- Adds constructors for all impl types within assembly mesh
- Adds tests for eight node mesh

## Issue Number

Closes #1279 
## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
