### PR TITLE
Updated the Jenkins workflow to install in separate directories.

### DIFF
--- a/.jenkins/gnu_compiler_checks.gvy
+++ b/.jenkins/gnu_compiler_checks.gvy
@@ -62,7 +62,12 @@ pipeline{
                                         module load cmake/3.30.8
                                         module load boost/1.85.0
                                         module load ${GNU_COMPILER_MODULE}
-                                        cmake3 -S . -B build_cpu_${GNU_COMPILER_NAME}_${CMAKE_HOST_NAME}_${SIMD_NAME}_${env.BUILD_TAG} -DCMAKE_BUILD_TYPE=Release ${CMAKE_HOST_FLAGS} ${SIMD_FLAGS} -DSPECFEM_BUILD_TESTS=ON -DSPECFEM_BUILD_BENCHMARKS=OFF
+                                        cmake3 -S . -B build_cpu_${GNU_COMPILER_NAME}_${CMAKE_HOST_NAME}_${SIMD_NAME}_${env.BUILD_TAG} \
+                                          -DCMAKE_BUILD_TYPE=Release \
+                                          -D CMAKE_INSTALL_PREFIX=install_cpu_${GNU_COMPILER_NAME}_${CMAKE_HOST_NAME}_${SIMD_NAME}_${env.BUILD_TAG}/bin \
+                                          ${CMAKE_HOST_FLAGS} ${SIMD_FLAGS} \
+                                          -D SPECFEM_BUILD_TESTS=ON \
+                                          -D SPECFEM_BUILD_BENCHMARKS=OFF
                                         cmake3 --build build_cpu_${GNU_COMPILER_NAME}_${CMAKE_HOST_NAME}_${SIMD_NAME}_${env.BUILD_TAG}
                                     """
                                     echo ' Build completed '
@@ -87,6 +92,7 @@ pipeline{
                             always {
                                 echo ' Cleaning '
                                 sh "rm -rf build_cpu_${GNU_COMPILER_NAME}_${CMAKE_HOST_NAME}_${SIMD_NAME}_${env.BUILD_TAG}"
+                                sh "rm -rf install_cpu_${GNU_COMPILER_NAME}_${CMAKE_HOST_NAME}_${SIMD_NAME}_${env.BUILD_TAG}"
                             }
                         }
                     }

--- a/.jenkins/intel_compiler_checks.gvy
+++ b/.jenkins/intel_compiler_checks.gvy
@@ -63,7 +63,13 @@ pipeline{
                                         module load ${INTEL_MODULE}
                                         export CC=icx
                                         export CXX=icpx
-                                        cmake3 -S . -B build_cpu_${INTEL_COMPILER_NAME}_${CMAKE_HOST_NAME}_${SIMD_NAME}_${env.BUILD_TAG} -DCMAKE_BUILD_TYPE=Release ${CMAKE_HOST_FLAGS} ${SIMD_FLAGS} -D SPECFEM_BUILD_TESTS=ON -D SPECFEM_BUILD_BENCHMARKS=OFF
+                                        cmake3 -S . -B build_cpu_${INTEL_COMPILER_NAME}_${CMAKE_HOST_NAME}_${SIMD_NAME}_${env.BUILD_TAG} \
+                                          -DCMAKE_BUILD_TYPE=Release \
+                                          -DCMAKE_INSTALL_PREFIX=install_cpu_${INTEL_COMPILER_NAME}_${CMAKE_HOST_NAME}_${SIMD_NAME}_${env.BUILD_TAG}/bin \
+                                          ${CMAKE_HOST_FLAGS} \
+                                          ${SIMD_FLAGS} \
+                                          -D SPECFEM_BUILD_TESTS=ON \
+                                          -D SPECFEM_BUILD_BENCHMARKS=OFF
                                         cmake3 --build build_cpu_${INTEL_COMPILER_NAME}_${CMAKE_HOST_NAME}_${SIMD_NAME}_${env.BUILD_TAG}
                                     """
                                     echo ' Build completed '
@@ -88,6 +94,7 @@ pipeline{
                             always {
                                 echo ' Cleaning '
                                 sh "rm -rf build_cpu_${INTEL_COMPILER_NAME}_${CMAKE_HOST_NAME}_${SIMD_NAME}_${env.BUILD_TAG}"
+                                sh "rm -rf install_cpu_${INTEL_COMPILER_NAME}_${CMAKE_HOST_NAME}_${SIMD_NAME}_${env.BUILD_TAG}"
                             }
                         }
                     }

--- a/.jenkins/nvidia_compiler_checks.gvy
+++ b/.jenkins/nvidia_compiler_checks.gvy
@@ -77,7 +77,14 @@ pipeline{
                                         module load cmake/3.30.8
                                         module load boost/1.85.0
                                         module load ${CUDA_MODULE}
-                                        cmake3 -S . -B build_cuda_${CUDA_COMPILER_NAME}_${CMAKE_HOST_NAME}_${CMAKE_DEVICE_NAME}_${SIMD_NAME}_${env.BUILD_TAG} -DCMAKE_BUILD_TYPE=Release ${CMAKE_HOST_FLAGS} ${CMAKE_DEVICE_FLAGS} ${SIMD_FLAGS} -D SPECFEM_BUILD_TESTS=ON -D SPECFEM_BUILD_BENCHMARKS=OFF
+                                        cmake3 -S . -B build_cuda_${CUDA_COMPILER_NAME}_${CMAKE_HOST_NAME}_${CMAKE_DEVICE_NAME}_${SIMD_NAME}_${env.BUILD_TAG} \
+                                          -DCMAKE_BUILD_TYPE=Release \
+                                          -DCMAKE_INSTALL_PREFIX=install_cuda_${CUDA_COMPILER_NAME}_${CMAKE_HOST_NAME}_${CMAKE_DEVICE_NAME}_${SIMD_NAME}_${env.BUILD_TAG}/bin \
+                                          ${CMAKE_HOST_FLAGS} \
+                                          ${CMAKE_DEVICE_FLAGS} \
+                                          ${SIMD_FLAGS} \
+                                          -D SPECFEM_BUILD_TESTS=ON \
+                                          -D SPECFEM_BUILD_BENCHMARKS=OFF
                                         cmake3 --build build_cuda_${CUDA_COMPILER_NAME}_${CMAKE_HOST_NAME}_${CMAKE_DEVICE_NAME}_${SIMD_NAME}_${env.BUILD_TAG}
                                     """
                                     echo ' Build completed '
@@ -102,6 +109,7 @@ pipeline{
                             always {
                                 echo ' Cleaning '
                                 sh "rm -rf build_cuda_${CUDA_COMPILER_NAME}_${CMAKE_HOST_NAME}_${CMAKE_DEVICE_NAME}_${SIMD_NAME}_${env.BUILD_TAG}"
+                                sh "rm -rf install_cuda_${CUDA_COMPILER_NAME}_${CMAKE_HOST_NAME}_${CMAKE_DEVICE_NAME}_${SIMD_NAME}_${env.BUILD_TAG}"
                             }
                         }
                     }


### PR DESCRIPTION
## Description

There seems to be a bug that is triggered at installation of the executables. The only explanation I have is that all pipeline installations happen in the same directory.

This PR fixes that by setting specific `CMAKE_INSTALL_PREFIX` and removing it afterwards as part of the clean post build.

Alternative is not installing at all, but the process should at least be tested.

## Issue Number

-/-

## Checklist

Please make sure to check developer documentation on specfem docs.

- [x] I ran the code through pre-commit to check style
- [x] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [x] I have added labels to the PR (see right hand side of the PR page)
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
