### PR TITLE
Specfem Core Framework Mpi Ref

### DIFF
--- a/core/specfem.cpp
+++ b/core/specfem.cpp
@@ -88,7 +88,6 @@ int main(int argc, char **argv) {
   try {
     // Initialize context with RAII guard
     specfem::ContextGuard guard(argc, argv);
-    auto &context = guard.get_context();
 
     // Extract parameters (dimension is already extracted as positional
     // argument)

--- a/core/specfem/assembly/receivers/dim2/receivers.cpp
+++ b/core/specfem/assembly/receivers/dim2/receivers.cpp
@@ -73,6 +73,7 @@ specfem::assembly::receivers<specfem::dimension::type::dim2>::receivers(
         specfem::point::global_coordinates<specfem::dimension::type::dim2>{
           receiver->get_x(), receiver->get_z()
         };
+
     const auto lcoord = specfem::algorithms::locate_point(gcoord, mesh);
 
     h_elements(ireceiver) = lcoord.ispec;

--- a/core/specfem/periodic_tasks/plot_wavefield.cpp
+++ b/core/specfem/periodic_tasks/plot_wavefield.cpp
@@ -57,12 +57,12 @@ specfem::periodic_tasks::plot_wavefield::plot_wavefield(
     const specfem::wavefield::type &wavefield_type,
     const specfem::wavefield::simulation_field &wavefield, const type_real &dt,
     const int &time_interval, const boost::filesystem::path &output_folder,
-    specfem::MPI::MPI *mpi)
+    std::weak_ptr<specfem::MPI::MPI> mpi)
     : assembly(assembly), wavefield(wavefield), wavefield_type(wavefield_type),
       plotter(time_interval), output_format(output_format),
       output_folder(output_folder), nspec(assembly.mesh.nspec), dt(dt),
       ngllx(assembly.mesh.element_grid.ngllx),
-      ngllz(assembly.mesh.element_grid.ngllz), mpi(mpi) {
+      ngllz(assembly.mesh.element_grid.ngllz), mpi_(mpi) {
   std::ostringstream message;
   message
       << "Display section is not enabled, since SPECFEM++ was built without "
@@ -111,12 +111,12 @@ specfem::periodic_tasks::plot_wavefield::plot_wavefield(
     const specfem::wavefield::type &wavefield_type,
     const specfem::wavefield::simulation_field &wavefield, const type_real &dt,
     const int &time_interval, const boost::filesystem::path &output_folder,
-    specfem::MPI::MPI *mpi)
+    std::weak_ptr<specfem::MPI::MPI> mpi)
     : assembly(assembly), wavefield(wavefield), wavefield_type(wavefield_type),
       plotter(time_interval), output_format(output_format),
       output_folder(output_folder), nspec(assembly.mesh.nspec), dt(dt),
       ngllx(assembly.mesh.element_grid.ngllx),
-      ngllz(assembly.mesh.element_grid.ngllz), mpi(mpi) {};
+      ngllz(assembly.mesh.element_grid.ngllz), mpi_(mpi) {};
 
 // Sigmoid function centered at 0.0
 double specfem::periodic_tasks::plot_wavefield::sigmoid(double x) {
@@ -847,8 +847,12 @@ void specfem::periodic_tasks::plot_wavefield::initialize<
   H5Gclose(vtkhdf_group);
   H5Fclose(hdf5_file_id);
 
-  this->mpi->cout("Initialized VTK HDF5 file for wavefield output: " +
-                  this->hdf5_filename + " (extensible datasets)");
+  if (auto mpi = this->mpi_.lock()) {
+    mpi->cout("Initialized VTK HDF5 file for wavefield output: " +
+              this->hdf5_filename + " (extensible datasets)");
+  } else {
+    throw std::runtime_error("MPI pointer expired. Cannot plot wavefield.");
+  }
 
 #else
   throw std::runtime_error(
@@ -1053,7 +1057,11 @@ void specfem::periodic_tasks::plot_wavefield::run<
   writer->SetInputConnection(image_filter->GetOutputPort());
   writer->Write();
   std::string message = "Wrote wavefield image to " + filename.string();
-  this->mpi->cout(message);
+  if (auto mpi = this->mpi_.lock()) {
+    mpi->cout(message);
+  } else {
+    throw std::runtime_error("MPI pointer expired. Cannot export PNG.");
+  }
 }
 
 template <>
@@ -1073,7 +1081,11 @@ void specfem::periodic_tasks::plot_wavefield::run<
   writer->SetInputConnection(image_filter->GetOutputPort());
   writer->Write();
   std::string message = "Wrote wavefield image to " + filename.string();
-  this->mpi->cout(message);
+  if (auto mpi = this->mpi_.lock()) {
+    mpi->cout(message);
+  } else {
+    throw std::runtime_error("MPI pointer expired. Cannot export JPG.");
+  }
 }
 
 template <>
@@ -1290,9 +1302,14 @@ void specfem::periodic_tasks::plot_wavefield::run<
 
   this->current_timestep++;
 
-  this->mpi->cout("Wrote wavefield data for timestep " + std::to_string(istep) +
-                  " to HDF5 file (step " +
-                  std::to_string(this->current_timestep) + ")");
+  if (auto mpi = this->mpi_.lock()) {
+    mpi->cout("Wrote wavefield data for timestep " + std::to_string(istep) +
+              " to HDF5 file (step " + std::to_string(this->current_timestep) +
+              ")");
+  } else {
+    throw std::runtime_error(
+        "MPI pointer expired. Cannot write wavefield to HDF5.");
+  }
 
 #else
   throw std::runtime_error(

--- a/core/specfem/periodic_tasks/plot_wavefield.hpp
+++ b/core/specfem/periodic_tasks/plot_wavefield.hpp
@@ -55,7 +55,8 @@ public:
       const specfem::wavefield::type &wavefield_type,
       const specfem::wavefield::simulation_field &wavefield,
       const type_real &dt, const int &time_interval,
-      const boost::filesystem::path &output_folder, specfem::MPI::MPI *mpi);
+      const boost::filesystem::path &output_folder,
+      std::weak_ptr<specfem::MPI::MPI> mpi);
 
   /**
    * @brief Updates the wavefield within open window
@@ -98,8 +99,8 @@ public:
   int ngllx; ///< Number of GLL points in x direction per element
   int ngllz; ///< Number of GLL points in z direction per element
 
-  // MPI object
-  specfem::MPI::MPI *mpi;
+  // MPI object (weak_ptr for safe non-owning access)
+  std::weak_ptr<specfem::MPI::MPI> mpi_;
 
   type_real dt; ///< Time step
 

--- a/core/specfem/simulation.hpp
+++ b/core/specfem/simulation.hpp
@@ -25,14 +25,14 @@ namespace specfem::simulation {
  * @brief Execute SPECFEM simulation with runtime dimension selection
  *
  * @param dimension Dimension string ("2d" or "3d")
- * @param mpi MPI instance pointer
+ * @param mpi MPI instance weak pointer for safe non-owning access
  * @param parameter_dict YAML parameter configuration
  * @param default_dict YAML default configuration
  * @param tasks Vector of periodic tasks
  * @return true if execution successful, false otherwise
  */
 bool execute(
-    const std::string &dimension, specfem::MPI::MPI *mpi,
+    const std::string &dimension, std::weak_ptr<specfem::MPI::MPI> mpi,
     const YAML::Node &parameter_dict, const YAML::Node &default_dict,
     std::vector<std::shared_ptr<specfem::periodic_tasks::periodic_task> >
         &tasks);

--- a/core/specfem/simulation/CMakeLists.txt
+++ b/core/specfem/simulation/CMakeLists.txt
@@ -9,6 +9,7 @@ target_link_libraries(specfem_simulation
     PUBLIC
         yaml-cpp::yaml-cpp
         ${BOOST_LIBS}
+        Kokkos::kokkos
         specfem_mpi
         Kokkos::kokkos
         mesh

--- a/core/specfem/simulation/context.cpp
+++ b/core/specfem/simulation/context.cpp
@@ -7,11 +7,11 @@ namespace specfem {
 
 Context::Context(int argc, char *argv[])
     : kokkos_guard_(argc, argv),
-      mpi_(std::make_unique<specfem::MPI::MPI>(&argc, &argv)) {}
+      mpi_(std::make_shared<specfem::MPI::MPI>(&argc, &argv)) {}
 
 Context::~Context() = default;
 
-specfem::MPI::MPI *Context::get_mpi() const { return mpi_.get(); }
+std::weak_ptr<specfem::MPI::MPI> Context::get_mpi() const { return mpi_; }
 
 // ============================================================================
 // ContextGuard Implementation
@@ -39,7 +39,9 @@ ContextGuard::~ContextGuard() = default;
 
 Context &ContextGuard::get_context() { return *context_; }
 
-specfem::MPI::MPI *ContextGuard::get_mpi() const { return context_->get_mpi(); }
+std::weak_ptr<specfem::MPI::MPI> ContextGuard::get_mpi() const {
+  return context_->get_mpi();
+}
 
 void ContextGuard::setup_argc_argv(const std::vector<std::string> &args,
                                    int &argc, char **&argv) {

--- a/core/specfem/simulation/context.hpp
+++ b/core/specfem/simulation/context.hpp
@@ -32,9 +32,9 @@ public:
   /**
    * @brief Get MPI instance
    *
-   * @return Pointer to MPI instance
+   * @return Weak pointer to MPI instance for safe non-owning access
    */
-  specfem::MPI::MPI *get_mpi() const;
+  std::weak_ptr<specfem::MPI::MPI> get_mpi() const;
 
   /**
    * @brief Destructor - ensures proper cleanup via RAII
@@ -49,7 +49,7 @@ public:
 
 private:
   Kokkos::ScopeGuard kokkos_guard_;
-  std::unique_ptr<specfem::MPI::MPI> mpi_;
+  std::shared_ptr<specfem::MPI::MPI> mpi_;
 };
 
 /**
@@ -103,9 +103,9 @@ public:
   /**
    * @brief Get MPI instance for convenience
    *
-   * @return Pointer to MPI instance
+   * @return Weak pointer to MPI instance for safe non-owning access
    */
-  specfem::MPI::MPI *get_mpi() const;
+  std::weak_ptr<specfem::MPI::MPI> get_mpi() const;
 
   /**
    * @brief Delete copy constructor and assignment operator

--- a/core/specfem/simulation/simulation.cpp
+++ b/core/specfem/simulation/simulation.cpp
@@ -47,7 +47,7 @@ print_end_message(std::chrono::time_point<std::chrono::system_clock> start_time,
 void simulation_2d(
     const YAML::Node &parameter_dict, const YAML::Node &default_dict,
     std::vector<std::shared_ptr<specfem::periodic_tasks::periodic_task> > tasks,
-    specfem::MPI::MPI *mpi) {
+    const std::shared_ptr<specfem::MPI::MPI> &mpi) {
 
   // --------------------------------------------------------------
   //                    Read parameter file
@@ -66,7 +66,7 @@ void simulation_2d(
   const auto quadrature = setup.instantiate_quadrature();
   const auto mesh = specfem::io::read_2d_mesh(
       database_filename, setup.get_elastic_wave_type(),
-      setup.get_electromagnetic_wave_type(), mpi);
+      setup.get_electromagnetic_wave_type(), *mpi);
   // --------------------------------------------------------------
 
   // --------------------------------------------------------------
@@ -253,7 +253,7 @@ void simulation_2d(
 void simulation_3d(
     const YAML::Node &parameter_dict, const YAML::Node &default_dict,
     std::vector<std::shared_ptr<specfem::periodic_tasks::periodic_task> > tasks,
-    specfem::MPI::MPI *mpi) {
+    const std::shared_ptr<specfem::MPI::MPI> &mpi) {
 
   // --------------------------------------------------------------
   //                    Read parameter file
@@ -277,7 +277,7 @@ void simulation_3d(
   mpi->cout("===================");
   const auto quadrature = setup.instantiate_quadrature();
   const auto mesh = specfem::io::read_3d_mesh(mesh_parameters_filename,
-                                              database_filename, mpi);
+                                              database_filename, *mpi);
   std::chrono::duration<double> elapsed_seconds =
       std::chrono::system_clock::now() - start_time;
   mpi->cout("Time to read mesh: " + std::to_string(elapsed_seconds.count()) +
@@ -369,11 +369,18 @@ void simulation_3d(
 } // anonymous namespace
 
 bool specfem::simulation::execute(
-    const std::string &dimension, specfem::MPI::MPI *mpi,
+    const std::string &dimension, std::weak_ptr<specfem::MPI::MPI> mpi_weak,
     const YAML::Node &parameter_dict, const YAML::Node &default_dict,
     std::vector<std::shared_ptr<specfem::periodic_tasks::periodic_task> >
         &tasks) {
   try {
+    // Lock the weak_ptr to get a shared_ptr
+    auto mpi = mpi_weak.lock();
+    if (!mpi) {
+      std::cerr << "Error: MPI object is no longer valid" << std::endl;
+      return false;
+    }
+
     // Use simulation model enumeration for validation
     specfem::simulation::model simulation_model =
         specfem::simulation::from_string(dimension);

--- a/include/io/interface.hpp
+++ b/include/io/interface.hpp
@@ -24,7 +24,7 @@ specfem::mesh::mesh<specfem::dimension::type::dim2>
 read_2d_mesh(const std::string &filename,
              const specfem::enums::elastic_wave wave,
              const specfem::enums::electromagnetic_wave electromagnetic_wave,
-             const specfem::MPI::MPI *mpi);
+             const specfem::MPI::MPI &mpi);
 
 /**
  * @brief Construct a 3D mesh object from a Fortran binary database file
@@ -39,7 +39,7 @@ read_2d_mesh(const std::string &filename,
 specfem::mesh::mesh<specfem::dimension::type::dim3>
 read_3d_mesh(const std::string &mesh_parameters_file,
              const std::string &mesh_databases_file,
-             const specfem::MPI::MPI *mpi);
+             const specfem::MPI::MPI &mpi);
 
 namespace meshfem3d {
 /**
@@ -56,7 +56,7 @@ namespace meshfem3d {
  * @endcode
  */
 specfem::mesh::meshfem3d::mesh<specfem::dimension::type::dim3>
-read_3d_mesh(const std::string &database_file, const specfem::MPI::MPI *mpi);
+read_3d_mesh(const std::string &database_file, const specfem::MPI::MPI &mpi);
 } // namespace meshfem3d
 
 // namespace meshfem3d {

--- a/include/io/mesh/impl/fortran/dim2/read_boundaries.hpp
+++ b/include/io/mesh/impl/fortran/dim2/read_boundaries.hpp
@@ -66,7 +66,7 @@ specfem::mesh::boundaries<specfem::dimension::type::dim2>
 read_boundaries(std::ifstream &stream, const int nspec, const int n_absorbing,
                 const int n_acoustic_surface, const int n_acforcing,
                 const Kokkos::View<int **, Kokkos::HostSpace> knods,
-                const specfem::MPI::MPI *mpi);
+                const specfem::MPI::MPI &mpi);
 
 } // namespace dim2
 } // namespace fortran

--- a/include/io/mesh/impl/fortran/dim2/read_elements.hpp
+++ b/include/io/mesh/impl/fortran/dim2/read_elements.hpp
@@ -35,7 +35,7 @@ read_tangential_elements(std::ifstream &stream,
  */
 specfem::mesh::elements::axial_elements<specfem::dimension::type::dim2>
 read_axial_elements(std::ifstream &stream, const int nelem_on_the_axis,
-                    const int nspec, const specfem::MPI::MPI *mpi);
+                    const int nspec, const specfem::MPI::MPI &mpi);
 
 } // namespace dim2
 } // namespace fortran

