### PR TITLE
Issue 1319 - Add tests for 2D/3D gradient computation

### DIFF
--- a/core/specfem/assembly/jacobian_matrix/dim3/jacobian_matrix.cpp
+++ b/core/specfem/assembly/jacobian_matrix/dim3/jacobian_matrix.cpp
@@ -2,6 +2,43 @@
 #include "mesh/mesh.hpp"
 #include "specfem/jacobian.hpp"
 
+specfem::assembly::jacobian_matrix<
+    specfem::dimension::type::dim3>::jacobian_matrix(const int nspec,
+                                                     const int ngllx,
+                                                     const int nglly,
+                                                     const int ngllz)
+    : nspec(nspec), ngllx(ngllx), nglly(nglly), ngllz(ngllz),
+      xix("specfem::assembly::jacobian_matrix::xix", nspec, ngllz, nglly,
+          ngllx),
+      xiy("specfem::assembly::jacobian_matrix::xiy", nspec, ngllz, nglly,
+          ngllx),
+      xiz("specfem::assembly::jacobian_matrix::xiz", nspec, ngllz, nglly,
+          ngllx),
+      etax("specfem::assembly::jacobian_matrix::etax", nspec, ngllz, nglly,
+           ngllx),
+      etay("specfem::assembly::jacobian_matrix::etay", nspec, ngllz, nglly,
+           ngllx),
+      etaz("specfem::assembly::jacobian_matrix::etaz", nspec, ngllz, nglly,
+           ngllx),
+      gammax("specfem::assembly::jacobian_matrix::gammax", nspec, ngllz, nglly,
+             ngllx),
+      gammay("specfem::assembly::jacobian_matrix::gammay", nspec, ngllz, nglly,
+             ngllx),
+      gammaz("specfem::assembly::jacobian_matrix::gammaz", nspec, ngllz, nglly,
+             ngllx),
+      jacobian("specfem::assembly::jacobian_matrix::jacobian", nspec, ngllz,
+               nglly, ngllx),
+      h_xix(Kokkos::create_mirror_view(xix)),
+      h_xiy(Kokkos::create_mirror_view(xiy)),
+      h_xiz(Kokkos::create_mirror_view(xiz)),
+      h_etax(Kokkos::create_mirror_view(etax)),
+      h_etay(Kokkos::create_mirror_view(etay)),
+      h_etaz(Kokkos::create_mirror_view(etaz)),
+      h_gammax(Kokkos::create_mirror_view(gammax)),
+      h_gammay(Kokkos::create_mirror_view(gammay)),
+      h_gammaz(Kokkos::create_mirror_view(gammaz)),
+      h_jacobian(Kokkos::create_mirror_view(jacobian)) {}
+
 specfem::assembly::jacobian_matrix<specfem::dimension::type::dim3>::
     jacobian_matrix(
         const specfem::mesh::jacobian_matrix<dimension_tag> &mesh_jacobian)

--- a/core/specfem/assembly/jacobian_matrix/dim3/jacobian_matrix.hpp
+++ b/core/specfem/assembly/jacobian_matrix/dim3/jacobian_matrix.hpp
@@ -49,6 +49,9 @@ struct jacobian_matrix<specfem::dimension::type::dim3>
 
   jacobian_matrix() = default;
 
+  jacobian_matrix(const int nspec, const int ngllx, const int nglly,
+                  const int ngllz);
+
   jacobian_matrix(
       const specfem::mesh::jacobian_matrix<dimension_tag> &mesh_jacobian);
 

