### PR TITLE
Conforming-nonconforming kernel agreement test

### DIFF
--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -316,16 +316,20 @@ add_executable(
   nonconforming_tests
   nonconforming/reparameterizations/compute_intersection_test.cpp
   nonconforming/reparameterizations/set_transfer_functions_test.cpp
+  nonconforming/kernel_compare/fixture.cpp
+  nonconforming/kernel_compare/kernel_compare_test.cpp
   nonconforming/runner.cpp
 )
 
 target_link_libraries(
   nonconforming_tests
+  io
   mesh
   assembly
   quadrature
   mpi_environment
   kokkos_environment
+  kokkos_kernels
   yaml-cpp
   utilities
   boost
@@ -932,6 +936,7 @@ if(NOT MPI_PARALLEL)
     io
     mesh
     policies
+    nonconforming
   )
 
   foreach(dir_name IN LISTS LINK_DIRS)

--- a/tests/unit-tests/nonconforming/kernel_compare/README.md
+++ b/tests/unit-tests/nonconforming/kernel_compare/README.md
@@ -1,0 +1,33 @@
+# Unit Test: Nonconforming Kernel Comparison
+
+`nonconforming/kernel_compare`
+
+This test verifies the standard acoustic-elastic coupling to the nonconforming implementation on the same mesh. The coupling is done by enforcing traction and displacement continuity in the normal direction on the interface in the weak problem ([Komatitsch, Barnes, Tromp (2000)](https://doi.org/10.1190/1.1444758)).
+
+The nonconforming kernel that uses this same approach can be tested directly, using the weakly-conforming interface as a ground truth. They should be in agreement up to the error of `compute_intersection`. This is that test.
+
+## Implementation
+
+Let $S = \{x_i\}_{i=0}^{N-1}$ denote the set of $N$ nodes (post-assembly) that correspond to an element with an edge on the boundary.
+
+$$S = \bigcup_{\verb+elements+(i_\text{spec})\cap \Gamma_i \ne \emptyset} \verb+nodes+\left(\verb+assembly_index_mapping+(i_\text{spec}, \cdots)\right)$$
+
+Note that in both the conforming and nonconforming meshes, the same assembly is performed, as interfacial nodes must have a different field value for each side.
+
+The test proceeds as follows:
+
+```pseudocode
+for each xi in S:
+  for di in range(dim(field at xi)):
+    set conforming displacement field = SHAPE_FUNCTION(xi,k)
+    set nonconforming displacement field = SHAPE_FUNCTION(xi,k)
+
+    conforming_kernels.update_wavefields<acoustic>();
+    conforming_kernels.update_wavefields<elastic>();
+    nonconforming_kernels.update_wavefields<acoustic>();
+    nonconforming_kernels.update_wavefields<elastic>();
+
+    for each xj in S:
+      for dj in range(dim(field at xj)):
+        assert( conforming accel field (xj,dj) == nonconforming accel field (xj,dj) )
+```

--- a/tests/unit-tests/nonconforming/kernel_compare/fixture.cpp
+++ b/tests/unit-tests/nonconforming/kernel_compare/fixture.cpp
@@ -1,0 +1,131 @@
+#include "fixture.hpp"
+#include "io/interface.hpp"
+
+#include <map>
+
+specfem::mesh::mesh<specfem::dimension::type::dim2> convert_to_conforming(
+    const specfem::mesh::mesh<specfem::dimension::type::dim2> &ncmesh) {
+  specfem::mesh::mesh<specfem::dimension::type::dim2> mesh = ncmesh;
+
+  using EdgeProperties = specfem::mesh::adjacency_graph<
+      specfem::dimension::type::dim2>::EdgeProperties;
+
+  // remember -- copy constructor is shallow.
+  mesh.adjacency_graph =
+      specfem::mesh::adjacency_graph<specfem::dimension::type::dim2>(
+          mesh.nspec);
+
+  const auto &ncgraph = ncmesh.adjacency_graph.graph();
+  auto &graph = mesh.adjacency_graph.graph();
+
+  std::unordered_map<int, std::tuple<int, specfem::mesh_entity::dim2::type, int,
+                                     specfem::mesh_entity::dim2::type> >
+      nc_to_c_interface;
+  int num_nc_edges = 0;
+
+  for (const auto &edge : boost::make_iterator_range(boost::edges(ncgraph))) {
+    auto edge_conf = ncgraph[edge];
+
+    const auto src = boost::source(edge, ncgraph);
+    const auto tgt = boost::target(edge, ncgraph);
+
+    // convert nonconforming connections to conforming
+    if (edge_conf.connection == specfem::connections::type::nonconforming) {
+      // only add edges, not corners
+
+      const auto [inverse, found] = boost::edge(tgt, src, ncgraph);
+      if (!found) {
+        throw std::runtime_error(
+            "kernel_compare test: Non-symmetric adjacency graph "
+            "detected in `compute_intersection`.");
+      }
+      if ((!specfem::mesh_entity::contains(specfem::mesh_entity::dim2::edges,
+                                           edge_conf.orientation)) ||
+          (!specfem::mesh_entity::contains(specfem::mesh_entity::dim2::edges,
+                                           ncgraph[inverse].orientation))) {
+        continue;
+      }
+
+      // should this be weakly conforming instead?
+      edge_conf.connection = specfem::connections::type::strongly_conforming;
+      num_nc_edges++;
+      if (auto search = nc_to_c_interface.find(tgt);
+          search == nc_to_c_interface.end() ||
+          std::get<2>(nc_to_c_interface[tgt]) != src) {
+        // inverse not already inside. add ourselves
+        nc_to_c_interface.insert(
+            std::make_pair(src, std::make_tuple(src, edge_conf.orientation, tgt,
+                                                ncgraph[inverse].orientation)));
+      }
+    }
+
+    boost::add_edge(src, tgt, edge_conf, graph);
+  }
+  mesh.adjacency_graph.assert_symmetry();
+
+  // fill mesh::coupled_interfaces, since assembly needs to get conforming from
+  // there:
+  if (nc_to_c_interface.size() != num_nc_edges / 2) {
+    throw std::runtime_error(
+        "Constructing conforming mesh from nonconforming mesh: the number of "
+        "nonconforming edges is not twice the number of acoustic-elastic "
+        "interfaces found!");
+  }
+
+  mesh.coupled_interfaces.elastic_acoustic =
+      decltype(mesh.coupled_interfaces.elastic_acoustic)(num_nc_edges / 2);
+
+  auto it = nc_to_c_interface.begin();
+  for (int i = 0; i < num_nc_edges / 2; i++) {
+    const auto &[src, src_edge, tgt, tgt_edge] = it->second;
+    if (mesh.tags.tags_container(src).medium_tag ==
+        specfem::element::medium_tag::elastic_psv) {
+      mesh.coupled_interfaces.elastic_acoustic.medium1_index_mapping(i) = src;
+      mesh.coupled_interfaces.elastic_acoustic.medium2_index_mapping(i) = tgt;
+      mesh.coupled_interfaces.elastic_acoustic.medium1_edge_type(i) = src_edge;
+      mesh.coupled_interfaces.elastic_acoustic.medium2_edge_type(i) = tgt_edge;
+    } else {
+      mesh.coupled_interfaces.elastic_acoustic.medium2_index_mapping(i) = src;
+      mesh.coupled_interfaces.elastic_acoustic.medium1_index_mapping(i) = tgt;
+      mesh.coupled_interfaces.elastic_acoustic.medium2_edge_type(i) = src_edge;
+      mesh.coupled_interfaces.elastic_acoustic.medium1_edge_type(i) = tgt_edge;
+    }
+    it++;
+  }
+
+  return mesh;
+}
+
+specfem::testing::kernel_compare::Test::Test(const YAML::Node &Node,
+                                             specfem::MPI::MPI *mpi)
+    : name(Node["name"].as<std::string>()),
+      description(Node["description"].as<std::string>()),
+      nonconforming_database_file(Node["mesh"].as<std::string>()),
+      nonconforming_mesh(specfem::io::read_2d_mesh(
+          this->nonconforming_database_file, specfem::enums::elastic_wave::psv,
+          specfem::enums::electromagnetic_wave::te, mpi)),
+      conforming_mesh(convert_to_conforming(this->nonconforming_mesh)),
+      quadrature(specfem::quadrature::gll::gll()), sources(), receivers(),
+      nonconforming_assembly(
+          specfem::assembly::assembly<specfem::dimension::type::dim2>(
+              this->nonconforming_mesh, this->quadrature, this->sources,
+              this->receivers, {}, 0.0, 0.1, 1, 1, 1,
+              specfem::simulation::type::forward, false, nullptr)),
+      conforming_assembly(
+          specfem::assembly::assembly<specfem::dimension::type::dim2>(
+              this->conforming_mesh, this->quadrature, this->sources,
+              this->receivers, {}, 0.0, 0.1, 1, 1, 1,
+              specfem::simulation::type::forward, false, nullptr)) {}
+
+specfem::testing::kernel_compare::mesh_list::mesh_list() {
+
+  std::string config_filename = "nonconforming/kernel_compare/test_config.yaml";
+  const YAML::Node yaml_root = YAML::LoadFile(config_filename);
+  YAML::Node all_tests = yaml_root["Tests"];
+  assert(all_tests.IsSequence());
+  specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
+
+  for (const auto &test_node : all_tests) {
+    this->push_back(specfem::testing::kernel_compare::Test(test_node, mpi));
+  }
+}

--- a/tests/unit-tests/nonconforming/kernel_compare/fixture.hpp
+++ b/tests/unit-tests/nonconforming/kernel_compare/fixture.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "../../MPI_environment.hpp"
+#include "mesh/mesh.hpp"
+#include "specfem/assembly.hpp"
+#include "specfem/source.hpp"
+#include "utilities/strings.hpp"
+#include <gtest/gtest.h>
+#include <iostream>
+#include <vector>
+#include <yaml-cpp/yaml.h>
+
+namespace specfem::testing::kernel_compare {
+
+/**
+ * @brief Stores information for each kernel compare test. Meshes are stored in
+ * here, since tests and meshes should be in 1-1 correspondence.
+ *
+ */
+struct Test {
+public:
+  Test(const YAML::Node &Node, specfem::MPI::MPI *mpi);
+
+  const std::string name;
+  const std::string description;
+  const std::string nonconforming_database_file;
+  const specfem::mesh::mesh<specfem::dimension::type::dim2> nonconforming_mesh;
+  const specfem::mesh::mesh<specfem::dimension::type::dim2> conforming_mesh;
+
+private:
+  // values in assembly need to be references. Store them here
+  std::vector<std::shared_ptr<
+      specfem::sources::source<specfem::dimension::type::dim2> > >
+      sources;
+  std::vector<std::shared_ptr<
+      specfem::receivers::receiver<specfem::dimension::type::dim2> > >
+      receivers;
+  const specfem::quadrature::quadratures quadrature;
+
+public:
+  specfem::assembly::assembly<specfem::dimension::type::dim2>
+      nonconforming_assembly;
+  specfem::assembly::assembly<specfem::dimension::type::dim2>
+      conforming_assembly;
+};
+
+class mesh_list : public ::testing::Test,
+                  public std::vector<specfem::testing::kernel_compare::Test> {
+
+protected:
+  mesh_list();
+};
+
+} // namespace specfem::testing::kernel_compare

--- a/tests/unit-tests/nonconforming/kernel_compare/kernel_compare_test.cpp
+++ b/tests/unit-tests/nonconforming/kernel_compare/kernel_compare_test.cpp
@@ -1,0 +1,480 @@
+#include "enumerations/medium.hpp"
+#include "fixture.hpp"
+#include "kokkos_kernels/domain_kernels.hpp"
+
+#include "gtest/gtest.h"
+#include <boost/graph/filtered_graph.hpp>
+#include <stdexcept>
+
+/**
+ * For a given field acessor, clear those values.
+ */
+template <template <specfem::dimension::type, specfem::element::medium_tag,
+                    bool> typename PointFieldType,
+          specfem::dimension::type dimension>
+void clear_field(specfem::assembly::assembly<dimension> &assembly) {
+  const auto &field = assembly.fields.template get_simulation_field<
+      specfem::wavefield::simulation_field::forward>();
+  FOR_EACH_IN_PRODUCT(
+      (DIMENSION_TAG(DIM2), MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC,
+                                       POROELASTIC, ELASTIC_PSV_T)),
+      {
+        const auto &elements =
+            assembly.element_types.get_elements_on_host(_medium_tag_);
+        const int nelem = elements.extent(0);
+
+        PointFieldType<dimension, _medium_tag_, false> clear_point;
+        for (int icomp = 0; icomp < decltype(clear_point)::components;
+             icomp++) {
+          clear_point(icomp) = 0;
+        }
+
+        for (int i = 0; i < nelem; i++) {
+          const int ispec = elements(i);
+
+          for (int iz = 0; iz < assembly.mesh.element_grid.ngllz; iz++) {
+            for (int ix = 0; ix < assembly.mesh.element_grid.ngllx; ix++) {
+              const specfem::point::index<dimension> index(ispec, iz, ix);
+              specfem::assembly::store_on_host(index, field, clear_point);
+            }
+          }
+        }
+      })
+}
+
+/**
+ * Assuming the fields have been set by the kernels, ensures that accelerations
+ * are within a small tolerance. This is the
+ * foreach(DoF) { assert accell fields close }
+ * section of the test.
+ */
+void validate_field_at_points(
+    specfem::assembly::simulation_field<
+        specfem::dimension::type::dim2,
+        specfem::wavefield::simulation_field::forward> &expected,
+    specfem::assembly::simulation_field<
+        specfem::dimension::type::dim2,
+        specfem::wavefield::simulation_field::forward> &tested,
+    const std::unordered_map<
+        specfem::element::medium_tag,
+        std::unordered_map<
+            int, std::pair<
+                     specfem::point::index<specfem::dimension::type::dim2>,
+                     specfem::point::index<specfem::dimension::type::dim2> > > >
+        &nodes_to_check_per_medium,
+    const int &current_mesh_iglob, const int &current_icomp,
+    const type_real &elastic_acceleration_scale,
+    const type_real &acoustic_acceleration_scale) {
+
+  // give extra information only on the first failure
+  bool first_failure = true;
+
+  const auto iglob_elaboration =
+      [&nodes_to_check_per_medium](std::ostringstream &oss, const int &iglob) {
+        for (const auto &[medium, nodes_to_check] : nodes_to_check_per_medium) {
+          const auto &found = nodes_to_check.find(iglob);
+          if (found != nodes_to_check.end()) {
+            const auto &index = found->second.first;
+            oss << "[ispec = " << index.ispec << " ("
+                << specfem::element::to_string(medium) << "), ix = " << index.ix
+                << ", iz = " << index.iz << "]";
+            break;
+          }
+        }
+      };
+
+  // ==================================
+  // begin(foreach degree of freedom j)
+  // ==================================
+  for (const auto &[medium, nodes_to_check] : nodes_to_check_per_medium) {
+    FOR_EACH_IN_PRODUCT(
+        (DIMENSION_TAG(DIM2), MEDIUM_TAG(ELASTIC_PSV, ACOUSTIC)), {
+          using PointAccelerationType =
+              specfem::point::acceleration<_dimension_tag_, _medium_tag_,
+                                           false>;
+          if (medium == _medium_tag_) {
+            PointAccelerationType test_read_accel;
+            PointAccelerationType expect_read_accel;
+            const type_real acceleration_scale =
+                (medium == specfem::element::medium_tag::acoustic)
+                    ? acoustic_acceleration_scale
+                    : elastic_acceleration_scale;
+            for (const auto &[nc_iglob, inds] : nodes_to_check) {
+              const auto &[nc_index, c_index] = inds;
+
+              specfem::assembly::load_on_host(c_index, expected,
+                                              expect_read_accel);
+              specfem::assembly::load_on_host(nc_index, tested,
+                                              test_read_accel);
+
+              for (int icomp = 0; icomp < PointAccelerationType::components;
+                   icomp++) {
+                // ===================================
+                // (foreach degree of freedom j) then:
+                // ===================================
+
+                if (!specfem::utilities::is_close(
+                        expect_read_accel(icomp), test_read_accel(icomp),
+                        type_real(1e-4) * acceleration_scale,
+                        type_real(1e-5) * acceleration_scale)) {
+
+                  // overhaul this erroring if its needed when implementing
+                  // kernels.
+
+                  std::ostringstream oss;
+
+                  oss << "shape function (iglob = " << current_mesh_iglob
+                      << " ";
+                  iglob_elaboration(oss, current_mesh_iglob);
+                  oss << ", icomp = " << current_icomp
+                      << ") with values at (iglob = " << nc_iglob << " ";
+                  iglob_elaboration(oss, nc_iglob);
+                  oss << ", icomp = " << icomp << ")\n";
+                  oss << "    Got " << test_read_accel(icomp)
+                      << "\n    Expected " << expect_read_accel(icomp);
+
+                  oss << "  (" << std::showpos << std::scientific;
+                  if (std::abs(expect_read_accel(icomp)) /
+                          std::abs(1e-10 + test_read_accel(icomp)) >
+                      1e-5) {
+                    oss << (test_read_accel(icomp) - expect_read_accel(icomp)) /
+                               expect_read_accel(icomp)
+                        << " rel, ";
+                  }
+                  oss << (test_read_accel(icomp) - expect_read_accel(icomp)) /
+                             acceleration_scale
+                      << " * est. accel scale)" << std::fixed;
+                  if (first_failure) {
+                    oss << "\nshape function full index";
+                    first_failure = false;
+                  }
+                  ADD_FAILURE() << oss.str();
+                }
+
+                // ================================
+                // end(foreach degree of freedom j)
+                // ================================
+              }
+            }
+          }
+        })
+  }
+}
+
+void nonconforming_kernel_comparison(
+    specfem::testing::kernel_compare::Test &test_config) {
+  static constexpr int NGLL = 5;
+  auto &c_assembly = test_config.conforming_assembly;
+  auto &nc_assembly = test_config.nonconforming_assembly;
+  EXPECT_EQ(nc_assembly.mesh.nspec, c_assembly.mesh.nspec)
+      << "Number of elements do not match for test: " << test_config.name;
+  EXPECT_EQ(nc_assembly.get_total_degrees_of_freedom(),
+            c_assembly.get_total_degrees_of_freedom())
+      << "Number of degrees of freedom do not match for test: "
+      << test_config.name;
+
+  FOR_EACH_IN_PRODUCT(
+      (DIMENSION_TAG(DIM2), CONNECTION_TAG(WEAKLY_CONFORMING),
+       INTERFACE_TAG(ELASTIC_ACOUSTIC, ACOUSTIC_ELASTIC),
+       BOUNDARY_TAG(NONE, STACEY, ACOUSTIC_FREE_SURFACE,
+                    COMPOSITE_STACEY_DIRICHLET)),
+      {
+        // the number of nonconforming edges on the conforming assembly should
+        // be zero and vice versa.
+        int n_nc_in_c =
+            std::get<0>(c_assembly.edge_types.get_edges_on_host(
+                            specfem::connections::type::nonconforming,
+                            _interface_tag_, _boundary_tag_))
+                .extent(0);
+        EXPECT_EQ(n_nc_in_c, 0)
+            << test_config.name
+            << ": conforming assembly should not have any nonconforming "
+               "edges. (interface = "
+            << specfem::interface::to_string(_interface_tag_) << ", medium = "
+            << specfem::element::to_string(
+                   specfem::interface::attributes<
+                       _dimension_tag_, _interface_tag_>::self_medium())
+            << ", boundary = " << specfem::element::to_string(_boundary_tag_)
+            << ")";
+        int n_c_in_nc =
+            std::get<0>(nc_assembly.edge_types.get_edges_on_host(
+                            specfem::connections::type::weakly_conforming,
+                            _interface_tag_, _boundary_tag_))
+                .extent(0);
+        EXPECT_EQ(n_c_in_nc, 0)
+            << test_config.name
+            << ": nonconforming assembly should not have any conforming "
+               "edges. (interface = "
+            << specfem::interface::to_string(_interface_tag_) << ", medium = "
+            << specfem::element::to_string(
+                   specfem::interface::attributes<
+                       _dimension_tag_, _interface_tag_>::self_medium())
+            << ", boundary = " << specfem::element::to_string(_boundary_tag_)
+            << ")";
+        // the number of edges should match between assemblies.
+
+        int n_c_in_c =
+            std::get<0>(c_assembly.edge_types.get_edges_on_host(
+                            specfem::connections::type::weakly_conforming,
+                            _interface_tag_, _boundary_tag_))
+                .extent(0);
+        int n_nc_in_nc =
+            std::get<0>(nc_assembly.edge_types.get_edges_on_host(
+                            specfem::connections::type::nonconforming,
+                            _interface_tag_, _boundary_tag_))
+                .extent(0);
+        EXPECT_EQ(n_c_in_c, n_nc_in_nc)
+            << test_config.name
+            << ": assembly configurations do not have the same number of "
+               "edges. (interface = "
+            << specfem::interface::to_string(_interface_tag_) << ", medium = "
+            << specfem::element::to_string(
+                   specfem::interface::attributes<
+                       _dimension_tag_, _interface_tag_>::self_medium())
+            << ", boundary = " << specfem::element::to_string(_boundary_tag_)
+            << ")";
+      })
+
+  // get indices to iterate over. items are (nc index, c index)
+  std::unordered_map<
+      specfem::element::medium_tag,
+      std::unordered_map<
+          int,
+          std::pair<specfem::point::index<specfem::dimension::type::dim2>,
+                    specfem::point::index<specfem::dimension::type::dim2> > > >
+      nodes_to_check_per_medium;
+
+  const auto &graph = nc_assembly.mesh.graph();
+  auto filter = [&graph](const auto &edge) {
+    return graph[edge].connection == specfem::connections::type::nonconforming;
+  };
+  const auto &nc_graph = boost::make_filtered_graph(graph, filter);
+
+  type_real min_cell_length_scale = std::numeric_limits<type_real>::max();
+  type_real max_cell_length_scale = 0;
+
+  for (const auto &edge : boost::make_iterator_range(boost::edges(nc_graph))) {
+    // we do not assume assembly indices are the same, but mesh indices should
+    // be.
+    const int nc_ispec = boost::source(edge, nc_graph);
+    const int mesh_ispec = nc_assembly.mesh.compute_to_mesh(nc_ispec);
+    const int c_ispec = c_assembly.mesh.mesh_to_compute(mesh_ispec);
+
+    const auto medium = nc_assembly.element_types.get_medium_tag(nc_ispec);
+    EXPECT_EQ(medium, c_assembly.element_types.get_medium_tag(c_ispec))
+        << "Element mesh_ispec = " << mesh_ispec
+        << " has unequal media in what should be the same element."
+           " nonconforming (assembly ispec: "
+        << nc_ispec << ", medium = " << specfem::element::to_string(medium)
+        << ") vs conforming (assembly ispec: " << c_ispec << ", medium = "
+        << specfem::element::to_string(
+               c_assembly.element_types.get_medium_tag(c_ispec))
+        << ")";
+
+    auto &nodes_to_check = [&]()
+        -> std::unordered_map<
+            int,
+            std::pair<specfem::point::index<specfem::dimension::type::dim2>,
+                      specfem::point::index<specfem::dimension::type::dim2> > >
+            & {
+              auto nodelist_it = nodes_to_check_per_medium.find(medium);
+              if (nodelist_it == nodes_to_check_per_medium.end()) {
+                return (nodes_to_check_per_medium.insert({ medium, {} }).first)
+                    ->second;
+              } else {
+                return nodelist_it->second;
+              }
+            }();
+
+    // add each iglob that is part of this element if not already added.
+    for (int iz = 0; iz < nc_assembly.mesh.element_grid.ngllz; iz++) {
+      for (int ix = 0; ix < nc_assembly.mesh.element_grid.ngllx; ix++) {
+        const int nc_iglob = nc_assembly.mesh.h_index_mapping(nc_ispec, iz, ix);
+        if (nodes_to_check.find(nc_iglob) == nodes_to_check.end()) {
+          nodes_to_check.insert(
+              { nc_iglob, { { nc_ispec, iz, ix }, { c_ispec, iz, ix } } });
+        }
+      }
+    }
+
+    // length scale: diagonals
+    type_real x_scale1 = nc_assembly.mesh.h_control_node_coord(0, nc_ispec, 0) -
+                         nc_assembly.mesh.h_control_node_coord(0, nc_ispec, 2);
+    type_real z_scale1 = nc_assembly.mesh.h_control_node_coord(1, nc_ispec, 0) -
+                         nc_assembly.mesh.h_control_node_coord(1, nc_ispec, 2);
+    type_real x_scale2 = nc_assembly.mesh.h_control_node_coord(0, nc_ispec, 1) -
+                         nc_assembly.mesh.h_control_node_coord(0, nc_ispec, 3);
+    type_real z_scale2 = nc_assembly.mesh.h_control_node_coord(1, nc_ispec, 1) -
+                         nc_assembly.mesh.h_control_node_coord(1, nc_ispec, 3);
+    min_cell_length_scale =
+        std::min(min_cell_length_scale,
+                 std::min(x_scale1 * x_scale1 + z_scale1 * z_scale1,
+                          x_scale2 * x_scale2 + z_scale2 * z_scale2));
+    max_cell_length_scale =
+        std::max(max_cell_length_scale,
+                 std::max(x_scale1 * x_scale1 + z_scale1 * z_scale1,
+                          x_scale2 * x_scale2 + z_scale2 * z_scale2));
+  }
+
+  specfem::kokkos_kernels::domain_kernels<
+      specfem::wavefield::simulation_field::forward,
+      specfem::dimension::type::dim2, NGLL>
+      nc_kernels(nc_assembly);
+  specfem::kokkos_kernels::domain_kernels<
+      specfem::wavefield::simulation_field::forward,
+      specfem::dimension::type::dim2, NGLL>
+      c_kernels(c_assembly);
+
+  nc_kernels.initialize(0.0);
+  c_kernels.initialize(0.0);
+
+  auto nc_field = nc_assembly.fields.template get_simulation_field<
+      specfem::wavefield::simulation_field::forward>();
+  auto c_field = c_assembly.fields.template get_simulation_field<
+      specfem::wavefield::simulation_field::forward>();
+
+  clear_field<specfem::point::displacement>(nc_assembly);
+  clear_field<specfem::point::displacement>(c_assembly);
+  clear_field<specfem::point::velocity>(nc_assembly);
+  clear_field<specfem::point::velocity>(c_assembly);
+  clear_field<specfem::point::acceleration>(nc_assembly);
+  clear_field<specfem::point::acceleration>(c_assembly);
+
+  // estimates for crossover values
+
+  type_real rho_inv =
+      test_config.nonconforming_mesh.materials.material_dim2_acoustic_isotropic
+          .element_materials[0]
+          .get_properties()
+          .rho_inverse();
+  type_real elastic_to_acoustic_factor = max_cell_length_scale / rho_inv;
+  type_real acoustic_to_elastic_factor = rho_inv / min_cell_length_scale;
+
+  // ==================================
+  // begin(foreach degree of freedom i)
+  // ==================================
+  for (const auto &[medium, nodes_to_check] : nodes_to_check_per_medium) {
+    FOR_EACH_IN_PRODUCT(
+        (DIMENSION_TAG(DIM2), MEDIUM_TAG(ELASTIC_PSV, ACOUSTIC)), {
+          using PointDisplacementType =
+              specfem::point::displacement<_dimension_tag_, _medium_tag_,
+                                           false>;
+          if (medium == _medium_tag_) {
+
+            PointDisplacementType displacement;
+
+            for (int icomp = 0; icomp < PointDisplacementType::components;
+                 icomp++) {
+              displacement(icomp) = 0;
+            }
+
+            for (const auto &[nc_iglob, inds] : nodes_to_check) {
+              const auto &[nc_index, c_index] = inds;
+              for (int icomp = 0; icomp < PointDisplacementType::components;
+                   icomp++) {
+                displacement(icomp) = 1;
+                // ===================================
+                // (foreach degree of freedom i) then:
+                // ===================================
+
+                clear_field<specfem::point::acceleration>(nc_assembly);
+                clear_field<specfem::point::acceleration>(c_assembly);
+
+                specfem::assembly::store_on_host(nc_index, nc_field,
+                                                 displacement);
+                specfem::assembly::store_on_host(c_index, c_field,
+                                                 displacement);
+
+                nc_field.copy_to_device();
+                c_field.copy_to_device();
+
+                // one will skip the printouts
+                nc_kernels.template update_wavefields<
+                    specfem::element::medium_tag::acoustic>(1);
+                c_kernels.template update_wavefields<
+                    specfem::element::medium_tag::acoustic>(1);
+
+                Kokkos::fence();
+
+                nc_kernels.template update_wavefields<
+                    specfem::element::medium_tag::elastic_psv>(1);
+                c_kernels.template update_wavefields<
+                    specfem::element::medium_tag::elastic_psv>(1);
+
+                Kokkos::fence();
+
+                nc_field.copy_to_host();
+                c_field.copy_to_host();
+
+                // recover the maximum expected value for a scale
+                type_real elastic_acceleration_scale = 1e-6;
+                type_real acoustic_acceleration_scale = 1e-6;
+
+                using AcousticPointAccelType = specfem::point::acceleration<
+                    _dimension_tag_, specfem::element::medium_tag::acoustic,
+                    false>;
+                using ElasticPointAccelType = specfem::point::acceleration<
+                    _dimension_tag_, specfem::element::medium_tag::elastic_psv,
+                    false>;
+                AcousticPointAccelType ac_accel_sample;
+                ElasticPointAccelType el_accel_sample;
+                for (const auto &[nc_iglob_, inds_] : nodes_to_check_per_medium
+                         [specfem::element::medium_tag::acoustic]) {
+                  const auto &[nc_index_, c_index_] = inds_;
+
+                  specfem::assembly::load_on_host(c_index_, c_field,
+                                                  ac_accel_sample);
+                  for (int icomp_ = 0;
+                       icomp_ < AcousticPointAccelType::components; icomp_++) {
+                    acoustic_acceleration_scale =
+                        std::max(acoustic_acceleration_scale,
+                                 std::abs(ac_accel_sample(icomp_)));
+                  }
+                }
+                for (const auto &[nc_iglob_, inds_] : nodes_to_check_per_medium
+                         [specfem::element::medium_tag::elastic_psv]) {
+                  const auto &[nc_index_, c_index_] = inds_;
+
+                  specfem::assembly::load_on_host(c_index_, c_field,
+                                                  el_accel_sample);
+                  for (int icomp_ = 0;
+                       icomp_ < ElasticPointAccelType::components; icomp_++) {
+                    elastic_acceleration_scale =
+                        std::max(elastic_acceleration_scale,
+                                 std::abs(el_accel_sample(icomp_)));
+                  }
+                }
+
+                validate_field_at_points(
+                    c_field, nc_field, nodes_to_check_per_medium, nc_iglob,
+                    icomp,
+                    std::max(acoustic_to_elastic_factor *
+                                 acoustic_acceleration_scale,
+                             elastic_acceleration_scale),
+                    std::max(acoustic_acceleration_scale,
+                             elastic_to_acoustic_factor *
+                                 elastic_acceleration_scale));
+                // ================================
+                // end(foreach degree of freedom i)
+                // ================================
+                displacement(icomp) = 0;
+                specfem::assembly::store_on_host(nc_index, nc_field,
+                                                 displacement);
+                specfem::assembly::store_on_host(c_index, c_field,
+                                                 displacement);
+              }
+            }
+          }
+        })
+  }
+}
+
+using NonconformingConformingMeshes =
+    specfem::testing::kernel_compare::mesh_list;
+
+TEST_F(NonconformingConformingMeshes, Test) {
+  for (auto &test_config : *this) {
+
+    nonconforming_kernel_comparison(test_config);
+  }
+}

--- a/tests/unit-tests/nonconforming/kernel_compare/test_config.yaml
+++ b/tests/unit-tests/nonconforming/kernel_compare/test_config.yaml
@@ -1,0 +1,7 @@
+Tests: []
+  # - name: "4x4 neumann"
+  #   description: "A 4x4 regular grid (cells 25x25 units) with neumann bcs"
+  #   mesh: "data/dim2/ncmarked_conforming_grid_flat/database.bin"
+  # - name: "8x8 neumann"
+  #   description: "An 8x8 bathymetrized grid (cells 12.5x12.5 units) with neumann bcs"
+  #   mesh: "data/dim2/ncmarked_conforming_grid_curved/database.bin"


### PR DESCRIPTION
## Description

(formerly #1259, this PR removes some history, since the "changed files" tab on GitHub was messed up)

Please describe the changes/features in this pull request.
~~- [ ] uncomments + populates NCI kernel from #1202~~
~~- [ ] closes dependencies for kernel implementation (#1256, #1257)~~
- [x] adds a test to verify, for conforming mesh(es), that the nonconforming and conforming kernel gives the same result when calling `kernel.update_wavefields<...>()`.

Edit: This will only be the unit test.

## Issue Number

If there is an issue created for these changes, link it here
closes #1258

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