--- a/include/io/mesh/impl/fortran/dim2/read_interfaces.hpp
+++ b/include/io/mesh/impl/fortran/dim2/read_interfaces.hpp
@@ -17,7 +17,7 @@ specfem::mesh::interface_container<DimensionTag, medium1, medium2>
 read_interfaces(
     const int num_interfaces,
     Kokkos::View<int **, Kokkos::LayoutRight, Kokkos::HostSpace> knods,
-    std::ifstream &stream, const specfem::MPI::MPI *mpi);
+    std::ifstream &stream, const specfem::MPI::MPI &mpi);
 
 /* @brief Read the coupled interfaces from the database file
  *
@@ -34,7 +34,7 @@ read_coupled_interfaces(
     const int num_interfaces_acoustic_poroelastic,
     const int num_interfaces_elastic_poroelastic,
     Kokkos::View<int **, Kokkos::LayoutRight, Kokkos::HostSpace> knods,
-    const specfem::MPI::MPI *mpi);
+    const specfem::MPI::MPI &mpi);
 
 } // namespace dim2
 } // namespace fortran

--- a/include/io/mesh/impl/fortran/dim2/read_material_properties.hpp
+++ b/include/io/mesh/impl/fortran/dim2/read_material_properties.hpp
@@ -31,7 +31,7 @@ read_material_properties(
     std::ifstream &stream, const int numat, const int nspec,
     const specfem::enums::elastic_wave wave,
     const specfem::enums::electromagnetic_wave electromagnetic_wave,
-    const specfem::kokkos::HostView2d<int> knods, const specfem::MPI::MPI *mpi);
+    const specfem::kokkos::HostView2d<int> knods, const specfem::MPI::MPI &mpi);
 
 } // namespace dim2
 } // namespace fortran

--- a/include/io/mesh/impl/fortran/dim2/read_mesh_database.hpp
+++ b/include/io/mesh/impl/fortran/dim2/read_mesh_database.hpp
@@ -26,7 +26,7 @@ namespace dim2 {
  * database file
  */
 std::tuple<int, int, int>
-read_mesh_database_header(std::ifstream &stream, const specfem::MPI::MPI *mpi);
+read_mesh_database_header(std::ifstream &stream, const specfem::MPI::MPI &mpi);
 /**
  * @brief Read coorg elements from fortran binary database file
  *
@@ -38,7 +38,7 @@ read_mesh_database_header(std::ifstream &stream, const specfem::MPI::MPI *mpi);
  */
 specfem::kokkos::HostView2d<type_real>
 read_coorg_elements(std::ifstream &stream, const int npgeo,
-                    const specfem::MPI::MPI *mpi);
+                    const specfem::MPI::MPI &mpi);
 
 /**
  * @warning These two routines need to be implemented
@@ -46,7 +46,7 @@ read_coorg_elements(std::ifstream &stream, const int npgeo,
 
 std::tuple<int, type_real, bool>
 read_mesh_database_attenuation(std::ifstream &stream,
-                               const specfem::MPI::MPI *mpi);
+                               const specfem::MPI::MPI &mpi);
 
 } // namespace dim2
 } // namespace fortran

--- a/include/io/mesh/impl/fortran/dim2/read_parameters.hpp
+++ b/include/io/mesh/impl/fortran/dim2/read_parameters.hpp
@@ -19,7 +19,7 @@ namespace dim2 {
  * parameters
  */
 specfem::mesh::parameters<specfem::dimension::type::dim2>
-read_mesh_parameters(std::ifstream &stream, const specfem::MPI::MPI *mpi);
+read_mesh_parameters(std::ifstream &stream, const specfem::MPI::MPI &mpi);
 
 } // namespace dim2
 } // namespace fortran