--- a/include/algorithms/gradient.hpp
+++ b/include/algorithms/gradient.hpp
@@ -177,6 +177,7 @@ KOKKOS_FORCEINLINE_FUNCTION void gradient(
       chunk_index.get_iterator(),
       [&](const typename ChunkIndexType::iterator_type::index_type
               &iterator_index) {
+        const auto index = iterator_index.get_index();
         const auto local_index = iterator_index.get_local_index();
         datatype df_dxi[components] = { 0.0 };
         datatype df_dgamma[components] = { 0.0 };
@@ -184,7 +185,7 @@ KOKKOS_FORCEINLINE_FUNCTION void gradient(
                                         using_simd>
             point_jacobian_matrix;
 
-        specfem::assembly::load_on_device(local_index, jacobian_matrix,
+        specfem::assembly::load_on_device(index, jacobian_matrix,
                                           point_jacobian_matrix);
 
         const auto df =
@@ -256,6 +257,7 @@ KOKKOS_FORCEINLINE_FUNCTION void gradient(
       chunk_index.get_iterator(),
       [&](const typename ChunkIndexType::iterator_type::index_type
               &iterator_index) {
+        const auto index = iterator_index.get_index();
         const auto local_index = iterator_index.get_local_index();
         datatype df_dxi[components] = { 0.0 };
         datatype df_dgamma[components] = { 0.0 };
@@ -263,7 +265,7 @@ KOKKOS_FORCEINLINE_FUNCTION void gradient(
                                         using_simd>
             point_jacobian_matrix;
 
-        specfem::assembly::load_on_device(local_index, jacobian_matrix,
+        specfem::assembly::load_on_device(index, jacobian_matrix,
                                           point_jacobian_matrix);
 
         const auto df =

--- a/include/algorithms/gradient.hpp
+++ b/include/algorithms/gradient.hpp
@@ -419,6 +419,7 @@ KOKKOS_FORCEINLINE_FUNCTION void gradient(
       [&](const typename ChunkIndexType::iterator_type::index_type
               &iterator_index) {
         const auto local_index = iterator_index.get_local_index();
+        const auto index = iterator_index.get_index();
         datatype df_dxi[components] = { 0.0 };
         datatype df_deta[components] = { 0.0 };
         datatype df_dgamma[components] = { 0.0 };
@@ -429,7 +430,7 @@ KOKKOS_FORCEINLINE_FUNCTION void gradient(
                                         using_simd>
             point_jacobian_matrix;
 
-        specfem::assembly::load_on_device(local_index, jacobian_matrix,
+        specfem::assembly::load_on_device(index, jacobian_matrix,
                                           point_jacobian_matrix);
 
         const auto df =

--- a/include/algorithms/gradient.hpp
+++ b/include/algorithms/gradient.hpp
@@ -279,5 +279,170 @@ KOKKOS_FORCEINLINE_FUNCTION void gradient(
 
   return;
 }
+
+/**
+ * @brief Compute the gradient of a scalar field f using the spectral element
+ * formulation for 3D elements
+ *
+ * @ingroup AlgorithmsGradient
+ *
+ * @tparam ChunkIndexType Chunk index type
+ * @tparam VectorFieldType Field view type (Chunk view)
+ * @tparam QuadratureType Quadrature view type
+ * @tparam CallbackFunctor Callback functor type
+ * @param chunk_index Chunk index specifying the elements within this chunk
+ * @param jacobian_matrix Jacobian matrix of basis functions
+ * @param quadrature Integration quadrature
+ * @param f Field to compute the gradient of
+ * @param callback Callback functor. Callback signature must be:
+ * @code void(const typename IteratorType::index_type, const
+ * specfem::datatype::TensorPointViewType<type_real, 3,
+ * VectorFieldType::components>)
+ * @endcode
+ */
+template <
+    typename ChunkIndexType, typename VectorFieldType, typename QuadratureType,
+    typename CallbackFunctor,
+    std::enable_if_t<
+        specfem::data_access::is_chunk_element<VectorFieldType>::value &&
+            VectorFieldType::dimension_tag == specfem::dimension::type::dim3,
+        int> = 0>
+KOKKOS_FORCEINLINE_FUNCTION void gradient(
+    const ChunkIndexType &chunk_index,
+    const specfem::assembly::jacobian_matrix<specfem::dimension::type::dim3>
+        &jacobian_matrix,
+    const QuadratureType &quadrature, const VectorFieldType &f,
+    const CallbackFunctor &callback) {
+  constexpr int components = VectorFieldType::components;
+  constexpr int dimension = 3;
+  constexpr bool using_simd = VectorFieldType::simd::using_simd;
+
+  using TensorPointViewType =
+      specfem::datatype::TensorPointViewType<type_real, components, dimension,
+                                             using_simd>;
+
+  using datatype = typename VectorFieldType::simd::datatype;
+
+  static_assert(
+      std::is_invocable_v<CallbackFunctor,
+                          typename ChunkIndexType::iterator_type::index_type,
+                          TensorPointViewType>,
+      "CallbackFunctor must be invocable with the following signature: "
+      "void(const int, const specfem::point::index, const "
+      "specfem::kokkos::array_type<type_real, components>, const "
+      "specfem::kokkos::array_type<type_real, components>, const "
+      "specfem::kokkos::array_type<type_real, components>)");
+
+  specfem::execution::for_each_level(
+      chunk_index.get_iterator(),
+      [&](const typename ChunkIndexType::iterator_type::index_type
+              &iterator_index) {
+        const auto index = iterator_index.get_index();
+        const auto local_index = iterator_index.get_local_index();
+        datatype df_dxi[components] = { 0.0 };
+        datatype df_deta[components] = { 0.0 };
+        datatype df_dgamma[components] = { 0.0 };
+        specfem::point::jacobian_matrix<specfem::dimension::type::dim3, false,
+                                        using_simd>
+            point_jacobian_matrix;
+
+        specfem::assembly::load_on_device(index, jacobian_matrix,
+                                          point_jacobian_matrix);
+
+        const auto df =
+            impl::element_gradient(f, local_index, point_jacobian_matrix,
+                                   quadrature, df_dxi, df_deta, df_dgamma);
+        callback(iterator_index, df);
+      });
+
+  return;
+}
+
+/**
+ * @brief Compute the gradient of a field f & g using the spectral element
+ * formulation for 3D elements
+ *
+ * @ingroup AlgorithmsGradient
+ *
+ * @tparam ChunkIndexType Chunk index type
+ * @tparam VectorFieldType Field view type (Chunk view)
+ * @tparam QuadratureType Quadrature view type
+ * @tparam CallbackFunctor Callback functor type
+ * @param chunk_index Chunk index specifying the elements within this chunk
+ * @param jacobian_matrix Jacobian matrix of basis functions
+ * @param quadrature Integration quadrature
+ * @param f Field to compute the gradient of
+ * @param g Field to compute the gradient of
+ * @param callback Callback functor. Callback signature must be:
+ * @code void(const typename IteratorType::index_type, const
+ * specfem::datatype::TensorPointViewType<type_real, 3,
+ * VectorFieldType::components>, const
+ * specfem::datatype::TensorPointViewType<type_real, 3,
+ * VectorFieldType::components>)
+ * @endcode
+ */
+template <
+    typename ChunkIndexType, typename VectorFieldType, typename QuadratureType,
+    typename CallbackFunctor,
+    std::enable_if_t<
+        specfem::data_access::is_chunk_element<VectorFieldType>::value &&
+            VectorFieldType::dimension_tag == specfem::dimension::type::dim3,
+        int> = 0>
+KOKKOS_FORCEINLINE_FUNCTION void gradient(
+    const ChunkIndexType &chunk_index,
+    const specfem::assembly::jacobian_matrix<specfem::dimension::type::dim3>
+        &jacobian_matrix,
+    const QuadratureType &quadrature, const VectorFieldType &f,
+    const VectorFieldType &g, const CallbackFunctor &callback) {
+  constexpr int components = VectorFieldType::components;
+  constexpr bool using_simd = VectorFieldType::simd::using_simd;
+  constexpr int dimension = 3;
+
+  using TensorPointViewType =
+      specfem::datatype::TensorPointViewType<type_real, components, dimension,
+                                             using_simd>;
+
+  using datatype = typename VectorFieldType::simd::datatype;
+
+  static_assert(
+      std::is_invocable_v<CallbackFunctor,
+                          typename ChunkIndexType::iterator_type::index_type,
+                          TensorPointViewType, TensorPointViewType>,
+      "CallbackFunctor must be invocable with the following signature: "
+      "void(const ChunkIndexType::iterator_type::index_type, "
+      "const specfem::datatype::TensorPointViewType<type_real, 3, components>, "
+      "const specfem::datatype::TensorPointViewType<type_real, 3, "
+      "components>)");
+
+  specfem::execution::for_each_level(
+      chunk_index.get_iterator(),
+      [&](const typename ChunkIndexType::iterator_type::index_type
+              &iterator_index) {
+        const auto local_index = iterator_index.get_local_index();
+        datatype df_dxi[components] = { 0.0 };
+        datatype df_deta[components] = { 0.0 };
+        datatype df_dgamma[components] = { 0.0 };
+        datatype dg_dxi[components] = { 0.0 };
+        datatype dg_deta[components] = { 0.0 };
+        datatype dg_dgamma[components] = { 0.0 };
+        specfem::point::jacobian_matrix<specfem::dimension::type::dim3, false,
+                                        using_simd>
+            point_jacobian_matrix;
+
+        specfem::assembly::load_on_device(local_index, jacobian_matrix,
+                                          point_jacobian_matrix);
+
+        const auto df =
+            impl::element_gradient(f, local_index, point_jacobian_matrix,
+                                   quadrature, df_dxi, df_deta, df_dgamma);
+        const auto dg =
+            impl::element_gradient(g, local_index, point_jacobian_matrix,
+                                   quadrature, dg_dxi, dg_deta, dg_dgamma);
+        callback(iterator_index, df, dg);
+      });
+
+  return;
+}
+
 } // namespace algorithms
 } // namespace specfem

--- a/include/execution/chunked_domain_iterator.hpp
+++ b/include/execution/chunked_domain_iterator.hpp
@@ -266,8 +266,8 @@ public:
     int ielement = i % num_elements;
     int ispec = indices(ielement);
     int xz = i / num_elements;
-    const int iz = xz / element_grid.ngllz;
-    const int ix = xz % element_grid.ngllz;
+    const int iz = xz / element_grid.ngllx;
+    const int ix = xz % element_grid.ngllx;
 #else
     const int ix = i % element_grid.ngllx;
     const int iz = (i / element_grid.ngllx) % element_grid.ngllz;

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -583,6 +583,7 @@ target_link_libraries(
 add_executable(
   gradient_tests
   algorithms/dim2/gradient.cpp
+  algorithms/dim3/gradient.cpp
 )
 
 target_link_libraries(

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -594,6 +594,8 @@ target_link_libraries(
   Kokkos::kokkos
   mpi_environment
   assembly
+  quadrature
+  utilities
   -lpthread -lm
 )
 
@@ -885,6 +887,7 @@ if(NOT MPI_PARALLEL)
     lagrange_tests
     locate_point_fixture_2d
     locate_point_fixture_3d
+    gradient_tests
     mass_matrix_tests
     compute_coupling_tests
     mesh_dim2_tests

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -581,6 +581,23 @@ target_link_libraries(
 )
 
 add_executable(
+  gradient_tests
+  algorithms/dim2/gradient.cpp
+)
+
+target_link_libraries(
+  gradient_tests
+  quadrature
+  algorithms
+  kokkos_environment
+  gtest_main
+  Kokkos::kokkos
+  mpi_environment
+  assembly
+  -lpthread -lm
+)
+
+add_executable(
   policies_tests
   policies/policies.cpp
 )

--- a/tests/unit-tests/algorithms/dim2/gradient.cpp
+++ b/tests/unit-tests/algorithms/dim2/gradient.cpp
@@ -1,0 +1,264 @@
+
+#include <Kokkos_Core.hpp>
+#include <array>
+#include <gtest/gtest.h>
+#include <tuple>
+#include <type_traits>
+#include <vector>
+
+#include "Kokkos_Environment.hpp"
+#include "MPI_environment.hpp"
+#include "algorithms/gradient.hpp"
+#include "datatypes/point_view.hpp"
+#include "datatypes/simd.hpp"
+#include "enumerations/interface.hpp"
+#include "execution/chunked_domain_iterator.hpp"
+#include "execution/for_each_level.hpp"
+#include "parallel_configuration/chunk_config.hpp"
+#include "specfem/assembly.hpp"
+
+namespace specfem::algorithms_test {
+
+constexpr static int ngll = 5;
+
+enum class FunctionInitializer { ZERO, UNIFORM };
+
+enum class QuadratureInitializer { IDENTITY };
+
+enum class JacobianInitializer { IDENTITY };
+
+template <typename Initializer> struct JacobianMatrix {
+  constexpr static specfem::dimension::type dimension_tag =
+      specfem::dimension::type::dim2;
+  std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5>
+      _jacobian;
+
+  JacobianMatrix(const Initializer &initializer)
+      : _jacobian(init_jacobian(initializer)) {}
+
+  specfem::assembly::jacobian_matrix<dimension_tag> jacobian() {
+    specfem::assembly::jacobian_matrix<dimension_tag> jacobian_matrix(1, 5, 5);
+    for (int iz = 0; iz < 5; ++iz) {
+      for (int ix = 0; ix < 5; ++ix) {
+        jacobian_matrix.xix(0, iz, ix) = _jacobian[iz][ix][0][0];
+        jacobian_matrix.xiz(0, iz, ix) = _jacobian[iz][ix][0][1];
+        jacobian_matrix.gammax(0, iz, ix) = _jacobian[iz][ix][1][0];
+        jacobian_matrix.gammaz(0, iz, ix) = _jacobian[iz][ix][1][1];
+      }
+    }
+    return jacobian_matrix;
+  }
+};
+
+std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5>
+init_jacobian(const std::integral_constant<JacobianInitializer,
+                                           JacobianInitializer::IDENTITY> &) {
+  std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5>
+      jacobian{};
+  for (int iz = 0; iz < 5; ++iz) {
+    for (int ix = 0; ix < 5; ++ix) {
+      jacobian[iz][ix][0][0] = 1.0;
+      jacobian[iz][ix][0][1] = 0.0;
+      jacobian[iz][ix][1][0] = 0.0;
+      jacobian[iz][ix][1][1] = 1.0;
+    }
+  }
+  return jacobian;
+}
+
+template <typename Initializer> struct Quadrature {
+  std::array<std::array<type_real, 5>, 5> _quadrature;
+
+  Quadrature(const Initializer &initializer)
+      : _quadrature(init_quadrature(initializer)) {}
+
+  type_real operator()(const int &i, const int &j) const {
+    return _quadrature[i][j];
+  }
+};
+
+std::array<std::array<type_real, 5>, 5> init_quadrature(
+    const std::integral_constant<QuadratureInitializer,
+                                 QuadratureInitializer::IDENTITY> &) {
+  std::array<std::array<type_real, 5>, 5> quadrature{};
+  for (int i = 0; i < 5; ++i) {
+    for (int j = 0; j < 5; ++j) {
+      quadrature[i][j] = (i == j) ? 1.0 : 0.0;
+    }
+  }
+  return quadrature;
+}
+
+template <typename Initializer> struct Function {
+  constexpr static specfem::dimension::type dimension_tag =
+      specfem::dimension::type::dim2;
+  constexpr static int components = 1;
+
+  using memory_space = Kokkos::HostSpace;
+  using memory_traits = Kokkos::MemoryTraits<>;
+
+  using view_type = specfem::datatype::VectorChunkElementViewType<
+      type_real, dimension_tag, 1, ngll, components, false, memory_space,
+      memory_traits>;
+
+  Function(const Initializer &initializer) : _f(init_function(initializer)) {}
+
+  view_type view() const {
+    view_type f_view("f_view");
+    for (int iz = 0; iz < ngll; ++iz) {
+      for (int ix = 0; ix < ngll; ++ix) {
+        f_view(0, iz, ix, 0) = _f[0][iz][ix];
+      }
+    }
+    return f_view;
+  }
+
+private:
+  std::vector<std::array<std::array<type_real, ngll>, ngll> > _f;
+};
+
+auto init_function(const std::integral_constant<FunctionInitializer,
+                                                FunctionInitializer::ZERO> &) {
+  std::vector<std::array<std::array<type_real, ngll>, ngll> > _f(1);
+  for (int icomp = 0; icomp < 1; ++icomp) {
+    for (int iz = 0; iz < ngll; ++iz) {
+      for (int ix = 0; ix < ngll; ++ix) {
+        _f[icomp][iz][ix] = 0.0;
+      }
+    }
+  }
+  return _f;
+}
+
+auto init_function(const std::integral_constant<
+                   FunctionInitializer, FunctionInitializer::UNIFORM> &) {
+  std::vector<std::array<std::array<type_real, 5>, 5> > _f(1);
+  for (int icomp = 0; icomp < 1; ++icomp) {
+    for (int iz = 0; iz < 5; ++iz) {
+      for (int ix = 0; ix < 5; ++ix) {
+        _f[icomp][iz][ix] = 1.0;
+      }
+    }
+  }
+  return _f;
+}
+
+template <JacobianInitializer JInit, QuadratureInitializer QInit,
+          FunctionInitializer FInit>
+std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5>
+gradient();
+
+template <>
+std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5>
+gradient<JacobianInitializer::IDENTITY, QuadratureInitializer::IDENTITY,
+         FunctionInitializer::ZERO>() {
+  std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5> grad{};
+  for (int iz = 0; iz < 5; ++iz) {
+    for (int ix = 0; ix < 5; ++ix) {
+      grad[iz][ix][0][0] = 1.0;
+      grad[iz][ix][0][1] = 0.0;
+      grad[iz][ix][1][0] = 0.0;
+      grad[iz][ix][1][1] = 1.0;
+    }
+  }
+  return grad;
+}
+
+template <>
+std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5>
+gradient<JacobianInitializer::IDENTITY, QuadratureInitializer::IDENTITY,
+         FunctionInitializer::UNIFORM>() {
+  std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5> grad{};
+  for (int iz = 0; iz < 5; ++iz) {
+    for (int ix = 0; ix < 5; ++ix) {
+      grad[iz][ix][0][0] = 0.0;
+      grad[iz][ix][0][1] = 0.0;
+      grad[iz][ix][1][0] = 0.0;
+      grad[iz][ix][1][1] = 0.0;
+    }
+  }
+  return grad;
+}
+
+} // namespace specfem::algorithms_test
+
+using namespace specfem::algorithms_test;
+
+template <typename TestingType>
+struct GradientTestFixture : public ::testing::Test {
+  using JacobianInitializer = std::tuple_element_t<0, TestingType>;
+  using QuadratureInitializer = std::tuple_element_t<1, TestingType>;
+  using FunctionInitializer = std::tuple_element_t<2, TestingType>;
+
+  GradientTestFixture()
+      : jacobian_matrix(JacobianInitializer{}),
+        quadrature(QuadratureInitializer{}), function(FunctionInitializer{}) {}
+
+  JacobianMatrix<JacobianInitializer> jacobian_matrix;
+  Quadrature<QuadratureInitializer> quadrature;
+  Function<FunctionInitializer> function;
+};
+
+using GradientTestTypes = ::testing::Types<
+    std::tuple<std::integral_constant<JacobianInitializer,
+                                      JacobianInitializer::IDENTITY>,
+               std::integral_constant<QuadratureInitializer,
+                                      QuadratureInitializer::IDENTITY>,
+               std::integral_constant<FunctionInitializer,
+                                      FunctionInitializer::ZERO> >,
+    std::tuple<std::integral_constant<JacobianInitializer,
+                                      JacobianInitializer::IDENTITY>,
+               std::integral_constant<QuadratureInitializer,
+                                      QuadratureInitializer::IDENTITY>,
+               std::integral_constant<FunctionInitializer,
+                                      FunctionInitializer::UNIFORM> > >;
+
+TYPED_TEST_SUITE(GradientTestFixture, GradientTestTypes);
+
+TYPED_TEST(GradientTestFixture, TestGradientComputation) {
+  // Implement test logic here using this->jacobian_matrix, this->quadrature,
+  // and this->function
+
+  constexpr static auto Jinit = TestFixture::JacobianInitializer::value;
+  constexpr static auto Qinit = TestFixture::QuadratureInitializer::value;
+  constexpr static auto Finit = TestFixture::FunctionInitializer::value;
+
+  // const auto expected_gradient =
+  //     specfem::algorithms_test::gradient<Jinit, Qinit, Finit>();
+
+  // Create an iterator single element;
+  using simd = specfem::datatype::simd<type_real, false>;
+  Kokkos::View<int *, Kokkos::HostSpace> element_indices("element_indices", 1);
+  element_indices(0) = 0;
+  using ParallelConfig = specfem::parallel_config::default_chunk_config<
+      specfem::dimension::type::dim2, simd, Kokkos::DefaultHostExecutionSpace>;
+
+  const specfem::mesh_entity::element element_grid(ngll, ngll);
+
+  const specfem::execution::ChunkedDomainIterator chunk(
+      ParallelConfig(), element_indices, element_grid);
+
+  // Call gradient computation
+  specfem::execution::for_each_level(chunk, [&](const typename decltype(
+                                                chunk)::index_type &index) {
+    // Call gradient algorithm here
+    specfem::algorithms::gradient(
+        index, this->jacobian_matrix.jacobian(), this->quadrature,
+        this->function.view(), [&](const auto &iterator_index, const auto &df) {
+          const auto local_index = iterator_index.get_local_index();
+          const int iz = local_index.iz;
+          const int ix = local_index.ix;
+
+          // Verify computed gradient against expected gradient
+        });
+  });
+
+  SUCCEED() << "Gradient computation test executed successfully.";
+}
+
+int main(int argc, char *argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new MPIEnvironment);
+  ::testing::AddGlobalTestEnvironment(new KokkosEnvironment);
+  return RUN_ALL_TESTS();
+}

--- a/tests/unit-tests/algorithms/dim2/gradient.cpp
+++ b/tests/unit-tests/algorithms/dim2/gradient.cpp
@@ -155,10 +155,13 @@ init_jacobian(const JacobianInitializer2D::TWO_ELEMENT &) {
 template <typename Initializer> struct JacobianMatrix2D {
   constexpr static specfem::dimension::type dimension_tag =
       specfem::dimension::type::dim2;
+
+private:
   std::vector<
       std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5> >
       _jacobian;
 
+public:
   /**
    * @brief Construct Jacobian data using the supplied initializer tag.
    *

--- a/tests/unit-tests/algorithms/dim2/gradient.cpp
+++ b/tests/unit-tests/algorithms/dim2/gradient.cpp
@@ -1,4 +1,25 @@
 
+/**
+ * @file gradient.cpp
+ * @brief Unit tests for 2D spectral element gradient computation algorithms.
+ *
+ *
+ * The test framework uses a tag-dispatch pattern to enable extensible test
+ * scenarios through initializer overloading. Recent development history:
+ * - commit 6bf3a5f1: Initial gradient test implementation
+ * - commit cdb4ba3d: Added comprehensive 2D test coverage including trivial
+ * cases, uniform functions, random fields, and multi-element meshes
+ *
+ * @note To add new test cases, follow the pattern:
+ * 1. Define new initializer tags in appropriate namespaces
+ * 2. Overload corresponding init_* functions
+ * 3. Add tuple combinations to GradientTestTypes
+ * 4. Optionally provide specialized gradient reference implementations
+ *
+ * @see specfem::algorithms::gradient
+ * @see ExpectedJacobian3D for related 3D testing patterns
+ */
+
 #include <Kokkos_Core.hpp>
 #include <array>
 #include <gtest/gtest.h>
@@ -20,25 +41,57 @@
 
 namespace specfem::algorithms_test {
 
-constexpr static int ngll = 5;
+constexpr static int ngll =
+    5; ///< Number of GLL points per dimension (5th order spectral elements)
 
+/**
+ * @brief Initializer tags for scalar field test data generation.
+ */
 namespace FunctionInitializer {
-struct ZERO {};
-struct UNIFORM {};
-struct RANDOM {};
-struct TWO_ELEMENT {};
+struct ZERO {};        ///< Zero-valued field: f(x,z) = 0 everywhere
+struct UNIFORM {};     ///< Uniform field: f(x,z) = 1 everywhere
+struct RANDOM {};      ///< Pseudo-random field values for stochastic testing
+struct TWO_ELEMENT {}; ///< Multi-element field with element-dependent values
 } // namespace FunctionInitializer
 
+/**
+ * @brief Initializer tags for quadrature derivative matrix configuration.
+ *
+ * These tags control the initialization of the derivative matrix used in
+ * gradient computation. The matrix represents \f$\frac{\partial L_j}{\partial
+ * \xi_i}\f$ where \f$L_j\f$ are Lagrange basis functions.
+ */
 namespace QuadratureInitializer {
-struct IDENTITY {};
-struct LAGRANGE {};
+struct IDENTITY {}; ///< Identity matrix for simplified analytical verification
+struct LAGRANGE {}; ///< Proper GLL Lagrange derivative matrix from quadrature
 } // namespace QuadratureInitializer
 
+/**
+ * @brief Initializer tags for Jacobian matrix test configurations.
+ *
+ * These tags define different geometric transformation scenarios for testing
+ * coordinate mapping between reference element \f$[-1,1]^2\f$ and physical
+ * space.
+ */
 namespace JacobianInitializer {
-struct IDENTITY {};
-struct TWO_ELEMENT {};
+struct IDENTITY {};    ///< Identity Jacobian (no geometric transformation)
+struct TWO_ELEMENT {}; ///< Multi-element mesh with scaled transformations
 } // namespace JacobianInitializer
 
+/**
+ * @brief Initialize identity Jacobian matrix for single-element test cases.
+ *
+ * Creates a single spectral element with identity Jacobian transformation at
+ * all GLL points. This represents a reference element with no geometric
+ * deformation, where \f$\frac{\partial \xi}{\partial x} = \frac{\partial
+ * \gamma}{\partial z} = 1\f$ and \f$\frac{\partial \xi}{\partial z} =
+ * \frac{\partial \gamma}{\partial x} = 0\f$.
+ *
+ * @return Vector containing single element's Jacobian data with identity values
+ *
+ * @note This configuration allows direct comparison between reference and
+ * physical space gradients since the coordinate transformation is trivial.
+ */
 std::vector<
     std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5> >
 init_jacobian(const JacobianInitializer::IDENTITY &) {
@@ -47,15 +100,28 @@ init_jacobian(const JacobianInitializer::IDENTITY &) {
       jacobian(1);
   for (int iz = 0; iz < 5; ++iz) {
     for (int ix = 0; ix < 5; ++ix) {
-      jacobian[0][iz][ix][0][0] = 1.0;
-      jacobian[0][iz][ix][0][1] = 0.0;
-      jacobian[0][iz][ix][1][0] = 0.0;
-      jacobian[0][iz][ix][1][1] = 1.0;
+      jacobian[0][iz][ix][0][0] = 1.0; // ξₓ = ∂ξ/∂x
+      jacobian[0][iz][ix][0][1] = 0.0; // ξᵤ = ∂ξ/∂z
+      jacobian[0][iz][ix][1][0] = 0.0; // γₓ = ∂γ/∂x
+      jacobian[0][iz][ix][1][1] = 1.0; // γᵤ = ∂γ/∂z
     }
   }
   return jacobian;
 }
 
+/**
+ * @brief Initialize two-element Jacobian dataset with scaled transformations.
+ *
+ * Creates a two-element mesh where each element has scaled identity Jacobian
+ * matrices. Element 0 has identity scaling (1.0), while element 1 has 2.0
+ * scaling, effectively creating elements of different sizes.
+ *
+ * @return Vector containing Jacobian data for both elements with scaling
+ * factors
+ *
+ * @note This tests multi-element gradient computation and coordinate
+ *       transformation consistency across element boundaries.
+ */
 std::vector<
     std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5> >
 init_jacobian(const JacobianInitializer::TWO_ELEMENT &) {
@@ -65,16 +131,27 @@ init_jacobian(const JacobianInitializer::TWO_ELEMENT &) {
   for (int ielement = 0; ielement < 2; ++ielement) {
     for (int iz = 0; iz < 5; ++iz) {
       for (int ix = 0; ix < 5; ++ix) {
-        jacobian[ielement][iz][ix][0][0] = 1.0 + ielement;
-        jacobian[ielement][iz][ix][0][1] = 0.0;
-        jacobian[ielement][iz][ix][1][0] = 0.0;
-        jacobian[ielement][iz][ix][1][1] = 1.0 + ielement;
+        const type_real scale = 1.0 + ielement;   // Element scaling factor
+        jacobian[ielement][iz][ix][0][0] = scale; // Scaled ξₓ
+        jacobian[ielement][iz][ix][0][1] = 0.0;   // ξᵤ = 0
+        jacobian[ielement][iz][ix][1][0] = 0.0;   // γₓ = 0
+        jacobian[ielement][iz][ix][1][1] = scale; // Scaled γᵤ
       }
     }
   }
   return jacobian;
 }
 
+/**
+ * @brief Helper wrapper that materializes jacobian_matrix containers for tests.
+ *
+ * This class provides a type-safe interface for creating and accessing Jacobian
+ * matrix data using compile-time dispatch based on initializer tags. It manages
+ * the storage and conversion between test data formats and SPECFEM++ assembly
+ * data structures.
+ *
+ * @tparam Initializer Tag describing which init_jacobian overload to invoke
+ */
 template <typename Initializer> struct JacobianMatrix {
   constexpr static specfem::dimension::type dimension_tag =
       specfem::dimension::type::dim2;
@@ -82,16 +159,46 @@ template <typename Initializer> struct JacobianMatrix {
       std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5> >
       _jacobian;
 
+  /**
+   * @brief Construct Jacobian data using the supplied initializer tag.
+   *
+   * @param initializer Tag-dispatch parameter selecting initialization strategy
+   */
   JacobianMatrix(const Initializer &initializer)
       : _jacobian(init_jacobian(initializer)) {}
 
+  /**
+   * @brief Accessor for individual Jacobian matrix components.
+   *
+   * @param ielement Element index
+   * @param iz GLL point index in z direction
+   * @param ix GLL point index in x direction
+   * @param idim First tensor index (0=ξ, 1=γ)
+   * @param jdim Second tensor index (0=x, 1=z)
+   * @return Reference to Jacobian component J[idim][jdim]
+   */
   const type_real &operator()(const int ielement, const int iz, const int ix,
                               const int idim, const int jdim) const {
     return _jacobian[ielement][iz][ix][idim][jdim];
   }
 
+  /**
+   * @brief Get the number of spectral elements in this dataset.
+   *
+   * @return Number of elements
+   */
   const int n_elements() const { return static_cast<int>(_jacobian.size()); }
 
+  /**
+   * @brief Convert to specfem::assembly::jacobian_matrix format.
+   *
+   * This method creates a properly formatted jacobian_matrix object that can
+   * be used with the production gradient algorithms. The conversion maps the
+   * internal storage to the xix, xiz, gammax, gammaz components expected by
+   * the assembly framework.
+   *
+   * @return Assembled jacobian_matrix ready for algorithm testing
+   */
   specfem::assembly::jacobian_matrix<dimension_tag> jacobian() {
     specfem::assembly::jacobian_matrix<dimension_tag> jacobian_matrix(
         n_elements(), 5, 5);
@@ -100,13 +207,13 @@ template <typename Initializer> struct JacobianMatrix {
       for (int iz = 0; iz < 5; ++iz) {
         for (int ix = 0; ix < 5; ++ix) {
           jacobian_matrix.xix(ielement, iz, ix) =
-              _jacobian[ielement][iz][ix][0][0];
+              _jacobian[ielement][iz][ix][0][0]; // ∂ξ/∂x
           jacobian_matrix.xiz(ielement, iz, ix) =
-              _jacobian[ielement][iz][ix][0][1];
+              _jacobian[ielement][iz][ix][0][1]; // ∂ξ/∂z
           jacobian_matrix.gammax(ielement, iz, ix) =
-              _jacobian[ielement][iz][ix][1][0];
+              _jacobian[ielement][iz][ix][1][0]; // ∂γ/∂x
           jacobian_matrix.gammaz(ielement, iz, ix) =
-              _jacobian[ielement][iz][ix][1][1];
+              _jacobian[ielement][iz][ix][1][1]; // ∂γ/∂z
         }
       }
     }
@@ -114,6 +221,15 @@ template <typename Initializer> struct JacobianMatrix {
   }
 };
 
+/**
+ * @brief Build identity derivative matrix for simplified testing.
+ *
+ * Creates an identity matrix that simplifies gradient computation validation
+ * by eliminating the complexity of proper Lagrange derivative evaluation.
+ * Useful for analytical verification of gradient transformation logic.
+ *
+ * @return 5×5 identity matrix for quadrature derivative operations
+ */
 std::array<std::array<type_real, 5>, 5>
 init_quadrature(const QuadratureInitializer::IDENTITY &) {
   std::array<std::array<type_real, 5>, 5> quadrature{};
@@ -125,6 +241,16 @@ init_quadrature(const QuadratureInitializer::IDENTITY &) {
   return quadrature;
 }
 
+/**
+ * @brief Build proper GLL Lagrange derivative matrix.
+ *
+ * Constructs the actual derivative matrix used in spectral element methods,
+ * \f$h'_{ij} = \frac{dL_j}{d\xi}\Big|_{\xi_i}\f$, where \f$L_j(\xi)\f$ are
+ * the Lagrange interpolating polynomials and \f$\xi_i\f$ are GLL quadrature
+ * points.
+ *
+ * @return 5×5 GLL derivative matrix for realistic gradient computation
+ */
 std::array<std::array<type_real, 5>, 5>
 init_quadrature(const QuadratureInitializer::LAGRANGE &) {
   std::array<std::array<type_real, 5>, 5> quadrature{};
@@ -133,23 +259,52 @@ init_quadrature(const QuadratureInitializer::LAGRANGE &) {
   const auto hprime = gll.get_hhprime();
   for (int i = 0; i < 5; ++i) {
     for (int j = 0; j < 5; ++j) {
-      quadrature[j][i] = hprime(i, j);
+      quadrature[j][i] = hprime(i, j); // Transpose for proper indexing
     }
   }
   return quadrature;
 }
 
+/**
+ * @brief Helper owning quadrature derivative matrix for gradient evaluation.
+ *
+ * This class manages derivative matrices used in gradient computation,
+ * providing type-safe access to different quadrature configurations through
+ * compile-time dispatch.
+ *
+ * @tparam Initializer Tag selecting which init_quadrature overload to use
+ */
 template <typename Initializer> struct Quadrature {
   std::array<std::array<type_real, 5>, 5> _quadrature;
 
+  /**
+   * @brief Construct derivative matrix using the selected initializer tag.
+   *
+   * @param initializer Tag-dispatch parameter for quadrature initialization
+   */
   Quadrature(const Initializer &initializer)
       : _quadrature(init_quadrature(initializer)) {}
 
+  /**
+   * @brief Access derivative matrix entry.
+   *
+   * @param i Row index (output GLL point)
+   * @param j Column index (input GLL point)
+   * @return Derivative value \f$\frac{dL_j}{d\xi}\Big|_{\xi_i}\f$
+   */
   type_real operator()(const int &i, const int &j) const {
     return _quadrature[i][j];
   }
 };
 
+/**
+ * @brief Generate zero-valued scalar field for manufactured solution tests.
+ *
+ * Creates a field where f(ξ,γ) = 0 at all GLL points. This provides a trivial
+ * case where the exact gradient is known analytically: ∇f = (0,0) everywhere.
+ *
+ * @return Single-element vector containing zero field data
+ */
 auto init_function(const FunctionInitializer::ZERO &) {
   std::vector<std::array<std::array<type_real, ngll>, ngll> > _f(1);
   for (int icomp = 0; icomp < 1; ++icomp) {
@@ -162,6 +317,15 @@ auto init_function(const FunctionInitializer::ZERO &) {
   return _f;
 }
 
+/**
+ * @brief Generate uniform scalar field for manufactured solution tests.
+ *
+ * Creates a constant field where f(ξ,γ) = 1 at all GLL points. For identity
+ * Jacobian and identity quadrature, this yields known gradient behavior that
+ * can be verified analytically.
+ *
+ * @return Single-element vector containing uniform field data
+ */
 auto init_function(const FunctionInitializer::UNIFORM &) {
   std::vector<std::array<std::array<type_real, 5>, 5> > _f(1);
   for (int icomp = 0; icomp < 1; ++icomp) {
@@ -174,6 +338,17 @@ auto init_function(const FunctionInitializer::UNIFORM &) {
   return _f;
 }
 
+/**
+ * @brief Generate pseudo-random scalar field for stochastic validation.
+ *
+ * Creates a field with random values between [0,1] to test gradient computation
+ * with non-trivial function values. Helps verify numerical stability and
+ * algorithmic correctness for arbitrary field configurations.
+ *
+ * @return Single-element vector containing random field data
+ *
+ * @warning Uses rand() for simplicity; not cryptographically secure
+ */
 auto init_function(const FunctionInitializer::RANDOM &) {
   std::vector<std::array<std::array<type_real, 5>, 5> > _f(1);
   for (int icomp = 0; icomp < 1; ++icomp) {
@@ -186,22 +361,41 @@ auto init_function(const FunctionInitializer::RANDOM &) {
   return _f;
 }
 
+/**
+ * @brief Generate two-element scalar field with element-wise constant values.
+ *
+ * Creates a multi-element field where element 0 has f = 1.0 and element 1 has
+ * f = 2.0. This tests gradient computation consistency across element
+ * boundaries and validates multi-element assembly pathways.
+ *
+ * @return Two-element vector containing element-dependent constant field data
+ */
 auto init_function(const FunctionInitializer::TWO_ELEMENT &) {
   std::vector<std::array<std::array<type_real, 5>, 5> > _f(2);
   for (int ielement = 0; ielement < 2; ++ielement) {
     for (int iz = 0; iz < 5; ++iz) {
       for (int ix = 0; ix < 5; ++ix) {
-        _f[ielement][iz][ix] = 1.0 + ielement;
+        _f[ielement][iz][ix] = 1.0 + ielement; // Element-dependent constant
       }
     }
   }
   return _f;
 }
 
+/**
+ * @brief Helper owning scalar test data and exposing Kokkos views for gradient
+ * calls.
+ *
+ * This class manages scalar field data for test cases, providing conversion
+ * between test-friendly storage formats and the Kokkos Views required by
+ * the production gradient algorithms.
+ *
+ * @tparam Initializer Tag selecting which init_function overload to invoke
+ */
 template <typename Initializer> struct Function {
   constexpr static specfem::dimension::type dimension_tag =
       specfem::dimension::type::dim2;
-  constexpr static int components = 1;
+  constexpr static int components = 1; ///< Scalar field (single component)
 
   using memory_space = Kokkos::HostSpace;
   using memory_traits = Kokkos::MemoryTraits<>;
@@ -209,15 +403,41 @@ template <typename Initializer> struct Function {
   using view_type = Kokkos::View<type_real *[ngll][ngll][components],
                                  memory_space, memory_traits>;
 
+  /**
+   * @brief Construct scalar field using the supplied initializer tag.
+   *
+   * @param initializer Tag-dispatch parameter for field initialization
+   */
   Function(const Initializer &initializer) : _f(init_function(initializer)) {}
 
+  /**
+   * @brief Element-wise access to scalar field values.
+   *
+   * @param ielement Element index
+   * @param iz GLL point index in z direction
+   * @param ix GLL point index in x direction
+   * @return Field value at specified location
+   */
   const type_real &operator()(const int &ielement, const int &iz,
                               const int &ix) const {
     return _f[ielement][iz][ix];
   }
 
+  /**
+   * @brief Get the number of spectral elements in this field.
+   *
+   * @return Number of elements
+   */
   int n_elements() const { return static_cast<int>(_f.size()); }
 
+  /**
+   * @brief Convert to Kokkos View format for gradient algorithm interface.
+   *
+   * Creates a Kokkos View that can be passed to specfem::algorithms::gradient()
+   * and related chunk-based execution frameworks.
+   *
+   * @return Kokkos View containing field data in algorithm-compatible format
+   */
   view_type view() const {
     view_type f_view("f_view", _f.size());
     for (int ielement = 0; ielement < static_cast<int>(_f.size()); ++ielement) {
@@ -231,9 +451,21 @@ template <typename Initializer> struct Function {
   }
 
 private:
-  std::vector<std::array<std::array<type_real, ngll>, ngll> > _f;
+  std::vector<std::array<std::array<type_real, ngll>, ngll> > _f; ///< Internal
+                                                                  ///< field
+                                                                  ///< storage
 };
 
+/**
+ * @brief Analytical gradient reference for zero field with identity
+ * configuration.
+ *
+ * For f(x,z) = 0 everywhere, the exact gradient is ∇f = (0,0) at all points.
+ * This provides a trivial but important validation case for algorithm
+ * correctness.
+ *
+ * @return Gradient field with zero values at all GLL points
+ */
 std::vector<
     std::array<std::array<std::array<std::array<type_real, 2>, 1>, 5>, 5> >
 gradient(const JacobianMatrix<JacobianInitializer::IDENTITY> &jacobian,
@@ -244,13 +476,23 @@ gradient(const JacobianMatrix<JacobianInitializer::IDENTITY> &jacobian,
       grad(1);
   for (int iz = 0; iz < 5; ++iz) {
     for (int ix = 0; ix < 5; ++ix) {
-      grad[0][iz][ix][0][0] = 0.0;
-      grad[0][iz][ix][0][1] = 0.0;
+      grad[0][iz][ix][0][0] = 0.0; // ∂f/∂x = 0
+      grad[0][iz][ix][0][1] = 0.0; // ∂f/∂z = 0
     }
   }
   return grad;
 }
 
+/**
+ * @brief Analytical gradient reference for uniform field with identity
+ * configuration.
+ *
+ * For f(x,z) = 1 (constant) with identity Jacobian and identity quadrature,
+ * the expected behavior depends on the specific derivative implementation.
+ * With identity quadrature, uniform functions produce unit gradients.
+ *
+ * @return Gradient field with unit values reflecting derivative matrix behavior
+ */
 std::vector<
     std::array<std::array<std::array<std::array<type_real, 2>, 1>, 5>, 5> >
 gradient(const JacobianMatrix<JacobianInitializer::IDENTITY> &jacobian,
@@ -261,20 +503,32 @@ gradient(const JacobianMatrix<JacobianInitializer::IDENTITY> &jacobian,
       grad(1);
   for (int iz = 0; iz < 5; ++iz) {
     for (int ix = 0; ix < 5; ++ix) {
-      grad[0][iz][ix][0][0] = 1.0;
-      grad[0][iz][ix][0][1] = 1.0;
+      grad[0][iz][ix][0][0] = 1.0; // Identity quadrature effect
+      grad[0][iz][ix][0][1] = 1.0; // Identity quadrature effect
     }
   }
   return grad;
 }
 
+/**
+ * @brief Generic reference gradient calculator mirroring
+ * specfem::algorithms::gradient().
+ *
+ *
+ * @tparam Jacobian JacobianMatrix type providing coordinate transformation data
+ * @tparam Quadrature Quadrature type providing derivative matrix
+ * @tparam Function Function type providing scalar field data
+ * @param jacobian Jacobian transformation data
+ * @param quadrature Derivative matrix for reference coordinate differentiation
+ * @param function Scalar field to differentiate
+ * @return Computed gradient at all GLL points in all elements
+ */
 template <typename Jacobian, typename Quadrature, typename Function>
 std::vector<
     std::array<std::array<std::array<std::array<type_real, 2>, 1>, 5>, 5> >
 gradient(const Jacobian &jacobian, const Quadrature &quadrature,
          const Function &function) {
 
-  // Placeholder for actual gradient computation logic
   std::vector<
       std::array<std::array<std::array<std::array<type_real, 2>, 1>, 5>, 5> >
       grad(function.n_elements());
@@ -282,19 +536,24 @@ gradient(const Jacobian &jacobian, const Quadrature &quadrature,
   for (int ielement = 0; ielement < function.n_elements(); ++ielement) {
     for (int iz = 0; iz < ngll; ++iz) {
       for (int ix = 0; ix < ngll; ++ix) {
-        type_real df_dxi = 0.0;
-        type_real df_gamma = 0.0;
+        // Compute reference coordinate derivatives using quadrature matrix
+        type_real df_dxi = 0.0;    // ∂f/∂ξ
+        type_real df_dgamma = 0.0; // ∂f/∂γ
+
+        // Sum over GLL points using derivative matrix
         for (int l = 0; l < ngll; ++l) {
-          // Compute gradient components here using f, jacobian, and quadrature
           df_dxi += quadrature(ix, l) * function(ielement, iz, l);
-          df_gamma += quadrature(iz, l) * function(ielement, l, ix);
+          df_dgamma += quadrature(iz, l) * function(ielement, l, ix);
         }
-        grad[ielement][iz][ix][0][0] =
-            df_dxi * jacobian(ielement, iz, ix, 0, 0) +
-            df_gamma * jacobian(ielement, iz, ix, 1, 0);
-        grad[ielement][iz][ix][0][1] =
-            df_dxi * jacobian(ielement, iz, ix, 0, 1) +
-            df_gamma * jacobian(ielement, iz, ix, 1, 1);
+
+        // Transform to physical coordinates using Jacobian
+        grad[ielement][iz][ix][0][0] =                    // ∂f/∂x
+            df_dxi * jacobian(ielement, iz, ix, 0, 0) +   // ∂f/∂ξ · ∂ξ/∂x
+            df_dgamma * jacobian(ielement, iz, ix, 1, 0); // ∂f/∂γ · ∂γ/∂x
+
+        grad[ielement][iz][ix][0][1] =                    // ∂f/∂z
+            df_dxi * jacobian(ielement, iz, ix, 0, 1) +   // ∂f/∂ξ · ∂ξ/∂z
+            df_dgamma * jacobian(ielement, iz, ix, 1, 1); // ∂f/∂γ · ∂γ/∂z
       }
     }
   }
@@ -306,21 +565,99 @@ gradient(const Jacobian &jacobian, const Quadrature &quadrature,
 
 using namespace specfem::algorithms_test;
 
+/**
+ * @brief GoogleTest fixture bundling manufactured data and Jacobian views.
+ *
+ * This fixture provides a type-safe framework for testing gradient computation
+ * with different combinations of Jacobian matrices, quadrature configurations,
+ * and scalar field data. Each test instantiation receives a unique combination
+ * of initializer tags that determine the specific test scenario.
+ *
+ * @tparam TestingType Tuple of (JacobianInitializer, QuadratureInitializer,
+ * FunctionInitializer)
+ */
 template <typename TestingType>
 struct GradientTestFixture : public ::testing::Test {
-  using JacobianInitializer = std::tuple_element_t<0, TestingType>;
-  using QuadratureInitializer = std::tuple_element_t<1, TestingType>;
-  using FunctionInitializer = std::tuple_element_t<2, TestingType>;
+  using JacobianInitializer =
+      std::tuple_element_t<0, TestingType>; ///< Jacobian initialization
+                                            ///< strategy
+  using QuadratureInitializer =
+      std::tuple_element_t<1, TestingType>; ///< Quadrature initialization
+                                            ///< strategy
+  using FunctionInitializer =
+      std::tuple_element_t<2, TestingType>; ///< Function initialization
+                                            ///< strategy
 
+  /**
+   * @brief Construct test helpers using tag dispatch for each component.
+   *
+   * This constructor uses the compile-time type information to instantiate
+   * the appropriate helper objects for the specific test combination.
+   */
   GradientTestFixture()
       : jacobian_matrix(JacobianInitializer{}),
         quadrature(QuadratureInitializer{}), function(FunctionInitializer{}) {}
 
-  JacobianMatrix<JacobianInitializer> jacobian_matrix;
-  Quadrature<QuadratureInitializer> quadrature;
-  Function<FunctionInitializer> function;
+  JacobianMatrix<JacobianInitializer> jacobian_matrix; ///< Coordinate
+                                                       ///< transformation data
+  Quadrature<QuadratureInitializer> quadrature; ///< Derivative matrix for
+                                                ///< gradient computation
+  Function<FunctionInitializer> function;       ///< Scalar field test data
 };
 
+/**
+ * @brief Test case combinations for parameterized gradient validation.
+ *
+ * This type list defines all the test scenarios that will be instantiated by
+ * GoogleTest's parameterized testing framework. Each tuple represents a unique
+ * combination of initialization strategies that exercises different aspects of
+ * the gradient computation algorithm.
+ *
+ * **Current test cases:**
+ * 1. **Identity+Zero**: Basic correctness test with trivial inputs
+ * 2. **Identity+Uniform**: Simple analytical validation case
+ * 3. **Lagrange+Random**: Realistic quadrature with arbitrary field data
+ * 4. **TwoElement+TwoElement**: Multi-element consistency validation
+ *
+ * **Adding new test cases:**
+ * To extend the test coverage, follow this process:
+ *
+ * 1. **Define new initializer tags** in the appropriate namespace:
+ *    ```cpp
+ *    namespace JacobianInitializer {
+ *    struct SCALED_ROTATION {}; // New Jacobian type
+ *    }
+ *    ```
+ *
+ * 2. **Overload the corresponding init_* function**:
+ *    ```cpp
+ *    std::vector<...> init_jacobian(const JacobianInitializer::SCALED_ROTATION
+ * &) {
+ *        // Implementation for rotated/scaled Jacobian
+ *    }
+ *    ```
+ *
+ * 3. **Add new tuple to GradientTestTypes**:
+ *    ```cpp
+ *    std::tuple<JacobianInitializer::SCALED_ROTATION,
+ *               QuadratureInitializer::LAGRANGE,
+ *               FunctionInitializer::POLYNOMIAL>
+ *    ```
+ *
+ * 4. **Optionally add specialized gradient() overload** for analytical
+ * reference:
+ *    ```cpp
+ *    std::vector<...> gradient(
+ *        const JacobianMatrix<JacobianInitializer::SCALED_ROTATION> &jacobian,
+ *        const Quadrature<QuadratureInitializer::LAGRANGE> &quadrature,
+ *        const Function<FunctionInitializer::POLYNOMIAL> &function) {
+ *        // Analytical reference implementation
+ *    }
+ *    ```
+ *
+ * The test framework will automatically instantiate and execute the new
+ * scenario.
+ */
 using GradientTestTypes = ::testing::Types<
     std::tuple<JacobianInitializer::IDENTITY, QuadratureInitializer::IDENTITY,
                FunctionInitializer::ZERO>,
@@ -332,19 +669,37 @@ using GradientTestTypes = ::testing::Types<
                QuadratureInitializer::IDENTITY,
                FunctionInitializer::TWO_ELEMENT> >;
 
+/**
+ * @brief Instantiate parameterized test suite for all declared tuple
+ * combinations.
+ */
 TYPED_TEST_SUITE(GradientTestFixture, GradientTestTypes);
 
+/**
+ * @brief Validate specfem::algorithms::gradient() against manufactured
+ * solutions.
+ *
+ * This test performs comprehensive validation of the gradient computation by:
+ * 1. Computing expected gradients using the reference implementation
+ * 2. Setting up chunked domain iteration matching production usage
+ * 3. Calling the production gradient algorithm with test data
+ * 4. Comparing computed vs. expected results at each GLL point
+ *
+ * The test validates both the mathematical accuracy and the execution pathway
+ * of the gradient algorithm, ensuring consistency between reference and
+ * production implementations across different geometric and field
+ * configurations.
+ */
 TYPED_TEST(GradientTestFixture, TestGradientComputation) {
-  // Implement test logic here using this->jacobian_matrix, this->quadrature,
-  // and this->function
-
+  // Verify consistency between function and Jacobian element counts
   ASSERT_TRUE(this->function.n_elements() == this->jacobian_matrix.n_elements())
       << "Mismatch in number of elements between function and jacobian matrix";
 
+  // Compute expected results using reference implementation
   const auto expected_gradient = specfem::algorithms_test::gradient(
       this->jacobian_matrix, this->quadrature, this->function);
 
-  // Create an iterator;
+  // Set up chunked domain iteration for production algorithm testing
   using simd = specfem::datatype::simd<type_real, false>;
   Kokkos::View<int *, Kokkos::HostSpace> element_indices(
       "element_indices", this->function.n_elements());
@@ -367,13 +722,14 @@ TYPED_TEST(GradientTestFixture, TestGradientComputation) {
       type_real, specfem::dimension::type::dim2, 1, ngll, 1, false,
       Kokkos::HostSpace, Kokkos::MemoryTraits<> >;
 
-  // Call gradient computation
+  // Execute production gradient algorithm and validate results
   specfem::execution::for_each_level(chunk, [&](const typename decltype(
                                                 chunk)::index_type &index) {
     const FunctionView f(Kokkos::subview(function_view, index.get_range(),
                                          Kokkos::ALL(), Kokkos::ALL(),
                                          Kokkos::ALL()));
-    // Call gradient algorithm here
+
+    // Call the production gradient algorithm
     specfem::algorithms::gradient(
         index, jacobian, this->quadrature, f,
         [&](const auto &iterator_index, const auto &df) {
@@ -384,18 +740,19 @@ TYPED_TEST(GradientTestFixture, TestGradientComputation) {
 
           const auto e = expected_gradient[ispec][iz][ix];
 
-          // Verify computed gradient against expected gradient
+          // Point-wise validation of computed gradient components
           if (!specfem::utilities::is_close(df(0, 0), e[0][0]) ||
               !specfem::utilities::is_close(df(0, 1), e[0][1])) {
-            FAIL() << "Mismatch for element " << local_index.ispec << "\n"
-                   << "    at quadrature point (" << iz << ", " << ix << ")\n"
+            FAIL() << "Gradient mismatch for element " << local_index.ispec
+                   << "\n"
+                   << "    at GLL point (" << iz << ", " << ix << ")\n"
                    << "    expected: (" << e[0][0] << ", " << e[0][1] << ")\n"
-                   << "    got: (" << df(0, 0) << ", " << df(0, 1) << ")";
+                   << "    computed: (" << df(0, 0) << ", " << df(0, 1) << ")";
           }
         });
   });
 
-  SUCCEED() << "Gradient computation test executed successfully.";
+  SUCCEED() << "Gradient computation validation passed for all test points.";
 }
 
 int main(int argc, char *argv[]) {

--- a/tests/unit-tests/algorithms/dim2/gradient.cpp
+++ b/tests/unit-tests/algorithms/dim2/gradient.cpp
@@ -47,12 +47,12 @@ constexpr static int ngll =
 /**
  * @brief Initializer tags for scalar field test data generation.
  */
-namespace FunctionInitializer {
+namespace FunctionInitializer2D {
 struct ZERO {};        ///< Zero-valued field: f(x,z) = 0 everywhere
 struct UNIFORM {};     ///< Uniform field: f(x,z) = 1 everywhere
 struct RANDOM {};      ///< Pseudo-random field values for stochastic testing
 struct TWO_ELEMENT {}; ///< Multi-element field with element-dependent values
-} // namespace FunctionInitializer
+} // namespace FunctionInitializer2D
 
 /**
  * @brief Initializer tags for quadrature derivative matrix configuration.
@@ -61,10 +61,10 @@ struct TWO_ELEMENT {}; ///< Multi-element field with element-dependent values
  * gradient computation. The matrix represents \f$\frac{\partial L_j}{\partial
  * \xi_i}\f$ where \f$L_j\f$ are Lagrange basis functions.
  */
-namespace QuadratureInitializer {
+namespace QuadratureInitializer2D {
 struct IDENTITY {}; ///< Identity matrix for simplified analytical verification
 struct LAGRANGE {}; ///< Proper GLL Lagrange derivative matrix from quadrature
-} // namespace QuadratureInitializer
+} // namespace QuadratureInitializer2D
 
 /**
  * @brief Initializer tags for Jacobian matrix test configurations.
@@ -73,10 +73,10 @@ struct LAGRANGE {}; ///< Proper GLL Lagrange derivative matrix from quadrature
  * coordinate mapping between reference element \f$[-1,1]^2\f$ and physical
  * space.
  */
-namespace JacobianInitializer {
+namespace JacobianInitializer2D {
 struct IDENTITY {};    ///< Identity Jacobian (no geometric transformation)
 struct TWO_ELEMENT {}; ///< Multi-element mesh with scaled transformations
-} // namespace JacobianInitializer
+} // namespace JacobianInitializer2D
 
 /**
  * @brief Initialize identity Jacobian matrix for single-element test cases.
@@ -94,7 +94,7 @@ struct TWO_ELEMENT {}; ///< Multi-element mesh with scaled transformations
  */
 std::vector<
     std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5> >
-init_jacobian(const JacobianInitializer::IDENTITY &) {
+init_jacobian(const JacobianInitializer2D::IDENTITY &) {
   std::vector<
       std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5> >
       jacobian(1);
@@ -124,7 +124,7 @@ init_jacobian(const JacobianInitializer::IDENTITY &) {
  */
 std::vector<
     std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5> >
-init_jacobian(const JacobianInitializer::TWO_ELEMENT &) {
+init_jacobian(const JacobianInitializer2D::TWO_ELEMENT &) {
   std::vector<
       std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5> >
       jacobian(2);
@@ -152,7 +152,7 @@ init_jacobian(const JacobianInitializer::TWO_ELEMENT &) {
  *
  * @tparam Initializer Tag describing which init_jacobian overload to invoke
  */
-template <typename Initializer> struct JacobianMatrix {
+template <typename Initializer> struct JacobianMatrix2D {
   constexpr static specfem::dimension::type dimension_tag =
       specfem::dimension::type::dim2;
   std::vector<
@@ -164,7 +164,7 @@ template <typename Initializer> struct JacobianMatrix {
    *
    * @param initializer Tag-dispatch parameter selecting initialization strategy
    */
-  JacobianMatrix(const Initializer &initializer)
+  JacobianMatrix2D(const Initializer &initializer)
       : _jacobian(init_jacobian(initializer)) {}
 
   /**
@@ -231,7 +231,7 @@ template <typename Initializer> struct JacobianMatrix {
  * @return 5×5 identity matrix for quadrature derivative operations
  */
 std::array<std::array<type_real, 5>, 5>
-init_quadrature(const QuadratureInitializer::IDENTITY &) {
+init_quadrature(const QuadratureInitializer2D::IDENTITY &) {
   std::array<std::array<type_real, 5>, 5> quadrature{};
   for (int i = 0; i < 5; ++i) {
     for (int j = 0; j < 5; ++j) {
@@ -252,7 +252,7 @@ init_quadrature(const QuadratureInitializer::IDENTITY &) {
  * @return 5×5 GLL derivative matrix for realistic gradient computation
  */
 std::array<std::array<type_real, 5>, 5>
-init_quadrature(const QuadratureInitializer::LAGRANGE &) {
+init_quadrature(const QuadratureInitializer2D::LAGRANGE &) {
   std::array<std::array<type_real, 5>, 5> quadrature{};
 
   const specfem::quadrature::gll::gll gll{};
@@ -274,7 +274,7 @@ init_quadrature(const QuadratureInitializer::LAGRANGE &) {
  *
  * @tparam Initializer Tag selecting which init_quadrature overload to use
  */
-template <typename Initializer> struct Quadrature {
+template <typename Initializer> struct Quadrature2D {
   std::array<std::array<type_real, 5>, 5> _quadrature;
 
   /**
@@ -282,7 +282,7 @@ template <typename Initializer> struct Quadrature {
    *
    * @param initializer Tag-dispatch parameter for quadrature initialization
    */
-  Quadrature(const Initializer &initializer)
+  Quadrature2D(const Initializer &initializer)
       : _quadrature(init_quadrature(initializer)) {}
 
   /**
@@ -305,7 +305,7 @@ template <typename Initializer> struct Quadrature {
  *
  * @return Single-element vector containing zero field data
  */
-auto init_function(const FunctionInitializer::ZERO &) {
+auto init_function(const FunctionInitializer2D::ZERO &) {
   std::vector<std::array<std::array<type_real, ngll>, ngll> > _f(1);
   for (int icomp = 0; icomp < 1; ++icomp) {
     for (int iz = 0; iz < ngll; ++iz) {
@@ -326,7 +326,7 @@ auto init_function(const FunctionInitializer::ZERO &) {
  *
  * @return Single-element vector containing uniform field data
  */
-auto init_function(const FunctionInitializer::UNIFORM &) {
+auto init_function(const FunctionInitializer2D::UNIFORM &) {
   std::vector<std::array<std::array<type_real, 5>, 5> > _f(1);
   for (int icomp = 0; icomp < 1; ++icomp) {
     for (int iz = 0; iz < 5; ++iz) {
@@ -349,7 +349,7 @@ auto init_function(const FunctionInitializer::UNIFORM &) {
  *
  * @warning Uses rand() for simplicity; not cryptographically secure
  */
-auto init_function(const FunctionInitializer::RANDOM &) {
+auto init_function(const FunctionInitializer2D::RANDOM &) {
   std::vector<std::array<std::array<type_real, 5>, 5> > _f(1);
   for (int icomp = 0; icomp < 1; ++icomp) {
     for (int iz = 0; iz < 5; ++iz) {
@@ -370,7 +370,7 @@ auto init_function(const FunctionInitializer::RANDOM &) {
  *
  * @return Two-element vector containing element-dependent constant field data
  */
-auto init_function(const FunctionInitializer::TWO_ELEMENT &) {
+auto init_function(const FunctionInitializer2D::TWO_ELEMENT &) {
   std::vector<std::array<std::array<type_real, 5>, 5> > _f(2);
   for (int ielement = 0; ielement < 2; ++ielement) {
     for (int iz = 0; iz < 5; ++iz) {
@@ -392,7 +392,7 @@ auto init_function(const FunctionInitializer::TWO_ELEMENT &) {
  *
  * @tparam Initializer Tag selecting which init_function overload to invoke
  */
-template <typename Initializer> struct Function {
+template <typename Initializer> struct Function2D {
   constexpr static specfem::dimension::type dimension_tag =
       specfem::dimension::type::dim2;
   constexpr static int components = 1; ///< Scalar field (single component)
@@ -408,7 +408,7 @@ template <typename Initializer> struct Function {
    *
    * @param initializer Tag-dispatch parameter for field initialization
    */
-  Function(const Initializer &initializer) : _f(init_function(initializer)) {}
+  Function2D(const Initializer &initializer) : _f(init_function(initializer)) {}
 
   /**
    * @brief Element-wise access to scalar field values.
@@ -468,9 +468,9 @@ private:
  */
 std::vector<
     std::array<std::array<std::array<std::array<type_real, 2>, 1>, 5>, 5> >
-gradient(const JacobianMatrix<JacobianInitializer::IDENTITY> &jacobian,
-         const Quadrature<QuadratureInitializer::IDENTITY> &quadrature,
-         const Function<FunctionInitializer::ZERO> &) {
+gradient(const JacobianMatrix2D<JacobianInitializer2D::IDENTITY> &jacobian,
+         const Quadrature2D<QuadratureInitializer2D::IDENTITY> &quadrature,
+         const Function2D<FunctionInitializer2D::ZERO> &) {
   std::vector<
       std::array<std::array<std::array<std::array<type_real, 2>, 1>, 5>, 5> >
       grad(1);
@@ -495,9 +495,9 @@ gradient(const JacobianMatrix<JacobianInitializer::IDENTITY> &jacobian,
  */
 std::vector<
     std::array<std::array<std::array<std::array<type_real, 2>, 1>, 5>, 5> >
-gradient(const JacobianMatrix<JacobianInitializer::IDENTITY> &jacobian,
-         const Quadrature<QuadratureInitializer::IDENTITY> &quadrature,
-         const Function<FunctionInitializer::UNIFORM> &) {
+gradient(const JacobianMatrix2D<JacobianInitializer2D::IDENTITY> &jacobian,
+         const Quadrature2D<QuadratureInitializer2D::IDENTITY> &quadrature,
+         const Function2D<FunctionInitializer2D::UNIFORM> &) {
   std::vector<
       std::array<std::array<std::array<std::array<type_real, 2>, 1>, 5>, 5> >
       grad(1);
@@ -515,19 +515,20 @@ gradient(const JacobianMatrix<JacobianInitializer::IDENTITY> &jacobian,
  * specfem::algorithms::gradient().
  *
  *
- * @tparam Jacobian JacobianMatrix type providing coordinate transformation data
- * @tparam Quadrature Quadrature type providing derivative matrix
- * @tparam Function Function type providing scalar field data
+ * @tparam Jacobian JacobianMatrix2D type providing coordinate transformation
+ * data
+ * @tparam Quadrature2D Quadrature2D type providing derivative matrix
+ * @tparam Function2D Function2D type providing scalar field data
  * @param jacobian Jacobian transformation data
  * @param quadrature Derivative matrix for reference coordinate differentiation
  * @param function Scalar field to differentiate
  * @return Computed gradient at all GLL points in all elements
  */
-template <typename Jacobian, typename Quadrature, typename Function>
+template <typename Jacobian, typename Quadrature2D, typename Function2D>
 std::vector<
     std::array<std::array<std::array<std::array<type_real, 2>, 1>, 5>, 5> >
-gradient(const Jacobian &jacobian, const Quadrature &quadrature,
-         const Function &function) {
+gradient(const Jacobian &jacobian, const Quadrature2D &quadrature,
+         const Function2D &function) {
 
   std::vector<
       std::array<std::array<std::array<std::array<type_real, 2>, 1>, 5>, 5> >
@@ -573,19 +574,19 @@ using namespace specfem::algorithms_test;
  * and scalar field data. Each test instantiation receives a unique combination
  * of initializer tags that determine the specific test scenario.
  *
- * @tparam TestingType Tuple of (JacobianInitializer, QuadratureInitializer,
- * FunctionInitializer)
+ * @tparam TestingType Tuple of (JacobianInitializer2D, QuadratureInitializer2D,
+ * FunctionInitializer2D)
  */
 template <typename TestingType>
-struct GradientTestFixture : public ::testing::Test {
-  using JacobianInitializer =
+struct GradientTestFixture2D : public ::testing::Test {
+  using JacobianInitializer2D =
       std::tuple_element_t<0, TestingType>; ///< Jacobian initialization
                                             ///< strategy
-  using QuadratureInitializer =
-      std::tuple_element_t<1, TestingType>; ///< Quadrature initialization
+  using QuadratureInitializer2D =
+      std::tuple_element_t<1, TestingType>; ///< Quadrature2D initialization
                                             ///< strategy
-  using FunctionInitializer =
-      std::tuple_element_t<2, TestingType>; ///< Function initialization
+  using FunctionInitializer2D =
+      std::tuple_element_t<2, TestingType>; ///< Function2D initialization
                                             ///< strategy
 
   /**
@@ -594,15 +595,17 @@ struct GradientTestFixture : public ::testing::Test {
    * This constructor uses the compile-time type information to instantiate
    * the appropriate helper objects for the specific test combination.
    */
-  GradientTestFixture()
-      : jacobian_matrix(JacobianInitializer{}),
-        quadrature(QuadratureInitializer{}), function(FunctionInitializer{}) {}
+  GradientTestFixture2D()
+      : jacobian_matrix(JacobianInitializer2D{}),
+        quadrature(QuadratureInitializer2D{}),
+        function(FunctionInitializer2D{}) {}
 
-  JacobianMatrix<JacobianInitializer> jacobian_matrix; ///< Coordinate
-                                                       ///< transformation data
-  Quadrature<QuadratureInitializer> quadrature; ///< Derivative matrix for
-                                                ///< gradient computation
-  Function<FunctionInitializer> function;       ///< Scalar field test data
+  JacobianMatrix2D<JacobianInitializer2D> jacobian_matrix; ///< Coordinate
+                                                           ///< transformation
+                                                           ///< data
+  Quadrature2D<QuadratureInitializer2D> quadrature; ///< Derivative matrix for
+                                                    ///< gradient computation
+  Function2D<FunctionInitializer2D> function;       ///< Scalar field test data
 };
 
 /**
@@ -624,14 +627,15 @@ struct GradientTestFixture : public ::testing::Test {
  *
  * 1. **Define new initializer tags** in the appropriate namespace:
  *    ```cpp
- *    namespace JacobianInitializer {
+ *    namespace JacobianInitializer2D {
  *    struct SCALED_ROTATION {}; // New Jacobian type
  *    }
  *    ```
  *
  * 2. **Overload the corresponding init_* function**:
  *    ```cpp
- *    std::vector<...> init_jacobian(const JacobianInitializer::SCALED_ROTATION
+ *    std::vector<...> init_jacobian(const
+ * JacobianInitializer2D::SCALED_ROTATION
  * &) {
  *        // Implementation for rotated/scaled Jacobian
  *    }
@@ -639,18 +643,18 @@ struct GradientTestFixture : public ::testing::Test {
  *
  * 3. **Add new tuple to GradientTestTypes**:
  *    ```cpp
- *    std::tuple<JacobianInitializer::SCALED_ROTATION,
- *               QuadratureInitializer::LAGRANGE,
- *               FunctionInitializer::POLYNOMIAL>
+ *    std::tuple<JacobianInitializer2D::SCALED_ROTATION,
+ *               QuadratureInitializer2D::LAGRANGE,
+ *               FunctionInitializer2D::POLYNOMIAL>
  *    ```
  *
  * 4. **Optionally add specialized gradient() overload** for analytical
  * reference:
  *    ```cpp
  *    std::vector<...> gradient(
- *        const JacobianMatrix<JacobianInitializer::SCALED_ROTATION> &jacobian,
- *        const Quadrature<QuadratureInitializer::LAGRANGE> &quadrature,
- *        const Function<FunctionInitializer::POLYNOMIAL> &function) {
+ *        const JacobianMatrix2D<JacobianInitializer2D::SCALED_ROTATION>
+ * &jacobian, const Quadrature2D<QuadratureInitializer2D::LAGRANGE> &quadrature,
+ *        const Function2D<FunctionInitializer2D::POLYNOMIAL> &function) {
  *        // Analytical reference implementation
  *    }
  *    ```
@@ -659,21 +663,23 @@ struct GradientTestFixture : public ::testing::Test {
  * scenario.
  */
 using GradientTestTypes = ::testing::Types<
-    std::tuple<JacobianInitializer::IDENTITY, QuadratureInitializer::IDENTITY,
-               FunctionInitializer::ZERO>,
-    std::tuple<JacobianInitializer::IDENTITY, QuadratureInitializer::IDENTITY,
-               FunctionInitializer::UNIFORM>,
-    std::tuple<JacobianInitializer::IDENTITY, QuadratureInitializer::LAGRANGE,
-               FunctionInitializer::RANDOM>,
-    std::tuple<JacobianInitializer::TWO_ELEMENT,
-               QuadratureInitializer::IDENTITY,
-               FunctionInitializer::TWO_ELEMENT> >;
+    std::tuple<JacobianInitializer2D::IDENTITY,
+               QuadratureInitializer2D::IDENTITY, FunctionInitializer2D::ZERO>,
+    std::tuple<JacobianInitializer2D::IDENTITY,
+               QuadratureInitializer2D::IDENTITY,
+               FunctionInitializer2D::UNIFORM>,
+    std::tuple<JacobianInitializer2D::IDENTITY,
+               QuadratureInitializer2D::LAGRANGE,
+               FunctionInitializer2D::RANDOM>,
+    std::tuple<JacobianInitializer2D::TWO_ELEMENT,
+               QuadratureInitializer2D::IDENTITY,
+               FunctionInitializer2D::TWO_ELEMENT> >;
 
 /**
  * @brief Instantiate parameterized test suite for all declared tuple
  * combinations.
  */
-TYPED_TEST_SUITE(GradientTestFixture, GradientTestTypes);
+TYPED_TEST_SUITE(GradientTestFixture2D, GradientTestTypes);
 
 /**
  * @brief Validate specfem::algorithms::gradient() against manufactured
@@ -690,7 +696,7 @@ TYPED_TEST_SUITE(GradientTestFixture, GradientTestTypes);
  * production implementations across different geometric and field
  * configurations.
  */
-TYPED_TEST(GradientTestFixture, TestGradientComputation) {
+TYPED_TEST(GradientTestFixture2D, TestGradientComputation) {
   // Verify consistency between function and Jacobian element counts
   ASSERT_TRUE(this->function.n_elements() == this->jacobian_matrix.n_elements())
       << "Mismatch in number of elements between function and jacobian matrix";
@@ -718,16 +724,16 @@ TYPED_TEST(GradientTestFixture, TestGradientComputation) {
   const auto jacobian = this->jacobian_matrix.jacobian();
   const auto function_view = this->function.view();
 
-  using FunctionView = specfem::datatype::VectorChunkElementViewType<
+  using Function2DView = specfem::datatype::VectorChunkElementViewType<
       type_real, specfem::dimension::type::dim2, 1, ngll, 1, false,
       Kokkos::HostSpace, Kokkos::MemoryTraits<> >;
 
   // Execute production gradient algorithm and validate results
   specfem::execution::for_each_level(chunk, [&](const typename decltype(
                                                 chunk)::index_type &index) {
-    const FunctionView f(Kokkos::subview(function_view, index.get_range(),
-                                         Kokkos::ALL(), Kokkos::ALL(),
-                                         Kokkos::ALL()));
+    const Function2DView f(Kokkos::subview(function_view, index.get_range(),
+                                           Kokkos::ALL(), Kokkos::ALL(),
+                                           Kokkos::ALL()));
 
     // Call the production gradient algorithm
     specfem::algorithms::gradient(

--- a/tests/unit-tests/algorithms/dim2/gradient.cpp
+++ b/tests/unit-tests/algorithms/dim2/gradient.cpp
@@ -15,55 +15,128 @@
 #include "execution/chunked_domain_iterator.hpp"
 #include "execution/for_each_level.hpp"
 #include "parallel_configuration/chunk_config.hpp"
+#include "quadrature/interface.hpp"
 #include "specfem/assembly.hpp"
 
 namespace specfem::algorithms_test {
 
 constexpr static int ngll = 5;
 
-enum class FunctionInitializer { ZERO, UNIFORM };
+namespace FunctionInitializer {
+struct ZERO {};
+struct UNIFORM {};
+struct RANDOM {};
+struct TWO_ELEMENT {};
+} // namespace FunctionInitializer
 
-enum class QuadratureInitializer { IDENTITY };
+namespace QuadratureInitializer {
+struct IDENTITY {};
+struct LAGRANGE {};
+} // namespace QuadratureInitializer
 
-enum class JacobianInitializer { IDENTITY };
+namespace JacobianInitializer {
+struct IDENTITY {};
+struct TWO_ELEMENT {};
+} // namespace JacobianInitializer
+
+std::vector<
+    std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5> >
+init_jacobian(const JacobianInitializer::IDENTITY &) {
+  std::vector<
+      std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5> >
+      jacobian(1);
+  for (int iz = 0; iz < 5; ++iz) {
+    for (int ix = 0; ix < 5; ++ix) {
+      jacobian[0][iz][ix][0][0] = 1.0;
+      jacobian[0][iz][ix][0][1] = 0.0;
+      jacobian[0][iz][ix][1][0] = 0.0;
+      jacobian[0][iz][ix][1][1] = 1.0;
+    }
+  }
+  return jacobian;
+}
+
+std::vector<
+    std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5> >
+init_jacobian(const JacobianInitializer::TWO_ELEMENT &) {
+  std::vector<
+      std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5> >
+      jacobian(2);
+  for (int ielement = 0; ielement < 2; ++ielement) {
+    for (int iz = 0; iz < 5; ++iz) {
+      for (int ix = 0; ix < 5; ++ix) {
+        jacobian[ielement][iz][ix][0][0] = 1.0 + ielement;
+        jacobian[ielement][iz][ix][0][1] = 0.0;
+        jacobian[ielement][iz][ix][1][0] = 0.0;
+        jacobian[ielement][iz][ix][1][1] = 1.0 + ielement;
+      }
+    }
+  }
+  return jacobian;
+}
 
 template <typename Initializer> struct JacobianMatrix {
   constexpr static specfem::dimension::type dimension_tag =
       specfem::dimension::type::dim2;
-  std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5>
+  std::vector<
+      std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5> >
       _jacobian;
 
   JacobianMatrix(const Initializer &initializer)
       : _jacobian(init_jacobian(initializer)) {}
 
+  const type_real &operator()(const int ielement, const int iz, const int ix,
+                              const int idim, const int jdim) const {
+    return _jacobian[ielement][iz][ix][idim][jdim];
+  }
+
+  const int n_elements() const { return static_cast<int>(_jacobian.size()); }
+
   specfem::assembly::jacobian_matrix<dimension_tag> jacobian() {
-    specfem::assembly::jacobian_matrix<dimension_tag> jacobian_matrix(1, 5, 5);
-    for (int iz = 0; iz < 5; ++iz) {
-      for (int ix = 0; ix < 5; ++ix) {
-        jacobian_matrix.xix(0, iz, ix) = _jacobian[iz][ix][0][0];
-        jacobian_matrix.xiz(0, iz, ix) = _jacobian[iz][ix][0][1];
-        jacobian_matrix.gammax(0, iz, ix) = _jacobian[iz][ix][1][0];
-        jacobian_matrix.gammaz(0, iz, ix) = _jacobian[iz][ix][1][1];
+    specfem::assembly::jacobian_matrix<dimension_tag> jacobian_matrix(
+        n_elements(), 5, 5);
+
+    for (int ielement = 0; ielement < n_elements(); ++ielement) {
+      for (int iz = 0; iz < 5; ++iz) {
+        for (int ix = 0; ix < 5; ++ix) {
+          jacobian_matrix.xix(ielement, iz, ix) =
+              _jacobian[ielement][iz][ix][0][0];
+          jacobian_matrix.xiz(ielement, iz, ix) =
+              _jacobian[ielement][iz][ix][0][1];
+          jacobian_matrix.gammax(ielement, iz, ix) =
+              _jacobian[ielement][iz][ix][1][0];
+          jacobian_matrix.gammaz(ielement, iz, ix) =
+              _jacobian[ielement][iz][ix][1][1];
+        }
       }
     }
     return jacobian_matrix;
   }
 };
 
-std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5>
-init_jacobian(const std::integral_constant<JacobianInitializer,
-                                           JacobianInitializer::IDENTITY> &) {
-  std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5>
-      jacobian{};
-  for (int iz = 0; iz < 5; ++iz) {
-    for (int ix = 0; ix < 5; ++ix) {
-      jacobian[iz][ix][0][0] = 1.0;
-      jacobian[iz][ix][0][1] = 0.0;
-      jacobian[iz][ix][1][0] = 0.0;
-      jacobian[iz][ix][1][1] = 1.0;
+std::array<std::array<type_real, 5>, 5>
+init_quadrature(const QuadratureInitializer::IDENTITY &) {
+  std::array<std::array<type_real, 5>, 5> quadrature{};
+  for (int i = 0; i < 5; ++i) {
+    for (int j = 0; j < 5; ++j) {
+      quadrature[i][j] = (i == j) ? 1.0 : 0.0;
     }
   }
-  return jacobian;
+  return quadrature;
+}
+
+std::array<std::array<type_real, 5>, 5>
+init_quadrature(const QuadratureInitializer::LAGRANGE &) {
+  std::array<std::array<type_real, 5>, 5> quadrature{};
+
+  const specfem::quadrature::gll::gll gll{};
+  const auto hprime = gll.get_hhprime();
+  for (int i = 0; i < 5; ++i) {
+    for (int j = 0; j < 5; ++j) {
+      quadrature[j][i] = hprime(i, j);
+    }
+  }
+  return quadrature;
 }
 
 template <typename Initializer> struct Quadrature {
@@ -77,48 +150,7 @@ template <typename Initializer> struct Quadrature {
   }
 };
 
-std::array<std::array<type_real, 5>, 5> init_quadrature(
-    const std::integral_constant<QuadratureInitializer,
-                                 QuadratureInitializer::IDENTITY> &) {
-  std::array<std::array<type_real, 5>, 5> quadrature{};
-  for (int i = 0; i < 5; ++i) {
-    for (int j = 0; j < 5; ++j) {
-      quadrature[i][j] = (i == j) ? 1.0 : 0.0;
-    }
-  }
-  return quadrature;
-}
-
-template <typename Initializer> struct Function {
-  constexpr static specfem::dimension::type dimension_tag =
-      specfem::dimension::type::dim2;
-  constexpr static int components = 1;
-
-  using memory_space = Kokkos::HostSpace;
-  using memory_traits = Kokkos::MemoryTraits<>;
-
-  using view_type = specfem::datatype::VectorChunkElementViewType<
-      type_real, dimension_tag, 1, ngll, components, false, memory_space,
-      memory_traits>;
-
-  Function(const Initializer &initializer) : _f(init_function(initializer)) {}
-
-  view_type view() const {
-    view_type f_view("f_view");
-    for (int iz = 0; iz < ngll; ++iz) {
-      for (int ix = 0; ix < ngll; ++ix) {
-        f_view(0, iz, ix, 0) = _f[0][iz][ix];
-      }
-    }
-    return f_view;
-  }
-
-private:
-  std::vector<std::array<std::array<type_real, ngll>, ngll> > _f;
-};
-
-auto init_function(const std::integral_constant<FunctionInitializer,
-                                                FunctionInitializer::ZERO> &) {
+auto init_function(const FunctionInitializer::ZERO &) {
   std::vector<std::array<std::array<type_real, ngll>, ngll> > _f(1);
   for (int icomp = 0; icomp < 1; ++icomp) {
     for (int iz = 0; iz < ngll; ++iz) {
@@ -130,8 +162,7 @@ auto init_function(const std::integral_constant<FunctionInitializer,
   return _f;
 }
 
-auto init_function(const std::integral_constant<
-                   FunctionInitializer, FunctionInitializer::UNIFORM> &) {
+auto init_function(const FunctionInitializer::UNIFORM &) {
   std::vector<std::array<std::array<type_real, 5>, 5> > _f(1);
   for (int icomp = 0; icomp < 1; ++icomp) {
     for (int iz = 0; iz < 5; ++iz) {
@@ -143,40 +174,131 @@ auto init_function(const std::integral_constant<
   return _f;
 }
 
-template <JacobianInitializer JInit, QuadratureInitializer QInit,
-          FunctionInitializer FInit>
-std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5>
-gradient();
+auto init_function(const FunctionInitializer::RANDOM &) {
+  std::vector<std::array<std::array<type_real, 5>, 5> > _f(1);
+  for (int icomp = 0; icomp < 1; ++icomp) {
+    for (int iz = 0; iz < 5; ++iz) {
+      for (int ix = 0; ix < 5; ++ix) {
+        _f[icomp][iz][ix] = static_cast<type_real>(rand()) / RAND_MAX;
+      }
+    }
+  }
+  return _f;
+}
 
-template <>
-std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5>
-gradient<JacobianInitializer::IDENTITY, QuadratureInitializer::IDENTITY,
-         FunctionInitializer::ZERO>() {
-  std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5> grad{};
+auto init_function(const FunctionInitializer::TWO_ELEMENT &) {
+  std::vector<std::array<std::array<type_real, 5>, 5> > _f(2);
+  for (int ielement = 0; ielement < 2; ++ielement) {
+    for (int iz = 0; iz < 5; ++iz) {
+      for (int ix = 0; ix < 5; ++ix) {
+        _f[ielement][iz][ix] = 1.0 + ielement;
+      }
+    }
+  }
+  return _f;
+}
+
+template <typename Initializer> struct Function {
+  constexpr static specfem::dimension::type dimension_tag =
+      specfem::dimension::type::dim2;
+  constexpr static int components = 1;
+
+  using memory_space = Kokkos::HostSpace;
+  using memory_traits = Kokkos::MemoryTraits<>;
+
+  using view_type = Kokkos::View<type_real *[ngll][ngll][components],
+                                 memory_space, memory_traits>;
+
+  Function(const Initializer &initializer) : _f(init_function(initializer)) {}
+
+  const type_real &operator()(const int &ielement, const int &iz,
+                              const int &ix) const {
+    return _f[ielement][iz][ix];
+  }
+
+  int n_elements() const { return static_cast<int>(_f.size()); }
+
+  view_type view() const {
+    view_type f_view("f_view", _f.size());
+    for (int ielement = 0; ielement < static_cast<int>(_f.size()); ++ielement) {
+      for (int iz = 0; iz < ngll; ++iz) {
+        for (int ix = 0; ix < ngll; ++ix) {
+          f_view(ielement, iz, ix, 0) = _f[ielement][iz][ix];
+        }
+      }
+    }
+    return f_view;
+  }
+
+private:
+  std::vector<std::array<std::array<type_real, ngll>, ngll> > _f;
+};
+
+std::vector<
+    std::array<std::array<std::array<std::array<type_real, 2>, 1>, 5>, 5> >
+gradient(const JacobianMatrix<JacobianInitializer::IDENTITY> &jacobian,
+         const Quadrature<QuadratureInitializer::IDENTITY> &quadrature,
+         const Function<FunctionInitializer::ZERO> &) {
+  std::vector<
+      std::array<std::array<std::array<std::array<type_real, 2>, 1>, 5>, 5> >
+      grad(1);
   for (int iz = 0; iz < 5; ++iz) {
     for (int ix = 0; ix < 5; ++ix) {
-      grad[iz][ix][0][0] = 1.0;
-      grad[iz][ix][0][1] = 0.0;
-      grad[iz][ix][1][0] = 0.0;
-      grad[iz][ix][1][1] = 1.0;
+      grad[0][iz][ix][0][0] = 0.0;
+      grad[0][iz][ix][0][1] = 0.0;
     }
   }
   return grad;
 }
 
-template <>
-std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5>
-gradient<JacobianInitializer::IDENTITY, QuadratureInitializer::IDENTITY,
-         FunctionInitializer::UNIFORM>() {
-  std::array<std::array<std::array<std::array<type_real, 2>, 2>, 5>, 5> grad{};
+std::vector<
+    std::array<std::array<std::array<std::array<type_real, 2>, 1>, 5>, 5> >
+gradient(const JacobianMatrix<JacobianInitializer::IDENTITY> &jacobian,
+         const Quadrature<QuadratureInitializer::IDENTITY> &quadrature,
+         const Function<FunctionInitializer::UNIFORM> &) {
+  std::vector<
+      std::array<std::array<std::array<std::array<type_real, 2>, 1>, 5>, 5> >
+      grad(1);
   for (int iz = 0; iz < 5; ++iz) {
     for (int ix = 0; ix < 5; ++ix) {
-      grad[iz][ix][0][0] = 0.0;
-      grad[iz][ix][0][1] = 0.0;
-      grad[iz][ix][1][0] = 0.0;
-      grad[iz][ix][1][1] = 0.0;
+      grad[0][iz][ix][0][0] = 1.0;
+      grad[0][iz][ix][0][1] = 1.0;
     }
   }
+  return grad;
+}
+
+template <typename Jacobian, typename Quadrature, typename Function>
+std::vector<
+    std::array<std::array<std::array<std::array<type_real, 2>, 1>, 5>, 5> >
+gradient(const Jacobian &jacobian, const Quadrature &quadrature,
+         const Function &function) {
+
+  // Placeholder for actual gradient computation logic
+  std::vector<
+      std::array<std::array<std::array<std::array<type_real, 2>, 1>, 5>, 5> >
+      grad(function.n_elements());
+
+  for (int ielement = 0; ielement < function.n_elements(); ++ielement) {
+    for (int iz = 0; iz < ngll; ++iz) {
+      for (int ix = 0; ix < ngll; ++ix) {
+        type_real df_dxi = 0.0;
+        type_real df_gamma = 0.0;
+        for (int l = 0; l < ngll; ++l) {
+          // Compute gradient components here using f, jacobian, and quadrature
+          df_dxi += quadrature(ix, l) * function(ielement, iz, l);
+          df_gamma += quadrature(iz, l) * function(ielement, l, ix);
+        }
+        grad[ielement][iz][ix][0][0] =
+            df_dxi * jacobian(ielement, iz, ix, 0, 0) +
+            df_gamma * jacobian(ielement, iz, ix, 1, 0);
+        grad[ielement][iz][ix][0][1] =
+            df_dxi * jacobian(ielement, iz, ix, 0, 1) +
+            df_gamma * jacobian(ielement, iz, ix, 1, 1);
+      }
+    }
+  }
+
   return grad;
 }
 
@@ -200,18 +322,15 @@ struct GradientTestFixture : public ::testing::Test {
 };
 
 using GradientTestTypes = ::testing::Types<
-    std::tuple<std::integral_constant<JacobianInitializer,
-                                      JacobianInitializer::IDENTITY>,
-               std::integral_constant<QuadratureInitializer,
-                                      QuadratureInitializer::IDENTITY>,
-               std::integral_constant<FunctionInitializer,
-                                      FunctionInitializer::ZERO> >,
-    std::tuple<std::integral_constant<JacobianInitializer,
-                                      JacobianInitializer::IDENTITY>,
-               std::integral_constant<QuadratureInitializer,
-                                      QuadratureInitializer::IDENTITY>,
-               std::integral_constant<FunctionInitializer,
-                                      FunctionInitializer::UNIFORM> > >;
+    std::tuple<JacobianInitializer::IDENTITY, QuadratureInitializer::IDENTITY,
+               FunctionInitializer::ZERO>,
+    std::tuple<JacobianInitializer::IDENTITY, QuadratureInitializer::IDENTITY,
+               FunctionInitializer::UNIFORM>,
+    std::tuple<JacobianInitializer::IDENTITY, QuadratureInitializer::LAGRANGE,
+               FunctionInitializer::RANDOM>,
+    std::tuple<JacobianInitializer::TWO_ELEMENT,
+               QuadratureInitializer::IDENTITY,
+               FunctionInitializer::TWO_ELEMENT> >;
 
 TYPED_TEST_SUITE(GradientTestFixture, GradientTestTypes);
 
@@ -219,17 +338,20 @@ TYPED_TEST(GradientTestFixture, TestGradientComputation) {
   // Implement test logic here using this->jacobian_matrix, this->quadrature,
   // and this->function
 
-  constexpr static auto Jinit = TestFixture::JacobianInitializer::value;
-  constexpr static auto Qinit = TestFixture::QuadratureInitializer::value;
-  constexpr static auto Finit = TestFixture::FunctionInitializer::value;
+  ASSERT_TRUE(this->function.n_elements() == this->jacobian_matrix.n_elements())
+      << "Mismatch in number of elements between function and jacobian matrix";
 
-  // const auto expected_gradient =
-  //     specfem::algorithms_test::gradient<Jinit, Qinit, Finit>();
+  const auto expected_gradient = specfem::algorithms_test::gradient(
+      this->jacobian_matrix, this->quadrature, this->function);
 
-  // Create an iterator single element;
+  // Create an iterator;
   using simd = specfem::datatype::simd<type_real, false>;
-  Kokkos::View<int *, Kokkos::HostSpace> element_indices("element_indices", 1);
-  element_indices(0) = 0;
+  Kokkos::View<int *, Kokkos::HostSpace> element_indices(
+      "element_indices", this->function.n_elements());
+  for (int i = 0; i < this->function.n_elements(); ++i) {
+    element_indices(i) = i;
+  }
+
   using ParallelConfig = specfem::parallel_config::default_chunk_config<
       specfem::dimension::type::dim2, simd, Kokkos::DefaultHostExecutionSpace>;
 
@@ -238,18 +360,38 @@ TYPED_TEST(GradientTestFixture, TestGradientComputation) {
   const specfem::execution::ChunkedDomainIterator chunk(
       ParallelConfig(), element_indices, element_grid);
 
+  const auto jacobian = this->jacobian_matrix.jacobian();
+  const auto function_view = this->function.view();
+
+  using FunctionView = specfem::datatype::VectorChunkElementViewType<
+      type_real, specfem::dimension::type::dim2, 1, ngll, 1, false,
+      Kokkos::HostSpace, Kokkos::MemoryTraits<> >;
+
   // Call gradient computation
   specfem::execution::for_each_level(chunk, [&](const typename decltype(
                                                 chunk)::index_type &index) {
+    const FunctionView f(Kokkos::subview(function_view, index.get_range(),
+                                         Kokkos::ALL(), Kokkos::ALL(),
+                                         Kokkos::ALL()));
     // Call gradient algorithm here
     specfem::algorithms::gradient(
-        index, this->jacobian_matrix.jacobian(), this->quadrature,
-        this->function.view(), [&](const auto &iterator_index, const auto &df) {
-          const auto local_index = iterator_index.get_local_index();
+        index, jacobian, this->quadrature, f,
+        [&](const auto &iterator_index, const auto &df) {
+          const auto local_index = iterator_index.get_index();
+          const int ispec = local_index.ispec;
           const int iz = local_index.iz;
           const int ix = local_index.ix;
 
+          const auto e = expected_gradient[ispec][iz][ix];
+
           // Verify computed gradient against expected gradient
+          if (!specfem::utilities::is_close(df(0, 0), e[0][0]) ||
+              !specfem::utilities::is_close(df(0, 1), e[0][1])) {
+            FAIL() << "Mismatch for element " << local_index.ispec << "\n"
+                   << "    at quadrature point (" << iz << ", " << ix << ")\n"
+                   << "    expected: (" << e[0][0] << ", " << e[0][1] << ")\n"
+                   << "    got: (" << df(0, 0) << ", " << df(0, 1) << ")";
+          }
         });
   });
 

--- a/tests/unit-tests/algorithms/dim2/gradient.cpp
+++ b/tests/unit-tests/algorithms/dim2/gradient.cpp
@@ -202,7 +202,7 @@ public:
    *
    * @return Assembled jacobian_matrix ready for algorithm testing
    */
-  specfem::assembly::jacobian_matrix<dimension_tag> jacobian() {
+  specfem::assembly::jacobian_matrix<dimension_tag> jacobian() const {
     specfem::assembly::jacobian_matrix<dimension_tag> jacobian_matrix(
         n_elements(), 5, 5);
 
@@ -282,9 +282,9 @@ init_quadrature(const QuadratureInitializer2D::LAGRANGE &) {
 template <typename Initializer> struct Quadrature2D {
   std::array<std::array<type_real, 5>, 5> _quadrature;
 
-  using view_type =
-      Kokkos::View<type_real[5][5],
-                   Kokkos::DefaultHostExecutionSpace::memory_space>;
+  using memory_space = Kokkos::DefaultExecutionSpace::memory_space;
+
+  using view_type = Kokkos::View<type_real[5][5], memory_space>;
 
   /**
    * @brief Construct derivative matrix using the selected initializer tag.
@@ -302,8 +302,8 @@ template <typename Initializer> struct Quadrature2D {
       }
     }
 
-    const auto d_quadrature = Kokkos::create_mirror_view_and_copy(
-        Kokkos::DefaultHostExecutionSpace(), quadrature_view);
+    const auto d_quadrature =
+        Kokkos::create_mirror_view_and_copy(memory_space(), quadrature_view);
     return d_quadrature;
   }
 
@@ -390,7 +390,7 @@ auto init_function(const FunctionInitializer2D::TWO_ELEMENT &) {
   for (int ielement = 0; ielement < 2; ++ielement) {
     for (int iz = 0; iz < 5; ++iz) {
       for (int ix = 0; ix < 5; ++ix) {
-        _f[ielement][iz][ix] = 1.0 + ielement; // Element-dependent constant
+        _f[ielement][iz][ix] = 1.0; // Element-dependent constant
       }
     }
   }
@@ -412,11 +412,10 @@ template <typename Initializer> struct Function2D {
       specfem::dimension::type::dim2;
   constexpr static int components = 1; ///< Scalar field (single component)
 
-  using memory_space = Kokkos::DefaultHostExecutionSpace::memory_space;
-  using memory_traits = Kokkos::MemoryTraits<>;
+  using memory_space = Kokkos::DefaultExecutionSpace::memory_space;
 
-  using view_type = Kokkos::View<type_real *[ngll][ngll][components],
-                                 memory_space, memory_traits>;
+  using view_type =
+      Kokkos::View<type_real *[ngll][ngll][components], memory_space>;
 
   /**
    * @brief Construct scalar field using the supplied initializer tag.
@@ -580,6 +579,69 @@ gradient(const Jacobian &jacobian, const Quadrature2D &quadrature,
   return grad;
 }
 
+template <typename Jacobian, typename Quadrature2D, typename Function2D>
+Kokkos::View<type_real ****, Kokkos::LayoutLeft, Kokkos::HostSpace>
+execute(const Jacobian &jacobian_matrix, const Quadrature2D &quadrature,
+        const Function2D &function) {
+  // Set up chunked domain iteration for production algorithm testing
+  using simd = specfem::datatype::simd<type_real, false>;
+  Kokkos::View<int *, Kokkos::HostSpace> h_element_indices(
+      "element_indices", function.n_elements());
+  for (int i = 0; i < function.n_elements(); ++i) {
+    h_element_indices(i) = i;
+  }
+
+  const auto element_indices = Kokkos::create_mirror_view_and_copy(
+      Kokkos::DefaultExecutionSpace(), h_element_indices);
+
+  using ParallelConfig =
+      specfem::parallel_config::chunk_config<specfem::dimension::type::dim2, 1,
+                                             1, 1, 1, simd,
+                                             Kokkos::DefaultExecutionSpace>;
+
+  const specfem::mesh_entity::element element_grid(ngll, ngll);
+
+  const specfem::execution::ChunkedDomainIterator chunk(
+      ParallelConfig(), element_indices, element_grid);
+
+  const auto jacobian = jacobian_matrix.jacobian();
+  const auto quadrature_view = quadrature.quadrature();
+  const auto function_view = function.view();
+
+  using Function2DView = specfem::datatype::VectorChunkElementViewType<
+      type_real, specfem::dimension::type::dim2, 1, ngll, 1, false,
+      Kokkos::DefaultExecutionSpace::memory_space, Kokkos::MemoryTraits<> >;
+
+  Kokkos::View<type_real ****, Kokkos::LayoutLeft,
+               Kokkos::DefaultExecutionSpace>
+      gradient_view("gradient_view", function.n_elements(), ngll, ngll, 2);
+
+  // Execute production gradient algorithm and validate results
+  specfem::execution::for_each_level(
+      chunk, KOKKOS_LAMBDA(const typename decltype(chunk)::index_type &index) {
+        const Function2DView f(Kokkos::subview(function_view, index.get_range(),
+                                               Kokkos::ALL(), Kokkos::ALL(),
+                                               Kokkos::ALL()));
+
+        // Call the production gradient algorithm
+        specfem::algorithms::gradient(
+            index, jacobian, quadrature_view, f,
+            [&](const auto &iterator_index, const auto &df) {
+              const auto local_index = iterator_index.get_index();
+              const int ispec = local_index.ispec;
+              const int iz = local_index.iz;
+              const int ix = local_index.ix;
+              // store computed gradient
+              gradient_view(ispec, iz, ix, 0) = df(0, 0);
+              gradient_view(ispec, iz, ix, 1) = df(0, 1);
+            });
+      });
+
+  const auto gradient_host =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), gradient_view);
+  return gradient_host;
+}
+
 } // namespace specfem::algorithms_test
 
 using namespace specfem::algorithms_test;
@@ -723,60 +785,8 @@ TYPED_TEST(GradientTestFixture2D, TestGradientComputation) {
   const auto expected_gradient = specfem::algorithms_test::gradient(
       this->jacobian_matrix, this->quadrature, this->function);
 
-  // Set up chunked domain iteration for production algorithm testing
-  using simd = specfem::datatype::simd<type_real, false>;
-  Kokkos::View<int *, Kokkos::HostSpace> h_element_indices(
-      "element_indices", this->function.n_elements());
-  for (int i = 0; i < this->function.n_elements(); ++i) {
-    h_element_indices(i) = i;
-  }
-
-  const auto element_indices = Kokkos::create_mirror_view_and_copy(
-      Kokkos::DefaultExecutionSpace(), h_element_indices);
-
-  using ParallelConfig = specfem::parallel_config::default_chunk_config<
-      specfem::dimension::type::dim2, simd, Kokkos::DefaultExecutionSpace>;
-
-  const specfem::mesh_entity::element element_grid(ngll, ngll);
-
-  const specfem::execution::ChunkedDomainIterator chunk(
-      ParallelConfig(), element_indices, element_grid);
-
-  const auto jacobian = this->jacobian_matrix.jacobian();
-  const auto quadrature = this->quadrature.quadrature();
-  const auto function_view = this->function.view();
-
-  using Function2DView = specfem::datatype::VectorChunkElementViewType<
-      type_real, specfem::dimension::type::dim2, 1, ngll, 1, false,
-      Kokkos::DefaultExecutionSpace::memory_space, Kokkos::MemoryTraits<> >;
-
-  Kokkos::View<type_real ****, Kokkos::DefaultExecutionSpace> gradient_view(
-      "gradient_view", this->function.n_elements(), ngll, ngll, 2);
-
-  // Execute production gradient algorithm and validate results
-  specfem::execution::for_each_level(
-      chunk, [&](const typename decltype(chunk)::index_type &index) {
-        const Function2DView f(Kokkos::subview(function_view, index.get_range(),
-                                               Kokkos::ALL(), Kokkos::ALL(),
-                                               Kokkos::ALL()));
-
-        // Call the production gradient algorithm
-        specfem::algorithms::gradient(
-            index, jacobian, quadrature, f,
-            [&](const auto &iterator_index, const auto &df) {
-              const auto local_index = iterator_index.get_index();
-              const int ispec = local_index.ispec;
-              const int iz = local_index.iz;
-              const int ix = local_index.ix;
-
-              // store computed gradient
-              gradient_view(ispec, iz, ix, 0) = df(0, 0);
-              gradient_view(ispec, iz, ix, 1) = df(0, 1);
-            });
-      });
-
-  const auto gradient_host =
-      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), gradient_view);
+  const auto gradient = specfem::algorithms_test::execute(
+      this->jacobian_matrix, this->quadrature, this->function);
 
   // Compare computed gradient against expected results
   for (int ielement = 0; ielement < this->function.n_elements(); ++ielement) {
@@ -784,15 +794,16 @@ TYPED_TEST(GradientTestFixture2D, TestGradientComputation) {
       for (int ix = 0; ix < ngll; ++ix) {
         const auto e = expected_gradient[ielement][iz][ix];
         const auto df =
-            Kokkos::subview(gradient_host, ielement, iz, ix, Kokkos::ALL());
+            Kokkos::subview(gradient, ielement, iz, ix, Kokkos::ALL());
 
         // Point-wise validation of computed gradient components
         if (!specfem::utilities::is_close(df(0), e[0][0]) ||
             !specfem::utilities::is_close(df(1), e[0][1])) {
-          FAIL() << "Gradient mismatch for element " << ielement << "\n"
-                 << "    at GLL point (" << iz << ", " << ix << ")\n"
-                 << "    expected: (" << e[0][0] << ", " << e[0][1] << ")\n"
-                 << "    computed: (" << df(0) << ", " << df(1) << ")";
+          ADD_FAILURE() << "Gradient mismatch for element " << ielement << "\n"
+                        << "    at GLL point (" << iz << ", " << ix << ")\n"
+                        << "    expected: (" << e[0][0] << ", " << e[0][1]
+                        << ")\n"
+                        << "    computed: (" << df(0) << ", " << df(1) << ")";
         }
       }
     }

--- a/tests/unit-tests/algorithms/dim3/gradient.cpp
+++ b/tests/unit-tests/algorithms/dim3/gradient.cpp
@@ -1,0 +1,845 @@
+/**
+ * @file gradient.cpp
+ * @brief Unit tests for 3D spectral element gradient computation algorithms.
+ *
+ * This file implements comprehensive tests for validating the 3D gradient
+ * computation in spectral element methods. The Jacobian matrix represents
+ * the transformation between reference coordinates \f$(\xi, \eta, \gamma)\f$
+ * and physical coordinates \f$(x, y, z)\f$ for hexahedral spectral elements.
+ *
+ * The test framework uses a tag-dispatch pattern to enable extensible test
+ * scenarios through initializer overloading. The tests verify:
+ * - Coordinate transformation between reference \f$[-1,1]^3\f$ and physical
+ * space
+ * - Gradient computation using equation 29 from Komatitsch and Tromp (1999)
+ * - Consistency across multi-element meshes
+ * - Validation against analytical solutions for manufactured test cases
+ *
+ * @note To add new test cases, follow the pattern:
+ * 1. Define new initializer tags in appropriate namespaces
+ * 2. Overload corresponding init_* functions
+ * 3. Add tuple combinations to GradientTestTypes
+ * 4. Optionally provide specialized gradient reference implementations
+ *
+ * @see specfem::algorithms::gradient
+ * @see specfem::algorithms::impl::element_gradient for 3D implementation
+ */
+
+#include <Kokkos_Core.hpp>
+#include <array>
+#include <gtest/gtest.h>
+#include <tuple>
+#include <type_traits>
+#include <vector>
+
+#include "Kokkos_Environment.hpp"
+#include "MPI_environment.hpp"
+#include "algorithms/gradient.hpp"
+#include "datatypes/point_view.hpp"
+#include "datatypes/simd.hpp"
+#include "enumerations/interface.hpp"
+#include "execution/chunked_domain_iterator.hpp"
+#include "execution/for_each_level.hpp"
+#include "parallel_configuration/chunk_config.hpp"
+#include "quadrature/interface.hpp"
+#include "specfem/assembly.hpp"
+
+namespace specfem::algorithms_test {
+
+constexpr static int ngll =
+    5; ///< Number of GLL points per dimension (5th order spectral elements)
+
+/**
+ * @brief Initializer tags for scalar field test data generation.
+ */
+namespace FunctionInitializer3D {
+struct ZERO {};        ///< Zero-valued field: f(x,y,z) = 0 everywhere
+struct UNIFORM {};     ///< Uniform field: f(x,y,z) = 1 everywhere
+struct RANDOM {};      ///< Pseudo-random field values for stochastic testing
+struct TWO_ELEMENT {}; ///< Multi-element field with element-dependent values
+} // namespace FunctionInitializer3D
+
+/**
+ * @brief Initializer tags for quadrature derivative matrix configuration.
+ *
+ * These tags control the initialization of the derivative matrix used in
+ * gradient computation. The matrix represents \f$\frac{\partial L_j}{\partial
+ * \xi_i}\f$ where \f$L_j\f$ are Lagrange basis functions.
+ */
+namespace QuadratureInitializer3D {
+struct IDENTITY {}; ///< Identity matrix for simplified analytical verification
+struct LAGRANGE {}; ///< Proper GLL Lagrange derivative matrix from quadrature
+} // namespace QuadratureInitializer3D
+
+/**
+ * @brief Initializer tags for Jacobian matrix test configurations.
+ *
+ * These tags define different geometric transformation scenarios for testing
+ * coordinate mapping between reference element \f$[-1,1]^3\f$ and physical
+ * space.
+ */
+namespace JacobianInitializer3D {
+struct IDENTITY {};    ///< Identity Jacobian (no geometric transformation)
+struct TWO_ELEMENT {}; ///< Multi-element mesh with scaled transformations
+} // namespace JacobianInitializer3D
+
+/**
+ * @brief Initialize identity Jacobian matrix for single-element test cases.
+ *
+ * Creates a single spectral element with identity Jacobian transformation at
+ * all GLL points. This represents a reference element with no geometric
+ * deformation, where the partial derivatives form identity relationships:
+ * \f$\frac{\partial \xi}{\partial x} = \frac{\partial \eta}{\partial y} =
+ * \frac{\partial \gamma}{\partial z} = 1\f$ and all cross terms are zero.
+ *
+ * @return Vector containing single element's Jacobian data with identity values
+ *
+ * @note This configuration allows direct comparison between reference and
+ * physical space gradients since the coordinate transformation is trivial.
+ */
+std::vector<std::array<
+    std::array<std::array<std::array<std::array<type_real, 3>, 3>, 5>, 5>, 5> >
+init_jacobian(const JacobianInitializer3D::IDENTITY &) {
+  std::vector<std::array<
+      std::array<std::array<std::array<std::array<type_real, 3>, 3>, 5>, 5>,
+      5> >
+      jacobian(1);
+  for (int iz = 0; iz < 5; ++iz) {
+    for (int iy = 0; iy < 5; ++iy) {
+      for (int ix = 0; ix < 5; ++ix) {
+        // Initialize identity Jacobian matrix
+        jacobian[0][iz][iy][ix][0][0] = 1.0; // ξₓ = ∂ξ/∂x
+        jacobian[0][iz][iy][ix][0][1] = 0.0; // ξᵧ = ∂ξ/∂y
+        jacobian[0][iz][iy][ix][0][2] = 0.0; // ξᵤ = ∂ξ/∂z
+        jacobian[0][iz][iy][ix][1][0] = 0.0; // ηₓ = ∂η/∂x
+        jacobian[0][iz][iy][ix][1][1] = 1.0; // ηᵧ = ∂η/∂y
+        jacobian[0][iz][iy][ix][1][2] = 0.0; // ηᵤ = ∂η/∂z
+        jacobian[0][iz][iy][ix][2][0] = 0.0; // γₓ = ∂γ/∂x
+        jacobian[0][iz][iy][ix][2][1] = 0.0; // γᵧ = ∂γ/∂y
+        jacobian[0][iz][iy][ix][2][2] = 1.0; // γᵤ = ∂γ/∂z
+      }
+    }
+  }
+  return jacobian;
+}
+
+/**
+ * @brief Initialize two-element Jacobian dataset with scaled transformations.
+ *
+ * Creates a two-element mesh where each element has scaled identity Jacobian
+ * matrices. Element 0 has identity scaling (1.0), while element 1 has 2.0
+ * scaling, effectively creating elements of different sizes.
+ *
+ * @return Vector containing Jacobian data for both elements with scaling
+ * factors
+ *
+ * @note This tests multi-element gradient computation and coordinate
+ *       transformation consistency across element boundaries.
+ */
+std::vector<std::array<
+    std::array<std::array<std::array<std::array<type_real, 3>, 3>, 5>, 5>, 5> >
+init_jacobian(const JacobianInitializer3D::TWO_ELEMENT &) {
+  std::vector<std::array<
+      std::array<std::array<std::array<std::array<type_real, 3>, 3>, 5>, 5>,
+      5> >
+      jacobian(2);
+  for (int ielement = 0; ielement < 2; ++ielement) {
+    for (int iz = 0; iz < 5; ++iz) {
+      for (int iy = 0; iy < 5; ++iy) {
+        for (int ix = 0; ix < 5; ++ix) {
+          const type_real scale = 1.0 + ielement; // Element scaling factor
+          jacobian[ielement][iz][iy][ix][0][0] = scale; // Scaled ξₓ
+          jacobian[ielement][iz][iy][ix][0][1] = 0.0;   // ξᵧ = 0
+          jacobian[ielement][iz][iy][ix][0][2] = 0.0;   // ξᵤ = 0
+          jacobian[ielement][iz][iy][ix][1][0] = 0.0;   // ηₓ = 0
+          jacobian[ielement][iz][iy][ix][1][1] = scale; // Scaled ηᵧ
+          jacobian[ielement][iz][iy][ix][1][2] = 0.0;   // ηᵤ = 0
+          jacobian[ielement][iz][iy][ix][2][0] = 0.0;   // γₓ = 0
+          jacobian[ielement][iz][iy][ix][2][1] = 0.0;   // γᵧ = 0
+          jacobian[ielement][iz][iy][ix][2][2] = scale; // Scaled γᵤ
+        }
+      }
+    }
+  }
+  return jacobian;
+}
+
+/**
+ * @brief Helper wrapper that materializes jacobian_matrix containers for tests.
+ *
+ * This class provides a type-safe interface for creating and accessing Jacobian
+ * matrix data using compile-time dispatch based on initializer tags. It manages
+ * the storage and conversion between test data formats and SPECFEM++ assembly
+ * data structures.
+ *
+ * @tparam Initializer Tag describing which init_jacobian overload to invoke
+ */
+template <typename Initializer> struct JacobianMatrix3D {
+  constexpr static specfem::dimension::type dimension_tag =
+      specfem::dimension::type::dim3;
+  std::vector<std::array<
+      std::array<std::array<std::array<std::array<type_real, 3>, 3>, 5>, 5>,
+      5> >
+      _jacobian;
+
+  /**
+   * @brief Construct Jacobian data using the supplied initializer tag.
+   *
+   * @param initializer Tag-dispatch parameter selecting initialization strategy
+   */
+  JacobianMatrix3D(const Initializer &initializer)
+      : _jacobian(init_jacobian(initializer)) {}
+
+  /**
+   * @brief Accessor for individual Jacobian matrix components.
+   *
+   * @param ielement Element index
+   * @param iz GLL point index in z direction
+   * @param iy GLL point index in y direction
+   * @param ix GLL point index in x direction
+   * @param idim First tensor index (0=ξ, 1=η, 2=γ)
+   * @param jdim Second tensor index (0=x, 1=y, 2=z)
+   * @return Reference to Jacobian component J[idim][jdim]
+   */
+  const type_real &operator()(const int ielement, const int iz, const int iy,
+                              const int ix, const int idim,
+                              const int jdim) const {
+    return _jacobian[ielement][iz][iy][ix][idim][jdim];
+  }
+
+  /**
+   * @brief Get the number of spectral elements in this dataset.
+   *
+   * @return Number of elements
+   */
+  const int n_elements() const { return static_cast<int>(_jacobian.size()); }
+
+  /**
+   * @brief Convert to specfem::assembly::jacobian_matrix format.
+   *
+   * This method creates a properly formatted jacobian_matrix object that can
+   * be used with the production gradient algorithms. The conversion maps the
+   * internal storage to the xix, xiy, xiz, etax, etay, etaz, gammax, gammay,
+   * gammaz components expected by the assembly framework.
+   *
+   * @return Assembled jacobian_matrix ready for algorithm testing
+   */
+  specfem::assembly::jacobian_matrix<dimension_tag> jacobian() {
+    specfem::assembly::jacobian_matrix<dimension_tag> jacobian_matrix(
+        n_elements(), 5, 5, 5);
+
+    for (int ielement = 0; ielement < n_elements(); ++ielement) {
+      for (int iz = 0; iz < 5; ++iz) {
+        for (int iy = 0; iy < 5; ++iy) {
+          for (int ix = 0; ix < 5; ++ix) {
+            jacobian_matrix.xix(ielement, iz, iy, ix) =
+                _jacobian[ielement][iz][iy][ix][0][0]; // ∂ξ/∂x
+            jacobian_matrix.xiy(ielement, iz, iy, ix) =
+                _jacobian[ielement][iz][iy][ix][0][1]; // ∂ξ/∂y
+            jacobian_matrix.xiz(ielement, iz, iy, ix) =
+                _jacobian[ielement][iz][iy][ix][0][2]; // ∂ξ/∂z
+            jacobian_matrix.etax(ielement, iz, iy, ix) =
+                _jacobian[ielement][iz][iy][ix][1][0]; // ∂η/∂x
+            jacobian_matrix.etay(ielement, iz, iy, ix) =
+                _jacobian[ielement][iz][iy][ix][1][1]; // ∂η/∂y
+            jacobian_matrix.etaz(ielement, iz, iy, ix) =
+                _jacobian[ielement][iz][iy][ix][1][2]; // ∂η/∂z
+            jacobian_matrix.gammax(ielement, iz, iy, ix) =
+                _jacobian[ielement][iz][iy][ix][2][0]; // ∂γ/∂x
+            jacobian_matrix.gammay(ielement, iz, iy, ix) =
+                _jacobian[ielement][iz][iy][ix][2][1]; // ∂γ/∂y
+            jacobian_matrix.gammaz(ielement, iz, iy, ix) =
+                _jacobian[ielement][iz][iy][ix][2][2]; // ∂γ/∂z
+          }
+        }
+      }
+    }
+    return jacobian_matrix;
+  }
+};
+
+/**
+ * @brief Build identity derivative matrix for simplified testing.
+ *
+ * Creates an identity matrix that simplifies gradient computation validation
+ * by eliminating the complexity of proper Lagrange derivative evaluation.
+ * Useful for analytical verification of gradient transformation logic.
+ *
+ * @return 5×5 identity matrix for quadrature derivative operations
+ */
+std::array<std::array<type_real, 5>, 5>
+init_quadrature(const QuadratureInitializer3D::IDENTITY &) {
+  std::array<std::array<type_real, 5>, 5> quadrature{};
+  for (int i = 0; i < 5; ++i) {
+    for (int j = 0; j < 5; ++j) {
+      quadrature[i][j] = (i == j) ? 1.0 : 0.0;
+    }
+  }
+  return quadrature;
+}
+
+/**
+ * @brief Build proper GLL Lagrange derivative matrix.
+ *
+ * Constructs the actual derivative matrix used in spectral element methods,
+ * \f$h'_{ij} = \frac{dL_j}{d\xi}\Big|_{\xi_i}\f$, where \f$L_j(\xi)\f$ are
+ * the Lagrange interpolating polynomials and \f$\xi_i\f$ are GLL quadrature
+ * points.
+ *
+ * @return 5×5 GLL derivative matrix for realistic gradient computation
+ */
+std::array<std::array<type_real, 5>, 5>
+init_quadrature(const QuadratureInitializer3D::LAGRANGE &) {
+  std::array<std::array<type_real, 5>, 5> quadrature{};
+
+  const specfem::quadrature::gll::gll gll{};
+  const auto hprime = gll.get_hhprime();
+  for (int i = 0; i < 5; ++i) {
+    for (int j = 0; j < 5; ++j) {
+      quadrature[j][i] = hprime(i, j); // Transpose for proper indexing
+    }
+  }
+  return quadrature;
+}
+
+/**
+ * @brief Helper owning quadrature derivative matrix for gradient evaluation.
+ *
+ * This class manages derivative matrices used in gradient computation,
+ * providing type-safe access to different quadrature configurations through
+ * compile-time dispatch.
+ *
+ * @tparam Initializer Tag selecting which init_quadrature overload to use
+ */
+template <typename Initializer> struct Quadrature3D {
+  std::array<std::array<type_real, 5>, 5> _quadrature;
+
+  /**
+   * @brief Construct derivative matrix using the selected initializer tag.
+   *
+   * @param initializer Tag-dispatch parameter for quadrature initialization
+   */
+  Quadrature3D(const Initializer &initializer)
+      : _quadrature(init_quadrature(initializer)) {}
+
+  /**
+   * @brief Access derivative matrix entry.
+   *
+   * @param i Row index (output GLL point)
+   * @param j Column index (input GLL point)
+   * @return Derivative value \f$\frac{dL_j}{d\xi}\Big|_{\xi_i}\f$
+   */
+  type_real operator()(const int &i, const int &j) const {
+    return _quadrature[i][j];
+  }
+};
+
+/**
+ * @brief Generate zero-valued scalar field for manufactured solution tests.
+ *
+ * Creates a field where f(ξ,η,γ) = 0 at all GLL points. This provides a trivial
+ * case where the exact gradient is known analytically: ∇f = (0,0,0) everywhere.
+ *
+ * @return Single-element vector containing zero field data
+ */
+auto init_function(const FunctionInitializer3D::ZERO &) {
+  std::vector<std::array<std::array<std::array<type_real, ngll>, ngll>, ngll> >
+      _f(1);
+  for (int icomp = 0; icomp < 1; ++icomp) {
+    for (int iz = 0; iz < ngll; ++iz) {
+      for (int iy = 0; iy < ngll; ++iy) {
+        for (int ix = 0; ix < ngll; ++ix) {
+          _f[icomp][iz][iy][ix] = 0.0;
+        }
+      }
+    }
+  }
+  return _f;
+}
+
+/**
+ * @brief Generate uniform scalar field for manufactured solution tests.
+ *
+ * Creates a constant field where f(ξ,η,γ) = 1 at all GLL points. For identity
+ * Jacobian and identity quadrature, this yields known gradient behavior that
+ * can be verified analytically.
+ *
+ * @return Single-element vector containing uniform field data
+ */
+auto init_function(const FunctionInitializer3D::UNIFORM &) {
+  std::vector<std::array<std::array<std::array<type_real, 5>, 5>, 5> > _f(1);
+  for (int icomp = 0; icomp < 1; ++icomp) {
+    for (int iz = 0; iz < 5; ++iz) {
+      for (int iy = 0; iy < 5; ++iy) {
+        for (int ix = 0; ix < 5; ++ix) {
+          _f[icomp][iz][iy][ix] = 1.0;
+        }
+      }
+    }
+  }
+  return _f;
+}
+
+/**
+ * @brief Generate pseudo-random scalar field for stochastic validation.
+ *
+ * Creates a field with random values between [0,1] to test gradient computation
+ * with non-trivial function values. Helps verify numerical stability and
+ * algorithmic correctness for arbitrary field configurations.
+ *
+ * @return Single-element vector containing random field data
+ *
+ * @warning Uses rand() for simplicity; not cryptographically secure
+ */
+auto init_function(const FunctionInitializer3D::RANDOM &) {
+  std::vector<std::array<std::array<std::array<type_real, 5>, 5>, 5> > _f(1);
+  for (int icomp = 0; icomp < 1; ++icomp) {
+    for (int iz = 0; iz < 5; ++iz) {
+      for (int iy = 0; iy < 5; ++iy) {
+        for (int ix = 0; ix < 5; ++ix) {
+          _f[icomp][iz][iy][ix] = static_cast<type_real>(rand()) / RAND_MAX;
+        }
+      }
+    }
+  }
+  return _f;
+}
+
+/**
+ * @brief Generate two-element scalar field with element-wise constant values.
+ *
+ * Creates a multi-element field where element 0 has f = 1.0 and element 1 has
+ * f = 2.0. This tests gradient computation consistency across element
+ * boundaries and validates multi-element assembly pathways.
+ *
+ * @return Two-element vector containing element-dependent constant field data
+ */
+auto init_function(const FunctionInitializer3D::TWO_ELEMENT &) {
+  std::vector<std::array<std::array<std::array<type_real, 5>, 5>, 5> > _f(2);
+  for (int ielement = 0; ielement < 2; ++ielement) {
+    for (int iz = 0; iz < 5; ++iz) {
+      for (int iy = 0; iy < 5; ++iy) {
+        for (int ix = 0; ix < 5; ++ix) {
+          _f[ielement][iz][iy][ix] =
+              1.0 + ielement; // Element-dependent constant
+        }
+      }
+    }
+  }
+  return _f;
+}
+
+/**
+ * @brief Helper owning scalar test data and exposing Kokkos views for gradient
+ * calls.
+ *
+ * This class manages scalar field data for test cases, providing conversion
+ * between test-friendly storage formats and the Kokkos Views required by
+ * the production gradient algorithms.
+ *
+ * @tparam Initializer Tag selecting which init_function overload to invoke
+ */
+template <typename Initializer> struct Function3D {
+  constexpr static specfem::dimension::type dimension_tag =
+      specfem::dimension::type::dim3;
+  constexpr static int components = 1; ///< Scalar field (single component)
+
+  using memory_space = Kokkos::HostSpace;
+  using memory_traits = Kokkos::MemoryTraits<>;
+
+  using view_type = Kokkos::View<type_real *[ngll][ngll][ngll][components],
+                                 memory_space, memory_traits>;
+
+  /**
+   * @brief Construct scalar field using the supplied initializer tag.
+   *
+   * @param initializer Tag-dispatch parameter for field initialization
+   */
+  Function3D(const Initializer &initializer) : _f(init_function(initializer)) {}
+
+  /**
+   * @brief Element-wise access to scalar field values.
+   *
+   * @param ielement Element index
+   * @param iz GLL point index in z direction
+   * @param iy GLL point index in y direction
+   * @param ix GLL point index in x direction
+   * @return Field value at specified location
+   */
+  const type_real &operator()(const int &ielement, const int &iz, const int &iy,
+                              const int &ix) const {
+    return _f[ielement][iz][iy][ix];
+  }
+
+  /**
+   * @brief Get the number of spectral elements in this field.
+   *
+   * @return Number of elements
+   */
+  int n_elements() const { return static_cast<int>(_f.size()); }
+
+  /**
+   * @brief Convert to Kokkos View format for gradient algorithm interface.
+   *
+   * Creates a Kokkos View that can be passed to specfem::algorithms::gradient()
+   * and related chunk-based execution frameworks.
+   *
+   * @return Kokkos View containing field data in algorithm-compatible format
+   */
+  view_type view() const {
+    view_type f_view("f_view", _f.size());
+    for (int ielement = 0; ielement < static_cast<int>(_f.size()); ++ielement) {
+      for (int iz = 0; iz < ngll; ++iz) {
+        for (int iy = 0; iy < ngll; ++iy) {
+          for (int ix = 0; ix < ngll; ++ix) {
+            f_view(ielement, iz, iy, ix, 0) = _f[ielement][iz][iy][ix];
+          }
+        }
+      }
+    }
+    return f_view;
+  }
+
+private:
+  std::vector<std::array<std::array<std::array<type_real, ngll>, ngll>, ngll> >
+      _f; ///< Internal
+          ///< field
+          ///< storage
+};
+
+/**
+ * @brief Analytical gradient reference for zero field with identity
+ * configuration.
+ *
+ * For f(x,y,z) = 0 everywhere, the exact gradient is ∇f = (0,0,0) at all
+ * points. This provides a trivial but important validation case for algorithm
+ * correctness.
+ *
+ * @return Gradient field with zero values at all GLL points
+ */
+std::vector<std::array<
+    std::array<std::array<std::array<std::array<type_real, 3>, 1>, 5>, 5>, 5> >
+gradient(const JacobianMatrix3D<JacobianInitializer3D::IDENTITY> &jacobian,
+         const Quadrature3D<QuadratureInitializer3D::IDENTITY> &quadrature,
+         const Function3D<FunctionInitializer3D::ZERO> &) {
+  std::vector<std::array<
+      std::array<std::array<std::array<std::array<type_real, 3>, 1>, 5>, 5>,
+      5> >
+      grad(1);
+  for (int iz = 0; iz < 5; ++iz) {
+    for (int iy = 0; iy < 5; ++iy) {
+      for (int ix = 0; ix < 5; ++ix) {
+        grad[0][iz][iy][ix][0][0] = 0.0; // ∂f/∂x = 0
+        grad[0][iz][iy][ix][0][1] = 0.0; // ∂f/∂y = 0
+        grad[0][iz][iy][ix][0][2] = 0.0; // ∂f/∂z = 0
+      }
+    }
+  }
+  return grad;
+}
+
+/**
+ * @brief Analytical gradient reference for uniform field with identity
+ * configuration.
+ *
+ * For f(x,y,z) = 1 (constant) with identity Jacobian and identity quadrature,
+ * the expected behavior depends on the specific derivative implementation.
+ * With identity quadrature, uniform functions produce unit gradients.
+ *
+ * @return Gradient field with unit values reflecting derivative matrix behavior
+ */
+std::vector<std::array<
+    std::array<std::array<std::array<std::array<type_real, 3>, 1>, 5>, 5>, 5> >
+gradient(const JacobianMatrix3D<JacobianInitializer3D::IDENTITY> &jacobian,
+         const Quadrature3D<QuadratureInitializer3D::IDENTITY> &quadrature,
+         const Function3D<FunctionInitializer3D::UNIFORM> &) {
+  std::vector<std::array<
+      std::array<std::array<std::array<std::array<type_real, 3>, 1>, 5>, 5>,
+      5> >
+      grad(1);
+  for (int iz = 0; iz < 5; ++iz) {
+    for (int iy = 0; iy < 5; ++iy) {
+      for (int ix = 0; ix < 5; ++ix) {
+        grad[0][iz][iy][ix][0][0] = 1.0; // Identity quadrature effect
+        grad[0][iz][iy][ix][0][1] = 1.0; // Identity quadrature effect
+        grad[0][iz][iy][ix][0][2] = 1.0; // Identity quadrature effect
+      }
+    }
+  }
+  return grad;
+}
+
+/**
+ * @brief Generic reference gradient calculator mirroring
+ * specfem::algorithms::impl::element_gradient() for 3D.
+ *
+ * This function implements the reference calculation following the 3D spectral
+ * element gradient formulation. It computes the gradient by:
+ * 1. Computing reference coordinate derivatives using the quadrature matrix
+ * 2. Transforming to physical coordinates using the Jacobian matrix
+ *
+ * @tparam Jacobian JacobianMatrix3D type providing coordinate transformation
+ * data
+ * @tparam Quadrature3D Quadrature3D type providing derivative matrix
+ * @tparam Function3D Function3D type providing scalar field data
+ * @param jacobian Jacobian transformation data
+ * @param quadrature Derivative matrix for reference coordinate differentiation
+ * @param function Scalar field to differentiate
+ * @return Computed gradient at all GLL points in all elements
+ */
+template <typename Jacobian, typename Quadrature3D, typename Function3D>
+std::vector<std::array<
+    std::array<std::array<std::array<std::array<type_real, 3>, 1>, 5>, 5>, 5> >
+gradient(const Jacobian &jacobian, const Quadrature3D &quadrature,
+         const Function3D &function) {
+
+  std::vector<std::array<
+      std::array<std::array<std::array<std::array<type_real, 3>, 1>, 5>, 5>,
+      5> >
+      grad(function.n_elements());
+
+  for (int ielement = 0; ielement < function.n_elements(); ++ielement) {
+    for (int iz = 0; iz < ngll; ++iz) {
+      for (int iy = 0; iy < ngll; ++iy) {
+        for (int ix = 0; ix < ngll; ++ix) {
+          // Compute reference coordinate derivatives using quadrature matrix
+          type_real df_dxi = 0.0;    // ∂f/∂ξ
+          type_real df_deta = 0.0;   // ∂f/∂η
+          type_real df_dgamma = 0.0; // ∂f/∂γ
+
+          // Sum over GLL points using derivative matrix
+          for (int l = 0; l < ngll; ++l) {
+            df_dxi += quadrature(ix, l) * function(ielement, iz, iy, l);
+            df_deta += quadrature(iy, l) * function(ielement, iz, l, ix);
+            df_dgamma += quadrature(iz, l) * function(ielement, l, iy, ix);
+          }
+
+          // Transform to physical coordinates using Jacobian
+          grad[ielement][iz][iy][ix][0][0] =                    // ∂f/∂x
+              df_dxi * jacobian(ielement, iz, iy, ix, 0, 0) +   // ∂f/∂ξ · ∂ξ/∂x
+              df_deta * jacobian(ielement, iz, iy, ix, 1, 0) +  // ∂f/∂η · ∂η/∂x
+              df_dgamma * jacobian(ielement, iz, iy, ix, 2, 0); // ∂f/∂γ · ∂γ/∂x
+
+          grad[ielement][iz][iy][ix][0][1] =                    // ∂f/∂y
+              df_dxi * jacobian(ielement, iz, iy, ix, 0, 1) +   // ∂f/∂ξ · ∂ξ/∂y
+              df_deta * jacobian(ielement, iz, iy, ix, 1, 1) +  // ∂f/∂η · ∂η/∂y
+              df_dgamma * jacobian(ielement, iz, iy, ix, 2, 1); // ∂f/∂γ · ∂γ/∂y
+
+          grad[ielement][iz][iy][ix][0][2] =                    // ∂f/∂z
+              df_dxi * jacobian(ielement, iz, iy, ix, 0, 2) +   // ∂f/∂ξ · ∂ξ/∂z
+              df_deta * jacobian(ielement, iz, iy, ix, 1, 2) +  // ∂f/∂η · ∂η/∂z
+              df_dgamma * jacobian(ielement, iz, iy, ix, 2, 2); // ∂f/∂γ · ∂γ/∂z
+        }
+      }
+    }
+  }
+
+  return grad;
+}
+
+} // namespace specfem::algorithms_test
+
+using namespace specfem::algorithms_test;
+
+/**
+ * @brief GoogleTest fixture bundling manufactured data and Jacobian views.
+ *
+ * This fixture provides a type-safe framework for testing gradient computation
+ * with different combinations of Jacobian matrices, quadrature configurations,
+ * and scalar field data. Each test instantiation receives a unique combination
+ * of initializer tags that determine the specific test scenario.
+ *
+ * @tparam TestingType Tuple of (JacobianInitializer3D, QuadratureInitializer3D,
+ * FunctionInitializer3D)
+ */
+template <typename TestingType>
+struct GradientTestFixture3D : public ::testing::Test {
+  using JacobianInitializer3D =
+      std::tuple_element_t<0, TestingType>; ///< Jacobian initialization
+                                            ///< strategy
+  using QuadratureInitializer3D =
+      std::tuple_element_t<1, TestingType>; ///< Quadrature3D initialization
+                                            ///< strategy
+  using FunctionInitializer3D =
+      std::tuple_element_t<2, TestingType>; ///< Function3D initialization
+                                            ///< strategy
+
+  /**
+   * @brief Construct test helpers using tag dispatch for each component.
+   *
+   * This constructor uses the compile-time type information to instantiate
+   * the appropriate helper objects for the specific test combination.
+   */
+  GradientTestFixture3D()
+      : jacobian_matrix(JacobianInitializer3D{}),
+        quadrature(QuadratureInitializer3D{}),
+        function(FunctionInitializer3D{}) {}
+
+  JacobianMatrix3D<JacobianInitializer3D> jacobian_matrix; ///< Coordinate
+                                                           ///< transformation
+                                                           ///< data
+  Quadrature3D<QuadratureInitializer3D> quadrature; ///< Derivative matrix for
+                                                    ///< gradient computation
+  Function3D<FunctionInitializer3D> function;       ///< Scalar field test data
+};
+
+/**
+ * @brief Test case combinations for parameterized gradient validation.
+ *
+ * This type list defines all the test scenarios that will be instantiated by
+ * GoogleTest's parameterized testing framework. Each tuple represents a unique
+ * combination of initialization strategies that exercises different aspects of
+ * the gradient computation algorithm.
+ *
+ * **Current test cases:**
+ * 1. **Identity+Zero**: Basic correctness test with trivial inputs
+ * 2. **Identity+Uniform**: Simple analytical validation case
+ * 3. **Lagrange+Random**: Realistic quadrature with arbitrary field data
+ * 4. **TwoElement+TwoElement**: Multi-element consistency validation
+ *
+ * **Adding new test cases:**
+ * To extend the test coverage, follow this process:
+ *
+ * 1. **Define new initializer tags** in the appropriate namespace:
+ *    ```cpp
+ *    namespace JacobianInitializer3D {
+ *    struct SCALED_ROTATION {}; // New Jacobian type
+ *    }
+ *    ```
+ *
+ * 2. **Overload the corresponding init_* function**:
+ *    ```cpp
+ *    std::vector<...> init_jacobian(const
+ * JacobianInitializer3D::SCALED_ROTATION &) {
+ *        // Implementation for rotated/scaled Jacobian
+ *    }
+ *    ```
+ *
+ * 3. **Add new tuple to GradientTestTypes**:
+ *    ```cpp
+ *    std::tuple<JacobianInitializer3D::SCALED_ROTATION,
+ *               QuadratureInitializer3D::LAGRANGE,
+ *               FunctionInitializer3D::POLYNOMIAL>
+ *    ```
+ *
+ * 4. **Optionally add specialized gradient() overload** for analytical
+ * reference:
+ *    ```cpp
+ *    std::vector<...> gradient(
+ *        const JacobianMatrix3D<JacobianInitializer3D::SCALED_ROTATION>
+ * &jacobian, const Quadrature3D<QuadratureInitializer3D::LAGRANGE> &quadrature,
+ *        const Function3D<FunctionInitializer3D::POLYNOMIAL> &function) {
+ *        // Analytical reference implementation
+ *    }
+ *    ```
+ *
+ * The test framework will automatically instantiate and execute the new
+ * scenario.
+ */
+using GradientTestTypes = ::testing::Types<
+    std::tuple<JacobianInitializer3D::IDENTITY,
+               QuadratureInitializer3D::IDENTITY, FunctionInitializer3D::ZERO>,
+    std::tuple<JacobianInitializer3D::IDENTITY,
+               QuadratureInitializer3D::IDENTITY,
+               FunctionInitializer3D::UNIFORM>,
+    std::tuple<JacobianInitializer3D::IDENTITY,
+               QuadratureInitializer3D::LAGRANGE,
+               FunctionInitializer3D::RANDOM>,
+    std::tuple<JacobianInitializer3D::TWO_ELEMENT,
+               QuadratureInitializer3D::IDENTITY,
+               FunctionInitializer3D::TWO_ELEMENT> >;
+
+/**
+ * @brief Instantiate parameterized test suite for all declared tuple
+ * combinations.
+ */
+TYPED_TEST_SUITE(GradientTestFixture3D, GradientTestTypes);
+
+/**
+ * @brief Validate specfem::algorithms::impl::element_gradient() against
+ * manufactured solutions.
+ *
+ * This test performs comprehensive validation of the 3D gradient computation
+ * by:
+ * 1. Computing expected gradients using the reference implementation
+ * 2. Setting up chunked domain iteration matching production usage
+ * 3. Calling the production element_gradient algorithm with test data
+ * 4. Comparing computed vs. expected results at each GLL point
+ *
+ * The test validates both the mathematical accuracy and the execution pathway
+ * of the gradient algorithm, ensuring consistency between reference and
+ * production implementations across different geometric and field
+ * configurations.
+ *
+ * @note This test directly calls the element_gradient implementation since
+ * there's no top-level 3D gradient wrapper function currently available.
+ */
+TYPED_TEST(GradientTestFixture3D, TestGradientComputation) {
+  // Verify consistency between function and Jacobian element counts
+  ASSERT_TRUE(this->function.n_elements() == this->jacobian_matrix.n_elements())
+      << "Mismatch in number of elements between function and jacobian matrix";
+
+  // Compute expected results using reference implementation
+  const auto expected_gradient = specfem::algorithms_test::gradient(
+      this->jacobian_matrix, this->quadrature, this->function);
+
+  // Set up chunked domain iteration for production algorithm testing
+  using simd = specfem::datatype::simd<type_real, false>;
+  Kokkos::View<int *, Kokkos::HostSpace> element_indices(
+      "element_indices", this->function.n_elements());
+  for (int i = 0; i < this->function.n_elements(); ++i) {
+    element_indices(i) = i;
+  }
+
+  using ParallelConfig = specfem::parallel_config::default_chunk_config<
+      specfem::dimension::type::dim3, simd, Kokkos::DefaultHostExecutionSpace>;
+
+  const specfem::mesh_entity::element element_grid(ngll, ngll, ngll);
+
+  const specfem::execution::ChunkedDomainIterator chunk(
+      ParallelConfig(), element_indices, element_grid);
+
+  const auto jacobian = this->jacobian_matrix.jacobian();
+  const auto function_view = this->function.view();
+
+  using Function3DView = specfem::datatype::VectorChunkElementViewType<
+      type_real, specfem::dimension::type::dim3, 1, ngll, 1, false,
+      Kokkos::HostSpace, Kokkos::MemoryTraits<> >;
+
+  // Execute production gradient algorithm and validate results
+  specfem::execution::for_each_level(
+      chunk, [&](const typename decltype(chunk)::index_type &index) {
+        const Function3DView f(Kokkos::subview(function_view, index.get_range(),
+                                               Kokkos::ALL(), Kokkos::ALL(),
+                                               Kokkos::ALL(), Kokkos::ALL()));
+
+        // Call the production gradient algorithm
+        specfem::algorithms::gradient(
+            index, jacobian, this->quadrature, f,
+            [&](const auto &iterator_index, const auto &df) {
+              const auto local_index = iterator_index.get_index();
+              const int ispec = local_index.ispec;
+              const int iz = local_index.iz;
+              const int iy = local_index.iy;
+              const int ix = local_index.ix;
+
+              const auto e = expected_gradient[ispec][iz][iy][ix];
+
+              // Point-wise validation of computed gradient components
+              if (!specfem::utilities::is_close(df(0, 0), e[0][0]) ||
+                  !specfem::utilities::is_close(df(0, 1), e[0][1]) ||
+                  !specfem::utilities::is_close(df(0, 2), e[0][2])) {
+                FAIL() << "Gradient mismatch for element " << local_index.ispec
+                       << "\n"
+                       << "    at GLL point (" << iz << ", " << iy << ", " << ix
+                       << ")\n"
+                       << "    expected: (" << e[0][0] << ", " << e[0][1]
+                       << ", " << e[0][2] << ")\n"
+                       << "    computed: (" << df(0, 0) << ", " << df(0, 1)
+                       << ", " << df(0, 2) << ")";
+              }
+            });
+      });
+
+  SUCCEED() << "Gradient computation validation passed for all test points.";
+}

--- a/tests/unit-tests/algorithms/dim3/gradient.cpp
+++ b/tests/unit-tests/algorithms/dim3/gradient.cpp
@@ -177,11 +177,14 @@ init_jacobian(const JacobianInitializer3D::TWO_ELEMENT &) {
 template <typename Initializer> struct JacobianMatrix3D {
   constexpr static specfem::dimension::type dimension_tag =
       specfem::dimension::type::dim3;
+
+private:
   std::vector<std::array<
       std::array<std::array<std::array<std::array<type_real, 3>, 3>, 5>, 5>,
       5> >
       _jacobian;
 
+public:
   /**
    * @brief Construct Jacobian data using the supplied initializer tag.
    *


### PR DESCRIPTION
## Description

- [x] Fix minor bug in gradient comptuation
- [x] Granular level tests for gradient computation
- [x] Tests have been added for
	1. Trivial case (Function = 0.0)
	2. Uniform function
	3. Random function
	4. Two elements (catches bug mentioned in first point) 

## Issue Number

Closes #1319 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
