### PR TITLE
Add `KOKKOS_PATH` flag to CMake

### DIFF
--- a/cmake/kokkos.cmake
+++ b/cmake/kokkos.cmake
@@ -1,5 +1,11 @@
 
 
+if (DEFINED Kokkos_ROOT)
+    message(STATUS "Using user-defined Kokkos root: ${Kokkos_ROOT}")
+    find_package(Kokkos REQUIRED PATHS ${Kokkos_ROOT} NO_DEFAULT_PATH)
+    return()
+endif()
+
 message(STATUS "Configuring Kokkos library...")
 
 # Prepend the CMAKE_MESSAGE_INDENT variable to ensure proper indentation in messages

--- a/cmake/kokkos.cmake
+++ b/cmake/kokkos.cmake
@@ -27,26 +27,33 @@ if (CMAKE_VERSION VERSION_GREATER "3.30.0")
     endif()
 endif()
 
-set(KOKKOS_VERSION "4.7.00")
-
-# Set common FetchContent parameters
-set(KOKKOS_URL "https://github.com/kokkos/kokkos/archive/refs/tags/${KOKKOS_VERSION}.zip")
-
-# For CMake versions < 3.28, EXCLUDE_FROM_ALL is not supported in FetchContent_Declare
-if (CMAKE_VERSION VERSION_LESS "3.28.0")
-    FetchContent_Declare(kokkos DOWNLOAD_EXTRACT_TIMESTAMP FALSE URL ${KOKKOS_URL})
-
-    FetchContent_GetProperties(kokkos)
-    if(NOT kokkos_POPULATED)
-        FetchContent_Populate(kokkos)
-        add_subdirectory(${kokkos_SOURCE_DIR} ${kokkos_BINARY_DIR} EXCLUDE_FROM_ALL)
-    endif()
-
-# For CMake versions >= 3.28, EXCLUDE_FROM_ALL is supported in FetchContent_Declare
+if (DEFINED KOKKOS_PATH)
+    message(STATUS "Using Kokkos from KOKKOS_PATH: ${KOKKOS_PATH}")
+    add_subdirectory(${KOKKOS_PATH} ${CMAKE_CURRENT_BINARY_DIR}/kokkos EXCLUDE_FROM_ALL)
+    # Pop the indentation for Kokkos messages
 else()
 
-    FetchContent_Declare(kokkos DOWNLOAD_EXTRACT_TIMESTAMP FALSE URL ${KOKKOS_URL} EXCLUDE_FROM_ALL)
-    FetchContent_MakeAvailable(kokkos)
+    set(KOKKOS_VERSION "4.7.00")
+
+    # Set common FetchContent parameters
+    set(KOKKOS_URL "https://github.com/kokkos/kokkos/archive/refs/tags/${KOKKOS_VERSION}.zip")
+
+    # For CMake versions < 3.28, EXCLUDE_FROM_ALL is not supported in FetchContent_Declare
+    if (CMAKE_VERSION VERSION_LESS "3.28.0")
+        FetchContent_Declare(kokkos DOWNLOAD_EXTRACT_TIMESTAMP FALSE URL ${KOKKOS_URL})
+
+        FetchContent_GetProperties(kokkos)
+        if(NOT kokkos_POPULATED)
+            FetchContent_Populate(kokkos)
+            add_subdirectory(${kokkos_SOURCE_DIR} ${kokkos_BINARY_DIR} EXCLUDE_FROM_ALL)
+        endif()
+
+    # For CMake versions >= 3.28, EXCLUDE_FROM_ALL is supported in FetchContent_Declare
+    else()
+
+        FetchContent_Declare(kokkos DOWNLOAD_EXTRACT_TIMESTAMP FALSE URL ${KOKKOS_URL} EXCLUDE_FROM_ALL)
+        FetchContent_MakeAvailable(kokkos)
+    endif()
 endif()
 
 # Pop the indentation for Kokkos messages


### PR DESCRIPTION
## Description

Please describe the changes/features in this pull request.

This PR adds support for using a local installation of Kokkos when building SPECFEM++

## Issue Number

If there is an issue created for these changes, link it here

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
