### PR TITLE
Documentation update - macros

### DIFF
--- a/core/specfem/macros.hpp
+++ b/core/specfem/macros.hpp
@@ -2,5 +2,5 @@
 
 #include "macros/enum_tags.hpp"
 #include "macros/kokkos_abort_with_location.hpp"
-#include "macros/material_definitions.hpp"
+#include "macros/material_iterators.hpp"
 #include "macros/suppress_warnings.hpp"

--- a/core/specfem/macros/enum_tags.hpp
+++ b/core/specfem/macros/enum_tags.hpp
@@ -1,8 +1,54 @@
 #pragma once
 
+/**
+ * @file enum_tags.hpp
+ * @brief Macros for enumeration tags used in template metaprogramming
+ */
+
+/**
+ * @brief ID for dimension tags
+ *
+ * Used to identify dimension tags such as @ref DIMENSION_TAG_DIM2 and @ref DIMENSION_TAG_DIM3.
+ * See @ref material_iterators.hpp.
+ */
 #define _ENUM_ID_DIMENSION_TAG 0
+
+/**
+ * @brief ID for medium tags
+ *
+ * Used to identify medium tags such as @ref MEDIUM_TAG_ELASTIC_PSV, @ref MEDIUM_TAG_ACOUSTIC, etc.
+ * See @ref material_iterators.hpp.
+ */
 #define _ENUM_ID_MEDIUM_TAG 1
+
+/**
+ * @brief ID for property tags
+ *
+ * Used to identify property tags such as @ref PROPERTY_TAG_ISOTROPIC and @ref PROPERTY_TAG_ANISOTROPIC.
+ * See @ref material_iterators.hpp.
+ */
 #define _ENUM_ID_PROPERTY_TAG 2
+
+/**
+ * @brief ID for boundary tags
+ *
+ * Used to identify boundary tags such as @ref BOUNDARY_TAG_NONE and @ref BOUNDARY_TAG_STACEY.
+ * See @ref material_iterators.hpp.
+ */
 #define _ENUM_ID_BOUNDARY_TAG 3
+
+/**
+ * @brief ID for connection tags
+ *
+ * Used to identify connection tags in interface definitions.
+ * See @ref interface_iterators.hpp.
+ */
 #define _ENUM_ID_CONNECTION_TAG 4
+
+/**
+ * @brief ID for interface tags
+ *
+ * Used to identify interface tags in interface definitions.
+ * See @ref interface_iterators.hpp.
+ */
 #define _ENUM_ID_INTERFACE_TAG 5

--- a/core/specfem/macros/interface_iterators.hpp
+++ b/core/specfem/macros/interface_iterators.hpp
@@ -1,39 +1,76 @@
 #pragma once
 
+/**
+ * @file interface_iterators.hpp
+ * @brief Macros for interface and connection definitions
+ */
+
 #include "enum_tags.hpp"
 #include "enumerations/interface.hpp"
 #include "macros_impl/array.hpp"
 #include "macros_impl/utils.hpp"
 #include <boost/preprocessor.hpp>
 
+/**
+ * @name Connection Tag macros
+ */
+/// @{
+/**
+ * @brief Strongly conforming connection tag
+ */
 #define CONNECTION_TAG_STRONGLY_CONFORMING                                     \
   (0, specfem::connections::type::strongly_conforming, strongly_conforming,    \
    _ENUM_ID_CONNECTION_TAG)
 
+/**
+ * @brief Weakly conforming connection tag
+ */
 #define CONNECTION_TAG_WEAKLY_CONFORMING                                       \
   (1, specfem::connections::type::weakly_conforming, weakly_conforming,        \
    _ENUM_ID_CONNECTION_TAG)
 
+/**
+ * @brief Non-conforming connection tag
+ */
 #define CONNECTION_TAG_NONCONFORMING                                           \
   (2, specfem::connections::type::nonconforming, nonconforming,                \
    _ENUM_ID_CONNECTION_TAG)
+/// @}
 
+/**
+ * @name Interface Tag macros
+ */
+/// @{
+/**
+ * @brief Elastic-Acoustic interface tag
+ */
 #define INTERFACE_TAG_ELASTIC_ACOUSTIC                                         \
   (0, specfem::interface::interface_tag::elastic_acoustic, elastic_acoustic,   \
    _ENUM_ID_INTERFACE_TAG)
