### PR TITLE
Pin Python version to 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
   { name = "Lucas Sawade", email = "lsawade@princeton.edu" },
   { name = "Congyue Cui", email = "ccui@princeton.edu" }
 ]
-requires-python = ">=3.12"
+requires-python = "==3.12"
 
 [tool.uv]
 package = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
   { name = "Lucas Sawade", email = "lsawade@princeton.edu" },
   { name = "Congyue Cui", email = "ccui@princeton.edu" }
 ]
-requires-python = "==3.12"
+requires-python = ">=3.12,<3.13"
 
 [tool.uv]
 package = false


### PR DESCRIPTION
Current dependency version cannot satisfy Python 3.13 or 3.14, pinning version to 3.12 is the easiest solution. When 3.14 gets more adoption we can do a major dependency upgrade.