--- a/include/io/mesh/impl/fortran/dim3/generate_database/interface.hpp
+++ b/include/io/mesh/impl/fortran/dim3/generate_database/interface.hpp
@@ -20,30 +20,7 @@ namespace dim3 {
  * parameters
  */
 specfem::mesh::parameters<specfem::dimension::type::dim3>
-read_mesh_parameters(std::ifstream &stream, const specfem::MPI::MPI *mpi);
-
-/**
- * @brief Read mapping from 3D mesh database
- *
- * @param stream Input stream
- * @param mapping Mapping object
- * @param mpi MPI object
- */
-void read_ibool(std::ifstream &stream,
-                specfem::mesh::mapping<specfem::dimension::type::dim3> &mapping,
-                const specfem::MPI::MPI *mpi);
-
-/**
- * @brief Read element types from 3D mesh database
- *
- * @param stream Input stream
- * @param element_types Element types object
- * @param mpi MPI object
- */
-void read_element_types(
-    std::ifstream &stream,
-    specfem::mesh::element_types<specfem::dimension::type::dim3> &element_types,
-    const specfem::MPI::MPI *mpi);
+read_mesh_parameters(std::ifstream &stream, const specfem::MPI::MPI &mpi);
 
 /**
  * @brief Read coordinates from 3D mesh database
@@ -55,7 +32,7 @@ void read_element_types(
 void read_xyz(
     std::ifstream &stream,
     specfem::mesh::coordinates<specfem::dimension::type::dim3> &coordinates,
-    const specfem::MPI::MPI *mpi);
+    const specfem::MPI::MPI &mpi);
 
 /**
  * @brief Read Jacobian from 3D mesh database
@@ -68,7 +45,7 @@ void read_jacobian_matrix(
     std::ifstream &stream,
     specfem::mesh::jacobian_matrix<specfem::dimension::type::dim3>
         &jacobian_matrix,
-    const specfem::MPI::MPI *mpi);
+    const specfem::MPI::MPI &mpi);
 
 /**
  * @brief Read array from 3D mesh database

--- a/include/io/mesh/impl/fortran/dim3/meshfem3d/read_adjacency_graph.hpp
+++ b/include/io/mesh/impl/fortran/dim3/meshfem3d/read_adjacency_graph.hpp
@@ -9,6 +9,6 @@ namespace specfem::io::mesh::impl::fortran::dim3::meshfem3d {
 
 specfem::mesh::meshfem3d::adjacency_graph<specfem::dimension::type::dim3>
 read_adjacency_graph(std::ifstream &stream, const int nspec,
-                     const specfem::MPI::MPI *mpi);
+                     const specfem::MPI::MPI &mpi);
 
 } // namespace specfem::io::mesh::impl::fortran::dim3::meshfem3d

--- a/include/io/mesh/impl/fortran/dim3/meshfem3d/read_boundaries.hpp
+++ b/include/io/mesh/impl/fortran/dim3/meshfem3d/read_boundaries.hpp
@@ -30,6 +30,6 @@ read_boundaries(
     std::ifstream &stream, const int nspec,
     const specfem::mesh::meshfem3d::ControlNodes<specfem::dimension::type::dim3>
         &control_nodes,
-    const specfem::MPI::MPI *mpi);
+    const specfem::MPI::MPI &mpi);
 
 } // namespace specfem::io::mesh::impl::fortran::dim3::meshfem3d

--- a/include/io/mesh/impl/fortran/dim3/meshfem3d/read_control_nodes.hpp
+++ b/include/io/mesh/impl/fortran/dim3/meshfem3d/read_control_nodes.hpp
@@ -20,6 +20,6 @@ namespace specfem::io::mesh::impl::fortran::dim3::meshfem3d {
  * @throws std::runtime_error if file reading fails
  */
 specfem::mesh::meshfem3d::ControlNodes<specfem::dimension::type::dim3>
-read_control_nodes(std::ifstream &stream, const specfem::MPI::MPI *mpi);
+read_control_nodes(std::ifstream &stream, const specfem::MPI::MPI &mpi);
 
 } // namespace specfem::io::mesh::impl::fortran::dim3::meshfem3d

--- a/include/io/mesh/impl/fortran/dim3/meshfem3d/read_materials.hpp
+++ b/include/io/mesh/impl/fortran/dim3/meshfem3d/read_materials.hpp
@@ -33,6 +33,6 @@ namespace specfem::io::mesh::impl::fortran::dim3::meshfem3d {
 std::tuple<int, Kokkos::View<int **, Kokkos::LayoutLeft, Kokkos::HostSpace>,
            specfem::mesh::meshfem3d::Materials<specfem::dimension::type::dim3> >
 read_materials(std::ifstream &stream, const int ngnod,
-               const specfem::MPI::MPI *mpi);
+               const specfem::MPI::MPI &mpi);
 
 } // namespace specfem::io::mesh::impl::fortran::dim3::meshfem3d

--- a/include/io/mesh/impl/fortran/dim3/meshfem3d/read_mpi_interfaces.hpp
+++ b/include/io/mesh/impl/fortran/dim3/meshfem3d/read_mpi_interfaces.hpp
@@ -48,6 +48,6 @@ namespace specfem::io::mesh::impl::fortran::dim3::meshfem3d {
  * @see specfem::io::mesh::impl::fortran::dim3::mesh
  * @todo Implement full MPI interface processing for parallel 3D simulations
  */
-void read_mpi_interfaces(std::ifstream &stream, const specfem::MPI::MPI *mpi);
+void read_mpi_interfaces(std::ifstream &stream, const specfem::MPI::MPI &mpi);
 
 } // namespace specfem::io::mesh::impl::fortran::dim3::meshfem3d

--- a/include/io/mesh/impl/fortran/dim3/meshfem3d/read_pml_boundaries.hpp
+++ b/include/io/mesh/impl/fortran/dim3/meshfem3d/read_pml_boundaries.hpp
@@ -51,6 +51,6 @@ namespace specfem::io::mesh::impl::fortran::dim3::meshfem3d {
  * @todo Implement full PML boundary processing for 3D absorbing boundary
  * conditions
  */
-void read_pml_boundaries(std::ifstream &stream, const specfem::MPI::MPI *mpi);
+void read_pml_boundaries(std::ifstream &stream, const specfem::MPI::MPI &mpi);
 
 } // namespace specfem::io::mesh::impl::fortran::dim3::meshfem3d

--- a/include/mesh/dim2/boundaries/forcing_boundaries.hpp
+++ b/include/mesh/dim2/boundaries/forcing_boundaries.hpp
@@ -131,7 +131,7 @@ template <> struct forcing_boundary<specfem::dimension::type::dim2> {
    * @param mpi Pointer to MPI object
    */
   forcing_boundary(std::ifstream &stream, const int nelement_acforcing,
-                   const int nspec, const specfem::MPI::MPI *mpi);
+                   const int nspec, const specfem::MPI::MPI &mpi);
 };
 
 } // namespace mesh

--- a/include/mesh/dim2/elements/axial_elements.hpp
+++ b/include/mesh/dim2/elements/axial_elements.hpp
@@ -25,7 +25,7 @@ template <> struct axial_elements<specfem::dimension::type::dim2> {
   axial_elements() {};
   axial_elements(const int nspec);
   axial_elements(std::ifstream &stream, const int nelem_on_the_axis,
-                 const int nspec, const specfem::MPI::MPI *mpi);
+                 const int nspec, const specfem::MPI::MPI &mpi);
 };
 } // namespace elements
 } // namespace mesh

--- a/include/mesh/dim2/mpi_interfaces/mpi_interfaces.hpp
+++ b/include/mesh/dim2/mpi_interfaces/mpi_interfaces.hpp
@@ -16,7 +16,7 @@ struct interface {
   specfem::kokkos::HostView3d<int> my_interfaces;
   interface() {};
   interface(const int ninterfaces, const int max_interface_size);
-  interface(std::ifstream &stream, const specfem::MPI::MPI *mpi);
+  interface(std::ifstream &stream, const specfem::MPI::MPI &mpi);
   ~interface() = default;
 };
 } // namespace interfaces

