### PR TITLE
Added `flux_scheme_tag` enum

### DIFF
--- a/include/enumerations/coupled_interface.hpp
+++ b/include/enumerations/coupled_interface.hpp
@@ -30,6 +30,16 @@ enum class interface_tag {
 };
 
 /**
+ * @brief Flux scheme used for a coupling
+ */
+enum class flux_scheme_tag {
+  natural, ///< Original SPECFEM acoustic-elastic interface (Komatitsch et al.
+           ///< 2000)
+  symmetric_interior_penalty ///< SIPG (Grote et al., Riviere et al., Antonietti
+                             ///< et al., etc.)
+};
+
+/**
  * @brief Compile-time interface field type determination.
  *
  * @tparam DimensionTag Spatial dimension (2D or 3D)
@@ -197,4 +207,18 @@ struct attributes<specfem::dimension::type::dim2,
  */
 std::string to_string(const interface_tag &interface_tag);
 
+/**
+ * @brief Convert flux scheme tag to string.
+ *
+ * @param flux_scheme_tag
+ * @return String representation
+ */
+std::string to_string(const flux_scheme_tag &flux_scheme_tag);
+
+std::ostream &
+operator<<(std::ostream &stream,
+           const specfem::interface::interface_tag &interface_tag);
+std::ostream &
+operator<<(std::ostream &stream,
+           const specfem::interface::flux_scheme_tag &flux_scheme_tag);
 } // namespace specfem::interface

--- a/include/kokkos_kernels/domain_kernels.hpp
+++ b/include/kokkos_kernels/domain_kernels.hpp
@@ -75,9 +75,10 @@ public:
                                              _interface_tag_>::self_medium();
           if constexpr (dimension_tag == _dimension_tag_ &&
                         self_medium == medium) {
-            impl::compute_coupling<_dimension_tag_, _connection_tag_, wavefield,
-                                   ngll, ngll, _interface_tag_, _boundary_tag_>(
-                assembly);
+            impl::compute_coupling<
+                _dimension_tag_, _connection_tag_, wavefield, ngll, ngll,
+                _interface_tag_, _boundary_tag_,
+                specfem::interface::flux_scheme_tag::natural>(assembly);
             // second ngll is the number of quadrature points on the mortar.
           }
         })

