### PR TITLE
Fix Cuda compilation 3D and Updates chunksizes

### DIFF
--- a/core/specfem/assembly/assembly/dim2/compute_wavefield/helper.hpp
+++ b/core/specfem/assembly/assembly/dim2/compute_wavefield/helper.hpp
@@ -49,20 +49,20 @@ public:
       return;
     }
 
-    using ParallelConfig = specfem::parallel_config::default_chunk_config<
-        dimension_tag, specfem::datatype::simd<type_real, false>,
-        Kokkos::DefaultExecutionSpace>;
+    using ParallelConfig =
+        specfem::parallel_configuration::default_chunk_config<
+            dimension_tag, specfem::datatype::simd<type_real, false>,
+            Kokkos::DefaultExecutionSpace>;
 
     using ChunkDisplacementType = specfem::chunk_element::displacement<
-        specfem::parallel_config::chunk_size, ngll, dimension_tag, medium_tag,
-        using_simd>;
-    using ChunkVelocityType =
-        specfem::chunk_element::velocity<specfem::parallel_config::chunk_size,
-                                         ngll, dimension_tag, medium_tag,
-                                         using_simd>;
+        specfem::parallel_configuration::chunk_size, ngll, dimension_tag,
+        medium_tag, using_simd>;
+    using ChunkVelocityType = specfem::chunk_element::velocity<
+        specfem::parallel_configuration::chunk_size, ngll, dimension_tag,
+        medium_tag, using_simd>;
     using ChunkAccelerationType = specfem::chunk_element::acceleration<
-        specfem::parallel_config::chunk_size, ngll, dimension_tag, medium_tag,
-        using_simd>;
+        specfem::parallel_configuration::chunk_size, ngll, dimension_tag,
+        medium_tag, using_simd>;
 
     using QuadratureType = specfem::quadrature::lagrange_derivative<
         ngll, dimension_tag, specfem::kokkos::DevScratchSpace,

--- a/core/specfem/assembly/assembly/dim3/compute_wavefield/helper.hpp
+++ b/core/specfem/assembly/assembly/dim3/compute_wavefield/helper.hpp
@@ -49,20 +49,20 @@ public:
       return;
     }
 
-    using ParallelConfig = specfem::parallel_config::default_chunk_config<
-        dimension_tag, specfem::datatype::simd<type_real, false>,
-        Kokkos::DefaultExecutionSpace>;
+    using ParallelConfig =
+        specfem::parallel_configuration::default_chunk_config<
+            dimension_tag, specfem::datatype::simd<type_real, false>,
+            Kokkos::DefaultExecutionSpace>;
 
     using ChunkDisplacementType = specfem::chunk_element::displacement<
-        specfem::parallel_config::chunk_size, ngll, dimension_tag, medium_tag,
-        using_simd>;
-    using ChunkVelocityType =
-        specfem::chunk_element::velocity<specfem::parallel_config::chunk_size,
-                                         ngll, dimension_tag, medium_tag,
-                                         using_simd>;
+        specfem::parallel_configuration::chunk_size, ngll, dimension_tag,
+        medium_tag, using_simd>;
+    using ChunkVelocityType = specfem::chunk_element::velocity<
+        specfem::parallel_configuration::chunk_size, ngll, dimension_tag,
+        medium_tag, using_simd>;
     using ChunkAccelerationType = specfem::chunk_element::acceleration<
-        specfem::parallel_config::chunk_size, ngll, dimension_tag, medium_tag,
-        using_simd>;
+        specfem::parallel_configuration::chunk_size, ngll, dimension_tag,
+        medium_tag, using_simd>;
 
     using QuadratureType = specfem::quadrature::lagrange_derivative<
         ngll, dimension_tag, specfem::kokkos::DevScratchSpace,

