### PR TITLE
Issue 1401 - Re-enable compute coupling test

### DIFF
--- a/core/specfem/assembly/conforming_interfaces/dim2/conforming_interface.hpp
+++ b/core/specfem/assembly/conforming_interfaces/dim2/conforming_interface.hpp
@@ -14,7 +14,7 @@
 namespace specfem::assembly {
 
 /**
- * @brief 2D coupled interfaces container for spectral element computations.
+ * @brief 2D conforming interfaces container for spectral element computations.
  *
  * This class manages the storage and access of data required to compute
  * coupling between elements connected via weakly conforming edges in a 2D
@@ -68,7 +68,7 @@ private:
 
 public:
   /**
-   * @brief Constructor for 2D coupled interfaces container
+   * @brief Constructor for 2D conforming interfaces container
    *
    * Initializes all interface containers for the supported combinations of
    * media types and boundary conditions.

--- a/core/specfem/assembly/conforming_interfaces/dim2/impl/interface_container.hpp
+++ b/core/specfem/assembly/conforming_interfaces/dim2/impl/interface_container.hpp
@@ -26,7 +26,7 @@ struct interface_container<specfem::dimension::type::dim2, InterfaceTag,
                            specfem::connections::type::weakly_conforming>
     : public specfem::data_access::Container<
           specfem::data_access::ContainerType::edge,
-          specfem::data_access::DataClassType::coupled_interface,
+          specfem::data_access::DataClassType::conforming_interface,
           specfem::dimension::type::dim2> {
 public:
   /** @brief Dimension tag for 2D specialization */
@@ -48,7 +48,7 @@ private:
   /** @brief Base container type alias */
   using base_type = specfem::data_access::Container<
       specfem::data_access::ContainerType::edge,
-      specfem::data_access::DataClassType::coupled_interface,
+      specfem::data_access::DataClassType::conforming_interface,
       specfem::dimension::type::dim2>;
   /** @brief View type for edge scaling factors */
   using EdgeFactorView = typename base_type::scalar_type<

--- a/core/specfem/assembly/nonconforming_interfaces/dim2/impl/interface_container.hpp
+++ b/core/specfem/assembly/nonconforming_interfaces/dim2/impl/interface_container.hpp
@@ -28,7 +28,7 @@ struct interface_container<specfem::dimension::type::dim2, InterfaceTag,
                            specfem::connections::type::nonconforming>
     : public specfem::data_access::Container<
           specfem::data_access::ContainerType::edge,
-          specfem::data_access::DataClassType::coupled_interface,
+          specfem::data_access::DataClassType::nonconforming_interface,
           specfem::dimension::type::dim2> {
 public:
   /** @brief Dimension tag for 2D specialization */
@@ -50,7 +50,7 @@ public:
   /** @brief Base container type alias */
   using base_type = specfem::data_access::Container<
       specfem::data_access::ContainerType::edge,
-      specfem::data_access::DataClassType::coupled_interface,
+      specfem::data_access::DataClassType::nonconforming_interface,
       specfem::dimension::type::dim2>;
   /** @brief View type for edge scaling factors */
   using EdgeFactorView = typename base_type::scalar_type<

--- a/core/specfem/data_access/check_compatibility.hpp
+++ b/core/specfem/data_access/check_compatibility.hpp
@@ -153,16 +153,6 @@ struct is_edge_index<
     : std::true_type {};
 
 template <typename T, typename = void>
-struct is_coupled_interface : std::false_type {};
-
-template <typename T>
-struct is_coupled_interface<
-    T,
-    std::enable_if_t<T::data_class ==
-                     specfem::data_access::DataClassType::coupled_interface> >
-    : std::true_type {};
-
-template <typename T, typename = void>
 struct is_intersection_factor : std::false_type {};
 
 template <typename T>

--- a/core/specfem/data_access/data_class.hpp
+++ b/core/specfem/data_access/data_class.hpp
@@ -18,7 +18,6 @@ enum DataClassType {
   stress,
   stress_integrand,
   boundary,
-  coupled_interface,
   lagrange_derivative,
   weights,
   transfer_function_self,

--- a/include/algorithms/transfer.hpp
+++ b/include/algorithms/transfer.hpp
@@ -49,14 +49,6 @@ transfer(const IndexType &chunk_edge_index,
                     specfem::data_access::is_field<EdgeFieldType>::value,
                 "coupled_field is not a point field type");
 
-  // no medium check for intersection.
-  static_assert(
-      specfem::interface::attributes<dimension_tag,
-                                     interface_tag>::coupled_medium() ==
-          edge_medium_tag,
-      "Inconsistent medium tag between TransferFunctionType's side of the "
-      "interface and EdgeFieldType");
-
   // TODO future consideration: use load_on_device for coupled field here.
   // We would want it to be a specialization, since we want to transfer more
   // things than just fields is there a better way of recovering global index?

--- a/include/kokkos_kernels/impl/compute_coupling.tpp
+++ b/include/kokkos_kernels/impl/compute_coupling.tpp
@@ -197,8 +197,6 @@ void specfem::kokkos_kernels::impl::compute_coupling(
         specfem::assembly::load_on_device(coupled_chunk_index, field,
                                           coupled_field);
 
-        // TODO add point access for mortar transfer function and replace self
-        // side of this:
         CouplingTermsPack interface_data(team);
 
         specfem::assembly::load_on_device(

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -697,7 +697,7 @@ add_executable(
   compute_coupling_tests
   compute_coupling/acoustic_elastic.cpp
   compute_coupling/elastic_acoustic.cpp
-  # compute_coupling/nonconforming.cpp // I'll fix this test in next PR
+  compute_coupling/nonconforming.cpp
 )
 
 target_link_libraries(

--- a/tests/unit-tests/compute_coupling/nonconforming.cpp
+++ b/tests/unit-tests/compute_coupling/nonconforming.cpp
@@ -125,20 +125,12 @@ struct EdgeToInterfaceParams : EdgeToInterfaceParamsBase {
    * the interpolation and the transfer are exact.
    */
   virtual void run_test(const std::string &testname) const {
-    using SelfTransferType =
-        specfem::chunk_edge::nonconforming_transfer_function<
-            true, num_edges, nquad_edge, nquad_intersection, dimension_tag,
-            specfem::connections::type::nonconforming, interface_tag,
-            specfem::element::boundary_tag::none,
-            specfem::kokkos::DevScratchSpace,
-            Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
-    using CoupledTransferType =
-        specfem::chunk_edge::nonconforming_transfer_function<
-            false, num_edges, nquad_edge, nquad_intersection, dimension_tag,
-            specfem::connections::type::nonconforming, interface_tag,
-            specfem::element::boundary_tag::none,
-            specfem::kokkos::DevScratchSpace,
-            Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+    using SelfTransferType = specfem::chunk_edge::transfer_function_self<
+        dimension_tag, interface_tag, specfem::element::boundary_tag::none,
+        num_edges, nquad_intersection, nquad_edge>;
+    using CoupledTransferType = specfem::chunk_edge::transfer_function_coupled<
+        dimension_tag, interface_tag, specfem::element::boundary_tag::none,
+        num_edges, nquad_intersection, nquad_edge>;
 
     constexpr auto self_medium =
         specfem::interface::attributes<dimension_tag,
@@ -236,10 +228,8 @@ struct EdgeToInterfaceParams : EdgeToInterfaceParamsBase {
                     type_real eval = eval_lagrange(
                         edge_quadrature_points, ipoint,
                         intersection_quadrature_points[iintersection]);
-                    self_transfer.transfer_function_self(iedge, ipoint,
-                                                         iintersection) = eval;
-                    coupled_transfer.transfer_function_coupled(
-                        iedge, ipoint, iintersection) = eval;
+                    self_transfer(iedge, ipoint, iintersection) = eval;
+                    coupled_transfer(iedge, ipoint, iintersection) = eval;
                   }
                 }
               });
@@ -272,30 +262,30 @@ struct EdgeToInterfaceParams : EdgeToInterfaceParamsBase {
           // validate (self and coupled are independent, so we shouldn't need a
           // barrier in between them)
 
-          specfem::algorithms::transfer_self(
+          specfem::algorithms::transfer(
               ChunkEdgeIndexSimulator<dimension_tag>(num_edges, team),
               self_transfer, self_disp,
-              [&](const int &iedge, const int &iinterface,
-                  const PointSelfDisplacementType &point) {
+              [&](const auto &index, const PointSelfDisplacementType &point) {
                 for (int icomp = 0; icomp < SelfDisplacementType::components;
                      icomp++)
-                  self_on_interface(iedge, iinterface, icomp) = point(icomp);
+                  self_on_interface(index(0), index(1), icomp) = point(icomp);
               });
-          specfem::algorithms::transfer_coupled(
+          specfem::algorithms::transfer(
               ChunkEdgeIndexSimulator<dimension_tag>(num_edges, team),
               coupled_transfer, coupled_disp,
-              [&](const int &iedge, const int &iinterface,
+              [&](const auto &index,
                   const PointCoupledDisplacementType &point) {
                 for (int icomp = 0; icomp < CoupledDisplacementType::components;
                      icomp++)
-                  coupled_on_interface(iedge, iinterface, icomp) = point(icomp);
+                  coupled_on_interface(index(0), index(1), icomp) =
+                      point(icomp);
               });
 
           team.team_barrier();
 
-          // transfer should send polys to themselves, but in the new basis.
-          // the expectation is just the intersection quadrature point to the
-          // same power.
+          // transfer should send polys to themselves, but in the new
+          // basis. the expectation is just the intersection quadrature
+          // point to the same power.
           Kokkos::parallel_for(
               Kokkos::TeamThreadRange(team, num_edges), [&](const auto &iedge) {
                 for (int iintersection = 0; iintersection < nquad_intersection;


### PR DESCRIPTION
## Description

- [x] Removes coupled interfaces dataclass enum
- [x] Re-activates the nonconforming compute coupling test. Uses new types. 

## Issue Number

If there is an issue created for these changes, link it here

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
