### PR TITLE
Change signed wavefields to B-R colors

### DIFF
--- a/core/specfem/periodic_tasks/plot_wavefield.cpp
+++ b/core/specfem/periodic_tasks/plot_wavefield.cpp
@@ -901,15 +901,17 @@ void specfem::periodic_tasks::plot_wavefield::initialize_display(
   } else {
     double range[2];
     scalars->GetRange(range);
-    double abs_max = std::max(std::abs(range[0]), std::abs(range[1]));
+    double abs_max = (std::abs(range[0]) + std::abs(range[1])) / 2.0;
     this->wavefield_mapper->SetScalarRange(-abs_max, abs_max);
     this->lut->SetRange(-abs_max, abs_max);
 
     for (int i = 0; i < 256; ++i) {
       double t = static_cast<double>(i) / 255.0;
-      double transparency = 2.0 * std::abs(0.5 - t);
-      double step = t > 0.5 ? 1.0 : 0.0;
-      this->lut->SetTableValue(i, step, 0.0, 1.0 - step, transparency);
+      double transparency = this->sigmoid(2.0 * std::abs(0.5 - t));
+      double blue_frac = std::min(2.0 - 2.0 * t, 1.0);
+      double red_frac = std::min(2.0 * t, 1.0);
+      this->lut->SetTableValue(i, red_frac, std::min(blue_frac, red_frac),
+                               blue_frac, transparency);
     }
   }
 
@@ -1048,7 +1050,7 @@ void specfem::periodic_tasks::plot_wavefield::run_render(
     this->wavefield_mapper->SetScalarRange(range[0], range[1]);
     this->lut->SetRange(range[0], range[1]);
   } else {
-    double abs_max = std::max(std::abs(range[0]), std::abs(range[1]));
+    double abs_max = (std::abs(range[0]), std::abs(range[1])) / 2.0;
     this->wavefield_mapper->SetScalarRange(-abs_max, abs_max);
     this->lut->SetRange(-abs_max, abs_max);
   }


### PR DESCRIPTION
## Description

Please describe the changes/features in this pull request.

For wavefields
```c++
        wavefield_type == specfem::wavefield::type::pressure ||
        wavefield_type == specfem::wavefield::type::rotation ||
        wavefield_type == specfem::wavefield::type::intrinsic_rotation ||
        wavefield_type == specfem::wavefield::type::curl
```
a blue-red display scheme is used for `plot_wavefield`.

## Issue Number

If there is an issue created for these changes, link it here

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
