### PR TITLE
Suppress `-Wreturn-local-addr` in coupled interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,16 @@ else(${CMAKE_CXX_COMPILER_ID} MATCHES "IntelLLVM")
     message(STATUS "IntelLLVM not detected -- setting __INTEL_LLVM__ FALSE")
 endif()
 
+# Check if Windows
+# https://cmake.org/cmake/help/latest/variable/MSVC.html
+if(MSVC)
+    set(__MSVC__ TRUE)
+    message(STATUS "MSVC detected -- setting __MSVC__ TRUE")
+else(MSVC)
+    set(__MSVC__ FALSE)
+    message(STATUS "MSVC not detected -- setting __MSVC__ FALSE")
+endif()
+
 # Install Kokkos as a dependency
 include("${CMAKE_SOURCE_DIR}/cmake/kokkos.cmake")
 
@@ -447,6 +457,10 @@ set_target_properties(kokkos_kernels PROPERTIES
         UNITY_BUILD $<NOT:$<BOOL:${__APPLE__}>>
         UNITY_BUILD_BATCH_SIZE $<IF:$<BOOL:${__APPLE__}>,0,4>
 )
+
+if(__MSVC__)
+target_compile_definitions(kokkos_kernels PRIVATE __MSVC__)
+endif(__MSVC__)
 
 target_link_libraries(
         kokkos_kernels

--- a/core/specfem/assembly/coupled_interfaces/dim2/coupled_interface.hpp
+++ b/core/specfem/assembly/coupled_interfaces/dim2/coupled_interface.hpp
@@ -13,6 +13,8 @@
 #include <Kokkos_Core.hpp>
 #include <type_traits>
 
+#include "__future__/suppress_warnings.hpp"
+
 namespace specfem::assembly {
 
 /**
@@ -152,7 +154,25 @@ public:
 #endif
 
     // Unreachable code - satisfy compiler return requirements
-    return {};
+
+    // #ifdef _MSC_VER
+    // #pragma warning( push )
+    // #pragma warning( disable : C4172 )
+    // #else
+    // #pragma GCC diagnostic push
+    // #pragma GCC diagnostic ignored "-Wreturn-local-addr"
+    // #endif
+    //     return {};
+    // #ifdef _MSC_VER
+    // #pragma warning( pop )
+    // #else
+    // #pragma GCC diagnostic pop
+    // #endif
+
+    return specfem::__future__::
+        SUPPRESS_WARNING_TEMPORARY_REF_BLANK_CONSTRUCTION<
+            const InterfaceContainerType<InterfaceTag, BoundaryTag,
+                                         ConnectionTag> &>();
   }
 };
 

--- a/core/specfem/assembly/coupled_interfaces/dim2/coupled_interface.hpp
+++ b/core/specfem/assembly/coupled_interfaces/dim2/coupled_interface.hpp
@@ -153,7 +153,7 @@ public:
 
     // Unreachable code - satisfy compiler return requirements
 
-#ifdef _MSC_VER
+#if __MSVC__
 #pragma warning(push)
 #pragma warning(disable : C4172)
 #else
@@ -161,7 +161,7 @@ public:
 #pragma GCC diagnostic ignored "-Wreturn-local-addr"
 #endif
     return {};
-#ifdef _MSC_VER
+#if __MSVC__
 #pragma warning(pop)
 #else
 #pragma GCC diagnostic pop

--- a/core/specfem/assembly/coupled_interfaces/dim2/coupled_interface.hpp
+++ b/core/specfem/assembly/coupled_interfaces/dim2/coupled_interface.hpp
@@ -13,8 +13,6 @@
 #include <Kokkos_Core.hpp>
 #include <type_traits>
 
-#include "__future__/suppress_warnings.hpp"
-
 namespace specfem::assembly {
 
 /**
@@ -155,24 +153,19 @@ public:
 
     // Unreachable code - satisfy compiler return requirements
 
-    // #ifdef _MSC_VER
-    // #pragma warning( push )
-    // #pragma warning( disable : C4172 )
-    // #else
-    // #pragma GCC diagnostic push
-    // #pragma GCC diagnostic ignored "-Wreturn-local-addr"
-    // #endif
-    //     return {};
-    // #ifdef _MSC_VER
-    // #pragma warning( pop )
-    // #else
-    // #pragma GCC diagnostic pop
-    // #endif
-
-    return specfem::__future__::
-        SUPPRESS_WARNING_TEMPORARY_REF_BLANK_CONSTRUCTION<
-            const InterfaceContainerType<InterfaceTag, BoundaryTag,
-                                         ConnectionTag> &>();
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : C4172)
+#else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wreturn-local-addr"
+#endif
+    return {};
+#ifdef _MSC_VER
+#pragma warning(pop)
+#else
+#pragma GCC diagnostic pop
+#endif
   }
 };
 

--- a/include/__future__/suppress_warnings.hpp
+++ b/include/__future__/suppress_warnings.hpp
@@ -47,15 +47,15 @@
     SUPPRESS_WARNING_END()                                                     \
   }
 
+#define SUPPRESS_WARNING_START_TEMPORARY_REF()                                 \
+  { _SUPPRESS_WARNING_START("-Wreturn-local-addr", C4172) }
+
 #define SUPPRESS_WARNING_TEMPORARY_REF(CODEBLOCK)                              \
   {                                                                            \
     SUPPRESS_WARNING_START_TEMPORARY_REF();                                    \
     CODEBLOCK;                                                                 \
     SUPPRESS_WARNING_END()                                                     \
   }
-
-#define SUPPRESS_WARNING_START_TEMPORARY_REF()                                 \
-  { _SUPPRESS_WARNING_START("-Wreturn-local-addr", C4172) }
 
 namespace specfem::__future__ {
 

--- a/include/__future__/suppress_warnings.hpp
+++ b/include/__future__/suppress_warnings.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <type_traits>
+
+#ifndef STRINGIFY
+#define STRINGIFY(x) #x
+#endif
+
+#ifdef _MSC_VER
+// mscv (microsoft)
+// this is untested.
+
+// https://learn.microsoft.com/en-us/cpp/preprocessor/warning?view=msvc-170#push-and-pop
+#define _SUPPRESS_WARNING_START(GCC_CLANG_CODE, WINDOWS_CODE)                  \
+  {                                                                            \
+    _Pragma("warning( push )");                                                \
+    _Pragma(STRINGIFY("warning( disable : " #WINDOWS_CODE " )"));              \
+  }
+
+#define _SUPPRESS_WARNING_END()                                                \
+  {                                                                            \
+    _Pragma("warning( pop )");                                                 \
+  }
+#else
+// gcc
+// https://gcc.gnu.org/onlinedocs/gcc/Diagnostic-Pragmas.html
+
+// clang should also be reading these (first paragraph of
+// https://clang.llvm.org/docs/UsersManual.html#controlling-diagnostics-via-pragmas
+//)
+#define _SUPPRESS_WARNING_START(GCC_CLANG_CODE, WINDOWS_CODE)                  \
+  {                                                                            \
+    _Pragma("GCC diagnostic push");                                            \
+    _Pragma(STRINGIFY("GCC diagnostic ignored " #GCC_CLANG_CODE));             \
+  }
+#define SUPPRESS_WARNING_END()                                                 \
+  {                                                                            \
+    _Pragma("GCC diagnostic pop");                                             \
+  }
+
+#endif
+
+#define _SUPPRESS_WARNING(GCC_CLANG_CODE, WINDOWS_CODE, CODEBLOCK)             \
+  {                                                                            \
+    _SUPPRESS_WARNING_START(GCC_CLANG_CODE, WINDOWS_CODE)                      \
+    CODEBLOCK;                                                                 \
+    SUPPRESS_WARNING_END()                                                     \
+  }
+
+#define SUPPRESS_WARNING_TEMPORARY_REF(CODEBLOCK)                              \
+  {                                                                            \
+    SUPPRESS_WARNING_START_TEMPORARY_REF();                                    \
+    CODEBLOCK;                                                                 \
+    SUPPRESS_WARNING_END()                                                     \
+  }
+
+#define SUPPRESS_WARNING_START_TEMPORARY_REF()                                 \
+  { _SUPPRESS_WARNING_START("-Wreturn-local-addr", C4172) }
+
+namespace specfem::__future__ {
+
+template <typename ConstructedType>
+inline ConstructedType SUPPRESS_WARNING_TEMPORARY_REF_BLANK_CONSTRUCTION() {
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : C4172)
+#else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wreturn-local-addr"
+#endif
+  return {};
+#ifdef _MSC_VER
+#pragma warning(pop)
+#else
+#pragma GCC diagnostic pop
+#endif
+}
+
+} // namespace specfem::__future__

--- a/include/__future__/suppress_warnings.hpp
+++ b/include/__future__/suppress_warnings.hpp
@@ -6,7 +6,7 @@
 #define STRINGIFY(x) #x
 #endif
 
-#ifdef _MSC_VER
+#if __MSVC__
 // mscv (microsoft)
 // this is untested.
 
@@ -61,7 +61,7 @@ namespace specfem::__future__ {
 
 template <typename ConstructedType>
 inline ConstructedType SUPPRESS_WARNING_TEMPORARY_REF_BLANK_CONSTRUCTION() {
-#ifdef _MSC_VER
+#if __MSVC__
 #pragma warning(push)
 #pragma warning(disable : C4172)
 #else
@@ -69,7 +69,7 @@ inline ConstructedType SUPPRESS_WARNING_TEMPORARY_REF_BLANK_CONSTRUCTION() {
 #pragma GCC diagnostic ignored "-Wreturn-local-addr"
 #endif
   return {};
-#ifdef _MSC_VER
+#if __MSVC__
 #pragma warning(pop)
 #else
 #pragma GCC diagnostic pop


### PR DESCRIPTION
## Description

*Please describe the changes/features in this pull request.*

As in title: adds suppression macros for the warnings from coupled interfaces.

## Issue Number

*If there is an issue created for these changes, link it here*

## Checklist

*Please make sure to check developer documentation on specfem docs.*

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