+
+/**
+ * @brief Acoustic-Elastic interface tag
+ */
 #define INTERFACE_TAG_ACOUSTIC_ELASTIC                                         \
   (1, specfem::interface::interface_tag::acoustic_elastic, acoustic_elastic,   \
    _ENUM_ID_INTERFACE_TAG)
+/// @}
 
 #define _MAKE_INTERFACE_TUPLE(r, product) BOOST_PP_SEQ_TO_TUPLE(product)
 
 #define _GENERATE_INTERFACE(seqs)                                              \
   (BOOST_PP_SEQ_FOR_EACH_PRODUCT(_MAKE_INTERFACE_TUPLE, seqs))
 
+/**
+ * @brief Converts interface tag arguments to a sequence of tag tuples
+ */
 #define INTERFACE_TAG(...)                                                     \
   BOOST_PP_SEQ_TRANSFORM(_TRANSFORM_TAGS, INTERFACE_TAG_,                      \
                          BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))
 
+/**
+ * @brief Converts connection tag arguments to a sequence of tag tuples
+ */
 #define CONNECTION_TAG(...)                                                    \
   BOOST_PP_SEQ_TRANSFORM(_TRANSFORM_TAGS, CONNECTION_TAG_,                     \
                          BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))
@@ -45,12 +82,18 @@
 #define _CONNECTION_TAG_ BOOST_PP_SEQ_TO_LIST((1))
 #define _INTERFACE_TAG_ BOOST_PP_SEQ_TO_LIST((2))
 
+/**
+ * @brief List of interface systems
+ */
 #define INTERFACE_SYSTEMS                                                      \
   ((DIMENSION_TAG_DIM2, CONNECTION_TAG_WEAKLY_CONFORMING,                      \
     INTERFACE_TAG_ELASTIC_ACOUSTIC))((DIMENSION_TAG_DIM2,                      \
                                       CONNECTION_TAG_WEAKLY_CONFORMING,        \
                                       INTERFACE_TAG_ACOUSTIC_ELASTIC))
 
