### PR TITLE
gmshlayerbuilder: allow solids to skip AFS mark

### DIFF
--- a/scripts/gmshlayerbuilder/README.md
+++ b/scripts/gmshlayerbuilder/README.md
@@ -39,7 +39,15 @@ Boundary conditions can be set on the top, bottom, left, and right sides of the 
 python gmshlayerbuilder gmshlayerbuilder/test_topo.dat ../results/gmsh_demo/ --top acoustic_free_surface
 ```
 
-Note that `gmshlayerbuilder` is not aware of the material, so make sure that you do not set an incompatible boundary condition to the material (`acoustic free surface` for elastic materials).
+Note that `gmshlayerbuilder` is not aware of the material by default. Currently, there is only one way of telling which material type each layer is:
+
+- `--materials [string-code]`: `string-code` is a case-insensitive string of material-type characters, which must have a length equal to the number of layers.
+  - `S`: solid
+  - `F`: fluid
+
+  Each layer's material type is set according to this string, from bottom to top. For example, `--materials SF` places a fluid layer on top of a solid layer.
+
+If materials are not specified, then for the purposes of setting the `acoustic_free_surface` condition, all layers are treated as fluid and given the `acoustic_free_surface` tag when relevant to the top, bottom, left, and right sides of the domain.
 
 ## Development Notes
 

--- a/scripts/gmshlayerbuilder/_gmsh2meshfem/topo_import/layer_builder/layer.py
+++ b/scripts/gmshlayerbuilder/_gmsh2meshfem/topo_import/layer_builder/layer.py
@@ -18,6 +18,7 @@ class Layer:
 
     nx: int
     nz: int
+    skip_acoustic_free_surface: bool = False
 
     def is_conforming(self, other: "Layer"):
         return self.nx == other.nx


### PR DESCRIPTION
## Description

Please describe the changes/features in this pull request.
- Adds a `--materials` flag to allow passing of a material string (eg: `--materials sf` for fluid layer on top of solid layer)
- Adds `skip_acoustic_free_surface` flag on `Layer` (defaults to `False`) that gets set for solid layers when `--materials` is passed.
- When adding geometry to the `acoustic_free_surface` `gmsh` physical group, layers marked with `skip_acoustic_free_surface == True` are skipped.

Omitting `--materials` provides the same behavior as before the change

## Issue Number

If there is an issue created for these changes, link it here
#1425

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