--- a/include/parameter_parser/setup.hpp
+++ b/include/parameter_parser/setup.hpp
@@ -221,7 +221,7 @@ public:
   instantiate_wavefield_plotter(
       const specfem::assembly::assembly<specfem::dimension::type::dim2>
           &assembly,
-      const type_real &dt, specfem::MPI::MPI *mpi) const {
+      const type_real &dt, std::weak_ptr<specfem::MPI::MPI> mpi) const {
     if (this->plot_wavefield) {
       return this->plot_wavefield->instantiate_wavefield_plotter(assembly, dt,
                                                                  mpi);

--- a/include/parameter_parser/writer/plot_wavefield.hpp
+++ b/include/parameter_parser/writer/plot_wavefield.hpp
@@ -55,7 +55,7 @@ public:
   instantiate_wavefield_plotter(
       const specfem::assembly::assembly<specfem::dimension::type::dim2>
           &assembly,
-      const type_real &dt, specfem::MPI::MPI *mpi) const;
+      const type_real &dt, std::weak_ptr<specfem::MPI::MPI> mpi) const;
 
 private:
   std::string output_format;  ///< format of output file

--- a/src/io/mesh/impl/fortran/dim2/mesh.cpp
+++ b/src/io/mesh/impl/fortran/dim2/mesh.cpp
@@ -28,7 +28,7 @@ specfem::mesh::mesh<specfem::dimension::type::dim2> specfem::io::read_2d_mesh(
     const std::string &filename,
     const specfem::enums::elastic_wave elastic_wave,
     const specfem::enums::electromagnetic_wave electromagnetic_wave,
-    const specfem::MPI::MPI *mpi) {
+    const specfem::MPI::MPI &mpi) {
 
   // Declaring empty mesh objects
   specfem::mesh::mesh<specfem::dimension::type::dim2> mesh;
@@ -75,11 +75,11 @@ specfem::mesh::mesh<specfem::dimension::type::dim2> specfem::io::read_2d_mesh(
   mesh.control_nodes.knods = specfem::kokkos::HostView2d<int>(
       "specfem::mesh::knods", mesh.parameters.ngnod, mesh.nspec);
 
-  int nspec_all = mpi->reduce(mesh.parameters.nspec, specfem::MPI::sum);
+  int nspec_all = mpi.reduce(mesh.parameters.nspec, specfem::MPI::sum);
   int nelem_acforcing_all =
-      mpi->reduce(mesh.parameters.nelem_acforcing, specfem::MPI::sum);
+      mpi.reduce(mesh.parameters.nelem_acforcing, specfem::MPI::sum);
   int nelem_acoustic_surface_all =
-      mpi->reduce(mesh.parameters.nelem_acoustic_surface, specfem::MPI::sum);
+      mpi.reduce(mesh.parameters.nelem_acoustic_surface, specfem::MPI::sum);
 
   try {
     auto [n_sls, attenuation_f0_reference, read_velocities_at_f0] =
@@ -157,11 +157,11 @@ specfem::mesh::mesh<specfem::dimension::type::dim2> specfem::io::read_2d_mesh(
 
   // Print material properties
 
-  mpi->cout("Material systems:\n"
-            "------------------------------");
+  mpi.cout("Material systems:\n"
+           "------------------------------");
 
-  mpi->cout("Number of material systems = " +
-            std::to_string(mesh.materials.n_materials) + "\n\n");
+  mpi.cout("Number of material systems = " +
+           std::to_string(mesh.materials.n_materials) + "\n\n");
 
   FOR_EACH_IN_PRODUCT(
       (DIMENSION_TAG(DIM2),
@@ -172,7 +172,7 @@ specfem::mesh::mesh<specfem::dimension::type::dim2> specfem::io::read_2d_mesh(
         for (const auto material :
              mesh.materials.get_container<_medium_tag_, _property_tag_>()
                  .element_materials) {
-          mpi->cout(material.print());
+          mpi.cout(material.print());
         }
       })
 

--- a/src/io/mesh/impl/fortran/dim2/read_boundaries.cpp
+++ b/src/io/mesh/impl/fortran/dim2/read_boundaries.cpp
@@ -139,7 +139,7 @@ inline void calculate_ib(const specfem::kokkos::HostView2d<bool> code,
 
 specfem::mesh::absorbing_boundary<specfem::dimension::type::dim2>
 read_absorbing_boundaries(std::ifstream &stream, int num_abs_boundary_faces,
-                          const int nspec, const specfem::MPI::MPI *mpi) {
+                          const int nspec, const specfem::MPI::MPI &mpi) {
 
   // Create base instance of the absorbing boundary
   specfem::mesh::absorbing_boundary<specfem::dimension::type::dim2>
@@ -152,7 +152,7 @@ read_absorbing_boundaries(std::ifstream &stream, int num_abs_boundary_faces,
   std::vector<int> iedgeread(8, 0);
   int numabsread, typeabsread;
   if (num_abs_boundary_faces < 0) {
-    mpi->cout("Warning: read in negative nelemabs resetting to 0!");
+    mpi.cout("Warning: read in negative nelemabs resetting to 0!");
     num_abs_boundary_faces = 0;
   }
 
@@ -276,7 +276,7 @@ specfem::mesh::acoustic_free_surface<specfem::dimension::type::dim2>
 read_acoustic_free_surface(std::ifstream &stream,
                            const int &nelem_acoustic_surface,
                            const Kokkos::View<int **, Kokkos::HostSpace> knods,
-                           const specfem::MPI::MPI *mpi) {
+                           const specfem::MPI::MPI &mpi) {
 
   std::vector<int> acfree_edge(4, 0);
   specfem::mesh::acoustic_free_surface<specfem::dimension::type::dim2>
@@ -294,14 +294,14 @@ read_acoustic_free_surface(std::ifstream &stream,
     }
   }
 
-  mpi->sync_all();
+  mpi.sync_all();
 
   return acoustic_free_surface;
 }
 
 specfem::mesh::forcing_boundary<specfem::dimension::type::dim2>
 read_forcing_boundaries(std::ifstream &stream, const int nelement_acforcing,
-                        const int nspec, const specfem::MPI::MPI *mpi) {
+                        const int nspec, const specfem::MPI::MPI &mpi) {
 
   bool codeacread1 = true, codeacread2 = true, codeacread3 = true,
        codeacread4 = true;
@@ -358,7 +358,7 @@ specfem::io::mesh::impl::fortran::dim2::read_boundaries(
     std::ifstream &stream, const int nspec, const int n_absorbing,
     const int n_acoustic_surface, const int n_acforcing,
     const Kokkos::View<int **, Kokkos::HostSpace> knods,
-    const specfem::MPI::MPI *mpi) {
+    const specfem::MPI::MPI &mpi) {
 
   // Read absorbing boundaries
   auto absorbing_boundary =

--- a/src/io/mesh/impl/fortran/dim2/read_elements.cpp
+++ b/src/io/mesh/impl/fortran/dim2/read_elements.cpp
@@ -7,7 +7,7 @@
 specfem::mesh::elements::axial_elements<specfem::dimension::type::dim2>
 specfem::io::mesh::impl::fortran::dim2::read_axial_elements(
     std::ifstream &stream, const int nelem_on_the_axis, const int nspec,
-    const specfem::MPI::MPI *mpi) {
+    const specfem::MPI::MPI &mpi) {
 
   int ispec;
 

--- a/src/io/mesh/impl/fortran/dim2/read_interfaces.cpp
+++ b/src/io/mesh/impl/fortran/dim2/read_interfaces.cpp
@@ -113,7 +113,7 @@ specfem::mesh::interface_container<DimensionTag, medium1, medium2>
 specfem::io::mesh::impl::fortran::dim2::read_interfaces(
     const int num_interfaces,
     Kokkos::View<int **, Kokkos::LayoutRight, Kokkos::HostSpace> knods,
-    std::ifstream &stream, const specfem::MPI::MPI *mpi) {
+    std::ifstream &stream, const specfem::MPI::MPI &mpi) {
 
   specfem::mesh::interface_container<DimensionTag, medium1, medium2> interface(
       num_interfaces);
@@ -148,7 +148,7 @@ specfem::io::mesh::impl::fortran::dim2::read_interfaces<
     specfem::element::medium_tag::acoustic>(
     const int num_interfaces,
     Kokkos::View<int **, Kokkos::LayoutRight, Kokkos::HostSpace> knods,
-    std::ifstream &stream, const specfem::MPI::MPI *mpi);
+    std::ifstream &stream, const specfem::MPI::MPI &mpi);
 
 // acoustic/poroelastic
 template specfem::mesh::interface_container<
@@ -159,7 +159,7 @@ specfem::io::mesh::impl::fortran::dim2::read_interfaces<
     specfem::element::medium_tag::poroelastic>(
     const int num_interfaces,
     Kokkos::View<int **, Kokkos::LayoutRight, Kokkos::HostSpace> knods,
-    std::ifstream &stream, const specfem::MPI::MPI *mpi);
+    std::ifstream &stream, const specfem::MPI::MPI &mpi);
 
 // elastic/poroelastic
 template specfem::mesh::interface_container<
@@ -170,7 +170,7 @@ specfem::io::mesh::impl::fortran::dim2::read_interfaces<
     specfem::element::medium_tag::poroelastic>(
     const int num_interfaces,
     Kokkos::View<int **, Kokkos::LayoutRight, Kokkos::HostSpace> knods,
-    std::ifstream &stream, const specfem::MPI::MPI *mpi);
+    std::ifstream &stream, const specfem::MPI::MPI &mpi);
 
 specfem::mesh::coupled_interfaces<specfem::dimension::type::dim2>
 specfem::io::mesh::impl::fortran::dim2::read_coupled_interfaces(
@@ -178,7 +178,7 @@ specfem::io::mesh::impl::fortran::dim2::read_coupled_interfaces(
     const int num_interfaces_acoustic_poroelastic,
     const int num_interfaces_elastic_poroelastic,
     Kokkos::View<int **, Kokkos::LayoutRight, Kokkos::HostSpace> knods,
-    const specfem::MPI::MPI *mpi) {
+    const specfem::MPI::MPI &mpi) {
 
   auto elastic_acoustic =
       specfem::io::mesh::impl::fortran::dim2::read_interfaces<

--- a/src/io/mesh/impl/fortran/dim2/read_material_properties.cpp
+++ b/src/io/mesh/impl/fortran/dim2/read_material_properties.cpp
@@ -51,7 +51,7 @@ read_materials(
         electromagnetic_te, isotropic> &electromagnetic_te_isotropic,
     specfem::mesh::materials<specfem::dimension::type::dim2>::material<
         elastic_psv_t, isotropic_cosserat> &elastic_psv_t_isotropic_cosserat,
-    const specfem::MPI::MPI *mpi) {
+    const specfem::MPI::MPI &mpi) {
 
   // Define the elastic medium tag based on input elastic wave type
   const specfem::element::medium_tag elastic = [elastic_wave]() {
@@ -91,9 +91,9 @@ read_materials(
   message << "Material systems:\n"
           << "------------------------------";
 
-  mpi->cout(message.str());
+  mpi.cout(message.str());
 
-  if (mpi->get_rank() == 0)
+  if (mpi.get_rank() == 0)
     std::cout << "Number of material systems = " << numat << "\n\n";
 
   // Section for acoustic isotropic
@@ -475,7 +475,7 @@ void read_material_indices(
         specfem::dimension::type::dim2>::material_specification>
         material_index_mapping,
     const specfem::kokkos::HostView2d<int> knods,
-    const specfem::MPI::MPI *mpi) {
+    const specfem::MPI::MPI &mpi) {
 
   const int ngnod = knods.extent(0);
 
@@ -515,7 +515,7 @@ specfem::io::mesh::impl::fortran::dim2::read_material_properties(
     const specfem::enums::elastic_wave elastic_wave,
     const specfem::enums::electromagnetic_wave electromagnetic_wave,
     const specfem::kokkos::HostView2d<int> knods,
-    const specfem::MPI::MPI *mpi) {
+    const specfem::MPI::MPI &mpi) {
 
   // Create materials instances
   specfem::mesh::materials<specfem::dimension::type::dim2> materials(nspec,

--- a/src/io/mesh/impl/fortran/dim2/read_mesh_database.cpp
+++ b/src/io/mesh/impl/fortran/dim2/read_mesh_database.cpp
@@ -10,7 +10,7 @@
 
 std::tuple<int, int, int>
 specfem::io::mesh::impl::fortran::dim2::read_mesh_database_header(
-    std::ifstream &stream, const specfem::MPI::MPI *mpi) {
+    std::ifstream &stream, const specfem::MPI::MPI &mpi) {
   // This subroutine reads header values of the database which are skipped
   std::string dummy_s;
   int dummy_i, dummy_i1, dummy_i2;
@@ -153,14 +153,14 @@ specfem::io::mesh::impl::fortran::dim2::read_mesh_database_header(
       stream, &dummy_b1,
       &dummy_b2); // ADD_RANDOM_PERTURBATION_TO_THE_MESH,ADD_PERTURBATION_AROUND_SOURCE_ONLY
 
-  mpi->sync_all();
+  mpi.sync_all();
 
   return std::make_tuple(nspec, npgeo, nproc);
 }
 
 specfem::kokkos::HostView2d<type_real>
 specfem::io::mesh::impl::fortran::dim2::read_coorg_elements(
-    std::ifstream &stream, const int npgeo, const specfem::MPI::MPI *mpi) {
+    std::ifstream &stream, const int npgeo, const specfem::MPI::MPI &mpi) {
 
   int ipoin = 0;
 
@@ -184,7 +184,7 @@ specfem::io::mesh::impl::fortran::dim2::read_coorg_elements(
 
 std::tuple<int, type_real, bool>
 specfem::io::mesh::impl::fortran::dim2::read_mesh_database_attenuation(
-    std::ifstream &stream, const specfem::MPI::MPI *mpi) {
+    std::ifstream &stream, const specfem::MPI::MPI &mpi) {
 
   int n_sls;
   double attenuation_f0_reference;

--- a/src/io/mesh/impl/fortran/dim2/read_parameters.cpp
+++ b/src/io/mesh/impl/fortran/dim2/read_parameters.cpp
@@ -4,7 +4,7 @@
 
 specfem::mesh::parameters<specfem::dimension::type::dim2>
 specfem::io::mesh::impl::fortran::dim2::read_mesh_parameters(
-    std::ifstream &stream, const specfem::MPI::MPI *mpi) {
+    std::ifstream &stream, const specfem::MPI::MPI &mpi) {
   // ---------------------------------------------------------------------
   // reading mesh properties
 
@@ -41,7 +41,7 @@ specfem::io::mesh::impl::fortran::dim2::read_mesh_parameters(
       &nnodes_tangential_curve, &nelem_on_the_axis);
   // ----------------------------------------------------------------------
 
-  mpi->sync_all();
+  mpi.sync_all();
 
   return { numat,
            ngnod,

--- a/src/io/mesh/impl/fortran/dim3/generate_database/mesh.cpp
+++ b/src/io/mesh/impl/fortran/dim3/generate_database/mesh.cpp
@@ -42,7 +42,7 @@ std::string try_print_medium_element(
 specfem::mesh::mesh<specfem::dimension::type::dim3>
 specfem::io::read_3d_mesh(const std::string &mesh_parameters_file,
                           const std::string &mesh_databases_file,
-                          const specfem::MPI::MPI *mpi) {
+                          const specfem::MPI::MPI &mpi) {
 
   // Creating aliases for Checking functions
   using specfem::io::mesh::impl::fortran::dim3::check_read_test_value;
@@ -82,7 +82,7 @@ specfem::io::read_3d_mesh(const std::string &mesh_parameters_file,
 
 #ifndef NDEBUG
   // Print the parameters
-  mpi->cout(mesh.parameters.print());
+  mpi.cout(mesh.parameters.print());
 #endif
 
   // Open the database file
@@ -117,9 +117,9 @@ specfem::io::read_3d_mesh(const std::string &mesh_parameters_file,
 
 #ifndef NDEBUG
   // Print Mapping parameters and the first spectral element
-  mpi->cout(mesh.mapping.print());
-  mpi->cout(mesh.mapping.print(0));
-  mpi->cout(mesh.mapping.print(mesh.parameters.nspec - 1));
+  mpi.cout(mesh.mapping.print());
+  mpi.cout(mesh.mapping.print(0));
+  mpi.cout(mesh.mapping.print(mesh.parameters.nspec - 1));
 #endif
 
   // Create the coordinates object
@@ -134,15 +134,15 @@ specfem::io::read_3d_mesh(const std::string &mesh_parameters_file,
 
 #ifndef NDEBUG
   // Print Coordinates parameters and the first global node
-  mpi->cout(mesh.coordinates.print());
-  mpi->cout(mesh.coordinates.print(0));
-  mpi->cout(mesh.coordinates.print(mesh.parameters.nglob - 1));
+  mpi.cout(mesh.coordinates.print());
+  mpi.cout(mesh.coordinates.print(0));
+  mpi.cout(mesh.coordinates.print(mesh.parameters.nglob - 1));
 
   // These print the coordinate array layout for the first spectral element
   // for debugging the array layout (Fortran v. C)
-  // mpi->cout(mesh.coordinates.print(0, mesh.mapping, "x"));
-  // mpi->cout(mesh.coordinates.print(0, mesh.mapping, "y"));
-  // mpi->cout(mesh.coordinates.print(0, mesh.mapping, "z"));
+  // mpi.cout(mesh.coordinates.print(0, mesh.mapping, "x"));
+  // mpi.cout(mesh.coordinates.print(0, mesh.mapping, "y"));
+  // mpi.cout(mesh.coordinates.print(0, mesh.mapping, "z"));
 #endif
 
   // Initialize irregular element number array
@@ -169,7 +169,7 @@ specfem::io::read_3d_mesh(const std::string &mesh_parameters_file,
   // Print xix and jacobian
   message << "xix_regular: " << mesh.xix_regular << "\n";
   message << "jacobian_regular: " << mesh.jacobian_regular << "\n";
-  mpi->cout(message.str());
+  mpi.cout(message.str());
 #endif
 
   // Fix for reading a regular mesh with 0 irregular elements
@@ -210,14 +210,14 @@ specfem::io::read_3d_mesh(const std::string &mesh_parameters_file,
 
 #ifndef NDEBUG
   // Print Jacobian matrix parameters and the first spectral element
-  mpi->cout(mesh.jacobian_matrix.print());
-  mpi->cout(mesh.jacobian_matrix.print(0, 0, 0, 0));
+  mpi.cout(mesh.jacobian_matrix.print());
+  mpi.cout(mesh.jacobian_matrix.print(0, 0, 0, 0));
 
   // These print the Jacobian matrix array layout for the first spectral
   // element for debugging the array layout (Fortran v. C)
-  // mpi->cout(mesh.jacobian_matrix.print(0, "xix"));
-  // mpi->cout(mesh.jacobian_matrix.print(0, "etay"));
-  // mpi->cout(mesh.jacobian_matrix.print(0, "gammaz"));
+  // mpi.cout(mesh.jacobian_matrix.print(0, "xix"));
+  // mpi.cout(mesh.jacobian_matrix.print(0, "etay"));
+  // mpi.cout(mesh.jacobian_matrix.print(0, "gammaz"));
 #endif
 
   // Marker that should be 10000
@@ -236,7 +236,7 @@ specfem::io::read_3d_mesh(const std::string &mesh_parameters_file,
 
 #ifndef NDEBUG
   // Print control nodes parameters and the first spectral element
-  mpi->cout(mesh.control_nodes.print());
+  mpi.cout(mesh.control_nodes.print());
 #endif
 
   // Create material object
@@ -251,7 +251,7 @@ specfem::io::read_3d_mesh(const std::string &mesh_parameters_file,
 
 #ifndef NDEBUG
   // Print the materials
-  mpi->cout(mesh.materials.print());
+  mpi.cout(mesh.materials.print());
 #endif
 
   int nacoustic, nelastic, nporoelastic;
@@ -274,15 +274,15 @@ specfem::io::read_3d_mesh(const std::string &mesh_parameters_file,
 
 #ifndef NDEBUG
   // Print the element types
-  mpi->cout(mesh.element_types.print());
-  mpi->cout(mesh.element_types.print(0));
+  mpi.cout(mesh.element_types.print());
+  mpi.cout(mesh.element_types.print(0));
 
   // Print elements first element of each category
-  mpi->cout(try_print_medium_element<specfem::element::medium_tag::acoustic>(
+  mpi.cout(try_print_medium_element<specfem::element::medium_tag::acoustic>(
       mesh.element_types, 0));
-  mpi->cout(try_print_medium_element<specfem::element::medium_tag::elastic>(
+  mpi.cout(try_print_medium_element<specfem::element::medium_tag::elastic>(
       mesh.element_types, 0));
-  mpi->cout(try_print_medium_element<specfem::element::medium_tag::poroelastic>(
+  mpi.cout(try_print_medium_element<specfem::element::medium_tag::poroelastic>(
       mesh.element_types, 0));
 #endif
 
@@ -400,12 +400,12 @@ specfem::io::read_3d_mesh(const std::string &mesh_parameters_file,
     }
 #ifndef NDEBUG
     // Print the absorbing boundaries
-    mpi->cout(mesh.boundaries.absorbing_boundary.print());
+    mpi.cout(mesh.boundaries.absorbing_boundary.print());
 
     // Print the absorbing boundaries for the first face
     // for debugging the array layout (Fortran v. C)
-    // mpi->cout(mesh.boundaries.absorbing_boundary.print_ijk(0));
-    // mpi->cout(mesh.boundaries.absorbing_boundary.print_ijk(num_abs_boundary_faces
+    // mpi.cout(mesh.boundaries.absorbing_boundary.print_ijk(0));
+    // mpi.cout(mesh.boundaries.absorbing_boundary.print_ijk(num_abs_boundary_faces
     // - 1));
 #endif
   }
@@ -433,7 +433,7 @@ specfem::io::read_3d_mesh(const std::string &mesh_parameters_file,
   message << "nspec2D_ymax: " << nspec2D_ymax << "\n";
   message << "nspec2D_bottom: " << nspec2D_bottom << "\n";
   message << "nspec2D_top: " << nspec2D_top << "\n";
-  mpi->cout(message.str());
+  mpi.cout(message.str());
 #endif
 
   // Check values
@@ -473,7 +473,7 @@ specfem::io::read_3d_mesh(const std::string &mesh_parameters_file,
     }
     // Print the absorbing boundaries
 #ifndef NDEBUG
-    mpi->cout(mesh.boundaries.absorbing_boundary.print());
+    mpi.cout(mesh.boundaries.absorbing_boundary.print());
 #endif
   }
 
@@ -500,12 +500,12 @@ specfem::io::read_3d_mesh(const std::string &mesh_parameters_file,
 
 #ifndef NDEBUG
   // Print the free surface
-  mpi->cout(mesh.boundaries.acoustic_free_surface.print());
+  mpi.cout(mesh.boundaries.acoustic_free_surface.print());
 
   // Print the free surface for the first face
   // for debugging the array layout (Fortran v. C)
-  // mpi->cout(mesh.acoustic_free_surface.print_ijk(0));
-  // mpi->cout(mesh.acoustic_free_surface.print_ijk(num_free_surface_faces -
+  // mpi.cout(mesh.acoustic_free_surface.print_ijk(0));
+  // mpi.cout(mesh.acoustic_free_surface.print_ijk(num_free_surface_faces -
   // 1));
 #endif
 
@@ -599,7 +599,7 @@ specfem::io::read_3d_mesh(const std::string &mesh_parameters_file,
 
 #ifndef NDEBUG
   // Print the interfaces
-  mpi->cout(mesh.coupled_interfaces.print());
+  mpi.cout(mesh.coupled_interfaces.print());
 #endif
 
   // Read test value 9997
@@ -632,7 +632,7 @@ specfem::io::read_3d_mesh(const std::string &mesh_parameters_file,
   }
 #ifndef NDEBUG
   else {
-    mpi->cout("No MPI information stored in the binary file.\n");
+    mpi.cout("No MPI information stored in the binary file.\n");
   }
 #endif
 
@@ -839,7 +839,7 @@ specfem::io::read_3d_mesh(const std::string &mesh_parameters_file,
   check_read_test_value(stream, 9989);
 
   // Final print with basic information
-  mpi->cout(mesh.print());
+  mpi.cout(mesh.print());
 
   stream.close();
 

--- a/src/io/mesh/impl/fortran/dim3/generate_database/read_coordinates.cpp
+++ b/src/io/mesh/impl/fortran/dim3/generate_database/read_coordinates.cpp
@@ -4,7 +4,7 @@
 void specfem::io::mesh::impl::fortran::dim3::read_xyz(
     std::ifstream &stream,
     specfem::mesh::coordinates<specfem::dimension::type::dim3> &coordinates,
-    const specfem::MPI::MPI *mpi) {
+    const specfem::MPI::MPI &mpi) {
 
   std::vector<type_real> dummy_f(coordinates.nglob, -9999.0);
 

--- a/src/io/mesh/impl/fortran/dim3/generate_database/read_jacobian_matrix.cpp
+++ b/src/io/mesh/impl/fortran/dim3/generate_database/read_jacobian_matrix.cpp
@@ -14,7 +14,7 @@ void specfem::io::mesh::impl::fortran::dim3::read_jacobian_matrix(
     std::ifstream &stream,
     specfem::mesh::jacobian_matrix<specfem::dimension::type::dim3>
         &jacobian_matrix,
-    const specfem::MPI::MPI *mpi) {
+    const specfem::MPI::MPI &mpi) {
 
   // Read Jacobian matrix
   const int nspec = jacobian_matrix.nspec;

--- a/src/io/mesh/impl/fortran/dim3/generate_database/read_parameters.cpp
+++ b/src/io/mesh/impl/fortran/dim3/generate_database/read_parameters.cpp
@@ -6,7 +6,7 @@
 
 specfem::mesh::parameters<specfem::dimension::type::dim3>
 specfem::io::mesh::impl::fortran::dim3::read_mesh_parameters(
-    std::ifstream &stream, const specfem::MPI::MPI *mpi) {
+    std::ifstream &stream, const specfem::MPI::MPI &mpi) {
 
   // Creating aliases for Array Reading functions
   using specfem::io::mesh::impl::fortran::dim3::check_read_test_value;
@@ -244,7 +244,7 @@ specfem::io::mesh::impl::fortran::dim3::read_mesh_parameters(
   /// Read test parameter
   check_read_test_value(stream, 9992);
 
-  mpi->sync_all();
+  mpi.sync_all();
 
   return parameters;
 }

--- a/src/io/mesh/impl/fortran/dim3/meshfem3d/mesh.cpp
+++ b/src/io/mesh/impl/fortran/dim3/meshfem3d/mesh.cpp
@@ -13,7 +13,7 @@
 
 specfem::mesh::meshfem3d::mesh<specfem::dimension::type::dim3>
 specfem::io::meshfem3d::read_3d_mesh(const std::string &database_file,
-                                     const specfem::MPI::MPI *mpi) {
+                                     const specfem::MPI::MPI &mpi) {
   // Read mesh parameters
   std::ifstream param_stream(database_file, std::ios::in | std::ios::binary);
   if (!param_stream.is_open()) {

--- a/src/io/mesh/impl/fortran/dim3/meshfem3d/read_adjacency_graph.cpp
+++ b/src/io/mesh/impl/fortran/dim3/meshfem3d/read_adjacency_graph.cpp
@@ -4,7 +4,7 @@
 
 specfem::mesh::meshfem3d::adjacency_graph<specfem::dimension::type::dim3>
 specfem::io::mesh::impl::fortran::dim3::meshfem3d::read_adjacency_graph(
-    std::ifstream &stream, const int nspec, const specfem::MPI::MPI *mpi) {
+    std::ifstream &stream, const int nspec, const specfem::MPI::MPI &mpi) {
 
   specfem::mesh::meshfem3d::adjacency_graph<specfem::dimension::type::dim3>
       graph(nspec);

--- a/src/io/mesh/impl/fortran/dim3/meshfem3d/read_boundaries.cpp
+++ b/src/io/mesh/impl/fortran/dim3/meshfem3d/read_boundaries.cpp
@@ -178,7 +178,7 @@ specfem::io::mesh::impl::fortran::dim3::meshfem3d::read_boundaries(
     std::ifstream &stream, const int nspec,
     const specfem::mesh::meshfem3d::ControlNodes<specfem::dimension::type::dim3>
         &control_nodes,
-    const specfem::MPI::MPI *mpi) {
+    const specfem::MPI::MPI &mpi) {
 
   int boundary_number;
   std::array<int, 6> nfaces_per_direction;

--- a/src/io/mesh/impl/fortran/dim3/meshfem3d/read_control_nodes.cpp
+++ b/src/io/mesh/impl/fortran/dim3/meshfem3d/read_control_nodes.cpp
@@ -6,7 +6,7 @@
 
 specfem::mesh::meshfem3d::ControlNodes<specfem::dimension::type::dim3>
 specfem::io::mesh::impl::fortran::dim3::meshfem3d::read_control_nodes(
-    std::ifstream &stream, const specfem::MPI::MPI *mpi) {
+    std::ifstream &stream, const specfem::MPI::MPI &mpi) {
 
   using ControlNodesType =
       specfem::mesh::meshfem3d::ControlNodes<specfem::dimension::type::dim3>;

--- a/src/io/mesh/impl/fortran/dim3/meshfem3d/read_materials.cpp
+++ b/src/io/mesh/impl/fortran/dim3/meshfem3d/read_materials.cpp
@@ -10,7 +10,7 @@
 std::tuple<int, Kokkos::View<int **, Kokkos::LayoutLeft, Kokkos::HostSpace>,
            specfem::mesh::meshfem3d::Materials<specfem::dimension::type::dim3> >
 specfem::io::mesh::impl::fortran::dim3::meshfem3d::read_materials(
-    std::ifstream &stream, const int ngnod, const specfem::MPI::MPI *mpi) {
+    std::ifstream &stream, const int ngnod, const specfem::MPI::MPI &mpi) {
 
   using MaterialsType =
       specfem::mesh::meshfem3d::Materials<specfem::dimension::type::dim3>;

--- a/src/io/mesh/impl/fortran/dim3/meshfem3d/read_mpi_interfaces.cpp
+++ b/src/io/mesh/impl/fortran/dim3/meshfem3d/read_mpi_interfaces.cpp
@@ -4,7 +4,7 @@
 #include <fstream>
 
 void specfem::io::mesh::impl::fortran::dim3::meshfem3d::read_mpi_interfaces(
-    std::ifstream &stream, const specfem::MPI::MPI *mpi) {
+    std::ifstream &stream, const specfem::MPI::MPI &mpi) {
 
   int num_interfaces, max_elements_per_interface;
 

--- a/src/io/mesh/impl/fortran/dim3/meshfem3d/read_pml_boundaries.cpp
+++ b/src/io/mesh/impl/fortran/dim3/meshfem3d/read_pml_boundaries.cpp
@@ -4,7 +4,7 @@
 #include <fstream>
 
 void specfem::io::mesh::impl::fortran::dim3::meshfem3d::read_pml_boundaries(
-    std::ifstream &stream, const specfem::MPI::MPI *mpi) {
+    std::ifstream &stream, const specfem::MPI::MPI &mpi) {
 
   int num_pml_boundaries;
 

--- a/src/parameter_parser/writer/plot_wavefield.cpp
+++ b/src/parameter_parser/writer/plot_wavefield.cpp
@@ -68,7 +68,7 @@ specfem::runtime_configuration::plot_wavefield::plot_wavefield(
 std::shared_ptr<specfem::periodic_tasks::periodic_task>
 specfem::runtime_configuration::plot_wavefield::instantiate_wavefield_plotter(
     const specfem::assembly::assembly<specfem::dimension::type::dim2> &assembly,
-    const type_real &dt, specfem::MPI::MPI *mpi) const {
+    const type_real &dt, std::weak_ptr<specfem::MPI::MPI> mpi) const {
 
   const auto output_format = [&]() {
     if (specfem::utilities::is_png_string(this->output_format)) {

--- a/tests/unit-tests/MPI_environment.hpp
+++ b/tests/unit-tests/MPI_environment.hpp
@@ -2,13 +2,15 @@
 
 #include "specfem_mpi/interface.hpp"
 #include <gtest/gtest.h>
+#include <memory>
 
 class MPIEnvironment : public ::testing::Environment {
 public:
   void SetUp();
   void TearDown();
 
-  static specfem::MPI::MPI *get_mpi() { return mpi_.get(); }
+  // Return shared_ptr so tests can use it directly or convert to weak_ptr
+  static std::shared_ptr<specfem::MPI::MPI> get_mpi() { return mpi_; }
 
 private:
   static std::shared_ptr<specfem::MPI::MPI> mpi_;

--- a/tests/unit-tests/algorithms/locate.cpp
+++ b/tests/unit-tests/algorithms/locate.cpp
@@ -12,7 +12,7 @@ TEST(ALGORITHMS, locate_point) {
   std::string database_file = "algorithms/serial/database.bin";
 
   // Read Mesh database
-  specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
+  auto mpi = MPIEnvironment::get_mpi();
   specfem::mesh::mesh mesh = specfem::io::read_2d_mesh(
       database_file, specfem::enums::elastic_wave::psv,
       specfem::enums::electromagnetic_wave::te, mpi);

--- a/tests/unit-tests/assembly/dim3/mesh/points.cpp
+++ b/tests/unit-tests/assembly/dim3/mesh/points.cpp
@@ -40,7 +40,7 @@ struct ExpectedMapping {
 
     // Get the mesh
     const auto expected_mesh = specfem::io::meshfem3d::read_3d_mesh(
-        database_file, MPIEnvironment::get_mpi());
+        database_file, *MPIEnvironment::get_mpi());
 
     ASSERT_EQ(points.nspec, total_quadrature_points.nelements)
         << "Number of spectral elements mismatch. "

--- a/tests/unit-tests/assembly/dim3/test_fixture.hpp
+++ b/tests/unit-tests/assembly/dim3/test_fixture.hpp
@@ -16,8 +16,9 @@ struct Assembly3D {
 
   Assembly3D() = default;
 
-  Assembly3D(const std::string &database_file, const specfem::MPI::MPI *mpi) {
-    const auto mesh = specfem::io::meshfem3d::read_3d_mesh(database_file, mpi);
+  Assembly3D(const std::string &database_file,
+             const std::shared_ptr<specfem::MPI::MPI> mpi) {
+    const auto mesh = specfem::io::meshfem3d::read_3d_mesh(database_file, *mpi);
 
     const int nspec = mesh.nspec;
     const int ngnod = mesh.control_nodes.ngnod;
@@ -49,7 +50,7 @@ protected:
     const auto &folder = GetParam();
     const std::string database_file = "data/dim3/" + folder + "/database.bin";
     // Initialize MPI (assuming MPIEnvironment is defined elsewhere)
-    specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
+    auto mpi = MPIEnvironment::get_mpi();
     assembly = specfem::test_configuration::Assembly3D(database_file, mpi);
   }
   void TearDown() override {

--- a/tests/unit-tests/assembly/nonconforming_interfaces/container_init_test.cpp
+++ b/tests/unit-tests/assembly/nonconforming_interfaces/container_init_test.cpp
@@ -344,11 +344,11 @@ void test_nonconforming_container_transfers(
 
 TEST(NonconformingInterfaces, ContainerInitialization) {
   std::string database_file("data/dim2/3_elem_nonconforming/database.bin");
-  specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
+  auto mpi = MPIEnvironment::get_mpi();
 
   const auto mesh = specfem::io::read_2d_mesh(
       database_file, specfem::enums::elastic_wave::psv,
-      specfem::enums::electromagnetic_wave::te, mpi);
+      specfem::enums::electromagnetic_wave::te, *mpi);
 
   const auto quadrature = []() {
     specfem::quadrature::gll::gll gll{};

--- a/tests/unit-tests/assembly/test_fixture/test_fixture.cpp
+++ b/tests/unit-tests/assembly/test_fixture/test_fixture.cpp
@@ -26,7 +26,7 @@ template <> Assembly<specfem::dimension::type::dim2>::Assembly() {
   parse_test_config<specfem::dimension::type::dim2>(
       YAML::LoadFile(config_filename), Tests, "2D");
 
-  specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
+  auto mpi = MPIEnvironment::get_mpi();
 
   const auto quadrature = []() {
     specfem::quadrature::gll::gll gll{};
@@ -40,7 +40,7 @@ template <> Assembly<specfem::dimension::type::dim2>::Assembly() {
     const auto elastic_wave = Test.get_elastic_wave();
     const auto electromagnetic_wave = Test.get_electromagnetic_wave();
     const auto mesh = specfem::io::read_2d_mesh(database_file, elastic_wave,
-                                                electromagnetic_wave, mpi);
+                                                electromagnetic_wave, *mpi);
 
     this->Meshes.push_back(mesh);
     this->suffixes.push_back(Test.suffix);
@@ -74,7 +74,7 @@ template <> Assembly<specfem::dimension::type::dim3>::Assembly() {
   parse_test_config<specfem::dimension::type::dim3>(
       YAML::LoadFile(config_filename), Tests, "3D");
 
-  specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
+  auto mpi = MPIEnvironment::get_mpi();
 
   const auto quadrature = []() {
     specfem::quadrature::gll::gll gll{};
@@ -87,7 +87,7 @@ template <> Assembly<specfem::dimension::type::dim3>::Assembly() {
 
     // For 3D, we need different mesh and source reading functions
     const auto mesh = specfem::io::read_3d_mesh(mesh_parameters_file,
-                                                mesh_database_file, mpi);
+                                                mesh_database_file, *mpi);
 
     this->Meshes.push_back(mesh);
     this->suffixes.push_back(Test.suffix);

--- a/tests/unit-tests/assembly_mesh/coupled_interfaces/coupled_interfaces_tests.cpp
+++ b/tests/unit-tests/assembly_mesh/coupled_interfaces/coupled_interfaces_tests.cpp
@@ -161,7 +161,7 @@ void test_edges(
 
 TEST(ASSEMBLY_MESH, coupled_interfaces_tests) {
 
-  specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
+  auto mpi = MPIEnvironment::get_mpi();
 
   std::string config_filename =
       "assembly_mesh/coupled_interfaces/test_config.yaml";
@@ -178,7 +178,7 @@ TEST(ASSEMBLY_MESH, coupled_interfaces_tests) {
 
     // Read mesh generated MESHFEM
     specfem::mesh::mesh mesh =
-        specfem::io::read_2d_mesh(Test.databases.mesh.database_filename, mpi);
+        specfem::io::read_2d_mesh(Test.databases.mesh.database_filename, *mpi);
 
     // Generate compute structs to be used by the solver
     specfem::assembly::mesh assembly(mesh.control_nodes, quadratures);

--- a/tests/unit-tests/assembly_mesh/index/compute_tests.cpp
+++ b/tests/unit-tests/assembly_mesh/index/compute_tests.cpp
@@ -35,7 +35,7 @@ void operator>>(YAML::Node &Node, test_config &test_config) {
 }
 
 test_config get_test_config(std::string config_filename,
-                            specfem::MPI::MPI *mpi) {
+                            std::shared_ptr<specfem::MPI::MPI> mpi) {
   // read test config file
   YAML::Node yaml = YAML::LoadFile(config_filename);
   test_config test_config{};
@@ -69,7 +69,7 @@ test_config get_test_config(std::string config_filename,
  */
 TEST(ASSEMBLY_MESH, compute_ibool) {
 
-  specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
+  auto mpi = MPIEnvironment::get_mpi();
 
   std::string config_filename = "assembly_mesh/index/test_config.yml";
   test_config test_config = get_test_config(config_filename, mpi);
@@ -82,7 +82,7 @@ TEST(ASSEMBLY_MESH, compute_ibool) {
   // Read mesh generated MESHFEM
   specfem::mesh::mesh mesh = specfem::io::read_2d_mesh(
       test_config.database_filename, specfem::enums::elastic_wave::psv,
-      specfem::enums::electromagnetic_wave::te, mpi);
+      specfem::enums::electromagnetic_wave::te, *mpi);
 
   // Setup compute structs
   specfem::assembly::mesh<specfem::dimension::type::dim2> compute_mesh(

--- a/tests/unit-tests/assembly_mesh/jacobian_matrix/compute_jacobian_matrix_tests.cpp
+++ b/tests/unit-tests/assembly_mesh/jacobian_matrix/compute_jacobian_matrix_tests.cpp
@@ -30,7 +30,7 @@ void operator>>(YAML::Node &Node, test_config &test_config) {
 }
 
 test_config get_test_config(std::string config_filename,
-                            specfem::MPI::MPI *mpi) {
+                            std::shared_ptr<specfem::MPI::MPI> mpi) {
   // read test config file
   YAML::Node yaml = YAML::LoadFile(config_filename);
   test_config test_config{};
@@ -64,7 +64,7 @@ test_config get_test_config(std::string config_filename,
  */
 TEST(ASSEMBLY_MESH, compute_jacobian_matrix) {
 
-  specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
+  auto mpi = MPIEnvironment::get_mpi();
 
   std::string config_filename = "assembly_mesh/jacobian_matrix/test_config.yml";
   test_config test_config = get_test_config(config_filename, mpi);
@@ -75,7 +75,7 @@ TEST(ASSEMBLY_MESH, compute_jacobian_matrix) {
 
   specfem::mesh::mesh mesh = specfem::io::read_2d_mesh(
       test_config.database_filename, specfem::enums::elastic_wave::psv,
-      specfem::enums::electromagnetic_wave::te, mpi);
+      specfem::enums::electromagnetic_wave::te, *mpi);
 
   specfem::assembly::mesh<specfem::dimension::type::dim2> compute_mesh(
       mesh.tags, mesh.control_nodes, quadratures, mesh.adjacency_graph);

--- a/tests/unit-tests/displacement_tests/Newmark/dim2/newmark_tests.cpp
+++ b/tests/unit-tests/displacement_tests/Newmark/dim2/newmark_tests.cpp
@@ -104,7 +104,8 @@ TEST_P(Newmark, 2D) {
             << "-------------------------------------------------------\n\n"
             << std::endl;
 
-  specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
+  // Get MPI from test environment (returns shared_ptr)
+  auto mpi = MPIEnvironment::get_mpi();
 
   const auto parameter_file = Test.specfem_config;
 
@@ -120,7 +121,7 @@ TEST_P(Newmark, 2D) {
 
   // Read mesh generated MESHFEM
   specfem::mesh::mesh mesh = specfem::io::read_2d_mesh(
-      database_file, elastic_wave, electromagnetic_wave, mpi);
+      database_file, elastic_wave, electromagnetic_wave, *mpi);
   const type_real dt = setup.get_dt();
   const int nsteps = setup.get_nsteps();
 

--- a/tests/unit-tests/displacement_tests/Newmark/dim3/newmark_tests.cpp
+++ b/tests/unit-tests/displacement_tests/Newmark/dim3/newmark_tests.cpp
@@ -106,7 +106,8 @@ TEST_P(Newmark, 3D) {
             << "-------------------------------------------------------\n\n"
             << std::endl;
 
-  specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
+  // Get MPI from test environment (returns shared_ptr)
+  auto mpi = MPIEnvironment::get_mpi();
 
   const auto parameter_file = Test.specfem_config;
 
@@ -122,7 +123,7 @@ TEST_P(Newmark, 3D) {
 
   // Read mesh generated MESHFEM
   auto mesh = specfem::io::read_3d_mesh(mesh_parameters_filename,
-                                        database_filename, mpi);
+                                        database_filename, *mpi);
   const type_real dt = setup.get_dt();
   const int nsteps = setup.get_nsteps();
 

--- a/tests/unit-tests/mesh/dim2/adjacency_graph/adjacency_graph_irregular_mesh.cpp
+++ b/tests/unit-tests/mesh/dim2/adjacency_graph/adjacency_graph_irregular_mesh.cpp
@@ -66,11 +66,11 @@ TEST_P(CheckConnections, Test) {
 
   const std::string mesh_file = mesh_files.at(mesh_name);
 
-  specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
+  auto mpi = MPIEnvironment::get_mpi();
 
   auto mesh =
       specfem::io::read_2d_mesh(mesh_file, specfem::enums::elastic_wave::psv,
-                                specfem::enums::electromagnetic_wave::te, mpi);
+                                specfem::enums::electromagnetic_wave::te, *mpi);
 
   const auto &adjacency_graph = mesh.adjacency_graph;
 

--- a/tests/unit-tests/mesh/dim2/adjacency_graph/adjacency_graph_regular_mesh.cpp
+++ b/tests/unit-tests/mesh/dim2/adjacency_graph/adjacency_graph_regular_mesh.cpp
@@ -34,11 +34,11 @@ const static std::unordered_map<int, std::vector<int> > expected_adjacency{
 TEST(AdjacencyGraphRegularMesh, CheckConnections) {
 
   const std::string mesh_file = "data/dim2/regular_mesh/database.bin";
-  specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
+  auto mpi = MPIEnvironment::get_mpi();
 
   auto mesh =
       specfem::io::read_2d_mesh(mesh_file, specfem::enums::elastic_wave::psv,
-                                specfem::enums::electromagnetic_wave::te, mpi);
+                                specfem::enums::electromagnetic_wave::te, *mpi);
 
   const auto &adjacency_graph = mesh.adjacency_graph;
   ASSERT_FALSE(adjacency_graph.empty()) << "Adjacency graph is empty";

--- a/tests/unit-tests/mesh/dim2/test_fixture/test_fixture.cpp
+++ b/tests/unit-tests/mesh/dim2/test_fixture/test_fixture.cpp
@@ -20,7 +20,8 @@ MESH::MESH() {
   std::string config_filename = "mesh/dim2/test_config.yaml";
   parse_test_config(YAML::LoadFile(config_filename), this->Tests);
 
-  specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
+  // Get MPI from test environment (returns shared_ptr)
+  auto mpi = MPIEnvironment::get_mpi();
 
   for (auto &Test : this->Tests) {
     const auto [database_file, sources_file, stations_file] =
@@ -29,7 +30,7 @@ MESH::MESH() {
     const auto elastic_wave = Test.get_elastic_wave();
     const auto electromagnetic_wave = Test.get_electromagnetic_wave();
     specfem::mesh::mesh mesh = specfem::io::read_2d_mesh(
-        database_file, elastic_wave, electromagnetic_wave, mpi);
+        database_file, elastic_wave, electromagnetic_wave, *mpi);
 
     meshes.push_back(mesh);
   }

--- a/tests/unit-tests/mesh/dim3/test_fixture.hpp
+++ b/tests/unit-tests/mesh/dim3/test_fixture.hpp
@@ -15,8 +15,9 @@ struct ActualMesh3D {
 
   ActualMesh3D() = default;
 
-  ActualMesh3D(const std::string &database_file, const specfem::MPI::MPI *mpi) {
-    mesh = specfem::io::meshfem3d::read_3d_mesh(database_file, mpi);
+  ActualMesh3D(const std::string &database_file,
+               std::shared_ptr<specfem::MPI::MPI> mpi) {
+    mesh = specfem::io::meshfem3d::read_3d_mesh(database_file, *mpi);
   }
 };
 } // namespace specfem::test_configuration
@@ -33,8 +34,8 @@ protected:
   void SetUp() override {
     const auto &folder = GetParam();
     const std::string database_file = "data/dim3/" + folder + "/database.bin";
-    // Initialize MPI (assuming MPIEnvironment is defined elsewhere)
-    specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
+    // Get MPI from test environment (returns shared_ptr)
+    auto mpi = MPIEnvironment::get_mpi();
     mesh = specfem::test_configuration::ActualMesh3D(database_file, mpi);
   }
   void TearDown() override {

--- a/tests/unit-tests/seismogram/acoustic/seismogram_tests.cpp
+++ b/tests/unit-tests/seismogram/acoustic/seismogram_tests.cpp
@@ -74,7 +74,7 @@ void read_field(
 TEST(SEISMOGRAM_TESTS, acoustic_seismograms_test) {
   std::string config_filename = "seismogram/acoustic/test_config.yaml";
 
-  specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
+  auto mpi = MPIEnvironment::get_mpi();
 
   test_config test_config = parse_test_config(config_filename, mpi);
 
@@ -89,7 +89,7 @@ TEST(SEISMOGRAM_TESTS, acoustic_seismograms_test) {
   const auto quadratures = setup.instantiate_quadrature();
 
   // Read mesh generated MESHFEM
-  specfem::mesh::mesh mesh = specfem::io::read_2d_mesh(database_file, mpi);
+  specfem::mesh::mesh mesh = specfem::io::read_2d_mesh(database_file, *mpi);
 
   std::vector<std::shared_ptr<specfem::sources::source> > sources(0);
 

--- a/tests/unit-tests/seismogram/elastic/seismogram_tests.cpp
+++ b/tests/unit-tests/seismogram/elastic/seismogram_tests.cpp
@@ -74,7 +74,7 @@ void read_field(
 TEST(SEISMOGRAM_TESTS, elastic_seismograms_test) {
   std::string config_filename = "seismogram/elastic/test_config.yaml";
 
-  specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
+  auto mpi = MPIEnvironment::get_mpi();
 
   test_config test_config = parse_test_config(config_filename, mpi);
 
@@ -89,7 +89,7 @@ TEST(SEISMOGRAM_TESTS, elastic_seismograms_test) {
   const auto quadratures = setup.instantiate_quadrature();
 
   // Read mesh generated MESHFEM
-  specfem::mesh::mesh mesh = specfem::io::read_2d_mesh(database_file, mpi);
+  specfem::mesh::mesh mesh = specfem::io::read_2d_mesh(database_file, *mpi);
 
   std::vector<std::shared_ptr<specfem::sources::source> > sources(0);
 

--- a/tests/unit-tests/source/location/source_location_tests.cpp
+++ b/tests/unit-tests/source/location/source_location_tests.cpp
@@ -144,7 +144,7 @@ TEST(SOURCES, compute_source_locations) {
   std::string config_filename = "source/test_config.yml";
 
   //  alias the mpi environment pointer
-  specfem::MPI::MPI *mpi = MPIEnvironment::get_mpi();
+  auto mpi = MPIEnvironment::get_mpi();
 
   // parse solutions file for future use
   test_config test_config = parse_test_config(config_filename);


### PR DESCRIPTION

## Description

This updates

- context keeps mpi as shared pointer
- all other places are converted to passing by references.


### Commits

- Convert MPI parameters from raw pointers to references/smart pointers (3b43489a)

## Issue Number

If there is an issue created for these changes, link it here

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