--- a/include/kokkos_kernels/impl/compute_coupling.hpp
+++ b/include/kokkos_kernels/impl/compute_coupling.hpp
@@ -9,7 +9,8 @@ namespace specfem::kokkos_kernels::impl {
 template <specfem::dimension::type DimensionTag,
           specfem::wavefield::simulation_field WavefieldType,
           specfem::interface::interface_tag InterfaceTag,
-          specfem::element::boundary_tag BoundaryTag>
+          specfem::element::boundary_tag BoundaryTag,
+          specfem::interface::flux_scheme_tag FluxSchemeTag>
 void compute_coupling(
     std::integral_constant<
         specfem::connections::type,
@@ -19,7 +20,8 @@ void compute_coupling(
 template <specfem::dimension::type DimensionTag,
           specfem::wavefield::simulation_field WavefieldType, int NGLL,
           int NQuad_interface, specfem::interface::interface_tag InterfaceTag,
-          specfem::element::boundary_tag BoundaryTag>
+          specfem::element::boundary_tag BoundaryTag,
+          specfem::interface::flux_scheme_tag FluxSchemeTag>
 void compute_coupling(
     std::integral_constant<
         specfem::connections::type,
@@ -47,7 +49,8 @@ template <specfem::dimension::type DimensionTag,
           specfem::connections::type ConnectionTag,
           specfem::wavefield::simulation_field WavefieldType, int NGLL,
           int NQuad_interface, specfem::interface::interface_tag InterfaceTag,
-          specfem::element::boundary_tag BoundaryTag>
+          specfem::element::boundary_tag BoundaryTag,
+          specfem::interface::flux_scheme_tag FluxSchemeTag>
 void compute_coupling(
     const specfem::assembly::assembly<DimensionTag> &assembly);
 } // namespace specfem::kokkos_kernels::impl

--- a/src/enumerations/coupled_interface.cpp
+++ b/src/enumerations/coupled_interface.cpp
@@ -19,4 +19,37 @@ std::string to_string(const interface_tag &interface_tag) {
 
   return interface_string;
 }
+
+std::string to_string(const flux_scheme_tag &flux_scheme_tag) {
+
+  std::string flux_scheme_string;
+
+  switch (flux_scheme_tag) {
+  case specfem::interface::flux_scheme_tag::natural:
+    flux_scheme_string = "natural";
+    break;
+  case specfem::interface::flux_scheme_tag::symmetric_interior_penalty:
+    flux_scheme_string = "symmetric_interior_penalty";
+    break;
+  default:
+    flux_scheme_string = "unknown";
+    break;
+  }
+
+  return flux_scheme_string;
+}
+
+std::ostream &
+operator<<(std::ostream &stream,
+           const specfem::interface::interface_tag &interface_tag) {
+  stream << to_string(interface_tag);
+  return stream;
+}
+std::ostream &
+operator<<(std::ostream &stream,
+           const specfem::interface::flux_scheme_tag &flux_scheme_tag) {
+
+  stream << to_string(flux_scheme_tag);
+  return stream;
+}
 } // namespace specfem::interface

--- a/src/kokkos_kernels/impl/compute_coupling.cpp
+++ b/src/kokkos_kernels/impl/compute_coupling.cpp
@@ -14,37 +14,37 @@ FOR_EACH_IN_PRODUCT(
         (template void specfem::kokkos_kernels::impl::compute_coupling,
          (_DIMENSION_TAG_, _CONNECTION_TAG_,
           specfem::wavefield::simulation_field::forward, 5, 5, _INTERFACE_TAG_,
-          _BOUNDARY_TAG_),
+          _BOUNDARY_TAG_, specfem::interface::flux_scheme_tag::natural),
          (const specfem::assembly::assembly<specfem::dimension::type::dim2>
               &);),
         (template void specfem::kokkos_kernels::impl::compute_coupling,
          (_DIMENSION_TAG_, _CONNECTION_TAG_,
           specfem::wavefield::simulation_field::backward, 5, 5, _INTERFACE_TAG_,
-          _BOUNDARY_TAG_),
+          _BOUNDARY_TAG_, specfem::interface::flux_scheme_tag::natural),
          (const specfem::assembly::assembly<specfem::dimension::type::dim2>
               &);),
         (template void specfem::kokkos_kernels::impl::compute_coupling,
          (_DIMENSION_TAG_, _CONNECTION_TAG_,
           specfem::wavefield::simulation_field::adjoint, 5, 5, _INTERFACE_TAG_,
-          _BOUNDARY_TAG_),
+          _BOUNDARY_TAG_, specfem::interface::flux_scheme_tag::natural),
          (const specfem::assembly::assembly<specfem::dimension::type::dim2>
               &);),
         /** instantiation for NGLL = 8     */
         (template void specfem::kokkos_kernels::impl::compute_coupling,
          (_DIMENSION_TAG_, _CONNECTION_TAG_,
           specfem::wavefield::simulation_field::forward, 8, 8, _INTERFACE_TAG_,
-          _BOUNDARY_TAG_),
+          _BOUNDARY_TAG_, specfem::interface::flux_scheme_tag::natural),
          (const specfem::assembly::assembly<specfem::dimension::type::dim2>
               &);),
         (template void specfem::kokkos_kernels::impl::compute_coupling,
          (_DIMENSION_TAG_, _CONNECTION_TAG_,
           specfem::wavefield::simulation_field::backward, 8, 8, _INTERFACE_TAG_,
-          _BOUNDARY_TAG_),
+          _BOUNDARY_TAG_, specfem::interface::flux_scheme_tag::natural),
          (const specfem::assembly::assembly<specfem::dimension::type::dim2>
               &);),
         (template void specfem::kokkos_kernels::impl::compute_coupling,
          (_DIMENSION_TAG_, _CONNECTION_TAG_,
           specfem::wavefield::simulation_field::adjoint, 8, 8, _INTERFACE_TAG_,
-          _BOUNDARY_TAG_),
+          _BOUNDARY_TAG_, specfem::interface::flux_scheme_tag::natural),
          (const specfem::assembly::assembly<specfem::dimension::type::dim2>
               &);)))


### PR DESCRIPTION
## Description

Please describe the changes/features in this pull request.
- adds `interface::flux_scheme_tag` + `to_string`
- adds `ostream& operator<<` functions to interface and flux scheme for easier prints.
- templates coupling kernel off of flux scheme

not added, but potentially part of issue #1471:

- does not template interface containers (should we?)

- does not add macro for `FOREACH_IN_PRODUCT` (not sure how to do that)

## Issue Number

If there is an issue created for these changes, link it here
#1471

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