+/**
+ * @brief List of edges with interfaces
+ */
 #define EDGES                                                                  \
   ((DIMENSION_TAG_DIM2, CONNECTION_TAG_WEAKLY_CONFORMING,                      \
     INTERFACE_TAG_ELASTIC_ACOUSTIC, BOUNDARY_TAG_NONE))(                       \
@@ -81,6 +124,14 @@
 
 namespace specfem::interface {
 
+/**
+ * @brief A constexpr function to generate a list of edges with interfaces within
+ * the simulation.
+ *
+ * This macro uses @ref EDGES to generate a list of edges automatically.
+ *
+ * @return constexpr auto list of edges
+ */
 template <specfem::dimension::type DimensionTag> constexpr auto edges();
 
 template <> constexpr auto edges<specfem::dimension::type::dim2>() {

--- a/core/specfem/macros/kokkos_abort_with_location.hpp
+++ b/core/specfem/macros/kokkos_abort_with_location.hpp
@@ -1,7 +1,20 @@
 #pragma once
 
+/**
+ * @file kokkos_abort_with_location.hpp
+ * @brief Macro to abort Kokkos execution with file and line information
+ */
+
 #include <Kokkos_Core.hpp>
 #include <boost/preprocessor/stringize.hpp>
 
+/**
+ * @brief Abort Kokkos execution with a message and location.
+ *
+ * This macro calls `Kokkos::abort` with a message that includes the file name
+ * and line number where the macro is called.
+ *
+ * @param message The error message to display.
+ */
 #define KOKKOS_ABORT_WITH_LOCATION(message)                                    \
   Kokkos::abort(__FILE__ ":" BOOST_PP_STRINGIZE(__LINE__) " - " message);

--- a/core/specfem/macros/macros_impl/array.hpp
+++ b/core/specfem/macros/macros_impl/array.hpp
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file array.hpp
+ * @brief Macros for creating arrays from sequences
+ */
+
 #include <boost/preprocessor.hpp>
 
 /**

--- a/core/specfem/macros/macros_impl/expand_seq.hpp
+++ b/core/specfem/macros/macros_impl/expand_seq.hpp
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file expand_seq.hpp
+ * @brief Macros for expanding sequences
+ */
+
 #include <boost/preprocessor.hpp>
 
 /**

--- a/core/specfem/macros/macros_impl/utils.hpp
+++ b/core/specfem/macros/macros_impl/utils.hpp
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file utils.hpp
+ * @brief Utility macros for tag manipulation and sequence processing
+ */
+
 #include "enumerations/interface.hpp"
 #include "expand_seq.hpp"
 #include <boost/preprocessor.hpp>

--- a/core/specfem/macros/material_iterators.hpp
+++ b/core/specfem/macros/material_iterators.hpp
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file material_iterators.hpp
+ * @brief Macros for material and element definitions
+ */
+
 #include "enum_tags.hpp"
 #include "enumerations/interface.hpp"
 #include "macros_impl/array.hpp"
@@ -9,52 +14,109 @@
 
 /**
  * @name Element Tag macros
- *
- * @defgroup element_tags Element Tags
- *
  */
 /// @{
+/**
+ * @brief Dimension tag for 2D
+ */
 #define DIMENSION_TAG_DIM2                                                     \
   (0, specfem::dimension::type::dim2, dim2, _ENUM_ID_DIMENSION_TAG)
+
+/**
+ * @brief Dimension tag for 3D
+ */
 #define DIMENSION_TAG_DIM3                                                     \
   (1, specfem::dimension::type::dim3, dim3, _ENUM_ID_DIMENSION_TAG)
 
+/**
+ * @brief Medium tag for Elastic P-SV
+ */
 #define MEDIUM_TAG_ELASTIC_PSV                                                 \
   (0, specfem::element::medium_tag::elastic_psv, elastic_psv,                  \
    _ENUM_ID_MEDIUM_TAG)
+
+/**
+ * @brief Medium tag for Elastic SH
+ */
 #define MEDIUM_TAG_ELASTIC_SH                                                  \
   (1, specfem::element::medium_tag::elastic_sh, elastic_sh, _ENUM_ID_MEDIUM_TAG)
+
+/**
+ * @brief Medium tag for Elastic P-SV Transverse Isotropic
+ */
 #define MEDIUM_TAG_ELASTIC_PSV_T                                               \
   (2, specfem::element::medium_tag::elastic_psv_t, elastic_psv_t,              \
    _ENUM_ID_MEDIUM_TAG)
+
+/**
+ * @brief Medium tag for Acoustic
+ */
 #define MEDIUM_TAG_ACOUSTIC                                                    \
   (3, specfem::element::medium_tag::acoustic, acoustic, _ENUM_ID_MEDIUM_TAG)
+
+/**
+ * @brief Medium tag for Poroelastic
+ */
 #define MEDIUM_TAG_POROELASTIC                                                 \
   (4, specfem::element::medium_tag::poroelastic, poroelastic,                  \
    _ENUM_ID_MEDIUM_TAG)
+
+/**
+ * @brief Medium tag for Electromagnetic TE
+ */
 #define MEDIUM_TAG_ELECTROMAGNETIC_TE                                          \
   (5, specfem::element::medium_tag::electromagnetic_te, electromagnetic_te,    \
    _ENUM_ID_MEDIUM_TAG)
+
+/**
+ * @brief Medium tag for Elastic
+ */
 #define MEDIUM_TAG_ELASTIC                                                     \
   (6, specfem::element::medium_tag::elastic, elastic, _ENUM_ID_MEDIUM_TAG)
 
+/**
+ * @brief Property tag for Isotropic
+ */
 #define PROPERTY_TAG_ISOTROPIC                                                 \
   (0, specfem::element::property_tag::isotropic, isotropic,                    \
    _ENUM_ID_PROPERTY_TAG)
+
+/**
+ * @brief Property tag for Anisotropic
+ */
 #define PROPERTY_TAG_ANISOTROPIC                                               \
   (1, specfem::element::property_tag::anisotropic, anisotropic,                \
    _ENUM_ID_PROPERTY_TAG)
+
+/**
+ * @brief Property tag for Isotropic Cosserat
+ */
 #define PROPERTY_TAG_ISOTROPIC_COSSERAT                                        \
   (2, specfem::element::property_tag::isotropic_cosserat, isotropic_cosserat,  \
    _ENUM_ID_PROPERTY_TAG)
 
+/**
+ * @brief Boundary tag for None
+ */
 #define BOUNDARY_TAG_NONE                                                      \
   (0, specfem::element::boundary_tag::none, none, _ENUM_ID_BOUNDARY_TAG)
+
+/**
+ * @brief Boundary tag for Stacey
+ */
 #define BOUNDARY_TAG_STACEY                                                    \
   (1, specfem::element::boundary_tag::stacey, stacey, _ENUM_ID_BOUNDARY_TAG)
+
+/**
+ * @brief Boundary tag for Acoustic Free Surface
+ */
 #define BOUNDARY_TAG_ACOUSTIC_FREE_SURFACE                                     \
   (2, specfem::element::boundary_tag::acoustic_free_surface,                   \
    acoustic_free_surface, _ENUM_ID_BOUNDARY_TAG)
+
+/**
+ * @brief Boundary tag for Composite Stacey Dirichlet
+ */
 #define BOUNDARY_TAG_COMPOSITE_STACEY_DIRICHLET                                \
   (3, specfem::element::boundary_tag::composite_stacey_dirichlet,              \
    composite_stacey_dirichlet, _ENUM_ID_BOUNDARY_TAG)
@@ -323,4 +385,4 @@ template <> constexpr auto element_types<specfem::dimension::type::dim3>() {
 } // namespace element
 } // namespace specfem
 
-#include "interface_definitions.hpp"
+#include "interface_iterators.hpp"

--- a/core/specfem/macros/suppress_warnings.hpp
+++ b/core/specfem/macros/suppress_warnings.hpp
@@ -1,21 +1,42 @@
 #pragma once
 
+/**
+ * @file suppress_warnings.hpp
+ * @brief Macros to suppress compiler warnings for different compilers
+ */
+
 #if defined(SPECFEMPP_MSVC_BUILD)
 // mscv (microsoft)
 // this is untested.
 
+/**
+ * @brief Pop warning state (MSVC)
+ */
 #define __SUPPRESS_WARNING_END __pragma("warning( pop )")
 
+/**
+ * @brief Disable warning 4172: returning address of local variable or temporary
+ * (MSVC)
+ */
 #define _SUPPRESS_TEMPORARY_RETURN_CODE __pragma("warning( disable : 4172 )")
 
 // https://learn.microsoft.com/en-us/cpp/preprocessor/warning?view=msvc-170#push-and-pop
+/**
+ * @brief Push warning state (MSVC)
+ */
 #define _SUPPRESS_WARNING_START __pragma("warning( push )")
 #endif
 
 #if defined(SPECFEMPP_GNU_BUILD)
 
+/**
+ * @brief Pop warning state (GCC)
+ */
 #define _SUPPRESS_WARNING_END _Pragma("GCC diagnostic pop")
 
+/**
+ * @brief Disable -Wreturn-local-addr (GCC)
+ */
 #define _SUPPRESS_TEMPORARY_RETURN_CODE                                        \
   _Pragma("GCC diagnostic ignored \"-Wreturn-local-addr\"")
 
@@ -25,6 +46,9 @@
 // clang should also be reading these (first paragraph of
 // https://clang.llvm.org/docs/UsersManual.html#controlling-diagnostics-via-pragmas
 //)
+/**
+ * @brief Push warning state (GCC)
+ */
 #define _SUPPRESS_WARNING_START _Pragma("GCC diagnostic push")
 
 #endif
@@ -34,25 +58,52 @@
 // https://clang.llvm.org/docs/UsersManual.html#controlling-diagnostics-via
 // pragmas
 
+/**
+ * @brief Pop warning state (Clang)
+ */
 #define _SUPPRESS_WARNING_END _Pragma("clang diagnostic pop")
 
+/**
+ * @brief Disable -Wreturn-stack-address (Clang)
+ */
 #define _SUPPRESS_TEMPORARY_RETURN_CODE                                        \
   _Pragma("clang diagnostic ignored \"-Wreturn-stack-address\"")
 
+/**
+ * @brief Push warning state (Clang)
+ */
 #define _SUPPRESS_WARNING_START _Pragma("clang diagnostic push")
 
 #endif
 
 // Fallback definitions for unsupported compilers
 #if !defined(_SUPPRESS_WARNING_START) || !defined(_SUPPRESS_WARNING_END)
+/**
+ * @brief Fallback for _SUPPRESS_WARNING_START (no-op)
+ */
 #define _SUPPRESS_WARNING_START
+/**
+ * @brief Fallback for _SUPPRESS_WARNING_END (no-op)
+ */
 #define _SUPPRESS_WARNING_END
 #endif
 
 #if !defined(_SUPPRESS_TEMPORARY_RETURN_CODE)
+/**
+ * @brief Fallback for _SUPPRESS_TEMPORARY_RETURN_CODE (no-op)
+ */
 #define _SUPPRESS_TEMPORARY_RETURN_CODE
 #endif
 
+/**
+ * @brief Suppress warnings about returning reference to temporary.
+ *
+ * This macro wraps a code block to suppress compiler warnings about returning
+ * the address of a local variable or temporary. It handles compiler-specific
+ * pragmas for MSVC, GCC, Clang, and Intel LLVM.
+ *
+ * @param CODEBLOCK The code to be executed with the warning suppressed.
+ */
 #define SUPPRESS_TEMPORARY_REF(CODEBLOCK)                                      \
   _SUPPRESS_WARNING_START                                                      \
   _SUPPRESS_TEMPORARY_RETURN_CODE                                              \

--- a/docs/sections/api/index.rst
+++ b/docs/sections/api/index.rst
@@ -19,6 +19,7 @@ New structure
 
     specfem/assembly/index
     specfem/chunk_element/index
+    specfem/macros/index
     specfem/periodic_tasks/index
     specfem/point/index
     specfem/receivers/index

--- a/docs/sections/api/specfem/macros/enum_tags.rst
+++ b/docs/sections/api/specfem/macros/enum_tags.rst
@@ -1,0 +1,6 @@
+.. _specfem_macros_enum_tags:
+
+Enum Tags
+=========
+
+.. doxygenfile:: enum_tags.hpp

--- a/docs/sections/api/specfem/macros/index.rst
+++ b/docs/sections/api/specfem/macros/index.rst
@@ -1,0 +1,14 @@
+.. _specfem_macros:
+
+
+Macros
+======
+
+.. toctree::
+    :maxdepth: 1
+
+    enum_tags.rst
+    interface_definitions.rst
+    kokkos_abort_with_location.rst
+    material_definitions.rst
+    suppress_warnings.rst

--- a/docs/sections/api/specfem/macros/interface_definitions.rst
+++ b/docs/sections/api/specfem/macros/interface_definitions.rst
@@ -1,0 +1,6 @@
+.. _specfem_macros_interface_definitions:
+
+Interface Iterators
+===================
+
+.. doxygenfile:: interface_iterators.hpp

--- a/docs/sections/api/specfem/macros/kokkos_abort_with_location.rst
+++ b/docs/sections/api/specfem/macros/kokkos_abort_with_location.rst
@@ -1,0 +1,6 @@
+.. _specfem_macros_kokkos_abort_with_location:
+
+``KOKKOS_ABORT_WITH_LOCATION``
+==============================
+
+.. doxygenfile:: kokkos_abort_with_location.hpp

--- a/docs/sections/api/specfem/macros/material_definitions.rst
+++ b/docs/sections/api/specfem/macros/material_definitions.rst
@@ -1,0 +1,6 @@
+.. _specfem_macros_material_definitions:
+
+Material Iterators
+==================
+
+.. doxygenfile:: material_iterators.hpp

--- a/docs/sections/api/specfem/macros/suppress_warnings.rst
+++ b/docs/sections/api/specfem/macros/suppress_warnings.rst
@@ -1,0 +1,6 @@
+.. _specfem_macros_suppress_warnings:
+
+Suppress Warnings
+=================
+
+.. doxygenfile:: suppress_warnings.hpp


### PR DESCRIPTION
## Description

- Update documentation on macros
- Rename `material_definitions.hpp` to `material_iterators.hpp`
- Rename `interface_definitions.hpp` to `interface_iterators.hpp`

## Issue Number

Closes #1392

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