--- a/core/specfem/assembly/fields/impl/field_impl.tpp
+++ b/core/specfem/assembly/fields/impl/field_impl.tpp
@@ -30,7 +30,7 @@ void assign_assembly_index_mapping<specfem::dimension::type::dim2>(
 
   int count = 0;
 
-  constexpr int chunk_size = specfem::parallel_config::storage_chunk_size;
+  constexpr int chunk_size = specfem::parallel_configuration::storage_chunk_size;
   for (int ichunk = 0; ichunk < nspec; ichunk += chunk_size) {
     for (int ix = 0; ix < ngllx; ix++) {
       for (int iz = 0; iz < ngllz; iz++) {

--- a/core/specfem/assembly/mesh/dim2/impl/assemble.tpp
+++ b/core/specfem/assembly/mesh/dim2/impl/assemble.tpp
@@ -68,7 +68,7 @@ void specfem::assembly::mesh<specfem::dimension::type::dim2>::assemble() {
 
   // ----
 
-  constexpr int chunk_size = specfem::parallel_config::storage_chunk_size;
+  constexpr int chunk_size = specfem::parallel_configuration::storage_chunk_size;
 
   this->h_index_mapping = Kokkos::View<int ***, Kokkos::LayoutLeft,
                                        Kokkos::DefaultHostExecutionSpace>(

--- a/core/specfem/assembly/mesh/dim2/impl/utilities.cpp
+++ b/core/specfem/assembly/mesh/dim2/impl/utilities.cpp
@@ -42,7 +42,8 @@ std::vector<point> flatten_coordinates(
 
   std::vector<point> points(nspec * ngllxz);
 
-  constexpr int chunk_size = specfem::parallel_config::storage_chunk_size;
+  constexpr int chunk_size =
+      specfem::parallel_configuration::storage_chunk_size;
 
   int iloc = 0;
   for (int ichunk = 0; ichunk < nspec; ichunk += chunk_size) {
@@ -132,7 +133,8 @@ create_coordinate_arrays(const std::vector<point> &reordered_points, int nspec,
           "coord", 2, nspec, ngll, ngll);
 
   std::vector<int> iglob_counted(nglob, -1);
-  constexpr int chunk_size = specfem::parallel_config::storage_chunk_size;
+  constexpr int chunk_size =
+      specfem::parallel_configuration::storage_chunk_size;
   int iloc = 0;
   int inum = 0;
 

--- a/core/specfem/timescheme/newmark.tpp
+++ b/core/specfem/timescheme/newmark.tpp
@@ -29,7 +29,7 @@ int corrector_phase_impl(
       specfem::point::velocity<DimensionTag, MediumTag,
                                using_simd>;
 
-  using parallel_config = specfem::parallel_config::default_range_config<
+  using parallel_config = specfem::parallel_configuration::default_range_config<
       specfem::datatype::simd<type_real, using_simd>,
       Kokkos::DefaultExecutionSpace>;
 
@@ -88,7 +88,7 @@ int predictor_phase_impl(
       specfem::point::displacement<DimensionTag, MediumTag,
                                    using_simd>;
 
-  using parallel_config = specfem::parallel_config::default_range_config<
+  using parallel_config = specfem::parallel_configuration::default_range_config<
       specfem::datatype::simd<type_real, using_simd>,
       Kokkos::DefaultExecutionSpace>;
 

--- a/include/domain_view.hpp
+++ b/include/domain_view.hpp
@@ -237,7 +237,7 @@ template <typename T, std::size_t Rank, typename MemorySpace>
 using DomainView2d =
     View<T, chunked_tiled_layout2d<Rank>,
          DomainViewMapping<specfem::dimension::type::dim2,
-                           specfem::parallel_config::storage_chunk_size>,
+                           specfem::parallel_configuration::storage_chunk_size>,
          MemorySpace>;
 
 template <specfem::dimension::type DimensionTag, typename T, std::size_t Rank,
@@ -245,7 +245,7 @@ template <specfem::dimension::type DimensionTag, typename T, std::size_t Rank,
 using DomainView =
     View<T, Kokkos::dextents<std::size_t, Rank>,
          DomainViewMapping<DimensionTag,
-                           specfem::parallel_config::storage_chunk_size>,
+                           specfem::parallel_configuration::storage_chunk_size>,
          MemorySpace>;
 
 template <typename ViewType>

--- a/include/enumerations/dim3/mesh_entities.hpp
+++ b/include/enumerations/dim3/mesh_entities.hpp
@@ -462,15 +462,34 @@ private:
   int ngll2d;
   int ngll;
 
-  std::unordered_map<specfem::mesh_entity::dim3::type,
-                     std::function<std::tuple<int, int, int>(int, int)> >
-      face_coordinates; ///< Maps face types to coordinate functions
-  std::unordered_map<specfem::mesh_entity::dim3::type,
-                     std::function<std::tuple<int, int, int>(int)> >
-      edge_coordinates; ///< Maps edge types to coordinate functions
-  std::unordered_map<specfem::mesh_entity::dim3::type,
-                     std::tuple<int, int, int> >
-      corner_coordinates; ///< Maps corner types to coordinates
+  /**
+   * @brief Get face coordinates using switch-based dispatch
+   * @param face The face type
+   * @param ipoint First point index
+   * @param jpoint Second point index
+   * @return Tuple of (iz, iy, ix) coordinates
+   */
+  std::tuple<int, int, int>
+  get_face_coordinates(const specfem::mesh_entity::dim3::type &face,
+                       const int ipoint, const int jpoint) const;
+
+  /**
+   * @brief Get edge coordinates using switch-based dispatch
+   * @param edge The edge type
+   * @param point Point index along the edge
+   * @return Tuple of (iz, iy, ix) coordinates
+   */
+  std::tuple<int, int, int>
+  get_edge_coordinates(const specfem::mesh_entity::dim3::type &edge,
+                       const int point) const;
+
+  /**
+   * @brief Get corner coordinates using switch-based dispatch
+   * @param corner The corner type
+   * @return Tuple of (iz, iy, ix) coordinates
+   */
+  std::tuple<int, int, int>
+  get_corner_coordinates(const specfem::mesh_entity::dim3::type &corner) const;
 };
 
 /**

--- a/include/execution/chunked_domain_iterator.hpp
+++ b/include/execution/chunked_domain_iterator.hpp
@@ -471,7 +471,7 @@ private:
  * `ParallelConfig::chunk_size` and iterates over them in parallel.
  * @tparam DimensionTag The dimension tag for the elements.
  * @tparam ParallelConfig Configuration for parallel execution. @ref
- * specfem::parallel_configuration::chunk_config
+ * specfem::parallel_configurationuration::chunk_config
  * @tparam ViewType Type of the view containing indices of elements.
  */
 template <specfem::dimension::type DimensionTag, typename ParallelConfig,

--- a/include/execution/chunked_edge_iterator.hpp
+++ b/include/execution/chunked_edge_iterator.hpp
@@ -14,7 +14,8 @@
  * #include "execution/chunked_edge_iterator.hpp"
  * #include "execution/for_all.hpp"
  *
- * using ParallelConfig = specfem::parallel_config::default_chunk_edge_config<
+ * using ParallelConfig =
+ * specfem::parallel_configuration::default_chunk_edge_config<
  *     specfem::dimension::type::dim2, Kokkos::DefaultExecutionSpace>;
  *
  * // Create views for storage and edges
@@ -408,7 +409,8 @@ private:
  * #include "execution/for_all.hpp"
  *
  * // Define parallel configuration
- * using ParallelConfig = specfem::parallel_config::default_chunk_edge_config<
+ * using ParallelConfig =
+ * specfem::parallel_configuration::default_chunk_edge_config<
  *     specfem::dimension::type::dim2, Kokkos::DefaultExecutionSpace>;
  *
  * // Create edge view and initialize

--- a/include/execution/chunked_intersection_iterator.hpp
+++ b/include/execution/chunked_intersection_iterator.hpp
@@ -12,7 +12,8 @@
  * #include "execution/chunked_intersection_iterator.hpp"
  * #include "execution/for_all.hpp"
  *
- * using ParallelConfig = specfem::parallel_config::default_chunk_edge_config<
+ * using ParallelConfig =
+ * specfem::parallel_configuration::default_chunk_edge_config<
  *     specfem::dimension::type::dim2, Kokkos::DefaultExecutionSpace>;
  *
  * // Create views for edge intersections
@@ -471,7 +472,8 @@ private:
  * #include "execution/for_all.hpp"
  *
  * // Define parallel configuration
- * using ParallelConfig = specfem::parallel_config::default_chunk_edge_config<
+ * using ParallelConfig =
+ * specfem::parallel_configuration::default_chunk_edge_config<
  *     specfem::dimension::type::dim2, Kokkos::DefaultExecutionSpace>;
  *
  * // Create edge views for intersection

--- a/include/execution/policy.hpp
+++ b/include/execution/policy.hpp
@@ -15,7 +15,7 @@ enum class PolicyType {
  * @brief Base class for all iterators using on @c Kokkos::RangePolicy.
  *
  * @tparam ParallelConfig Configuration for parallel execution. @ref
- * specfem::parallel_configuration::range_config
+ * specfem::parallel_configurationuration::range_config
  */
 template <typename ParallelConfig>
 class RangePolicy
@@ -42,7 +42,7 @@ public:
  * @brief Base class for all iterators using on @c Kokkos::TeamPolicy.
  *
  * @tparam ParallelConfig Configuration for parallel execution. @ref
- * specfem::parallel_configuration::team_config
+ * specfem::parallel_configurationuration::team_config
  */
 template <typename ParallelConfig>
 class TeamPolicy

--- a/include/execution/range_iterator.hpp
+++ b/include/execution/range_iterator.hpp
@@ -104,7 +104,7 @@ private:
  * This iterator iterates over a range of GLL points between [0, RangeSize).
  *
  * @tparam ParallelConfig Configuration for parallel execution. @ref
- * specfem::parallel_configuration::range_config
+ * specfem::parallel_configurationuration::range_config
  *
  */
 template <typename ParallelConfig>

--- a/include/kokkos_kernels/impl/compute_coupling.tpp
+++ b/include/kokkos_kernels/impl/compute_coupling.tpp
@@ -52,7 +52,7 @@ void specfem::kokkos_kernels::impl::compute_coupling(
 
   const auto num_points = assembly.mesh.element_grid.ngllx;
 
-  using parallel_config = specfem::parallel_config::default_chunk_edge_config<
+  using parallel_config = specfem::parallel_configuration::default_chunk_edge_config<
       DimensionTag, Kokkos::DefaultExecutionSpace>;
 
   using CoupledFieldType = typename specfem::interface::attributes<
@@ -130,7 +130,7 @@ void specfem::kokkos_kernels::impl::compute_coupling(
 
   const auto num_points = assembly.mesh.element_grid.ngllx;
 
-  using parallel_config = specfem::parallel_config::default_chunk_edge_config<
+  using parallel_config = specfem::parallel_configuration::default_chunk_edge_config<
       DimensionTag, Kokkos::DefaultExecutionSpace>;
 
   // As written, field types cannot readily be defined in attributes. Define

--- a/include/kokkos_kernels/impl/compute_mass_matrix.tpp
+++ b/include/kokkos_kernels/impl/compute_mass_matrix.tpp
@@ -62,7 +62,7 @@ void specfem::kokkos_kernels::impl::compute_mass_matrix(
 #endif
 
   using simd = specfem::datatype::simd<type_real, using_simd>;
-  using parallel_config = specfem::parallel_config::default_chunk_config<
+  using parallel_config = specfem::parallel_configuration::default_chunk_config<
       dimension_tag, simd, Kokkos::DefaultExecutionSpace>;
 
   using PointMassType =

--- a/include/kokkos_kernels/impl/compute_mass_matrix.tpp
+++ b/include/kokkos_kernels/impl/compute_mass_matrix.tpp
@@ -60,6 +60,7 @@ void specfem::kokkos_kernels::impl::compute_mass_matrix(
 #else
   constexpr bool using_simd = (DimensionTag == specfem::dimension::type::dim2) ? true : false;
 #endif
+
   using simd = specfem::datatype::simd<type_real, using_simd>;
   using parallel_config = specfem::parallel_config::default_chunk_config<
       dimension_tag, simd, Kokkos::DefaultExecutionSpace>;

--- a/include/kokkos_kernels/impl/compute_material_derivatives.tpp
+++ b/include/kokkos_kernels/impl/compute_material_derivatives.tpp
@@ -51,11 +51,11 @@ void specfem::kokkos_kernels::impl::compute_material_derivatives(
 
 
   using simd = specfem::datatype::simd<type_real, using_simd>;
-  using ParallelConfig = specfem::parallel_config::default_chunk_config<
+  using ParallelConfig = specfem::parallel_configuration::default_chunk_config<
       DimensionTag, simd, Kokkos::DefaultExecutionSpace>;
 
   using ChunkElementFieldType =
-      specfem::chunk_element::displacement<specfem::parallel_config::chunk_size,
+      specfem::chunk_element::displacement<specfem::parallel_configuration::chunk_size,
                                            NGLL, DimensionTag, MediumTag,
                                            using_simd>;
 

--- a/include/kokkos_kernels/impl/compute_seismogram.tpp
+++ b/include/kokkos_kernels/impl/compute_seismogram.tpp
@@ -70,6 +70,7 @@ void specfem::kokkos_kernels::impl::compute_seismograms(
 #else
   constexpr int nthreads = 1;
   constexpr int lane_size = 1;
+  constexpr int chunk_size = 1;
 #endif
 
   // nthreads unused?

--- a/include/kokkos_kernels/impl/compute_seismogram.tpp
+++ b/include/kokkos_kernels/impl/compute_seismogram.tpp
@@ -74,7 +74,7 @@ void specfem::kokkos_kernels::impl::compute_seismograms(
 
   // nthreads unused?
   using ParallelConfig =
-      specfem::parallel_config::chunk_config<dimension_tag, chunk_size, 1, nthreads,
+      specfem::parallel_configuration::chunk_config<dimension_tag, chunk_size, 1, nthreads,
                                              lane_size, no_simd,
                                              Kokkos::DefaultExecutionSpace>;
 

--- a/include/kokkos_kernels/impl/compute_seismogram.tpp
+++ b/include/kokkos_kernels/impl/compute_seismogram.tpp
@@ -66,24 +66,26 @@ void specfem::kokkos_kernels::impl::compute_seismograms(
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
   constexpr int nthreads = 32;
   constexpr int lane_size = 1;
+  constexpr int chunk_size = (dimension_tag == specfem::dimension::type::dim2) ? 16 : 4;
 #else
   constexpr int nthreads = 1;
   constexpr int lane_size = 1;
 #endif
 
+  // nthreads unused?
   using ParallelConfig =
-      specfem::parallel_config::chunk_config<dimension_tag, 1, 1, nthreads,
+      specfem::parallel_config::chunk_config<dimension_tag, chunk_size, 1, nthreads,
                                              lane_size, no_simd,
                                              Kokkos::DefaultExecutionSpace>;
 
   using ChunkDisplacementType =
-      specfem::chunk_element::displacement<parallel_config::chunk_size, ngll,
+      specfem::chunk_element::displacement<ParallelConfig::chunk_size, ngll,
                                            dimension_tag, medium_tag, using_simd>;
   using ChunkVelocityType =
-      specfem::chunk_element::velocity<parallel_config::chunk_size, ngll,
+      specfem::chunk_element::velocity<ParallelConfig::chunk_size, ngll,
                                        dimension_tag, medium_tag, using_simd>;
   using ChunkAccelerationType =
-      specfem::chunk_element::acceleration<parallel_config::chunk_size, ngll,
+      specfem::chunk_element::acceleration<ParallelConfig::chunk_size, ngll,
                                            dimension_tag, medium_tag, using_simd>;
   using ElementQuadratureType = specfem::quadrature::lagrange_derivative<
       ngll, dimension_tag, specfem::kokkos::DevScratchSpace,

--- a/include/kokkos_kernels/impl/compute_source_interaction.tpp
+++ b/include/kokkos_kernels/impl/compute_source_interaction.tpp
@@ -63,7 +63,7 @@ void specfem::kokkos_kernels::impl::compute_source_interaction(
       specfem::point::boundary<boundary_tag, dimension, false>;
   using PointIndexType = specfem::point::mapped_index<dimension, false>;
 
-      using simd = specfem::datatype::simd<type_real, false>;
+  using simd = specfem::datatype::simd<type_real, false>;
 
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
   constexpr int nthreads = 32;

--- a/include/kokkos_kernels/impl/compute_source_interaction.tpp
+++ b/include/kokkos_kernels/impl/compute_source_interaction.tpp
@@ -74,7 +74,7 @@ void specfem::kokkos_kernels::impl::compute_source_interaction(
 #endif
 
   using ParallelConfig =
-      specfem::parallel_config::chunk_config<dimension, 1, 1, nthreads,
+      specfem::parallel_configuration::chunk_config<dimension, 1, 1, nthreads,
                                              lane_size, simd,
                                              Kokkos::DefaultExecutionSpace>;
 

--- a/include/kokkos_kernels/impl/compute_stiffness_interaction.tpp
+++ b/include/kokkos_kernels/impl/compute_stiffness_interaction.tpp
@@ -78,7 +78,7 @@ int specfem::kokkos_kernels::impl::compute_stiffness_interaction(
 
   using simd = specfem::datatype::simd<type_real, using_simd>;
 
-  using ParallelConfig = specfem::parallel_config::default_chunk_config<
+  using ParallelConfig = specfem::parallel_configuration::default_chunk_config<
                   dimension_tag, simd, Kokkos::DefaultExecutionSpace>;
 
   using ChunkElementFieldType = specfem::chunk_element::displacement<

--- a/include/kokkos_kernels/impl/divide_mass_matrix.tpp
+++ b/include/kokkos_kernels/impl/divide_mass_matrix.tpp
@@ -31,7 +31,7 @@ void specfem::kokkos_kernels::impl::divide_mass_matrix(
   using PointMassInverseType =
       specfem::point::mass_inverse<dimension, medium_tag, using_simd>;
 
-  using parallel_config = specfem::parallel_config::default_range_config<
+  using parallel_config = specfem::parallel_configuration::default_range_config<
       specfem::datatype::simd<type_real, using_simd>,
       Kokkos::DefaultExecutionSpace>;
 

--- a/include/kokkos_kernels/impl/invert_mass_matrix.tpp
+++ b/include/kokkos_kernels/impl/invert_mass_matrix.tpp
@@ -29,7 +29,7 @@ void specfem::kokkos_kernels::impl::invert_mass_matrix(
   using PointMassType =
       specfem::point::mass_inverse<dimension, medium_tag, using_simd>;
 
-  using parallel_config = specfem::parallel_config::default_range_config<
+  using parallel_config = specfem::parallel_configuration::default_range_config<
       specfem::datatype::simd<type_real, using_simd>,
       Kokkos::DefaultExecutionSpace>;
 

--- a/include/parallel_configuration/chunk_config.hpp
+++ b/include/parallel_configuration/chunk_config.hpp
@@ -6,7 +6,7 @@
 #include <Kokkos_Core.hpp>
 
 namespace specfem {
-namespace parallel_config {
+namespace parallel_configuration {
 
 namespace impl {
 constexpr int cuda_chunk_size = 32;
@@ -61,7 +61,7 @@ struct chunk_config {
  * Execution space.
  *
  * Defines chunk size, tile size, number of threads, number of vector lanes
- * defaults for @ref specfem::parallel_config::chunk_config
+ * defaults for @ref specfem::parallel_configuration::chunk_config
  *
  * @tparam DimensionTag Dimension type of the elements within a chunk.
  * @tparam SIMD SIMD type to use simd operations. @ref specfem::datatypes::simd
@@ -146,5 +146,5 @@ struct default_chunk_config<specfem::dimension::type::dim3, SIMD,
     : default_chunk_config<specfem::dimension::type::dim3, SIMD,
                            Kokkos::Serial> {};
 #endif
-} // namespace parallel_config
+} // namespace parallel_configuration
 } // namespace specfem

--- a/include/parallel_configuration/chunk_config.hpp
+++ b/include/parallel_configuration/chunk_config.hpp
@@ -10,6 +10,7 @@ namespace parallel_config {
 
 namespace impl {
 constexpr int cuda_chunk_size = 32;
+constexpr int cuda_chunk_size_3d = 4;
 constexpr int hip_chunk_size = 64;
 constexpr int openmp_chunk_size = 1;
 constexpr int serial_chunk_size = 1;
@@ -78,8 +79,8 @@ struct default_chunk_config<specfem::dimension::type::dim2, SIMD, Kokkos::Cuda>
 
 template <typename SIMD>
 struct default_chunk_config<specfem::dimension::type::dim3, SIMD, Kokkos::Cuda>
-    : chunk_config<specfem::dimension::type::dim3, impl::cuda_chunk_size,
-                   impl::cuda_chunk_size, 512, 1, SIMD, Kokkos::Cuda> {};
+    : chunk_config<specfem::dimension::type::dim3, impl::cuda_chunk_size_3d,
+                   impl::cuda_chunk_size_3d, 512, 1, SIMD, Kokkos::Cuda> {};
 #endif
 
 #if defined(KOKKOS_ENABLE_HIP)

--- a/include/parallel_configuration/chunk_edge_config.hpp
+++ b/include/parallel_configuration/chunk_edge_config.hpp
@@ -4,7 +4,7 @@
 #include "enumerations/dimension.hpp"
 #include <Kokkos_Core.hpp>
 
-namespace specfem::parallel_config {
+namespace specfem::parallel_configuration {
 
 template <specfem::dimension::type DimensionTag, int ChunkSize,
           typename ExecutionSpace>
@@ -44,4 +44,4 @@ template <specfem::dimension::type DimensionTag>
 struct default_chunk_edge_config<DimensionTag, Kokkos::HostSpace>
     : default_chunk_edge_config<DimensionTag, Kokkos::Serial> {};
 #endif
-} // namespace specfem::parallel_config
+} // namespace specfem::parallel_configuration

--- a/include/parallel_configuration/edge_config.hpp
+++ b/include/parallel_configuration/edge_config.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 namespace specfem {
-namespace parallel_config {
+namespace parallel_configuration {
 
 /**
  * @brief Parallel configuration for edge policy.
@@ -58,5 +58,5 @@ struct default_edge_config<specfem::dimension::type::dim2, Kokkos::Serial>
     : edge_config<specfem::dimension::type::dim2, 1, 1, Kokkos::Serial> {};
 #endif
 
-} // namespace parallel_config
+} // namespace parallel_configuration
 } // namespace specfem

--- a/include/parallel_configuration/range_config.hpp
+++ b/include/parallel_configuration/range_config.hpp
@@ -3,7 +3,7 @@
 #include <cstddef>
 
 namespace specfem {
-namespace parallel_config {
+namespace parallel_configuration {
 
 /**
  * @brief Parallel configuration for range policy
@@ -30,5 +30,5 @@ struct range_config {
 template <typename SIMD, typename ExecutionSpace>
 using default_range_config = range_config<SIMD, ExecutionSpace, 1, 1>;
 
-} // namespace parallel_config
+} // namespace parallel_configuration
 } // namespace specfem

--- a/include/policies/edge.hpp
+++ b/include/policies/edge.hpp
@@ -185,7 +185,7 @@ namespace policy {
  * between 2 elements.
  *
  * @tparam ParallelConfig Parallel configuration for element edge policy. @ref
- * specfem::parallel_config::edge_config
+ * specfem::parallel_configuration::edge_config
  */
 template <typename ParallelConfig>
 struct element_edge

--- a/src/enumerations/dim3/mesh_entities.cpp
+++ b/src/enumerations/dim3/mesh_entities.cpp
@@ -204,7 +204,7 @@ specfem::mesh_entity::element<specfem::dimension::type::dim3>::element(
   // ymin = front, ymax = back
 
   face_coordinates[specfem::mesh_entity::dim3::type::bottom] =
-      [*this](const int ipoint, const int jpoint) {
+      [this](const int ipoint, const int jpoint) {
         const int iz = 0;
         const int iy = ipoint;
         const int ix = jpoint;
@@ -212,7 +212,7 @@ specfem::mesh_entity::element<specfem::dimension::type::dim3>::element(
       };
 
   face_coordinates[specfem::mesh_entity::dim3::type::top] =
-      [*this](const int ipoint, const int jpoint) {
+      [this](const int ipoint, const int jpoint) {
         const int iz = this->ngllz - 1;
         const int iy = ipoint;
         const int ix = jpoint;
@@ -220,7 +220,7 @@ specfem::mesh_entity::element<specfem::dimension::type::dim3>::element(
       };
 
   face_coordinates[specfem::mesh_entity::dim3::type::front] =
-      [*this](const int ipoint, const int jpoint) {
+      [this](const int ipoint, const int jpoint) {
         const int iz = ipoint;
         const int iy = 0;
         const int ix = jpoint;
@@ -228,7 +228,7 @@ specfem::mesh_entity::element<specfem::dimension::type::dim3>::element(
       };
 
   face_coordinates[specfem::mesh_entity::dim3::type::back] =
-      [*this](const int ipoint, const int jpoint) {
+      [this](const int ipoint, const int jpoint) {
         const int iz = ipoint;
         const int iy = this->nglly - 1;
         const int ix = jpoint;
@@ -236,7 +236,7 @@ specfem::mesh_entity::element<specfem::dimension::type::dim3>::element(
       };
 
   face_coordinates[specfem::mesh_entity::dim3::type::left] =
-      [*this](const int ipoint, const int jpoint) {
+      [this](const int ipoint, const int jpoint) {
         const int iz = ipoint;
         const int iy = jpoint;
         const int ix = 0;
@@ -244,7 +244,7 @@ specfem::mesh_entity::element<specfem::dimension::type::dim3>::element(
       };
 
   face_coordinates[specfem::mesh_entity::dim3::type::right] =
-      [*this](const int ipoint, const int jpoint) {
+      [this](const int ipoint, const int jpoint) {
         const int iz = ipoint;
         const int iy = jpoint;
         const int ix = this->ngllx - 1;
@@ -252,7 +252,7 @@ specfem::mesh_entity::element<specfem::dimension::type::dim3>::element(
       };
 
   edge_coordinates[specfem::mesh_entity::dim3::type::front_bottom] =
-      [*this](const int point) {
+      [this](const int point) {
         const int iz = 0;
         const int iy = 0;
         const int ix = point;
@@ -260,7 +260,7 @@ specfem::mesh_entity::element<specfem::dimension::type::dim3>::element(
       };
 
   edge_coordinates[specfem::mesh_entity::dim3::type::back_bottom] =
-      [*this](const int point) {
+      [this](const int point) {
         const int iz = 0;
         const int iy = this->nglly - 1;
         const int ix = point;
@@ -268,7 +268,7 @@ specfem::mesh_entity::element<specfem::dimension::type::dim3>::element(
       };
 
   edge_coordinates[specfem::mesh_entity::dim3::type::front_top] =
-      [*this](const int point) {
+      [this](const int point) {
         const int iz = this->ngllz - 1;
         const int iy = 0;
         const int ix = point;
@@ -276,7 +276,7 @@ specfem::mesh_entity::element<specfem::dimension::type::dim3>::element(
       };
 
   edge_coordinates[specfem::mesh_entity::dim3::type::back_top] =
-      [*this](const int point) {
+      [this](const int point) {
         const int iz = this->ngllz - 1;
         const int iy = this->nglly - 1;
         const int ix = point;
@@ -284,7 +284,7 @@ specfem::mesh_entity::element<specfem::dimension::type::dim3>::element(
       };
 
   edge_coordinates[specfem::mesh_entity::dim3::type::bottom_left] =
-      [*this](const int point) {
+      [this](const int point) {
         const int iz = 0;
         const int iy = point;
         const int ix = 0;
@@ -292,7 +292,7 @@ specfem::mesh_entity::element<specfem::dimension::type::dim3>::element(
       };
 
   edge_coordinates[specfem::mesh_entity::dim3::type::bottom_right] =
-      [*this](const int point) {
+      [this](const int point) {
         const int iz = 0;
         const int iy = point;
         const int ix = this->ngllx - 1;
@@ -300,7 +300,7 @@ specfem::mesh_entity::element<specfem::dimension::type::dim3>::element(
       };
 
   edge_coordinates[specfem::mesh_entity::dim3::type::top_left] =
-      [*this](const int point) {
+      [this](const int point) {
         const int iz = this->ngllz - 1;
         const int iy = point;
         const int ix = 0;
@@ -308,7 +308,7 @@ specfem::mesh_entity::element<specfem::dimension::type::dim3>::element(
       };
 
   edge_coordinates[specfem::mesh_entity::dim3::type::top_right] =
-      [*this](const int point) {
+      [this](const int point) {
         const int iz = this->ngllz - 1;
         const int iy = point;
         const int ix = this->ngllx - 1;
@@ -316,7 +316,7 @@ specfem::mesh_entity::element<specfem::dimension::type::dim3>::element(
       };
 
   edge_coordinates[specfem::mesh_entity::dim3::type::front_left] =
-      [*this](const int point) {
+      [this](const int point) {
         const int iz = point;
         const int iy = 0;
         const int ix = 0;
@@ -324,7 +324,7 @@ specfem::mesh_entity::element<specfem::dimension::type::dim3>::element(
       };
 
   edge_coordinates[specfem::mesh_entity::dim3::type::front_right] =
-      [*this](const int point) {
+      [this](const int point) {
         const int iz = point;
         const int iy = 0;
         const int ix = this->ngllx - 1;
@@ -332,7 +332,7 @@ specfem::mesh_entity::element<specfem::dimension::type::dim3>::element(
       };
 
   edge_coordinates[specfem::mesh_entity::dim3::type::back_left] =
-      [*this](const int point) {
+      [this](const int point) {
         const int iz = point;
         const int iy = this->nglly - 1;
         const int ix = 0;
@@ -340,7 +340,7 @@ specfem::mesh_entity::element<specfem::dimension::type::dim3>::element(
       };
 
   edge_coordinates[specfem::mesh_entity::dim3::type::back_right] =
-      [*this](const int point) {
+      [this](const int point) {
         const int iz = point;
         const int iy = this->nglly - 1;
         const int ix = this->ngllx - 1;

--- a/src/enumerations/dim3/mesh_entities.cpp
+++ b/src/enumerations/dim3/mesh_entities.cpp
@@ -196,174 +196,90 @@ specfem::mesh_entity::element<specfem::dimension::type::dim3>::element(
 
 specfem::mesh_entity::element<specfem::dimension::type::dim3>::element(
     const int ngllz, const int nglly, const int ngllx)
-    : element_grid(ngllz, nglly, ngllx), ngll2d(ngllz * ngllx), ngll(ngllz) {
+    : element_grid(ngllz, nglly, ngllx), ngll2d(ngllz * ngllx), ngll(ngllz) {}
 
-  // Initialize edge coordinates
+std::tuple<int, int, int>
+specfem::mesh_entity::element<specfem::dimension::type::dim3>::
+    get_face_coordinates(const specfem::mesh_entity::dim3::type &face,
+                         const int ipoint, const int jpoint) const {
   // xmin = left, xmax = right
   // zmin = bottom, zmax = top
   // ymin = front, ymax = back
+  switch (face) {
+  case specfem::mesh_entity::dim3::type::bottom:
+    return std::make_tuple(0, ipoint, jpoint);
+  case specfem::mesh_entity::dim3::type::top:
+    return std::make_tuple(ngllz - 1, ipoint, jpoint);
+  case specfem::mesh_entity::dim3::type::front:
+    return std::make_tuple(ipoint, 0, jpoint);
+  case specfem::mesh_entity::dim3::type::back:
+    return std::make_tuple(ipoint, nglly - 1, jpoint);
+  case specfem::mesh_entity::dim3::type::left:
+    return std::make_tuple(ipoint, jpoint, 0);
+  case specfem::mesh_entity::dim3::type::right:
+    return std::make_tuple(ipoint, jpoint, ngllx - 1);
+  default:
+    throw std::runtime_error("Invalid face type");
+  }
+}
 
-  face_coordinates[specfem::mesh_entity::dim3::type::bottom] =
-      [this](const int ipoint, const int jpoint) {
-        const int iz = 0;
-        const int iy = ipoint;
-        const int ix = jpoint;
-        return std::make_tuple(iz, iy, ix);
-      };
+std::tuple<int, int, int>
+specfem::mesh_entity::element<specfem::dimension::type::dim3>::
+    get_edge_coordinates(const specfem::mesh_entity::dim3::type &edge,
+                         const int point) const {
+  switch (edge) {
+  case specfem::mesh_entity::dim3::type::front_bottom:
+    return std::make_tuple(0, 0, point);
+  case specfem::mesh_entity::dim3::type::back_bottom:
+    return std::make_tuple(0, nglly - 1, point);
+  case specfem::mesh_entity::dim3::type::front_top:
+    return std::make_tuple(ngllz - 1, 0, point);
+  case specfem::mesh_entity::dim3::type::back_top:
+    return std::make_tuple(ngllz - 1, nglly - 1, point);
+  case specfem::mesh_entity::dim3::type::bottom_left:
+    return std::make_tuple(0, point, 0);
+  case specfem::mesh_entity::dim3::type::bottom_right:
+    return std::make_tuple(0, point, ngllx - 1);
+  case specfem::mesh_entity::dim3::type::top_left:
+    return std::make_tuple(ngllz - 1, point, 0);
+  case specfem::mesh_entity::dim3::type::top_right:
+    return std::make_tuple(ngllz - 1, point, ngllx - 1);
+  case specfem::mesh_entity::dim3::type::front_left:
+    return std::make_tuple(point, 0, 0);
+  case specfem::mesh_entity::dim3::type::front_right:
+    return std::make_tuple(point, 0, ngllx - 1);
+  case specfem::mesh_entity::dim3::type::back_left:
+    return std::make_tuple(point, nglly - 1, 0);
+  case specfem::mesh_entity::dim3::type::back_right:
+    return std::make_tuple(point, nglly - 1, ngllx - 1);
+  default:
+    throw std::runtime_error("Invalid edge type");
+  }
+}
 
-  face_coordinates[specfem::mesh_entity::dim3::type::top] =
-      [this](const int ipoint, const int jpoint) {
-        const int iz = this->ngllz - 1;
-        const int iy = ipoint;
-        const int ix = jpoint;
-        return std::make_tuple(iz, iy, ix);
-      };
-
-  face_coordinates[specfem::mesh_entity::dim3::type::front] =
-      [this](const int ipoint, const int jpoint) {
-        const int iz = ipoint;
-        const int iy = 0;
-        const int ix = jpoint;
-        return std::make_tuple(iz, iy, ix);
-      };
-
-  face_coordinates[specfem::mesh_entity::dim3::type::back] =
-      [this](const int ipoint, const int jpoint) {
-        const int iz = ipoint;
-        const int iy = this->nglly - 1;
-        const int ix = jpoint;
-        return std::make_tuple(iz, iy, ix);
-      };
-
-  face_coordinates[specfem::mesh_entity::dim3::type::left] =
-      [this](const int ipoint, const int jpoint) {
-        const int iz = ipoint;
-        const int iy = jpoint;
-        const int ix = 0;
-        return std::make_tuple(iz, iy, ix);
-      };
-
-  face_coordinates[specfem::mesh_entity::dim3::type::right] =
-      [this](const int ipoint, const int jpoint) {
-        const int iz = ipoint;
-        const int iy = jpoint;
-        const int ix = this->ngllx - 1;
-        return std::make_tuple(iz, iy, ix);
-      };
-
-  edge_coordinates[specfem::mesh_entity::dim3::type::front_bottom] =
-      [this](const int point) {
-        const int iz = 0;
-        const int iy = 0;
-        const int ix = point;
-        return std::make_tuple(iz, iy, ix);
-      };
-
-  edge_coordinates[specfem::mesh_entity::dim3::type::back_bottom] =
-      [this](const int point) {
-        const int iz = 0;
-        const int iy = this->nglly - 1;
-        const int ix = point;
-        return std::make_tuple(iz, iy, ix);
-      };
-
-  edge_coordinates[specfem::mesh_entity::dim3::type::front_top] =
-      [this](const int point) {
-        const int iz = this->ngllz - 1;
-        const int iy = 0;
-        const int ix = point;
-        return std::make_tuple(iz, iy, ix);
-      };
-
-  edge_coordinates[specfem::mesh_entity::dim3::type::back_top] =
-      [this](const int point) {
-        const int iz = this->ngllz - 1;
-        const int iy = this->nglly - 1;
-        const int ix = point;
-        return std::make_tuple(iz, iy, ix);
-      };
-
-  edge_coordinates[specfem::mesh_entity::dim3::type::bottom_left] =
-      [this](const int point) {
-        const int iz = 0;
-        const int iy = point;
-        const int ix = 0;
-        return std::make_tuple(iz, iy, ix);
-      };
-
-  edge_coordinates[specfem::mesh_entity::dim3::type::bottom_right] =
-      [this](const int point) {
-        const int iz = 0;
-        const int iy = point;
-        const int ix = this->ngllx - 1;
-        return std::make_tuple(iz, iy, ix);
-      };
-
-  edge_coordinates[specfem::mesh_entity::dim3::type::top_left] =
-      [this](const int point) {
-        const int iz = this->ngllz - 1;
-        const int iy = point;
-        const int ix = 0;
-        return std::make_tuple(iz, iy, ix);
-      };
-
-  edge_coordinates[specfem::mesh_entity::dim3::type::top_right] =
-      [this](const int point) {
-        const int iz = this->ngllz - 1;
-        const int iy = point;
-        const int ix = this->ngllx - 1;
-        return std::make_tuple(iz, iy, ix);
-      };
-
-  edge_coordinates[specfem::mesh_entity::dim3::type::front_left] =
-      [this](const int point) {
-        const int iz = point;
-        const int iy = 0;
-        const int ix = 0;
-        return std::make_tuple(iz, iy, ix);
-      };
-
-  edge_coordinates[specfem::mesh_entity::dim3::type::front_right] =
-      [this](const int point) {
-        const int iz = point;
-        const int iy = 0;
-        const int ix = this->ngllx - 1;
-        return std::make_tuple(iz, iy, ix);
-      };
-
-  edge_coordinates[specfem::mesh_entity::dim3::type::back_left] =
-      [this](const int point) {
-        const int iz = point;
-        const int iy = this->nglly - 1;
-        const int ix = 0;
-        return std::make_tuple(iz, iy, ix);
-      };
-
-  edge_coordinates[specfem::mesh_entity::dim3::type::back_right] =
-      [this](const int point) {
-        const int iz = point;
-        const int iy = this->nglly - 1;
-        const int ix = this->ngllx - 1;
-        return std::make_tuple(iz, iy, ix);
-      };
-
-  // Initialize corner coordinates
-  corner_coordinates[specfem::mesh_entity::dim3::type::bottom_front_left] =
-      std::make_tuple(0, 0, 0);
-  corner_coordinates[specfem::mesh_entity::dim3::type::bottom_front_right] =
-      std::make_tuple(0, 0, this->ngllx - 1);
-  corner_coordinates[specfem::mesh_entity::dim3::type::bottom_back_left] =
-      std::make_tuple(0, this->nglly - 1, 0);
-  corner_coordinates[specfem::mesh_entity::dim3::type::bottom_back_right] =
-      std::make_tuple(0, this->nglly - 1, this->ngllx - 1);
-  corner_coordinates[specfem::mesh_entity::dim3::type::top_front_left] =
-      std::make_tuple(this->ngllz - 1, 0, 0);
-  corner_coordinates[specfem::mesh_entity::dim3::type::top_front_right] =
-      std::make_tuple(this->ngllz - 1, 0, this->ngllx - 1);
-  corner_coordinates[specfem::mesh_entity::dim3::type::top_back_left] =
-      std::make_tuple(this->ngllz - 1, this->nglly - 1, 0);
-  corner_coordinates[specfem::mesh_entity::dim3::type::top_back_right] =
-      std::make_tuple(this->ngllz - 1, this->nglly - 1, this->ngllx - 1);
+std::tuple<int, int, int> specfem::mesh_entity::
+    element<specfem::dimension::type::dim3>::get_corner_coordinates(
+        const specfem::mesh_entity::dim3::type &corner) const {
+  switch (corner) {
+  case specfem::mesh_entity::dim3::type::bottom_front_left:
+    return std::make_tuple(0, 0, 0);
+  case specfem::mesh_entity::dim3::type::bottom_front_right:
+    return std::make_tuple(0, 0, ngllx - 1);
+  case specfem::mesh_entity::dim3::type::bottom_back_left:
+    return std::make_tuple(0, nglly - 1, 0);
+  case specfem::mesh_entity::dim3::type::bottom_back_right:
+    return std::make_tuple(0, nglly - 1, ngllx - 1);
+  case specfem::mesh_entity::dim3::type::top_front_left:
+    return std::make_tuple(ngllz - 1, 0, 0);
+  case specfem::mesh_entity::dim3::type::top_front_right:
+    return std::make_tuple(ngllz - 1, 0, ngllx - 1);
+  case specfem::mesh_entity::dim3::type::top_back_left:
+    return std::make_tuple(ngllz - 1, nglly - 1, 0);
+  case specfem::mesh_entity::dim3::type::top_back_right:
+    return std::make_tuple(ngllz - 1, nglly - 1, ngllx - 1);
+  default:
+    throw std::runtime_error("Invalid corner type");
+  }
 }
 
 int specfem::mesh_entity::element<specfem::dimension::type::dim3>::
@@ -397,13 +313,13 @@ specfem::mesh_entity::element<specfem::dimension::type::dim3>::map_coordinates(
   }
 
   if (specfem::mesh_entity::contains(specfem::mesh_entity::dim3::edges, entity))
-    return edge_coordinates.at(entity)(point);
+    return get_edge_coordinates(entity, point);
 
   if (specfem::mesh_entity::contains(specfem::mesh_entity::dim3::faces,
                                      entity)) {
     const int ipoint = point % ngll;
     const int jpoint = point / ngll;
-    return face_coordinates.at(entity)(ipoint, jpoint);
+    return get_face_coordinates(entity, ipoint, jpoint);
   }
 
   throw std::runtime_error("Unknown entity type");
@@ -417,7 +333,7 @@ specfem::mesh_entity::element<specfem::dimension::type::dim3>::map_coordinates(
     throw std::runtime_error("The argument is not a corner");
   }
 
-  return corner_coordinates.at(corner);
+  return get_corner_coordinates(corner);
 }
 
 /**

--- a/tests/unit-tests/algorithms/dim2/gradient.cpp
+++ b/tests/unit-tests/algorithms/dim2/gradient.cpp
@@ -608,10 +608,9 @@ execute(const Jacobian &jacobian_matrix, const Quadrature2D &quadrature,
   const auto element_indices = Kokkos::create_mirror_view_and_copy(
       Kokkos::DefaultExecutionSpace(), h_element_indices);
 
-  using ParallelConfig =
-      specfem::parallel_config::chunk_config<specfem::dimension::type::dim2, 1,
-                                             1, 1, 1, simd,
-                                             Kokkos::DefaultExecutionSpace>;
+  using ParallelConfig = specfem::parallel_configuration::chunk_config<
+      specfem::dimension::type::dim2, 1, 1, 1, 1, simd,
+      Kokkos::DefaultExecutionSpace>;
 
   const specfem::mesh_entity::element_grid element_grid(ngll, ngll);
 

--- a/tests/unit-tests/algorithms/dim3/gradient.cpp
+++ b/tests/unit-tests/algorithms/dim3/gradient.cpp
@@ -691,10 +691,9 @@ execute(const Jacobian &jacobian_matrix, const Quadrature3D &quadrature,
   const auto element_indices = Kokkos::create_mirror_view_and_copy(
       Kokkos::DefaultExecutionSpace(), h_element_indices);
 
-  using ParallelConfig =
-      specfem::parallel_config::chunk_config<specfem::dimension::type::dim3, 1,
-                                             1, 1, 1, simd,
-                                             Kokkos::DefaultExecutionSpace>;
+  using ParallelConfig = specfem::parallel_configuration::chunk_config<
+      specfem::dimension::type::dim3, 1, 1, 1, 1, simd,
+      Kokkos::DefaultExecutionSpace>;
 
   const specfem::mesh_entity::element_grid element_grid(ngll, ngll, ngll);
 

--- a/tests/unit-tests/assembly/kernels/kernels.cpp
+++ b/tests/unit-tests/assembly/kernels/kernels.cpp
@@ -8,7 +8,7 @@
 #include <gtest/gtest.h>
 
 template <bool using_simd, typename ExecutionSpace>
-using ParallelConfig = specfem::parallel_config::default_chunk_config<
+using ParallelConfig = specfem::parallel_configuration::default_chunk_config<
     specfem::dimension::type::dim2,
     specfem::datatype::simd<type_real, using_simd>, ExecutionSpace>;
 

--- a/tests/unit-tests/assembly/properties/properties.cpp
+++ b/tests/unit-tests/assembly/properties/properties.cpp
@@ -11,7 +11,7 @@
 #include <gtest/gtest.h>
 
 template <bool using_simd, typename ExecutionSpace>
-using ParallelConfig = specfem::parallel_config::default_chunk_config<
+using ParallelConfig = specfem::parallel_configuration::default_chunk_config<
     specfem::dimension::type::dim2,
     specfem::datatype::simd<type_real, using_simd>, ExecutionSpace>;
 

--- a/tests/unit-tests/compute_coupling/nonconforming.cpp
+++ b/tests/unit-tests/compute_coupling/nonconforming.cpp
@@ -377,8 +377,9 @@ struct EdgeToInterfaceCouplingTestParams {
   template <specfem::dimension::type DimensionTag,
             specfem::interface::interface_tag InterfaceTag,
             std::size_t nquad_edge, std::size_t nquad_intersection,
-            int num_edges = specfem::parallel_config::default_chunk_edge_config<
-                DimensionTag, Kokkos::DefaultExecutionSpace>::chunk_size>
+            int num_edges =
+                specfem::parallel_configuration::default_chunk_edge_config<
+                    DimensionTag, Kokkos::DefaultExecutionSpace>::chunk_size>
   static EdgeToInterfaceCouplingTestParams
   from(const std::string &name, const type_real (&edge)[nquad_edge],
        const type_real (&intersection)[nquad_intersection]) {

--- a/tests/unit-tests/mesh_utilities/mapping.cpp
+++ b/tests/unit-tests/mesh_utilities/mapping.cpp
@@ -44,7 +44,8 @@ flatten_coordinates(const HostView4d &global_coordinates) {
 
   std::vector<point_2d> points(nspec * ngllxz);
 
-  constexpr int chunk_size = specfem::parallel_config::storage_chunk_size;
+  constexpr int chunk_size =
+      specfem::parallel_configuration::storage_chunk_size;
 
   int iloc = 0;
   for (int ichunk = 0; ichunk < nspec; ichunk += chunk_size) {
@@ -135,7 +136,8 @@ create_coordinate_arrays(const std::vector<point_2d> &reordered_points,
           "coord", 2, nspec, ngll, ngll);
 
   std::vector<int> iglob_counted(nglob, -1);
-  constexpr int chunk_size = specfem::parallel_config::storage_chunk_size;
+  constexpr int chunk_size =
+      specfem::parallel_configuration::storage_chunk_size;
   int iloc = 0;
   int inum = 0;
 
@@ -223,7 +225,8 @@ flatten_coordinates(const HostView5d &global_coordinates) {
 
   std::vector<point_3d> points(nspec * ngllxyz);
 
-  constexpr int chunk_size = specfem::parallel_config::storage_chunk_size;
+  constexpr int chunk_size =
+      specfem::parallel_configuration::storage_chunk_size;
 
   int iloc = 0;
   for (int ichunk = 0; ichunk < nspec; ichunk += chunk_size) {
@@ -324,7 +327,8 @@ create_coordinate_arrays(const std::vector<point_3d> &reordered_points,
           "coord", nspec, ngll, ngll, ngll, 3); // (ispec, iz, iy, ix, icoord)
 
   std::vector<int> iglob_counted(nglob, -1);
-  constexpr int chunk_size = specfem::parallel_config::storage_chunk_size;
+  constexpr int chunk_size =
+      specfem::parallel_configuration::storage_chunk_size;
   int iloc = 0;
   int inum = 0;
 

--- a/tests/unit-tests/policies/chunked_edge.cpp
+++ b/tests/unit-tests/policies/chunked_edge.cpp
@@ -15,8 +15,9 @@
 // Base fixture for common functionality
 class ChunkedIteratorTestBase {
 public:
-  using ParallelConfig = specfem::parallel_config::default_chunk_edge_config<
-      specfem::dimension::type::dim2, Kokkos::DefaultExecutionSpace>;
+  using ParallelConfig =
+      specfem::parallel_configuration::default_chunk_edge_config<
+          specfem::dimension::type::dim2, Kokkos::DefaultExecutionSpace>;
 
   constexpr static int num_points = 5;
   using StorageViewType =

--- a/tests/unit-tests/policies/policies.cpp
+++ b/tests/unit-tests/policies/policies.cpp
@@ -333,10 +333,12 @@ TEST_P(RangePolicyTest, VisitAllPoints) {
   const auto params = GetParam();
   const int nglob = params.nglob;
 
-  using ParallelConfig = specfem::parallel_config::default_range_config<
+  using ParallelConfig = specfem::parallel_configuration::default_range_config<
       specfem::datatype::simd<type_real, false>, Kokkos::DefaultExecutionSpace>;
-  using SimdParallelConfig = specfem::parallel_config::default_range_config<
-      specfem::datatype::simd<type_real, true>, Kokkos::DefaultExecutionSpace>;
+  using SimdParallelConfig =
+      specfem::parallel_configuration::default_range_config<
+          specfem::datatype::simd<type_real, true>,
+          Kokkos::DefaultExecutionSpace>;
 
   const auto check_test_view = [&](const auto &test_view,
                                    const std::string &error) {
@@ -360,13 +362,15 @@ TEST_P(ChunkElementPolicyTest, VisitAllPoints) {
   const int ngllz = params.ngllz;
   const int ngllx = params.ngllx;
 
-  using ParallelConfig = specfem::parallel_config::default_chunk_config<
+  using ParallelConfig = specfem::parallel_configuration::default_chunk_config<
       specfem::dimension::type::dim2, specfem::datatype::simd<type_real, false>,
       Kokkos::DefaultExecutionSpace>;
 
-  using SimdParallelConfig = specfem::parallel_config::default_chunk_config<
-      specfem::dimension::type::dim2, specfem::datatype::simd<type_real, true>,
-      Kokkos::DefaultExecutionSpace>;
+  using SimdParallelConfig =
+      specfem::parallel_configuration::default_chunk_config<
+          specfem::dimension::type::dim2,
+          specfem::datatype::simd<type_real, true>,
+          Kokkos::DefaultExecutionSpace>;
 
   const auto check_test_view = [&](const auto &test_view,
                                    const std::string &error) {
@@ -398,13 +402,15 @@ TEST_P(ChunkElementPolicy3DTest, VisitAllPoints) {
   const int nglly = params.nglly;
   const int ngllx = params.ngllx;
 
-  using ParallelConfig = specfem::parallel_config::default_chunk_config<
+  using ParallelConfig = specfem::parallel_configuration::default_chunk_config<
       specfem::dimension::type::dim3, specfem::datatype::simd<type_real, false>,
       Kokkos::DefaultExecutionSpace>;
 
-  using SimdParallelConfig = specfem::parallel_config::default_chunk_config<
-      specfem::dimension::type::dim3, specfem::datatype::simd<type_real, true>,
-      Kokkos::DefaultExecutionSpace>;
+  using SimdParallelConfig =
+      specfem::parallel_configuration::default_chunk_config<
+          specfem::dimension::type::dim3,
+          specfem::datatype::simd<type_real, true>,
+          Kokkos::DefaultExecutionSpace>;
 
   const auto check_test_view = [&](const auto &test_view,
                                    const std::string &error) {


### PR DESCRIPTION
## Description

Once that was fixed, I was able to update the default chunk config for not only 3D but also 2D. So the computation should be slightly faster now in 


### Discussion point

Seismograms computation for 2 and 3D have drastically different chunksizes, which begs the question whether we should actually create separate values for dimension and kernel computation on CUDA. That is,

- chunksize_mass_{2d,3d}
- chunksize_seis_{2d,3d}
- chunksize_stif_{2d,3d}

etc.

## Commits

- There was a bug that required the allocation of memory during cuda execution. Once that was fixed, I was able to update the default chunk config. (96b15ddc)

## Issue Number

If there is an issue created for these changes, link it here

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
