### PR TITLE
Issue 1336 - Bug fix for 3D iteration policies

### DIFF
--- a/core/specfem/assembly/mesh/dim2/mesh.hpp
+++ b/core/specfem/assembly/mesh/dim2/mesh.hpp
@@ -42,8 +42,10 @@ public:
                                       ///< elements
   int ngnod;                          ///< Number of control
                                       ///< nodes
-  specfem::mesh_entity::element<dimension_tag> element_grid; ///< Element number
-                                                             ///< of GLL points
+  specfem::mesh_entity::element_grid<dimension_tag> element_grid; ///< Element
+                                                                  ///< number of
+                                                                  ///< GLL
+                                                                  ///< points
 
   mesh() = default;
 

--- a/core/specfem/assembly/mesh/dim2/mesh.tpp
+++ b/core/specfem/assembly/mesh/dim2/mesh.tpp
@@ -128,8 +128,7 @@ specfem::assembly::mesh<specfem::dimension::type::dim2>::mesh(
   // struct
   ngnod = control_nodes_in.ngnod;
 
-  this->element_grid = specfem::mesh_entity::element<
-      specfem::dimension::type::dim2>(ngllz, ngllx);
+  this->element_grid = specfem::mesh_entity::element_grid(ngllz, ngllx);
 
   auto &mapping =
       static_cast<specfem::assembly::mesh_impl::mesh_to_compute_mapping<

--- a/core/specfem/assembly/mesh/dim3/impl/points.tpp
+++ b/core/specfem/assembly/mesh/dim3/impl/points.tpp
@@ -128,7 +128,7 @@ specfem::assembly::mesh_impl::points<specfem::dimension::type::dim3>::points(
   // Create a filtered graph view
   const auto fg = boost::make_filtered_graph(graph, filter);
 
-  const auto mapping = specfem::mesh_entity::element<specfem::dimension::type::dim3>(ngllz, nglly, ngllx);
+  const auto mapping = specfem::mesh_entity::element(ngllz, nglly, ngllx);
 
   // Iterate over all faces
   for (int ichunk = 0; ichunk < nspec; ichunk += chunk_size) {

--- a/core/specfem/assembly/mesh/dim3/impl/points.tpp
+++ b/core/specfem/assembly/mesh/dim3/impl/points.tpp
@@ -128,7 +128,7 @@ specfem::assembly::mesh_impl::points<specfem::dimension::type::dim3>::points(
   // Create a filtered graph view
   const auto fg = boost::make_filtered_graph(graph, filter);
 
-  const auto mapping = specfem::mesh_entity::element(ngllz, nglly, ngllx);
+  const auto mapping = specfem::mesh_entity::element<specfem::dimension::type::dim3>(ngllz, nglly, ngllx);
 
   // Iterate over all faces
   for (int ichunk = 0; ichunk < nspec; ichunk += chunk_size) {

--- a/include/enumerations/dim2/mesh_entities.hpp
+++ b/include/enumerations/dim2/mesh_entities.hpp
@@ -157,7 +157,7 @@ template <> struct edge<specfem::dimension::type::dim2> {
 /**
  * @brief Mesh element structure for 2D elements (Specialization)
  */
-template <> struct element<specfem::dimension::type::dim2> {
+template <> struct element_grid<specfem::dimension::type::dim2> {
 
 public:
   int ngllz;  ///< Number of Gauss-Lobatto-Legendre points in the z-direction
@@ -169,7 +169,7 @@ public:
   /**
    * @brief Default constructor for the element struct
    */
-  element() = default;
+  element_grid() = default;
 
   /**
    * @brief Constructs an element entity given the number of
@@ -177,7 +177,7 @@ public:
    *
    * @param ngll The number of Gauss-Lobatto-Legendre points
    */
-  element(const int ngll)
+  element_grid(const int ngll)
       : ngllz(ngll), ngllx(ngll), orderz(ngll - 1), orderx(ngll - 1),
         size(ngll * ngll) {}
 
@@ -187,7 +187,7 @@ public:
    *
    * @param ngll The number of Gauss-Lobatto-Legendre points
    */
-  element(const int ngllz, const int ngllx)
+  element_grid(const int ngllz, const int ngllx)
       : ngllz(ngllz), ngllx(ngllx), orderz(ngllz - 1), orderx(ngllx - 1),
         size(ngllz * ngllx) {
     if (ngllz != ngllx) {

--- a/include/enumerations/mesh_entities.hpp
+++ b/include/enumerations/mesh_entities.hpp
@@ -10,6 +10,8 @@ namespace specfem::mesh_entity {
  */
 template <specfem::dimension::type DimensionTag> struct edge;
 
+template <specfem::dimension::type DimensionTag> struct element_grid;
+
 /**
  * @brief Mesh element structure for a specific dimension
  *
@@ -25,7 +27,11 @@ template <specfem::dimension::type DimensionTag> struct element;
 // CTAD guides
 namespace specfem::mesh_entity {
 
-element(const int, const int) -> element<specfem::dimension::type::dim2>;
+element_grid(const int, const int)
+    -> element_grid<specfem::dimension::type::dim2>;
+
+element_grid(const int, const int, const int)
+    -> element_grid<specfem::dimension::type::dim3>;
 
 element(const int, const int, const int)
     -> element<specfem::dimension::type::dim3>;

--- a/include/execution/chunked_domain_iterator.hpp
+++ b/include/execution/chunked_domain_iterator.hpp
@@ -348,7 +348,7 @@ public:
    */
   KOKKOS_INLINE_FUNCTION ChunkElementIterator(
       const TeamMemberType &team, const ViewType indices,
-      const specfem::mesh_entity::element<dimension_tag> &element_grid)
+      const specfem::mesh_entity::element_grid<dimension_tag> &element_grid)
       : indices(indices), element_grid(element_grid),
         num_elements((indices.extent(0) / simd_size) +
                      ((indices.extent(0) % simd_size) != 0)),
@@ -359,8 +359,9 @@ public:
 private:
   ViewType indices; ///< View of indices of elements within this chunk
   int num_elements; ///< Number of elements in the chunk, adjusted for SIMD
-  specfem::mesh_entity::element<dimension_tag> element_grid; ///< Element grid
-                                                             ///< information
+  specfem::mesh_entity::element_grid<dimension_tag>
+      element_grid; ///< Element grid
+                    ///< information
 };
 
 /**
@@ -432,7 +433,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   ChunkElementIndex(
       const ViewType indices,
-      const specfem::mesh_entity::element<DimensionTag> &element_grid,
+      const specfem::mesh_entity::element_grid<DimensionTag> &element_grid,
       const TeamMemberType &kokkos_index)
       : indices(indices), element_grid(element_grid),
         kokkos_index(kokkos_index),
@@ -454,9 +455,10 @@ public:
   }
 
 private:
-  ViewType indices;                                         ///< View of indices
-  specfem::mesh_entity::element<DimensionTag> element_grid; ///< Element grid
-                                                            ///< information
+  ViewType indices; ///< View of indices
+  specfem::mesh_entity::element_grid<DimensionTag>
+      element_grid;            ///< Element grid
+                               ///< information
   TeamMemberType kokkos_index; ///< Kokkos index type
   iterator_type iterator;      ///< Iterator for iterating over the elements
                                ///< in the chunk.
@@ -518,7 +520,7 @@ public:
    */
   ChunkedDomainIterator(
       const ViewType indices,
-      const specfem::mesh_entity::element<DimensionTag> &element_grid)
+      const specfem::mesh_entity::element_grid<DimensionTag> &element_grid)
       : indices(indices), element_grid(element_grid),
         base_type(((indices.extent(0) / (chunk_size * simd_size)) +
                    ((indices.extent(0) % (chunk_size * simd_size)) != 0)),
@@ -535,7 +537,7 @@ public:
    */
   ChunkedDomainIterator(
       const ParallelConfig, const ViewType indices,
-      const specfem::mesh_entity::element<DimensionTag> &element_grid)
+      const specfem::mesh_entity::element_grid<DimensionTag> &element_grid)
       : ChunkedDomainIterator(indices, element_grid) {}
 
   /**
@@ -578,20 +580,21 @@ public:
 
 protected:
   ViewType indices; ///< View of indices of elements within this iterator
-  specfem::mesh_entity::element<DimensionTag> element_grid; ///< Element grid
-                                                            ///< information
+  specfem::mesh_entity::element_grid<DimensionTag>
+      element_grid; ///< Element grid
+                    ///< information
 };
 
 // Template argument deduction guides
 template <typename ParallelConfig, typename ViewType,
           specfem::dimension::type DimensionTag>
 ChunkedDomainIterator(ParallelConfig, ViewType,
-                      const specfem::mesh_entity::element<DimensionTag> &)
+                      const specfem::mesh_entity::element_grid<DimensionTag> &)
     -> ChunkedDomainIterator<DimensionTag, ParallelConfig, ViewType>;
 
 template <typename ViewType, specfem::dimension::type DimensionTag>
 ChunkedDomainIterator(ViewType,
-                      const specfem::mesh_entity::element<DimensionTag> &)
+                      const specfem::mesh_entity::element_grid<DimensionTag> &)
     -> ChunkedDomainIterator<
         DimensionTag,
         decltype(std::declval<typename ViewType::execution_space>()), ViewType>;

--- a/include/execution/mapped_chunked_domain_iterator.hpp
+++ b/include/execution/mapped_chunked_domain_iterator.hpp
@@ -103,7 +103,7 @@ public:
   MappedChunkElementIterator(
       const TeamMemberType &team, const ViewType indices,
       const ViewType mapping,
-      const specfem::mesh_entity::element<DimensionTag> &element_grid)
+      const specfem::mesh_entity::element_grid<DimensionTag> &element_grid)
       : base_type(team, indices, element_grid), mapping(mapping) {}
 
 private:
@@ -138,7 +138,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   MappedChunkElementIndex(
       const ViewType indices, const ViewType mapping,
-      const specfem::mesh_entity::element<DimensionTag> &element_grid,
+      const specfem::mesh_entity::element_grid<DimensionTag> &element_grid,
       const TeamMemberType &kokkos_index)
       : base_type(indices, element_grid, kokkos_index), mapping(mapping),
         iterator(kokkos_index, indices, mapping, element_grid) {}
@@ -171,12 +171,12 @@ public:
 
   MappedChunkedDomainIterator(
       const ViewType indices, const ViewType mapping,
-      const specfem::mesh_entity::element<DimensionTag> &element_grid)
+      const specfem::mesh_entity::element_grid<DimensionTag> &element_grid)
       : base_type(indices, element_grid), mapping(mapping) {}
 
   MappedChunkedDomainIterator(
       const ParallelConfig, const ViewType indices, const ViewType mapping,
-      const specfem::mesh_entity::element<DimensionTag> &element_grid)
+      const specfem::mesh_entity::element_grid<DimensionTag> &element_grid)
       : MappedChunkedDomainIterator(indices, mapping, element_grid) {}
 
   KOKKOS_INLINE_FUNCTION
@@ -207,13 +207,15 @@ private:
 // Template argument deduction guides
 template <typename ParallelConfig, typename ViewType,
           specfem::dimension::type DimensionTag>
-MappedChunkedDomainIterator(ParallelConfig, ViewType, ViewType,
-                            const specfem::mesh_entity::element<DimensionTag> &)
+MappedChunkedDomainIterator(
+    ParallelConfig, ViewType, ViewType,
+    const specfem::mesh_entity::element_grid<DimensionTag> &)
     -> MappedChunkedDomainIterator<DimensionTag, ParallelConfig, ViewType>;
 
 template <typename ViewType, specfem::dimension::type DimensionTag>
-MappedChunkedDomainIterator(ViewType, ViewType,
-                            const specfem::mesh_entity::element<DimensionTag> &)
+MappedChunkedDomainIterator(
+    ViewType, ViewType,
+    const specfem::mesh_entity::element_grid<DimensionTag> &)
     -> MappedChunkedDomainIterator<
         DimensionTag,
         decltype(std::declval<typename ViewType::execution_space>()), ViewType>;

--- a/src/enumerations/dim3/connections.cpp
+++ b/src/enumerations/dim3/connections.cpp
@@ -342,7 +342,5 @@ specfem::connections::connection_mapping<specfem::dimension::type::dim3>::
                                        to)))
     throw std::runtime_error("Both entities must be corners for this mapping.");
 
-  return specfem::mesh_entity::element<specfem::dimension::type::dim3>(
-             ngllz, nglly, ngllx)
-      .map_coordinates(to);
+  return specfem::mesh_entity::element(ngllz, nglly, ngllx).map_coordinates(to);
 }

--- a/src/enumerations/dim3/mesh_entities.cpp
+++ b/src/enumerations/dim3/mesh_entities.cpp
@@ -191,20 +191,12 @@ const std::string specfem::mesh_entity::dim3::to_string(
 }
 
 specfem::mesh_entity::element<specfem::dimension::type::dim3>::element(
+    const int ngll)
+    : element(ngll, ngll, ngll) {}
+
+specfem::mesh_entity::element<specfem::dimension::type::dim3>::element(
     const int ngllz, const int nglly, const int ngllx)
-    : ngllz(ngllz), nglly(nglly), ngllx(ngllx), orderz(ngllz - 1),
-      ordery(nglly - 1), orderx(ngllx - 1), size(ngllz * nglly * ngllx),
-      ngll2d(ngllx * nglly), ngll(ngllx) {
-
-  if (ngllz < 2 || nglly < 2 || ngllx < 2) {
-    throw std::runtime_error(
-        "ngllz, nglly, and ngllx must be at least 2 to define a 3D element");
-  }
-
-  if (ngllz != nglly || ngllz != ngllx) {
-    throw std::runtime_error(
-        "ngllz, nglly, and ngllx must be equal for a cubic 3D element");
-  }
+    : element_grid(ngllz, nglly, ngllx), ngll2d(ngllz * ngllx), ngll(ngllz) {
 
   // Initialize edge coordinates
   // xmin = left, xmax = right

--- a/tests/unit-tests/algorithms/dim2/gradient.cpp
+++ b/tests/unit-tests/algorithms/dim2/gradient.cpp
@@ -369,7 +369,9 @@ auto init_function(const FunctionInitializer2D::RANDOM &) {
   for (int icomp = 0; icomp < 1; ++icomp) {
     for (int iz = 0; iz < 5; ++iz) {
       for (int ix = 0; ix < 5; ++ix) {
-        _f[icomp][iz][ix] = static_cast<type_real>(rand()) / RAND_MAX;
+        _f[icomp][iz][ix] =
+            static_cast<type_real>(rand()) /
+            static_cast<type_real>(RAND_MAX); // Random value in [0,1]
       }
     }
   }

--- a/tests/unit-tests/algorithms/dim2/gradient.cpp
+++ b/tests/unit-tests/algorithms/dim2/gradient.cpp
@@ -599,7 +599,7 @@ execute(const Jacobian &jacobian_matrix, const Quadrature2D &quadrature,
                                              1, 1, 1, simd,
                                              Kokkos::DefaultExecutionSpace>;
 
-  const specfem::mesh_entity::element element_grid(ngll, ngll);
+  const specfem::mesh_entity::element_grid element_grid(ngll, ngll);
 
   const specfem::execution::ChunkedDomainIterator chunk(
       ParallelConfig(), element_indices, element_grid);

--- a/tests/unit-tests/algorithms/dim3/gradient.cpp
+++ b/tests/unit-tests/algorithms/dim3/gradient.cpp
@@ -419,7 +419,8 @@ auto init_function(const FunctionInitializer3D::RANDOM &) {
     for (int iz = 0; iz < 5; ++iz) {
       for (int iy = 0; iy < 5; ++iy) {
         for (int ix = 0; ix < 5; ++ix) {
-          _f[icomp][iz][iy][ix] = static_cast<type_real>(rand()) / RAND_MAX;
+          _f[icomp][iz][iy][ix] =
+              static_cast<type_real>(rand()) / static_cast<type_real>(RAND_MAX);
         }
       }
     }
@@ -682,7 +683,7 @@ execute(const Jacobian &jacobian_matrix, const Quadrature3D &quadrature,
                                              1, 1, 1, simd,
                                              Kokkos::DefaultExecutionSpace>;
 
-  const specfem::mesh_entity::element element_grid(ngll, ngll, ngll);
+  const specfem::mesh_entity::element_grid element_grid(ngll, ngll, ngll);
 
   const specfem::execution::ChunkedDomainIterator chunk(
       ParallelConfig(), element_indices, element_grid);

--- a/tests/unit-tests/enumerations/dim3/connections.cpp
+++ b/tests/unit-tests/enumerations/dim3/connections.cpp
@@ -416,8 +416,7 @@ TEST_P(CoupledElements, FaceConnections) {
 TEST_P(CoupledElements, EdgeConnections) {
   const auto &config = GetParam();
   // Create connection mapping between the two elements
-  specfem::mesh_entity::element<specfem::dimension::type::dim3> mapping(5, 5,
-                                                                        5);
+  specfem::mesh_entity::element mapping(5, 5, 5);
 
   specfem::connections::connection_mapping<specfem::dimension::type::dim3>
       connection(5, 5, 5, element1.control_nodes, element2.control_nodes);
@@ -457,8 +456,7 @@ TEST_P(CoupledElements, EdgeConnections) {
 TEST_P(CoupledElements, NodeConnections) {
   const auto &config = GetParam();
   // Create connection mapping between the two elements
-  specfem::mesh_entity::element<specfem::dimension::type::dim3> mapping(5, 5,
-                                                                        5);
+  specfem::mesh_entity::element mapping(5, 5, 5);
 
   specfem::connections::connection_mapping<specfem::dimension::type::dim3>
       connection(5, 5, 5, element1.control_nodes, element2.control_nodes);

--- a/tests/unit-tests/enumerations/dim3/connections.cpp
+++ b/tests/unit-tests/enumerations/dim3/connections.cpp
@@ -383,8 +383,7 @@ compute_coordinates(const specfem::connections_test::TestElement &element) {
 TEST_P(CoupledElements, FaceConnections) {
   const auto &config = GetParam();
   // Create connection mapping between the two elements
-  specfem::mesh_entity::element<specfem::dimension::type::dim3> mapping(5, 5,
-                                                                        5);
+  specfem::mesh_entity::element mapping(5, 5, 5);
 
   specfem::connections::connection_mapping<specfem::dimension::type::dim3>
       connection(5, 5, 5, element1.control_nodes, element2.control_nodes);

--- a/tests/unit-tests/enumerations/dim3/mesh_entity.cpp
+++ b/tests/unit-tests/enumerations/dim3/mesh_entity.cpp
@@ -421,8 +421,7 @@ struct Element8Node {
  */
 TEST(MeshEntity3D, ConnectionsPerNode) {
 
-  specfem::mesh_entity::element<specfem::dimension::type::dim3> element(
-      5, 5, 5); // ngllz, nglly, ngllx
+  specfem::mesh_entity::element element(5, 5, 5); // ngllz, nglly, ngllx
 
   for (const auto face : specfem::mesh_entity::dim3::faces) {
     const int npoints = element.number_of_points_on_orientation(face);
@@ -551,7 +550,7 @@ protected:
   specfem::mesh_entity_test::Element8Node element;
 
   /** @brief 3D mesh entity connection mapping */
-  specfem::mesh_entity::element<specfem::dimension::type::dim3> mapping;
+  specfem::mesh_entity::element mapping;
 };
 
 /** @brief Alias for wildcard coordinate type */

--- a/tests/unit-tests/enumerations/dim3/mesh_entity.cpp
+++ b/tests/unit-tests/enumerations/dim3/mesh_entity.cpp
@@ -550,7 +550,7 @@ protected:
   specfem::mesh_entity_test::Element8Node element;
 
   /** @brief 3D mesh entity connection mapping */
-  specfem::mesh_entity::element mapping;
+  specfem::mesh_entity::element<specfem::dimension::type::dim3> mapping;
 };
 
 /** @brief Alias for wildcard coordinate type */

--- a/tests/unit-tests/policies/policies.cpp
+++ b/tests/unit-tests/policies/policies.cpp
@@ -133,7 +133,8 @@ execute_chunk_element_policy(const int nspec, const int ngllz,
 
   constexpr auto dimension = specfem::dimension::type::dim2;
 
-  const specfem::mesh_entity::element<dimension> element_grid(ngllz, ngllx);
+  const specfem::mesh_entity::element_grid<dimension> element_grid(ngllz,
+                                                                   ngllx);
 
   Kokkos::View<int *, Kokkos::DefaultExecutionSpace> elements("elements",
                                                               nspec);
@@ -212,8 +213,7 @@ execute_chunk_element_policy_3d(const int nspec, const int ngllz,
 
   constexpr auto dimension = specfem::dimension::type::dim3;
 
-  const specfem::mesh_entity::element<dimension> element_grid(ngllz, nglly,
-                                                              ngllx);
+  const specfem::mesh_entity::element element_grid(ngllz, nglly, ngllx);
 
   Kokkos::View<int *, Kokkos::DefaultExecutionSpace> elements("elements",
                                                               nspec);


### PR DESCRIPTION
## Description

Please describe the changes/features in this pull request.

A previous PR had added mapping functions for quadrature points. These were getting copy constructed for every team. However the policy only needs element grid.

This PR separates element grids from mapping coordinates.

- [x] The policy tests take reasonable time

## Issue Number

If there is an issue created for these changes, link it here

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
