### PR TITLE
Specfem Core Framework Depr Mpi Func

### DIFF
--- a/core/specfem/mpi/mpi.hpp
+++ b/core/specfem/mpi/mpi.hpp
@@ -9,6 +9,15 @@
 
 namespace specfem {
 
+#ifdef MPI_PARALLEL
+using reduce_type = MPI_Op;
+const static reduce_type sum = MPI_SUM;
+const static reduce_type min = MPI_MIN;
+const static reduce_type max = MPI_MAX;
+#else
+enum reduce_type { sum, min, max };
+#endif
+
 // Forward declaration
 namespace program {
 class Context;
@@ -56,21 +65,96 @@ public:
   }
 
   /**
-   * @brief Print strings from the head node
+   * @brief Synchronize all MPI processes (alias for sync())
    *
+   * @throws Exits with error code 1 if called outside Context scope
    */
+  static void sync_all() { sync(); }
 
-  template <typename T> void cout(T s, bool root_only) const {
-#ifdef MPI_PARALLEL
-    if (my_rank == 0 || !root_only) {
-      std::cout << s << std::endl;
-    }
-#else
-    std::cout << s << std::endl;
-#endif
+  /**
+   * @brief Get MPI rank
+   *
+   * @return int Current MPI rank
+   * @throws Exits with error code 1 if called outside Context scope
+   */
+  static int get_rank() {
+    check_context();
+    return rank;
   }
 
-  template <typename T> void print(T s) const { this->cout(s, true); }
+  /**
+   * @brief Get MPI world size
+   *
+   * @return int Total number of MPI processes
+   * @throws Exits with error code 1 if called outside Context scope
+   */
+  static int get_size() {
+    check_context();
+    return size;
+  }
+
+  /**
+   * @brief Check if current process is the main process (rank 0)
+   *
+   * @return bool True if rank == 0
+   * @throws Exits with error code 1 if called outside Context scope
+   */
+  static bool main_proc() {
+    check_context();
+    return rank == 0;
+  }
+
+  /**
+   * @brief MPI reduce operation
+   *
+   * @param lvalue Local value to reduce
+   * @param reduce_op Reduction operation (specfem::sum, specfem::min,
+   * specfem::max)
+   * @return Reduced value (only valid on root process)
+   * @throws Exits with error code 1 if called outside Context scope
+   */
+  static int reduce(int lvalue, specfem::reduce_type reduce_op) {
+    check_context();
+    int result = lvalue;
+#ifdef MPI_PARALLEL
+    MPI_Reduce(&lvalue, &result, 1, MPI_INT, reduce_op, 0, MPI_COMM_WORLD);
+#endif
+    return result;
+  }
+
+  /**
+   * @brief MPI reduce operation for float
+   *
+   * @param lvalue Local value to reduce
+   * @param reduce_op Reduction operation
+   * @return Reduced value (only valid on root process)
+   * @throws Exits with error code 1 if called outside Context scope
+   */
+  static float reduce(float lvalue, specfem::reduce_type reduce_op) {
+    check_context();
+    float result = lvalue;
+#ifdef MPI_PARALLEL
+    MPI_Reduce(&lvalue, &result, 1, MPI_FLOAT, reduce_op, 0, MPI_COMM_WORLD);
+#endif
+    return result;
+  }
+
+  /**
+   * @brief MPI reduce operation for double
+   *
+   * @param lvalue Local value to reduce
+   * @param reduce_op Reduction operation
+   * @return Reduced value (only valid on root process)
+   * @throws Exits with error code 1 if called outside Context scope
+   */
+  static double reduce(double lvalue, specfem::reduce_type reduce_op) {
+    check_context();
+    double result = lvalue;
+#ifdef MPI_PARALLEL
+    MPI_Reduce(&lvalue, &result, 1, MPI_DOUBLE, reduce_op, 0, MPI_COMM_WORLD);
+#endif
+    return result;
+  }
 
 private:
   MPI_new() = default;

--- a/core/specfem/program/program.cpp
+++ b/core/specfem/program/program.cpp
@@ -124,8 +124,7 @@ void program_2d(
   // --------------------------------------------------------------
   const auto time_scheme = setup.instantiate_timescheme(assembly.fields);
 
-  if (mpi->main_proc())
-    std::cout << *time_scheme << std::endl;
+  specfem::Logger::info(time_scheme->print());
 
   // --------------------------------------------------------------
 
@@ -317,10 +316,7 @@ void program_3d(
   // --------------------------------------------------------------
   const auto time_scheme = setup.instantiate_timescheme(assembly.fields);
 
-  if (mpi->main_proc())
-    std::cout << *time_scheme << std::endl;
-
-  specfem::Logger::info(assembly.print());
+  specfem::Logger::info(time_scheme->print());
 
   // --------------------------------------------------------------
   // NOTE: Full 3D solver and writer support is not yet implemented

--- a/core/specfem/timescheme.hpp
+++ b/core/specfem/timescheme.hpp
@@ -188,6 +188,8 @@ public:
 
   virtual void print(std::ostream &out) const = 0;
 
+  virtual std::string print() const = 0;
+
   virtual type_real get_timestep() const = 0;
 
   /**

--- a/core/specfem/timescheme/newmark.hpp
+++ b/core/specfem/timescheme/newmark.hpp
@@ -58,6 +58,13 @@ public:
   void print(std::ostream &out) const override;
 
   /**
+   * @brief Print timescheme details
+   *
+   * @return std::string Timescheme details as string
+   */
+  std::string print() const override;
+
+  /**
    * @brief Apply the predictor phase for forward simulation on fields within
    * the elements within a medium.
    *
@@ -171,6 +178,13 @@ public:
    * @name Print timescheme details
    */
   void print(std::ostream &out) const override;
+
+  /**
+   * @brief Print timescheme details
+   *
+   * @return std::string Timescheme details as string
+   */
+  std::string print() const override;
 
   /**
    * @brief Apply the predictor phase for forward simulation on fields within

--- a/core/specfem/timescheme/newmark.tpp
+++ b/core/specfem/timescheme/newmark.tpp
@@ -268,8 +268,8 @@ int specfem::time_scheme::newmark<AssemblyFields,
 
 
 template <typename AssemblyFields>
-void specfem::time_scheme::newmark<AssemblyFields, specfem::simulation::type::forward>::print(
-    std::ostream &message) const {
+std::string specfem::time_scheme::newmark<AssemblyFields, specfem::simulation::type::forward>::print() const {
+  std::ostringstream message;
   message << "  Time Scheme:\n"
           << "------------------------------\n"
           << "- Newmark\n"
@@ -278,11 +278,19 @@ void specfem::time_scheme::newmark<AssemblyFields, specfem::simulation::type::fo
           << "\n"
           // << "    number of time steps = " << this->nstep << "\n"
           << "    Start time = " << this->t0 << "\n";
+  return message.str();
+}
+
+
+template <typename AssemblyFields>
+void specfem::time_scheme::newmark<AssemblyFields, specfem::simulation::type::forward>::print(
+    std::ostream &message) const {
+  message << this->print();
 }
 
 template <typename AssemblyFields>
-void specfem::time_scheme::newmark<AssemblyFields, specfem::simulation::type::combined>::print(
-    std::ostream &message) const {
+std::string specfem::time_scheme::newmark<AssemblyFields, specfem::simulation::type::combined>::print() const {
+  std::ostringstream message;
   message << "  Time Scheme:\n"
           << "------------------------------\n"
           << "- Newmark\n"
@@ -291,4 +299,11 @@ void specfem::time_scheme::newmark<AssemblyFields, specfem::simulation::type::co
           << "\n"
           // << "    number of time steps = " << this->nstep << "\n"
           << "    Start time = " << this->t0 << "\n";
+  return message.str();
+}
+
+template <typename AssemblyFields>
+void specfem::time_scheme::newmark<AssemblyFields, specfem::simulation::type::combined>::print(
+    std::ostream &message) const {
+  message << this->print();
 }

--- a/core/specfem/timescheme/timescheme.cpp
+++ b/core/specfem/timescheme/timescheme.cpp
@@ -16,3 +16,8 @@ void specfem::time_scheme::time_scheme::print(std::ostream &out) const {
   throw std::runtime_error(
       "Time scheme wasn't initialized properly. Base class being called");
 }
+
+std::string specfem::time_scheme::time_scheme::print() const {
+  throw std::runtime_error(
+      "Time scheme wasn't initialized properly. Base class being called");
+}

--- a/src/io/mesh/impl/fortran/dim2/mesh.cpp
+++ b/src/io/mesh/impl/fortran/dim2/mesh.cpp
@@ -76,11 +76,11 @@ specfem::mesh::mesh<specfem::dimension::type::dim2> specfem::io::read_2d_mesh(
   mesh.control_nodes.knods = specfem::kokkos::HostView2d<int>(
       "specfem::mesh::knods", mesh.parameters.ngnod, mesh.nspec);
 
-  int nspec_all = mpi->reduce(mesh.parameters.nspec, specfem::MPI::sum);
+  int nspec_all = specfem::MPI_new::reduce(mesh.parameters.nspec, specfem::sum);
   int nelem_acforcing_all =
-      mpi->reduce(mesh.parameters.nelem_acforcing, specfem::MPI::sum);
-  int nelem_acoustic_surface_all =
-      mpi->reduce(mesh.parameters.nelem_acoustic_surface, specfem::MPI::sum);
+      specfem::MPI_new::reduce(mesh.parameters.nelem_acforcing, specfem::sum);
+  int nelem_acoustic_surface_all = specfem::MPI_new::reduce(
+      mesh.parameters.nelem_acoustic_surface, specfem::sum);
 
   try {
     auto [n_sls, attenuation_f0_reference, read_velocities_at_f0] =

--- a/src/io/mesh/impl/fortran/dim2/read_boundaries.cpp
+++ b/src/io/mesh/impl/fortran/dim2/read_boundaries.cpp
@@ -295,7 +295,7 @@ read_acoustic_free_surface(std::ifstream &stream,
     }
   }
 
-  mpi->sync_all();
+  specfem::MPI_new::sync_all();
 
   return acoustic_free_surface;
 }

--- a/src/io/mesh/impl/fortran/dim2/read_mesh_database.cpp
+++ b/src/io/mesh/impl/fortran/dim2/read_mesh_database.cpp
@@ -153,7 +153,7 @@ specfem::io::mesh::impl::fortran::dim2::read_mesh_database_header(
       stream, &dummy_b1,
       &dummy_b2); // ADD_RANDOM_PERTURBATION_TO_THE_MESH,ADD_PERTURBATION_AROUND_SOURCE_ONLY
 
-  mpi->sync_all();
+  specfem::MPI_new::sync_all();
 
   return std::make_tuple(nspec, npgeo, nproc);
 }

--- a/src/io/mesh/impl/fortran/dim2/read_parameters.cpp
+++ b/src/io/mesh/impl/fortran/dim2/read_parameters.cpp
@@ -41,7 +41,7 @@ specfem::io::mesh::impl::fortran::dim2::read_mesh_parameters(
       &nnodes_tangential_curve, &nelem_on_the_axis);
   // ----------------------------------------------------------------------
 
-  mpi->sync_all();
+  specfem::MPI_new::sync_all();
 
   return { numat,
            ngnod,

--- a/src/io/mesh/impl/fortran/dim3/generate_database/read_parameters.cpp
+++ b/src/io/mesh/impl/fortran/dim3/generate_database/read_parameters.cpp
@@ -244,7 +244,7 @@ specfem::io::mesh::impl::fortran::dim3::read_mesh_parameters(
   /// Read test parameter
   check_read_test_value(stream, 9992);
 
-  mpi->sync_all();
+  specfem::MPI_new::sync_all();
 
   return parameters;
 }

--- a/tests/unit-tests/assembly_mesh/index/compute_tests.cpp
+++ b/tests/unit-tests/assembly_mesh/index/compute_tests.cpp
@@ -4,6 +4,7 @@
 #include "mesh/mesh.hpp"
 #include "quadrature/interface.hpp"
 #include "specfem/assembly.hpp"
+#include "specfem/mpi.hpp"
 #include "yaml-cpp/yaml.h"
 #include <fstream>
 #include <iostream>
@@ -38,7 +39,7 @@ test_config get_test_config(std::string config_filename,
   // read test config file
   YAML::Node yaml = YAML::LoadFile(config_filename);
   test_config test_config{};
-  if (mpi->get_size() == 1) {
+  if (specfem::MPI_new::get_size() == 1) {
     YAML::Node Node = yaml["SerialTest"];
     YAML::Node database = Node["database"];
     assert(database.IsSequence());
@@ -50,9 +51,9 @@ test_config get_test_config(std::string config_filename,
     YAML::Node database = Node["database"];
     assert(database.IsSequence());
     assert(database.size() == Node["config"]["nproc"].as<int>());
-    assert(mpi->get_size() == Node["config"]["nproc"].as<int>());
+    assert(specfem::MPI_new::get_size() == Node["config"]["nproc"].as<int>());
     for (auto N : database) {
-      if (N["processor"].as<int>() == mpi->get_rank())
+      if (N["processor"].as<int>() == specfem::MPI_new::get_rank())
         N >> test_config;
     }
   }

--- a/tests/unit-tests/assembly_mesh/jacobian_matrix/compute_jacobian_matrix_tests.cpp
+++ b/tests/unit-tests/assembly_mesh/jacobian_matrix/compute_jacobian_matrix_tests.cpp
@@ -3,6 +3,7 @@
 #include "io/interface.hpp"
 #include "quadrature/interface.hpp"
 #include "specfem/assembly.hpp"
+#include "specfem/mpi.hpp"
 #include "yaml-cpp/yaml.h"
 #include <fstream>
 #include <iostream>
@@ -33,7 +34,7 @@ test_config get_test_config(std::string config_filename,
   // read test config file
   YAML::Node yaml = YAML::LoadFile(config_filename);
   test_config test_config{};
-  if (mpi->get_size() == 1) {
+  if (specfem::MPI_new::get_size() == 1) {
     YAML::Node Node = yaml["SerialTest"];
     YAML::Node database = Node["database"];
     assert(database.IsSequence());
@@ -45,9 +46,9 @@ test_config get_test_config(std::string config_filename,
     YAML::Node database = Node["database"];
     assert(database.IsSequence());
     assert(database.size() == Node["config"]["nproc"].as<int>());
-    assert(mpi->get_size() == Node["config"]["nproc"].as<int>());
+    assert(specfem::MPI_new::get_size() == Node["config"]["nproc"].as<int>());
     for (auto N : database) {
-      if (N["processor"].as<int>() == mpi->get_rank())
+      if (N["processor"].as<int>() == specfem::MPI_new::get_rank())
         N >> test_config;
     }
   }

--- a/tests/unit-tests/displacement_tests/Newmark/dim2/newmark_tests.cpp
+++ b/tests/unit-tests/displacement_tests/Newmark/dim2/newmark_tests.cpp
@@ -8,6 +8,8 @@
 #include "quadrature/interface.hpp"
 #include "solver/solver.hpp"
 #include "specfem/assembly.hpp"
+#include "specfem/logger.hpp"
+#include "specfem/mpi.hpp"
 #include "specfem/timescheme.hpp"
 #include "yaml-cpp/yaml.h"
 #include <algorithm>
@@ -130,8 +132,7 @@ TEST_P(Newmark, 2D) {
       source_node, nsteps, setup.get_t0(), dt, setup.get_simulation_type());
 
   for (auto &source : sources) {
-    if (mpi->main_proc())
-      std::cout << source->print() << std::endl;
+    specfem::Logger::info(source->print());
   }
 
   setup.update_t0(t0);
@@ -144,8 +145,7 @@ TEST_P(Newmark, 2D) {
   std::cout << "  Receiver information\n";
   std::cout << "------------------------------" << std::endl;
   for (auto &receiver : receivers) {
-    if (mpi->main_proc())
-      std::cout << receiver->print() << std::endl;
+    specfem::Logger::info(receiver->print());
   }
 
   const auto seismogram_types = setup.get_seismogram_types();
@@ -172,8 +172,7 @@ TEST_P(Newmark, 2D) {
   auto time_scheme = setup.instantiate_timescheme(assembly.fields);
 
   // User output
-  if (mpi->main_proc())
-    std::cout << *time_scheme << std::endl;
+  specfem::Logger::info(time_scheme->print());
 
   std::shared_ptr<specfem::solver::solver> solver =
       setup.instantiate_solver<5>(setup.get_dt(), assembly, time_scheme, {});

--- a/tests/unit-tests/displacement_tests/Newmark/dim3/newmark_tests.cpp
+++ b/tests/unit-tests/displacement_tests/Newmark/dim3/newmark_tests.cpp
@@ -133,8 +133,7 @@ TEST_P(Newmark, 3D) {
       source_node, nsteps, setup.get_t0(), dt, setup.get_simulation_type());
 
   for (auto &source : sources) {
-    if (mpi->main_proc())
-      std::cout << source->print() << std::endl;
+    specfem::Logger::info(source->print());
   }
 
   setup.update_t0(t0);
@@ -182,8 +181,7 @@ TEST_P(Newmark, 3D) {
   auto it = setup.instantiate_timescheme(assembly.fields);
 
   // User output
-  if (mpi->main_proc())
-    std::cout << *it << std::endl;
+  specfem::Logger::info(it->print());
 
   // std::shared_ptr<specfem::solver::solver> solver =
   //     setup.instantiate_solver<5>(setup.get_dt(), assembly, it, {});

--- a/tests/unit-tests/seismogram/acoustic/seismogram_tests.cpp
+++ b/tests/unit-tests/seismogram/acoustic/seismogram_tests.cpp
@@ -37,7 +37,7 @@ test_config parse_test_config(std::string test_configuration_file,
   const YAML::Node &serial = tests["serial"];
 
   test_config test_config;
-  if (mpi->get_size() == 1) {
+  if (specfem::MPI_new::get_size() == 1) {
     serial >> test_config;
   }
 

--- a/tests/unit-tests/seismogram/elastic/seismogram_tests.cpp
+++ b/tests/unit-tests/seismogram/elastic/seismogram_tests.cpp
@@ -37,7 +37,7 @@ test_config parse_test_config(std::string test_configuration_file,
   const YAML::Node &serial = tests["serial"];
 
   test_config test_config;
-  if (mpi->get_size() == 1) {
+  if (specfem::MPI_new::get_size() == 1) {
     serial >> test_config;
   }
 

--- a/tests/unit-tests/source/location/source_location_tests.cpp
+++ b/tests/unit-tests/source/location/source_location_tests.cpp
@@ -58,8 +58,8 @@ struct solution {
   //   // communicate correct size from main proc
   //   mpi->bcast(count);
   //   // resize sources for rest of processors
-  //   if (!mpi->main_proc())
-  //     sources.resize(count);
+  //   specfem::Logger::info("Sources size: " +
+  //   std::to_string(sources.resize(count)));
 
   //   specfem::MPI::datatype mpi_source_type = source.get_mpi_type();
 
@@ -187,7 +187,7 @@ TEST(SOURCES, compute_source_locations) {
   bool tested = false;
 
   for (solution &solution : solutions) {
-    if (mpi->get_size() == solution.nnodes) {
+    if (specfem::MPI_new::get_size() == solution.nnodes) {
       tested = true;
       ASSERT_EQ(sources.size(), solution.sources.size());
 
@@ -210,7 +210,8 @@ TEST(SOURCES, compute_source_locations) {
   }
 
   if (!tested)
-    FAIL() << "Solution doesn't exist for current nnodes = " << mpi->get_size();
+    FAIL() << "Solution doesn't exist for current nnodes = "
+           << specfem::MPI_new::get_size();
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
## Description

This is a follow up PR that deprecates the rest of the mpi functions.

The next PR will remove the passing of the MPI struct and deprecate the old MPI struct


### Commits

- This deprecates mpi->cout in favor of Logging methods. (0967b858)

## Issue Number

Updates #1149 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
