### PR TITLE
Adds Configure tests flag to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ option(SPECFEM_INSTALL "Creates clean executable directory. Location Controlled 
 option(SPECFEM_ENABLE_DOUBLE_PRECISION "Enable double precision" OFF)
 option(SPECFEM_BUILD_BENCHMARKS "Benchmarks included" ON)
 option(SPECFEM_ENABLE_UNITY_BUILD "Enable unity build to speed up compilation" ON)
+option(SPECFEMPP_CONFIGURE_TESTS "Configure test files used to generate data for unit tests" OFF)
 
 # set(CMAKE_BUILD_TYPE Release)
 set(CHUNK_SIZE 32)

--- a/tests/unit-tests/data/dim2/ncmarked_conforming_grid_curved/provenance/CMakeLists.txt
+++ b/tests/unit-tests/data/dim2/ncmarked_conforming_grid_curved/provenance/CMakeLists.txt
@@ -1,4 +1,4 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.17.5)
 
-configure_file(CMakeFiles/Snakefile.in ${CMAKE_CURRENT_SOURCE_DIR}/Snakefile)
-configure_file(CMakeFiles/Par_file.in ${CMAKE_CURRENT_SOURCE_DIR}/Par_file)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CMakeFiles/Snakefile.in ${CMAKE_CURRENT_SOURCE_DIR}/Snakefile)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CMakeFiles/Par_file.in ${CMAKE_CURRENT_SOURCE_DIR}/Par_file)

--- a/tests/unit-tests/data/dim2/ncmarked_conforming_grid_curved/provenance/CMakeLists.txt
+++ b/tests/unit-tests/data/dim2/ncmarked_conforming_grid_curved/provenance/CMakeLists.txt
@@ -1,4 +1,6 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.17.5)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CMakeFiles/Snakefile.in ${CMAKE_CURRENT_SOURCE_DIR}/Snakefile)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CMakeFiles/Par_file.in ${CMAKE_CURRENT_SOURCE_DIR}/Par_file)
+if(SPECFEMPP_CONFIGURE_TEST)
+    configure_file(CMakeFiles/Snakefile.in ${CMAKE_CURRENT_SOURCE_DIR}/Snakefile)
+    configure_file(CMakeFiles/Par_file.in ${CMAKE_CURRENT_SOURCE_DIR}/Par_file)
+endif()


### PR DESCRIPTION
## Description

Please describe the changes/features in this pull request.

- Some tests are failing since cmake is not able to find configure files.

## Issue Number

If there is an issue created for these changes, link it here

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
