### PR TITLE
Fix snakemake params in benchmarks folder

### DIFF
--- a/benchmarks/src/dim2/fluid-solid-interface/CMakeFiles/Snakefile.in
+++ b/benchmarks/src/dim2/fluid-solid-interface/CMakeFiles/Snakefile.in
@@ -54,6 +54,8 @@ rule run_solver:
         tasks=1,
         cpus_per_task=1,
         runtime=10,
+    params:
+        KOKKOS_TOOLS_LIBS='""',
     shell:
         """
             # module purge

--- a/benchmarks/src/dim2/homogeneous-medium-flat-topography/CMakeFiles/Snakefile.in
+++ b/benchmarks/src/dim2/homogeneous-medium-flat-topography/CMakeFiles/Snakefile.in
@@ -42,6 +42,8 @@ rule run_solver:
         tasks=1,
         cpus_per_task=1,
         runtime=10,
+    params:
+        KOKKOS_TOOLS_LIBS='""',
     shell:
         """
             # module purge


### PR DESCRIPTION
Fixes the error `params.KOKKOS_TOOLS_LIBS` not defined when running snakemake in benchmarks folder.