### PR TITLE
Testing: tabulator draft

### DIFF
--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -47,6 +47,15 @@ add_library(
   utilities/src/compare_array.cpp
 )
 
+
+add_library(
+  tabulate
+  utilities/src/tabulate.cpp
+)
+target_link_libraries(
+  tabulate
+  Kokkos::kokkos
+)
 target_link_libraries(
   compare_arrays
   Kokkos::kokkos

--- a/tests/unit-tests/utilities/include/tabulate.hpp
+++ b/tests/unit-tests/utilities/include/tabulate.hpp
@@ -1,0 +1,253 @@
+#pragma once
+#include "tabulate_impl/entry.hpp"
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <iostream>
+namespace specfem::test {
+
+/**
+ * @brief Manages the printing of a table of data by fixing row and column width
+ * of each data entry. Both rows and columns may be labeled by a string.
+ *
+ *
+ * By default, a table will be formatted using box characters, akin to
+ * ┌───────┬──────────┬──────────┬─────┐
+ * │       │ column 0 │ column 1 │ ... │
+ * │───────┼──────────┼──────────┼─────│
+ * │ row 0 │ row0data │ row0data │ ... │
+ * │───────┼──────────┼──────────┼─────│
+ * │ row 0 │ row1data │ row1data │ ... │
+ * └───────┴──────────┴──────────┴─────┘
+ *
+ * If no rows are labeled, then the column to the left of "column 0" is skipped.
+ * Similarly, if no column is labeled, then the row above "row 0" is skipped.
+ *
+ * Data can be of any type, with a formatter specified per row / column to
+ * convert that cell to a string (more specifically, a vector of strings in the
+ * case of multiline entries).
+ */
+class Table {
+public:
+  using EntryType = specfem::test::tabulate_impl::EntryType;
+  using EntryFormatType = specfem::test::tabulate_impl::EntryFormat;
+
+private:
+  // =======================================
+  //   Table members
+  // =======================================
+  int ncols; // number of columns
+  int nrows; // number of rows
+
+  std::vector<std::string> column_labels;
+  std::vector<std::string> row_labels;
+  bool has_column_label;
+  bool has_row_label;
+
+  std::vector<std::unique_ptr<std::any> > data; // the columns in this
+                                                // table with their
+                                                // data
+
+  std::vector<EntryFormatType> column_formats;
+  std::vector<EntryFormatType> row_formats;
+
+private:
+  std::pair<int, int> to_2d_index(const int &index) const {
+    return std::make_pair(index / ncols, index % ncols);
+  }
+  int from_2d_index(const int &irow, const int &icol) const {
+    return irow * ncols + icol;
+  }
+
+  /**
+   * @brief Handles Python-like indexing for negative values, as well as bounds
+   * checking on the row.
+   */
+  int handle_relative_row(int row) {
+
+    if (row < 0) {
+      row = nrows + row;
+    }
+
+    if (row > nrows) {
+      std::ostringstream oss;
+      oss << "Cannot index row " << row << " of table with " << nrows
+          << " rows (out of bounds)";
+      throw std::runtime_error(oss.str());
+    }
+    if (row < 0) {
+      std::ostringstream oss;
+      oss << "Position " << row - nrows << " is too negative for a table with "
+          << nrows << " rows (out of bounds)";
+      throw std::runtime_error(oss.str());
+    }
+    return row;
+  }
+
+  /**
+   * @brief Handles Python-like indexing for negative values, as well as bounds
+   * checking on the column.
+   */
+  int handle_relative_col(int col) {
+
+    if (col < 0) {
+      col = ncols + col;
+    }
+
+    if (col > ncols) {
+      std::ostringstream oss;
+      oss << "Cannot index column " << col << " of table with " << ncols
+          << " columns (out of bounds)";
+      throw std::runtime_error(oss.str());
+    }
+    if (col < 0) {
+      std::ostringstream oss;
+      oss << "Position " << col - ncols << " is too negative for a table with "
+          << ncols << " cols (out of bounds)";
+      throw std::runtime_error(oss.str());
+    }
+    return col;
+  }
+
+public:
+  Table(const int &nrows = 0, const int &ncols = 0)
+      : ncols(ncols), nrows(nrows), data(ncols * nrows), column_labels(ncols),
+        row_labels(nrows), column_formats(ncols), row_formats(nrows),
+        has_row_label(false), has_column_label(false) {}
+
+  /**
+   * @brief Gets the width of the given column in number of characters. Padding
+   * (and dividers) not included.
+   *
+   * @param column Index of the column
+   * @return int Width of the column, in number of characters.
+   */
+  int width_of_column(const int &column) const;
+  /**
+   * @brief Gets the height of the given row in number of characters. Padding
+   * (and dividers) not included.
+   *
+   * @param row Index of the row
+   * @return int Height of the row, in number of characters.
+   */
+  int height_of_row(const int &row) const;
+
+  /**
+   * @brief Inserts a column at a given index. All columns originally at or
+   * after `position` are shifted by one.
+   *
+   * @param position index to insert into (a negative value counts back from the
+   * end)
+   * @return int the index (positive) of the new column.
+   */
+  int insert_column(int position = -1);
+
+  /**
+   * @brief Inserts a row at a given index. All rows originally at or
+   * after `position` are shifted by one.
+   *
+   * @param position index to insert into (a negative value counts back from the
+   * end)
+   * @return int the index (positive) of the new row.
+   */
+  int insert_row(int position = -1);
+
+  /**
+   * @brief Set the data at the given row and column.
+   *
+   * @param row row to place data in
+   * @param column column to place data in
+   * @param data the data to place. This is copied into a unique_ptr.
+   */
+  void set_data(const int &row, const int &column, const std::any &data) {
+    this->data[from_2d_index(handle_relative_row(row),
+                             handle_relative_col(column))] =
+        std::make_unique<std::any>(data);
+  }
+
+  void set_row_format(const int &row, const EntryType &type) {
+    row_formats[handle_relative_row(row)] =
+        specfem::test::tabulate_impl::formatter_from_type(type);
+  }
+  void set_column_format(const int &column, const EntryType &type) {
+    column_formats[handle_relative_col(column)] =
+        specfem::test::tabulate_impl::formatter_from_type(type);
+  }
+  void set_row_label(int row, const std::string &label) {
+    row = handle_relative_row(row);
+    row_labels[row] = label;
+    if (label.length() > 0) {
+      has_row_label = true;
+    } else {
+      // see if any labels are still set
+      has_row_label = false;
+      for (int irow = 0; irow < nrows; irow++) {
+        if (row_labels[irow].length() > 0) {
+          has_row_label = true;
+          break;
+        }
+      }
+    }
+  }
+  void set_column_label(int column, const std::string &label) {
+    column = handle_relative_col(column);
+    column_labels[column] = label;
+    if (label.length() > 0) {
+      has_column_label = true;
+    } else {
+      // see if any labels are still set
+      has_column_label = false;
+      for (int icol = 0; icol < ncols; icol++) {
+        if (column_labels[icol].length() > 0) {
+          has_column_label = true;
+          break;
+        }
+      }
+    }
+  }
+
+  EntryFormatType entry_formatter_at(const int &row, const int &column) const {
+    return row_formats[row] | column_formats[column];
+  }
+
+  std::vector<std::string> data_as_lines(const int &row,
+                                         const int &column) const {
+    const auto &data = this->data[from_2d_index(row, column)];
+    if (data == nullptr) {
+      return { "" };
+    }
+
+    try {
+      const auto formatter = entry_formatter_at(row, column);
+      return formatter.format(*data);
+    } catch (std::bad_any_cast) {
+      std::ostringstream oss;
+      oss << "When reading data at row " << row << " and column " << column
+          << ": Failed to cast data (type = " << (*data).type().name() << ").";
+      throw std::runtime_error(oss.str());
+    }
+  }
+
+  int get_nrows() const { return nrows; }
+  int get_ncols() const { return ncols; }
+  bool has_row_labels() const { return has_row_label; }
+  bool has_column_labels() const { return has_column_label; }
+  const std::string &get_row_label(const int &row) const {
+    return row_labels[row];
+  }
+  const std::string &get_column_label(const int &column) const {
+    return column_labels[column];
+  }
+};
+
+} // namespace specfem::test
+
+namespace std {
+std::ostream &operator<<(std::ostream &stream,
+                         const specfem::test::Table &table);
+std::string to_string(const specfem::test::Table &table);
+} // namespace std

--- a/tests/unit-tests/utilities/include/tabulate_impl/entry.hpp
+++ b/tests/unit-tests/utilities/include/tabulate_impl/entry.hpp
@@ -12,7 +12,7 @@ namespace specfem::test::tabulate_impl {
  * @brief The type of entry (grid cell) we expect to use
  *
  */
-enum class EntryType {
+enum class EntryType : int {
   string,
   real,
   vector,
@@ -164,10 +164,10 @@ public:
  * expansion.(Helper)
  *
  */
-template <std::underlying_type_t<EntryType>... types>
-static EntryFormat formatter_from_type(
-    const EntryType &type,
-    std::integer_sequence<std::underlying_type_t<EntryType>, types...>) {
+template <int... types> // explicit "int" instead of underlying_type -- not sure
+                        // why it doesn't compile on cuda 12.8
+static EntryFormat formatter_from_type(const EntryType &type,
+                                       std::integer_sequence<int, types...>) {
   std::unique_ptr<EntryFormatBase> data;
 
   (
@@ -196,10 +196,8 @@ static EntryFormat formatter_from_type(
  */
 static EntryFormat formatter_from_type(const EntryType &type) {
   return formatter_from_type(
-      type, std::make_integer_sequence<
-                std::underlying_type_t<EntryType>,
-                static_cast<std::underlying_type_t<EntryType> >(
-                    EntryType::num_types)>{});
+      type, std::make_integer_sequence<int, static_cast<int>(
+                                                EntryType::num_types)>{});
 }
 
 } // namespace specfem::test::tabulate_impl

--- a/tests/unit-tests/utilities/include/tabulate_impl/entry.hpp
+++ b/tests/unit-tests/utilities/include/tabulate_impl/entry.hpp
@@ -1,0 +1,205 @@
+#pragma once
+#include "specfem_setup.hpp"
+#include <any>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+namespace specfem::test::tabulate_impl {
+
+/**
+ * @brief The type of entry (grid cell) we expect to use
+ *
+ */
+enum class EntryType {
+  string,
+  real,
+  vector,
+  integer,
+
+  num_types
+};
+
+/**
+ * @brief (WIP) base class for formats.
+ *
+ */
+struct EntryFormatBase {
+  virtual bool is_union() const { return false; }
+  virtual std::vector<std::string> format(const std::any &data) const = 0;
+  virtual std::unique_ptr<EntryFormatBase> copy() const = 0;
+};
+
+/**
+ * @brief type-templated struct for a EntryType -> EntryFormatBase mapping.
+ */
+template <EntryType> struct TypedEntryFormatter;
+
+template <>
+struct TypedEntryFormatter<EntryType::string> : public EntryFormatBase {
+  std::vector<std::string> format(const std::any &data) const {
+    return { std::any_cast<std::string>(data) };
+  }
+  std::unique_ptr<EntryFormatBase> copy() const {
+    return std::make_unique<TypedEntryFormatter>();
+  }
+};
+template <>
+struct TypedEntryFormatter<EntryType::real> : public EntryFormatBase {
+  std::vector<std::string> format(const std::any &data) const {
+    return { std::to_string(std::any_cast<type_real>(data)) };
+  }
+  std::unique_ptr<EntryFormatBase> copy() const {
+    return std::make_unique<TypedEntryFormatter>();
+  }
+};
+template <>
+struct TypedEntryFormatter<EntryType::vector> : public EntryFormatBase {
+  std::vector<std::string> format(const std::any &data) const {
+    const auto &vec = std::any_cast<std::vector<type_real> >(data);
+    std::vector<std::string> repr;
+    for (const float &val : vec) {
+      repr.push_back(std::to_string(val));
+    }
+    return repr;
+  }
+  std::unique_ptr<EntryFormatBase> copy() const {
+    return std::make_unique<TypedEntryFormatter>();
+  }
+};
+template <>
+struct TypedEntryFormatter<EntryType::integer> : public EntryFormatBase {
+  std::vector<std::string> format(const std::any &data) const {
+    return { std::to_string(std::any_cast<int>(data)) };
+  }
+  std::unique_ptr<EntryFormatBase> copy() const {
+    return std::make_unique<TypedEntryFormatter>();
+  }
+};
+
+/**
+ * @brief Used when joining different format rules (WIP)
+ *
+ */
+struct EntryFormatUnion : public EntryFormatBase {
+  bool is_union() const { return true; }
+  std::vector<std::unique_ptr<const EntryFormatBase> > formats;
+
+  template <typename... EntryFormats>
+  EntryFormatUnion(const EntryFormats &...format_pack) {
+    ([&]() -> void { append(format_pack); }(), ...);
+  }
+
+  void append(const EntryFormatBase &fmt) {
+    if (fmt.is_union()) {
+      for (const auto &fmt : static_cast<EntryFormatUnion>(fmt).formats) {
+        formats.push_back(fmt->copy());
+      }
+    } else {
+      formats.push_back(fmt.copy());
+    }
+  }
+
+  std::vector<std::string> format(const std::any &data) const {
+    throw std::runtime_error("CombinedFormat not yet implemented!");
+  };
+  std::unique_ptr<EntryFormatBase> copy() const {
+    auto fmt = std::make_unique<EntryFormatUnion>();
+    fmt->append(*this);
+    return fmt;
+  };
+};
+
+/**
+ * @brief Class hiding virtual function magic behind unique_ptr
+ *
+ */
+struct EntryFormat {
+private:
+  std::unique_ptr<const EntryFormatBase> impl;
+
+public:
+  EntryFormat(std::unique_ptr<EntryFormatBase> formatter)
+      : impl(std::move(formatter)) {}
+
+  EntryFormat() = default;
+  std::vector<std::string> format(const std::any &data) const {
+    if (impl == nullptr) {
+      return { "" };
+    } else {
+      return impl->format(data);
+    }
+  }
+  EntryFormat(const EntryFormat &other)
+      : impl((other.impl == nullptr) ? nullptr : other.impl->copy()) {}
+
+  // EntryFormat(EntryFormat &&other) : impl(std::move(other.impl)) {}
+
+  void operator=(EntryFormat &&other) { impl = std::move(other.impl); }
+
+  /**
+   * @brief Combines two formatters, if they are compatible.
+   *
+   * @param other The format to combine with this one.
+   * @return EntryFormat The combined format.
+   */
+  EntryFormat operator|(const EntryFormat &other) const {
+    if (impl == nullptr) {
+      return other;
+    } else {
+      if (other.impl == nullptr) {
+        return *this;
+      } else {
+
+        return EntryFormat(
+            std::make_unique<EntryFormatUnion>(*impl, *other.impl));
+      }
+    }
+  }
+};
+
+/**
+ * @brief Runtime conversion from EntryType to EntryFormat by pack
+ * expansion.(Helper)
+ *
+ */
+template <std::underlying_type_t<EntryType>... types>
+static EntryFormat formatter_from_type(
+    const EntryType &type,
+    std::integer_sequence<std::underlying_type_t<EntryType>, types...>) {
+  std::unique_ptr<EntryFormatBase> data;
+
+  (
+      [&]() {
+        constexpr EntryType type_to_check = static_cast<EntryType>(types);
+        static_assert(
+            std::is_base_of_v<EntryFormatBase,
+                              TypedEntryFormatter<type_to_check> >,
+            "TypedEntryFormatter<EntryType::...> not properly implemented for "
+            "some "
+            "EntryType.");
+        if (type_to_check == type) {
+          data = std::make_unique<TypedEntryFormatter<type_to_check> >();
+        }
+      }(),
+      ...);
+
+  return EntryFormat(std::move(data));
+}
+
+/**
+ * @brief Gets an EntryFormat from a given EntryType
+ *
+ * @param type The type we should format for
+ * @return EntryFormat The generated Formatter
+ */
+static EntryFormat formatter_from_type(const EntryType &type) {
+  return formatter_from_type(
+      type, std::make_integer_sequence<
+                std::underlying_type_t<EntryType>,
+                static_cast<std::underlying_type_t<EntryType> >(
+                    EntryType::num_types)>{});
+}
+
+} // namespace specfem::test::tabulate_impl

--- a/tests/unit-tests/utilities/src/tabulate.cpp
+++ b/tests/unit-tests/utilities/src/tabulate.cpp
@@ -1,0 +1,220 @@
+#include "utilities/include/tabulate.hpp"
+
+static void pad_string(std::ostream &stream, const std::string &str,
+                       int length) {
+  int remainder = std::max(0, length - (int)str.length());
+  stream << std::string(remainder / 2, ' ') << str
+         << std::string(remainder - remainder / 2, ' ');
+}
+
+std::ostream &std::operator<<(std::ostream &stream,
+                              const specfem::test::Table &table) {
+
+  std::vector<int> col_widths;
+  int row_label_length = 0;
+
+  if (table.has_row_labels()) {
+    for (int irow = 0; irow < table.get_nrows(); ++irow) {
+      row_label_length =
+          std::max(row_label_length, (int)table.get_row_label(irow).length());
+    }
+  }
+
+  for (int icol = 0; icol < table.get_ncols(); ++icol) {
+    col_widths.push_back(table.width_of_column(icol));
+  }
+
+  const auto print_row_divider = [&](bool has_above, bool has_below) {
+    stream << (has_above ? (has_below ? "├" : "└") : (has_below ? "┌" : "╴"));
+    std::string central =
+        has_above ? (has_below ? "┼" : "┴") : (has_below ? "┬" : "─");
+
+    if (row_label_length > 0) {
+      for (int i = 0; i < row_label_length; ++i) {
+        stream << "─";
+      }
+      stream << central;
+    }
+
+    // fill each column
+    int icol;
+    for (icol = 0; icol < table.get_ncols() - 1; ++icol) {
+
+      for (int i = 0; i < col_widths[icol]; ++i) {
+        stream << "─";
+      }
+      stream << central;
+    }
+    for (int i = 0; i < col_widths[icol]; ++i) {
+      stream << "─";
+    }
+
+    stream << (has_above ? (has_below ? "┤" : "┘") : (has_below ? "┐" : "╶"))
+           << '\n';
+  };
+
+  // top
+  print_row_divider(false, true);
+
+  // labels
+  if (table.has_column_labels()) {
+    stream << "│";
+
+    if (row_label_length > 0) {
+      for (int i = 0; i < row_label_length; ++i) {
+        stream << " ";
+      }
+      stream << "│";
+    }
+
+    for (int icol = 0; icol < table.get_ncols(); ++icol) {
+      pad_string(stream, table.get_column_label(icol), col_widths[icol]);
+      stream << "│";
+    }
+    stream << "\n";
+
+    print_row_divider(true, true);
+  }
+
+  for (int irow = 0; irow < table.get_nrows(); ++irow) {
+    // content
+    std::vector<std::vector<std::string> > data;
+    for (int icol = 0; icol < table.get_ncols(); ++icol) {
+      data.push_back(table.data_as_lines(irow, icol));
+    }
+    int rowheight = table.height_of_row(irow);
+
+    for (int isub = 0; isub < rowheight; ++isub) {
+
+      stream << "│";
+
+      if (row_label_length > 0) {
+        if (isub == (rowheight / 2)) {
+          pad_string(stream, table.get_row_label(irow), row_label_length);
+        } else {
+          pad_string(stream, std::string(), row_label_length);
+        }
+
+        stream << "│";
+      }
+
+      for (int icol = 0; icol < table.get_ncols(); ++icol) {
+        pad_string(stream,
+                   (data[icol].size() > isub) ? data[icol][isub]
+                                              : std::string(),
+                   col_widths[icol]);
+        stream << "│";
+      }
+      stream << "\n";
+    }
+
+    // divider
+    print_row_divider(true, irow < table.get_nrows() - 1);
+  }
+  stream << std::flush;
+
+  return stream;
+}
+
+std::string std::to_string(const specfem::test::Table &table) {
+  std::ostringstream oss;
+  oss << table;
+  return std::move(oss).str();
+}
+
+int specfem::test::Table::insert_column(int position) {
+  if (position < 0) {
+    position = ncols + 1 + position;
+  }
+
+  if (position > ncols) {
+    std::ostringstream oss;
+    oss << "Cannot insert column into table with " << ncols
+        << " columns at position " << position << " (out of bounds)";
+    throw std::runtime_error(oss.str());
+  }
+  if (position < 0) {
+    std::ostringstream oss;
+    oss << "Position " << position - ncols - 1
+        << " is too negative for a table with " << ncols
+        << " columns (out of bounds)";
+    throw std::runtime_error(oss.str());
+  }
+
+  data.resize(nrows * (ncols + 1));
+
+  // shift data (highest index first, so no overwriting happens)
+  for (int i = nrows * ncols - 1; i >= 0; --i) {
+    const auto [irow, icol] = to_2d_index(i);
+    if (icol >= position) {
+      ncols++;
+      data[from_2d_index(irow, icol + 1)] = std::move(data[i]);
+      ncols--;
+      // ptr in old location is killed for us
+    }
+  }
+  ncols++;
+  column_formats.emplace(column_formats.begin() + position);
+  column_labels.emplace(column_labels.begin() + position);
+
+  return position;
+}
+
+int specfem::test::Table::insert_row(int position) {
+  if (position < 0) {
+    position = nrows + 1 + position;
+  }
+
+  if (position > nrows) {
+    std::ostringstream oss;
+    oss << "Cannot insert row into table with " << nrows << " rows at position "
+        << position << " (out of bounds)";
+    throw std::runtime_error(oss.str());
+  }
+  if (position < 0) {
+    std::ostringstream oss;
+    oss << "Position " << position - nrows - 1
+        << " is too negative for a table with " << nrows
+        << " rows (out of bounds)";
+    throw std::runtime_error(oss.str());
+  }
+
+  data.resize((nrows + 1) * ncols);
+
+  // shift data (highest index first, so no overwriting happens)
+  for (int i = nrows * ncols - 1; i >= 0; --i) {
+    const auto [irow, icol] = to_2d_index(i);
+    if (irow >= position) {
+      nrows++;
+      data[from_2d_index(irow + 1, icol)] = std::move(data[i]);
+      nrows--;
+      // ptr in old location is killed for us
+    }
+  }
+
+  nrows++;
+  row_formats.emplace(row_formats.begin() + position);
+  row_labels.emplace(row_labels.begin() + position);
+
+  return position;
+}
+
+int specfem::test::Table::width_of_column(const int &column) const {
+  // this can be optimized / bugfixed. for now, take the largest string length
+  int len = 0;
+  for (int irow = 0; irow < nrows; ++irow) {
+    const auto &lines = data_as_lines(irow, column);
+    for (const auto &line : lines) {
+      len = std::max(len, (int)line.length());
+    }
+  }
+  return len;
+}
+int specfem::test::Table::height_of_row(const int &row) const {
+  // this can be optimized / bugfixed. for now, take the largest string length
+  int len = 0;
+  for (int icol = 0; icol < ncols; ++icol) {
+    len = std::max(len, (int)data_as_lines(row, icol).size());
+  }
+  return len;
+}


### PR DESCRIPTION
## Description

Please describe the changes/features in this pull request.

Adds a new utility in testing for creating tables. This is something I used in `compute_coupling` before splitting this feature:

```
self
┌───────────────┬─────────┬────────┐
│    ipoint     │    0    │   1    │
├───────────────┼─────────┼────────┤
│interface coord│-1.000000│1.000000│
├───────────────┼─────────┼────────┤
│     field     │-0.099833│0.099833│
└───────────────┴─────────┴────────┘

intersection
┌───────────────┬─────────┬─────────┐
│  self field   │0.000000 │0.099833 │
├───────────────┼─────────┼─────────┤
│interface coord│0.000000 │1.000000 │
├───────────────┼─────────┼─────────┤
│               │0.000000 │0.099833 │
│    normal     │-0.000000│-0.995004│
├───────────────┼─────────┼─────────┤
│               │0.000000 │0.995004 │
│ coupled field │0.000000 │0.099335 │
└───────────────┴─────────┴─────────┘

coupled
┌───────────────┬────────┬────────┐
│               │0.000000│1.990008│
│     field     │0.000000│0.397339│
├───────────────┼────────┼────────┤
│interface coord│0.000000│2.000000│
├───────────────┼────────┼────────┤
│    ipoint     │   0    │   1    │
└───────────────┴────────┴────────┘
```

## Issue Number

If there is an issue created for these changes, link it here

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
