### PR TITLE
Coupling integral test

### DIFF
--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -629,6 +629,27 @@ target_link_libraries(
 )
 
 add_executable(
+  coupling_integral_tests
+  algorithms/dim2/coupling_integral.cpp
+)
+
+target_link_libraries(
+  coupling_integral_tests
+  algorithms
+  enumerations
+  mesh
+  assembly
+  gtest_main
+  Kokkos::kokkos
+  specfem_environment
+  utilities
+
+  quadrature
+  yaml-cpp
+  -lpthread -lm
+)
+
+add_executable(
   policies_tests
   policies/policies.cpp
 )

--- a/tests/unit-tests/algorithms/dim2/coupling_integral.cpp
+++ b/tests/unit-tests/algorithms/dim2/coupling_integral.cpp
@@ -1,0 +1,80 @@
+
+#include "utilities/include/fixture/assembly.hpp"
+#include "utilities/include/fixture/assembly/assembly_2d.hpp"
+#include "utilities/include/fixture/mesh/mesh.hpp"
+
+void execute(const specfem::assembly::assembly<specfem::dimension::type::dim2>
+                 &assembly) {
+  assembly.check_jacobian_matrix();
+  std::cout << assembly.get_total_number_of_elements();
+}
+
+/**
+ * @brief Test fixture for 2D transfer function algorithms.
+ * @tparam TestingTypes Tuple of (TransferFunctionInitializer,
+ * FunctionInitializer)
+ */
+template <typename TestingTypes>
+struct AnalyticalCouplingIntegralTest2D : public ::testing::Test {
+  using AssemblyInitializer = std::tuple_element_t<0, TestingTypes>;
+
+  /**
+   * @brief Set up test with initialized transfer function and field.
+   */
+  AnalyticalCouplingIntegralTest2D() {}
+
+  specfem::test_fixture::Assembly2D<AssemblyInitializer> assembly;
+};
+using namespace specfem::test_fixture;
+
+/** Test type combinations for parameterized testing */
+using AnalyticalCouplingIntegralTestTypes2D =
+    ::testing::Types<std::tuple<AssemblyInitializer2D::FromMesh<
+        MeshInitializer2D::ThreeElementNonconforming> > >;
+
+TYPED_TEST_SUITE(AnalyticalCouplingIntegralTest2D,
+                 AnalyticalCouplingIntegralTestTypes2D);
+
+TYPED_TEST(AnalyticalCouplingIntegralTest2D, ComputeCouplingOnAnalyticalField) {
+  execute(this->assembly);
+}
+
+int main(int argc, char *argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new SPECFEMEnvironment);
+  return RUN_ALL_TESTS();
+}
+
+/*
+
+
+# add_executable(
+#   coupling_integral_tests
+#   algorithms/dim2/coupling_integral.cpp
+# )
+
+# target_link_libraries(
+#   coupling_integral_tests
+#   algorithms
+#   enumerations
+#   mesh
+#   assembly
+#   gtest_main
+#   Kokkos::kokkos
+#   specfem_environment
+#   utilities
+
+#   quadrature
+#   yaml-cpp
+#   parameter_reader
+#   compare_arrays
+#   timescheme
+#   point
+#   kokkos_kernels
+#   solver
+#   periodic_tasks
+#   boost
+#   -lpthread -lm
+# )
+
+*/

--- a/tests/unit-tests/algorithms/dim2/coupling_integral.cpp
+++ b/tests/unit-tests/algorithms/dim2/coupling_integral.cpp
@@ -1,56 +1,399 @@
 
+#include "Kokkos_Core.hpp"
 #include "execution/chunked_intersection_iterator.hpp"
 #include "parallel_configuration/chunk_edge_config.hpp"
 #include "utilities/include/fixture/assembly.hpp"
+
+#include "algorithms/integrate/coupling_integral1d.hpp"
+
 #include <sstream>
+
+/**
+ * @brief specfem::chunk_edge::intersection_factor monkey patch to remove
+ * scratch view
+ *
+ * @tparam InterfaceTag
+ * @tparam BoundaryTag
+ * @tparam NumberElements
+ * @tparam NQuadIntersection
+ * @tparam MemorySpace
+ */
+template <specfem::interface::interface_tag InterfaceTag,
+          specfem::element::boundary_tag BoundaryTag, int NumberElements,
+          int NQuadIntersection, typename MemorySpace>
+struct intersection_factor_patch
+    : public specfem::data_access::Accessor<
+          specfem::data_access::AccessorType::chunk_edge,
+          specfem::data_access::DataClassType::intersection_factor,
+          specfem::dimension::type::dim2, false> {
+
+public:
+  static constexpr auto dimension_tag = specfem::dimension::type::dim2;
+  static constexpr auto interface_tag = InterfaceTag;
+  static constexpr auto boundary_tag = BoundaryTag;
+  static constexpr auto connection_tag =
+      specfem::connections::type::nonconforming;
+  static constexpr int chunk_size = NumberElements;
+  static constexpr int n_quad_intersection = NQuadIntersection;
+  using IntersectionFactorViewType =
+      Kokkos::View<type_real[NumberElements][NQuadIntersection], MemorySpace>;
+
+private:
+  IntersectionFactorViewType data_;
+
+public:
+  KOKKOS_INLINE_FUNCTION
+  intersection_factor_patch() = default;
+
+  KOKKOS_INLINE_FUNCTION intersection_factor_patch(const std::string &name)
+      : data_(name) {}
+
+  // needed for accessor
+  template <typename... Indices>
+  KOKKOS_INLINE_FUNCTION auto &operator()(Indices... indices) const {
+    return data_(indices...);
+  }
+};
 
 template <specfem::interface::interface_tag interface_tag,
           specfem::element::boundary_tag boundary_tag>
 void verify_interfaces(
     const specfem::assembly::assembly<specfem::dimension::type::dim2>
         &assembly) {
-  constexpr auto DimensionTag = specfem::dimension::type::dim2;
+  constexpr int nquad_intersection = 5;
+  constexpr int ngll = 5;
+  constexpr type_real tol = 1e-6;
+
+  constexpr auto dimension_tag = specfem::dimension::type::dim2;
   constexpr auto connection_tag = specfem::connections::type::nonconforming;
+  constexpr bool using_simd = false;
   constexpr auto self_medium =
-      specfem::interface::attributes<DimensionTag,
+      specfem::interface::attributes<dimension_tag,
                                      interface_tag>::self_medium();
+  constexpr int ncomp_self =
+      specfem::element::attributes<dimension_tag, self_medium>::components;
 
   const auto [self_edges, coupled_edges] =
       assembly.edge_types.get_edges_on_device(connection_tag, interface_tag,
                                               boundary_tag);
-  if (self_edges.n_edges == 0)
+
+  const int &n_edges = self_edges.n_edges;
+  if (n_edges == 0) {
     return;
+  }
+
+  // ==============
+  // log initialize
+  // ==============
 
   std::ostringstream oss;
-  oss << "Interface execution (" << self_edges.n_edges << " edges):\n";
+  oss << "Interface execution (" << n_edges << " edges):\n";
   oss << "  - interface: " << specfem::interface::to_string(interface_tag)
       << " (self_medium = " << specfem::element::to_string(self_medium)
       << ")\n";
   oss << "  - boundary: " << specfem::element::to_string(boundary_tag) << "\n";
 
+  constexpr int num_trials_per_edge = nquad_intersection;
+  oss << "Each edge tested with " << num_trials_per_edge
+      << " intersection fields (all " << nquad_intersection
+      << " intersection basis functions"
+      // <<", then constant 1"
+      << ")\n";
+  oss << "Tolerance: " << std::scientific << tol << std::fixed << "\n";
+
+  // ==========
+  // data types
+  // ==========
+  using memory_space = Kokkos::DefaultExecutionSpace::memory_space;
+
   using parallel_config =
       specfem::parallel_configuration::default_chunk_edge_config<
-          DimensionTag, Kokkos::DefaultExecutionSpace>;
+          dimension_tag, Kokkos::DefaultExecutionSpace>;
+
+  using IntersectionFieldViewType = specfem::datatype::VectorChunkEdgeViewType<
+      type_real, dimension_tag, parallel_config::chunk_size, nquad_intersection,
+      ncomp_self, using_simd, memory_space,
+      Kokkos::MemoryTraits<
+          Kokkos::RandomAccess> >; // needed VectorChunkEdgeViewType since
+                                   // IntersectionFieldViewType::using_simd used
+                                   // in algorithms::coupling_integral.
+
+  using IntersectionFactorViewType =
+      intersection_factor_patch<interface_tag, boundary_tag,
+                                parallel_config::chunk_size, nquad_intersection,
+                                memory_space>;
+
+  using ExpectedIntegralViewType = specfem::datatype::VectorChunkEdgeViewType<
+      type_real, dimension_tag, parallel_config::chunk_size, ngll, ncomp_self,
+      using_simd, memory_space, Kokkos::MemoryTraits<Kokkos::RandomAccess> >;
+
+  using ResultsView_ipoint_hits =
+      Kokkos::View<int * /*edge index*/[ngll] /* ipoint indices */,
+                   memory_space, Kokkos::MemoryTraits<Kokkos::Atomic> >;
+
+  // failure gathering (total fail count, get diagnostic data from first n
+  // fails)
+  constexpr int failbin_num_iedge = 5;
+  constexpr int failbin_size = 5;
+  using ResultsView_failbins_counts =
+      Kokkos::View<int[failbin_num_iedge][ngll] /* ipoint indices */,
+                   memory_space, Kokkos::MemoryTraits<Kokkos::Atomic> >;
+  using ResultsView_failbins_inds = Kokkos::View<
+      int[failbin_num_iedge][ngll] /* ipoint indices*/[failbin_size][5],
+      memory_space, Kokkos::MemoryTraits<Kokkos::Atomic> >; // stores (is_set,
+                                                            // iedge, ipoint,
+                                                            // itrial, icomp)
+  using ResultsView_failbins_expect_got = Kokkos::View<
+      type_real[failbin_num_iedge][ngll] /* ipoint indices*/[failbin_size][2],
+      memory_space>; // stores itrial and icomp
+
+  // ==========
+  // init views
+  // ==========
+  IntersectionFieldViewType intersection_field("intersection field");
+  IntersectionFactorViewType intersection_factor("intersection factor");
+  ExpectedIntegralViewType expected_integral("expected integral");
+
+  ResultsView_ipoint_hits result_ipoint_hits("result: ipoint hits", n_edges);
+  Kokkos::deep_copy(result_ipoint_hits, 0);
+
+  ResultsView_failbins_counts failures_counts("result fails: counts");
+  ResultsView_failbins_inds failures_inds("result fails: indices");
+  ResultsView_failbins_expect_got failures_expect_got(
+      "result fails: expect / got");
+  Kokkos::deep_copy(failures_counts, 0);
+  Kokkos::deep_copy(failures_inds, 0);
+  // ============
+  // start kernel
+  // ============
+
   specfem::execution::ChunkedIntersectionIterator chunk(
       parallel_config(), self_edges, coupled_edges);
-
   specfem::execution::for_each_level(
-      "specfem::kokkos_kernels::impl::compute_coupling", chunk,
+      "algorithms/dim2/coupling_integral.cpp::coupling_integral", chunk,
       KOKKOS_LAMBDA(
           const typename decltype(chunk)::index_type &chunk_iterator_index) {
         const auto &chunk_index = chunk_iterator_index.get_index();
         const auto &self_chunk_iterator_index = chunk_index.get_self_index();
         const auto self_chunk_index = self_chunk_iterator_index.get_index();
 
-        // specfem::algorithms::coupling_integral(
-        //     assembly, self_chunk_index, _TODO_interface_field,
-        //     _TODO_integration_factor,
-        //     [&](const auto &self_index, auto &self_field) {
-        //       // TODO verify here
-        //     });
+        const auto &team = self_chunk_index.get_policy_index();
+        const int index_offset =
+            team.league_rank() * parallel_config::chunk_size;
+        const int &current_nelem = self_chunk_index.nedges();
+
+        // ========================
+        // ========================
+        // BEGIN RELEVANT TEST CODE
+
+        // ====================================
+        // fill parameters and expected results
+        // ====================================
+        specfem::assembly::load_on_device(self_chunk_index,
+                                          assembly.nonconforming_interfaces,
+                                          intersection_factor);
+
+        for (int itrial = 0; itrial < num_trials_per_edge; ++itrial) {
+          // set intersection field and expected integrals
+
+          // start with zeroing out everything
+          specfem::execution::for_each_level(
+              specfem::execution::TeamThreadMDRangeIterator(
+                  team, current_nelem, nquad_intersection, ncomp_self),
+              [&](const auto &index) {
+                intersection_field(index(0), index(1), index(2)) = 0;
+              });
+          specfem::execution::for_each_level(
+              specfem::execution::TeamThreadMDRangeIterator(team, current_nelem,
+                                                            ngll, ncomp_self),
+              [&](const auto &index) {
+                expected_integral(index(0), index(1), index(2)) = 0;
+              });
+
+          if (itrial < nquad_intersection) { // case: shape function
+            Kokkos::parallel_for(
+                Kokkos::TeamThreadRange(team, current_nelem),
+                [&](const auto &ielem) {
+                  const int ielem_global = index_offset + ielem;
+                  // round robin for nonzero component
+                  const int nonzero_component =
+                      (ielem_global * num_trials_per_edge + itrial) %
+                      ncomp_self;
+
+                  intersection_field(ielem, itrial, nonzero_component) =
+                      1; // delta(itrial, iintersection)
+
+                  for (int ipoint = 0; ipoint < ngll; ++ipoint) {
+                    // should be kronecker on iintersection (itrial), in the
+                    // integral sum
+
+                    // only iedge and ipoint is needed for transfer function
+                    // retrieval
+                    specfem::point::edge_index<dimension_tag> self_index(
+                        0, ielem_global, ipoint, 0, 0,
+                        specfem::mesh_entity::dim2::type::top);
+                    specfem::point::transfer_function_self<
+                        nquad_intersection, dimension_tag, interface_tag,
+                        boundary_tag>
+                        self_transfer;
+                    specfem::assembly::load_on_device(
+                        self_index, assembly.nonconforming_interfaces,
+                        self_transfer);
+                    expected_integral(ielem, ipoint, nonzero_component) =
+                        intersection_factor(ielem, itrial) *
+                        self_transfer(itrial);
+                  }
+                });
+          }
+
+          // =============================
+          // compute and compare solutions
+          // =============================
+
+          specfem::algorithms::coupling_integral(
+              assembly, self_chunk_index, intersection_field,
+              intersection_factor,
+              [&](const auto &self_index, auto &self_field) {
+                // later: when handling interiors, ipoint indices must change
+                const int &result_edge_index = self_index.iedge;
+                const int &result_point_index = self_index.ipoint;
+
+                ++result_ipoint_hits(result_edge_index, result_point_index);
+
+                const int &failbin_iedge =
+                    result_edge_index % failbin_num_iedge;
+
+                for (int icomp = 0; icomp < ncomp_self; icomp++) {
+                  const type_real &expect =
+                      expected_integral(result_edge_index - index_offset,
+                                        self_index.ipoint, icomp);
+                  const type_real &got = self_field(icomp);
+                  if (std::abs(got - expect) > tol) {
+                    const int failind = failures_counts(
+                        result_edge_index,
+                        result_point_index)++; // retrieve, then increment (same
+                                               // op for concurrency)
+
+                    // additional info if needed
+                    if (failind < failbin_size) {
+                      // failures_inds stores (is_set, iedge, ipoint, itrial,
+                      // icomp)
+                      ++failures_inds(failbin_iedge, result_point_index,
+                                      failind, 0);
+                      failures_inds(failbin_iedge, result_point_index, failind,
+                                    1) = result_edge_index;
+                      failures_inds(failbin_iedge, result_point_index, failind,
+                                    2) = result_point_index;
+                      failures_inds(failbin_iedge, result_point_index, failind,
+                                    3) = itrial;
+                      failures_inds(failbin_iedge, result_point_index, failind,
+                                    4) = icomp;
+
+                      failures_expect_got(failbin_iedge, result_point_index,
+                                          failind, 0) = expect;
+                      failures_expect_got(failbin_iedge, result_point_index,
+                                          failind, 1) = got;
+                    }
+                  }
+                }
+              });
+        }
+
+        //  END RELEVANT TEST CODE
+        // ========================
+        // ========================
       });
 
-  std::cout << oss.str();
+  // ==============
+  // verify results
+  // ==============
+
+  // ensuring everything got hit.
+  typename ResultsView_ipoint_hits::HostMirror h_result_ipoint_hits =
+      Kokkos::create_mirror_view(result_ipoint_hits);
+  Kokkos::deep_copy(h_result_ipoint_hits, result_ipoint_hits);
+
+  bool is_fail = false;
+
+  oss << "Counting number of times algorithms::coupling_integral called-back "
+         "each edge point (expects "
+      << num_trials_per_edge << ")...\n";
+
+  for (int iedge = 0; iedge < n_edges; iedge++) {
+    for (int ipoint = 0; ipoint < ngll; ipoint++) {
+      const int &nhits = h_result_ipoint_hits(iedge, ipoint);
+      if (nhits != num_trials_per_edge) {
+        is_fail = true;
+        oss << "  [iedge = " << iedge << ", ipoint = " << ipoint << "]: got "
+            << nhits << "\n";
+      }
+    }
+  }
+
+  oss << "Done!\n";
+
+  // retrieve failures from bins (if they exist)
+
+  oss << "Gathering failures...\n";
+
+  typename ResultsView_failbins_counts::HostMirror h_failures_counts =
+      Kokkos::create_mirror_view(failures_counts);
+  typename ResultsView_failbins_inds::HostMirror h_failures_inds =
+      Kokkos::create_mirror_view(failures_inds);
+  typename ResultsView_failbins_expect_got::HostMirror h_failures_expect_got =
+      Kokkos::create_mirror_view(failures_expect_got);
+  Kokkos::deep_copy(h_failures_counts, failures_counts);
+  Kokkos::deep_copy(h_failures_inds, failures_inds);
+  Kokkos::deep_copy(h_failures_expect_got, failures_expect_got);
+
+  for (int iedge_bin = 0; iedge_bin < failbin_num_iedge; ++iedge_bin) {
+    for (int ipoint = 0; ipoint < ngll; ++ipoint) {
+      const int &nfails = h_failures_counts(iedge_bin, ipoint);
+      if (nfails > 0) {
+        is_fail = true;
+        const int nfail_print = std::min(failbin_size, nfails);
+        oss << "  Bin (" << iedge_bin << ", " << ipoint << ") has collected "
+            << nfails << " failures. Listing " << nfail_print << ":\n";
+
+        for (int ifail = 0; ifail < nfail_print; ++ifail) {
+          // stores (is_set, iedge, ipoint, itrial, icomp)
+          oss << "  - " << ifail << ": ";
+          if (h_failures_inds(iedge_bin, ipoint, ifail, 0) != 1) {
+            oss << "[Missing or corrupted in collection] gathered "
+                << h_failures_inds(iedge_bin, ipoint, ifail, 0)
+                << "in index. Should be 1.\n";
+          } else {
+            const int &f_iedge = h_failures_inds(iedge_bin, ipoint, ifail, 1);
+            const int &f_ipoint = h_failures_inds(iedge_bin, ipoint, ifail, 2);
+            const int &f_itrial = h_failures_inds(iedge_bin, ipoint, ifail, 3);
+            const int &f_icomp = h_failures_inds(iedge_bin, ipoint, ifail, 4);
+            const type_real &expected =
+                h_failures_expect_got(iedge_bin, ipoint, ifail, 0);
+            const type_real &got =
+                h_failures_expect_got(iedge_bin, ipoint, ifail, 1);
+            oss << "\n      [iedge = " << f_iedge << ", ipoint = " << f_ipoint
+                << ", trial = " << f_itrial << ", component = " << f_icomp
+                << "]\n"
+                << "      expected: " << expected << "\n"
+                << "           got: " << got;
+            if (std::abs(expected) > 1e-4) {
+              oss << " (rel: " << std::showpos << std::scientific
+                  << (got - expected) / std::abs(expected) << std::fixed
+                  << std::noshowpos << ")";
+            }
+
+            oss << "\n";
+          }
+        }
+      }
+    }
+  }
+
+  oss << "Done!\n";
+
+  if (is_fail) {
+    ADD_FAILURE() << oss.str();
+  }
 }
 
 void execute(const specfem::assembly::assembly<specfem::dimension::type::dim2>
@@ -69,27 +412,27 @@ void execute(const specfem::assembly::assembly<specfem::dimension::type::dim2>
  * FunctionInitializer)
  */
 template <typename TestingTypes>
-struct AnalyticalCouplingIntegralTest2D : public ::testing::Test {
+struct MeshedCouplingIntegralTest2D : public ::testing::Test {
   using AssemblyInitializer = std::tuple_element_t<0, TestingTypes>;
 
   /**
    * @brief Set up test with initialized transfer function and field.
    */
-  AnalyticalCouplingIntegralTest2D() {}
+  MeshedCouplingIntegralTest2D() {}
 
   specfem::test_fixture::Assembly2D<AssemblyInitializer> assembly_fixture;
 };
 using namespace specfem::test_fixture;
 
 /** Test type combinations for parameterized testing */
-using AnalyticalCouplingIntegralTestTypes2D =
+using MeshedCouplingIntegralTestTypes2D =
     ::testing::Types<std::tuple<AssemblyInitializer2D::FromMesh<
         MeshInitializer2D::ThreeElementNonconforming> > >;
 
-TYPED_TEST_SUITE(AnalyticalCouplingIntegralTest2D,
-                 AnalyticalCouplingIntegralTestTypes2D);
+TYPED_TEST_SUITE(MeshedCouplingIntegralTest2D,
+                 MeshedCouplingIntegralTestTypes2D);
 
-TYPED_TEST(AnalyticalCouplingIntegralTest2D, ComputeCouplingOnAnalyticalField) {
+TYPED_TEST(MeshedCouplingIntegralTest2D, FullMeshOnKroneckeredFields) {
   execute(this->assembly_fixture.assembly_instance());
 }
 

--- a/tests/unit-tests/algorithms/dim2/coupling_integral.cpp
+++ b/tests/unit-tests/algorithms/dim2/coupling_integral.cpp
@@ -1,12 +1,66 @@
 
+#include "execution/chunked_intersection_iterator.hpp"
+#include "parallel_configuration/chunk_edge_config.hpp"
 #include "utilities/include/fixture/assembly.hpp"
-#include "utilities/include/fixture/assembly/assembly_2d.hpp"
-#include "utilities/include/fixture/mesh/mesh.hpp"
+#include <sstream>
+
+template <specfem::interface::interface_tag interface_tag,
+          specfem::element::boundary_tag boundary_tag>
+void verify_interfaces(
+    const specfem::assembly::assembly<specfem::dimension::type::dim2>
+        &assembly) {
+  constexpr auto DimensionTag = specfem::dimension::type::dim2;
+  constexpr auto connection_tag = specfem::connections::type::nonconforming;
+  constexpr auto self_medium =
+      specfem::interface::attributes<DimensionTag,
+                                     interface_tag>::self_medium();
+
+  const auto [self_edges, coupled_edges] =
+      assembly.edge_types.get_edges_on_device(connection_tag, interface_tag,
+                                              boundary_tag);
+  if (self_edges.n_edges == 0)
+    return;
+
+  std::ostringstream oss;
+  oss << "Interface execution (" << self_edges.n_edges << " edges):\n";
+  oss << "  - interface: " << specfem::interface::to_string(interface_tag)
+      << " (self_medium = " << specfem::element::to_string(self_medium)
+      << ")\n";
+  oss << "  - boundary: " << specfem::element::to_string(boundary_tag) << "\n";
+
+  using parallel_config =
+      specfem::parallel_configuration::default_chunk_edge_config<
+          DimensionTag, Kokkos::DefaultExecutionSpace>;
+  specfem::execution::ChunkedIntersectionIterator chunk(
+      parallel_config(), self_edges, coupled_edges);
+
+  specfem::execution::for_each_level(
+      "specfem::kokkos_kernels::impl::compute_coupling", chunk,
+      KOKKOS_LAMBDA(
+          const typename decltype(chunk)::index_type &chunk_iterator_index) {
+        const auto &chunk_index = chunk_iterator_index.get_index();
+        const auto &self_chunk_iterator_index = chunk_index.get_self_index();
+        const auto self_chunk_index = self_chunk_iterator_index.get_index();
+
+        // specfem::algorithms::coupling_integral(
+        //     assembly, self_chunk_index, _TODO_interface_field,
+        //     _TODO_integration_factor,
+        //     [&](const auto &self_index, auto &self_field) {
+        //       // TODO verify here
+        //     });
+      });
+
+  std::cout << oss.str();
+}
 
 void execute(const specfem::assembly::assembly<specfem::dimension::type::dim2>
                  &assembly) {
-  assembly.check_jacobian_matrix();
-  std::cout << assembly.get_total_number_of_elements();
+  FOR_EACH_IN_PRODUCT(
+      (DIMENSION_TAG(DIM2), CONNECTION_TAG(NONCONFORMING),
+       INTERFACE_TAG(ELASTIC_ACOUSTIC, ACOUSTIC_ELASTIC),
+       BOUNDARY_TAG(NONE, ACOUSTIC_FREE_SURFACE, STACEY,
+                    COMPOSITE_STACEY_DIRICHLET)),
+      { verify_interfaces<_interface_tag_, _boundary_tag_>(assembly); })
 }
 
 /**
@@ -23,7 +77,7 @@ struct AnalyticalCouplingIntegralTest2D : public ::testing::Test {
    */
   AnalyticalCouplingIntegralTest2D() {}
 
-  specfem::test_fixture::Assembly2D<AssemblyInitializer> assembly;
+  specfem::test_fixture::Assembly2D<AssemblyInitializer> assembly_fixture;
 };
 using namespace specfem::test_fixture;
 
@@ -36,7 +90,7 @@ TYPED_TEST_SUITE(AnalyticalCouplingIntegralTest2D,
                  AnalyticalCouplingIntegralTestTypes2D);
 
 TYPED_TEST(AnalyticalCouplingIntegralTest2D, ComputeCouplingOnAnalyticalField) {
-  execute(this->assembly);
+  execute(this->assembly_fixture.assembly_instance());
 }
 
 int main(int argc, char *argv[]) {
@@ -44,37 +98,3 @@ int main(int argc, char *argv[]) {
   ::testing::AddGlobalTestEnvironment(new SPECFEMEnvironment);
   return RUN_ALL_TESTS();
 }
-
-/*
-
-
-# add_executable(
-#   coupling_integral_tests
-#   algorithms/dim2/coupling_integral.cpp
-# )
-
-# target_link_libraries(
-#   coupling_integral_tests
-#   algorithms
-#   enumerations
-#   mesh
-#   assembly
-#   gtest_main
-#   Kokkos::kokkos
-#   specfem_environment
-#   utilities
-
-#   quadrature
-#   yaml-cpp
-#   parameter_reader
-#   compare_arrays
-#   timescheme
-#   point
-#   kokkos_kernels
-#   solver
-#   periodic_tasks
-#   boost
-#   -lpthread -lm
-# )
-
-*/

--- a/tests/unit-tests/algorithms/dim2/coupling_integral.cpp
+++ b/tests/unit-tests/algorithms/dim2/coupling_integral.cpp
@@ -407,6 +407,18 @@ void execute(const specfem::assembly::assembly<specfem::dimension::type::dim2>
 }
 
 /**
+ * @brief struct for naming the typed test suite.
+ * http://google.github.io/googletest/reference/testing.html#TYPED_TEST_SUITE
+ *
+ */
+struct MeshedCouplingIntegralTest2DNames {
+  template <typename TestingTypes> static std::string GetName(int) {
+    return specfem::test_fixture::impl::name<
+        std::tuple_element_t<0, TestingTypes> >::get();
+  }
+};
+
+/**
  * @brief Test fixture for 2D transfer function algorithms.
  * @tparam TestingTypes Tuple of (TransferFunctionInitializer,
  * FunctionInitializer)
@@ -421,7 +433,21 @@ struct MeshedCouplingIntegralTest2D : public ::testing::Test {
   MeshedCouplingIntegralTest2D() {}
 
   specfem::test_fixture::Assembly2D<AssemblyInitializer> assembly_fixture;
+
+  static void print_description() {
+    std::ostringstream oss;
+    oss << "====================================================\n";
+    oss << "-=-=- Test: "
+        << MeshedCouplingIntegralTest2DNames::GetName<TestingTypes>(0)
+        << " -=-=-\n";
+    oss << "  Assembly:\n";
+    oss << specfem::test_fixture::impl::description<AssemblyInitializer>::get(
+        4);
+    oss << "\n====================================================\n";
+    SPECFEMEnvironment::get_mpi()->cout(oss.str());
+  }
 };
+
 using namespace specfem::test_fixture;
 
 /** Test type combinations for parameterized testing */
@@ -430,10 +456,13 @@ using MeshedCouplingIntegralTestTypes2D =
         MeshInitializer2D::ThreeElementNonconforming> > >;
 
 TYPED_TEST_SUITE(MeshedCouplingIntegralTest2D,
-                 MeshedCouplingIntegralTestTypes2D);
+                 MeshedCouplingIntegralTestTypes2D,
+                 MeshedCouplingIntegralTest2DNames);
 
 TYPED_TEST(MeshedCouplingIntegralTest2D, FullMeshOnKroneckeredFields) {
-  execute(this->assembly_fixture.assembly_instance());
+  this->print_description();
+  const auto assembly = this->assembly_fixture.assembly_instance();
+  execute(*assembly);
 }
 
 int main(int argc, char *argv[]) {

--- a/tests/unit-tests/utilities/include/fixture/assembly.hpp
+++ b/tests/unit-tests/utilities/include/fixture/assembly.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace specfem::test_fixture {
+
+/**
+ * @brief Constructs a test assembly given a compile-time initializer.
+ *
+ * @tparam AssemblyInitializer2D initializer, of type
+ * MeshInitializer2D::MeshInitializer2D
+ */
+template <typename AssemblyInitializer2D> struct Assembly2D;
+
+/**
+ * @brief Initializes Assembly2D, an assembly fixture
+ *
+ */
+namespace AssemblyInitializer2D {
+struct AssemblyInitializer2D {};
+} // namespace AssemblyInitializer2D
+
+} // namespace specfem::test_fixture
+
+#include "assembly/assembly_2d.hpp"

--- a/tests/unit-tests/utilities/include/fixture/assembly/assembly_2d.hpp
+++ b/tests/unit-tests/utilities/include/fixture/assembly/assembly_2d.hpp
@@ -16,8 +16,9 @@ template <typename Initializer> struct Assembly2D {
   static constexpr int ndim = specfem::dimension::dimension<DimensionTag>::dim;
 
 private:
-  static std::unique_ptr<specfem::assembly::assembly<DimensionTag> >
-      _assembly_instance;
+  inline static std::unique_ptr<specfem::assembly::assembly<DimensionTag> >
+      _assembly_instance = nullptr;
+  inline static int refcount = 0;
 
 public:
   Assembly2D() {
@@ -25,6 +26,13 @@ public:
       _assembly_instance =
           std::make_unique<specfem::assembly::assembly<DimensionTag> >(
               Initializer::generate_assembly());
+    }
+    ++refcount;
+  }
+  ~Assembly2D() {
+    --refcount;
+    if (refcount == 0) {
+      _assembly_instance = nullptr;
     }
   }
 
@@ -38,7 +46,7 @@ static constexpr specfem::dimension::type DimensionTag =
     specfem::dimension::type::dim2;
 static constexpr int ndim = specfem::dimension::dimension<DimensionTag>::dim;
 
-template <typename MeshInitializer> struct FromMesh {
+template <typename MeshInitializer> struct FromMesh : AssemblyInitializer2D {
   static_assert(
       std::is_base_of_v<MeshInitializer2D::MeshInitializer2D, MeshInitializer>,
       "FromMesh template parameter expects MeshInitializer2D!");

--- a/tests/unit-tests/utilities/include/fixture/assembly/assembly_2d.hpp
+++ b/tests/unit-tests/utilities/include/fixture/assembly/assembly_2d.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "../assembly.hpp"
+#include "../mesh.hpp"
+#include "specfem/assembly.hpp"
+
+#include <type_traits>
+
+namespace specfem::test_fixture {
+template <typename Initializer> struct Assembly2D {
+  static_assert(std::is_base_of_v<AssemblyInitializer2D::AssemblyInitializer2D,
+                                  Initializer>,
+                "Assembly2D template parameter expects AssemblyInitializer2D!");
+  static constexpr specfem::dimension::type DimensionTag =
+      specfem::dimension::type::dim2;
+  static constexpr int ndim = specfem::dimension::dimension<DimensionTag>::dim;
+
+private:
+  static std::unique_ptr<specfem::assembly::assembly<DimensionTag> >
+      _assembly_instance;
+
+public:
+  Assembly2D() {
+    if (_assembly_instance == nullptr) {
+      _assembly_instance =
+          std::make_unique<specfem::assembly::assembly<DimensionTag> >(
+              Initializer::generate_assembly());
+    }
+  }
+
+  const specfem::assembly::assembly<DimensionTag> &assembly_instance() const {
+    return *_assembly_instance;
+  }
+};
+
+namespace AssemblyInitializer2D {
+static constexpr specfem::dimension::type DimensionTag =
+    specfem::dimension::type::dim2;
+static constexpr int ndim = specfem::dimension::dimension<DimensionTag>::dim;
+
+template <typename MeshInitializer> struct FromMesh {
+  static_assert(
+      std::is_base_of_v<MeshInitializer2D::MeshInitializer2D, MeshInitializer>,
+      "FromMesh template parameter expects MeshInitializer2D!");
+
+  static specfem::assembly::assembly<DimensionTag> generate_assembly() {
+    Mesh2D<MeshInitializer> mesh;
+
+    // TODO: consider how to handle other parameters
+    const auto quadrature = []() {
+      specfem::quadrature::gll::gll gll{};
+      return specfem::quadrature::quadratures(gll);
+    }();
+
+    std::vector<std::shared_ptr<
+        specfem::sources::source<specfem::dimension::type::dim2> > >
+        sources;
+    std::vector<std::shared_ptr<
+        specfem::receivers::receiver<specfem::dimension::type::dim2> > >
+        receivers;
+    return specfem::assembly::assembly<specfem::dimension::type::dim2>(
+        mesh.mesh_instance(), quadrature, sources, receivers, {}, 1.0, 0.0, 1,
+        1, 1, specfem::simulation::type::forward, false, nullptr);
+  }
+};
+} // namespace AssemblyInitializer2D
+} // namespace specfem::test_fixture

--- a/tests/unit-tests/utilities/include/fixture/assembly/assembly_2d.hpp
+++ b/tests/unit-tests/utilities/include/fixture/assembly/assembly_2d.hpp
@@ -1,43 +1,53 @@
 #pragma once
 
 #include "../assembly.hpp"
+#include "../impl/descriptions.hpp"
 #include "../mesh.hpp"
 #include "specfem/assembly.hpp"
-
-#include <type_traits>
 
 namespace specfem::test_fixture {
 template <typename Initializer> struct Assembly2D {
   static_assert(std::is_base_of_v<AssemblyInitializer2D::AssemblyInitializer2D,
                                   Initializer>,
                 "Assembly2D template parameter expects AssemblyInitializer2D!");
+  using AssemblyInitializer = Initializer;
   static constexpr specfem::dimension::type DimensionTag =
       specfem::dimension::type::dim2;
   static constexpr int ndim = specfem::dimension::dimension<DimensionTag>::dim;
 
 private:
-  inline static std::unique_ptr<specfem::assembly::assembly<DimensionTag> >
-      _assembly_instance = nullptr;
-  inline static int refcount = 0;
+  inline static std::shared_ptr<specfem::assembly::assembly<DimensionTag> >
+      _global_assembly_instance = nullptr;
+
+  std::shared_ptr<specfem::assembly::assembly<DimensionTag> >
+      _assembly_instance;
 
 public:
   Assembly2D() {
-    if (_assembly_instance == nullptr) {
-      _assembly_instance =
-          std::make_unique<specfem::assembly::assembly<DimensionTag> >(
+    if (_global_assembly_instance == nullptr) {
+      _global_assembly_instance =
+          std::make_shared<specfem::assembly::assembly<DimensionTag> >(
               Initializer::generate_assembly());
     }
-    ++refcount;
+    _assembly_instance = _global_assembly_instance;
   }
   ~Assembly2D() {
-    --refcount;
-    if (refcount == 0) {
-      _assembly_instance = nullptr;
+    _assembly_instance = nullptr;
+    if (_global_assembly_instance.use_count() == 1) {
+      _global_assembly_instance = nullptr;
     }
   }
 
-  const specfem::assembly::assembly<DimensionTag> &assembly_instance() const {
-    return *_assembly_instance;
+  std::shared_ptr<const specfem::assembly::assembly<DimensionTag> >
+  assembly_instance() const {
+    return _global_assembly_instance;
+  }
+
+  static std::string description(const int &indent = 0) {
+    return specfem::test_fixture::impl::description<Initializer>::get(indent);
+  }
+  static std::string name() {
+    return specfem::test_fixture::impl::name<Initializer>::get();
   }
 };
 
@@ -46,10 +56,11 @@ static constexpr specfem::dimension::type DimensionTag =
     specfem::dimension::type::dim2;
 static constexpr int ndim = specfem::dimension::dimension<DimensionTag>::dim;
 
-template <typename MeshInitializer> struct FromMesh : AssemblyInitializer2D {
+template <typename Initializer> struct FromMesh : AssemblyInitializer2D {
   static_assert(
-      std::is_base_of_v<MeshInitializer2D::MeshInitializer2D, MeshInitializer>,
+      std::is_base_of_v<MeshInitializer2D::MeshInitializer2D, Initializer>,
       "FromMesh template parameter expects MeshInitializer2D!");
+  using MeshInitializer = Initializer;
 
   static specfem::assembly::assembly<DimensionTag> generate_assembly() {
     Mesh2D<MeshInitializer> mesh;
@@ -67,8 +78,18 @@ template <typename MeshInitializer> struct FromMesh : AssemblyInitializer2D {
         specfem::receivers::receiver<specfem::dimension::type::dim2> > >
         receivers;
     return specfem::assembly::assembly<specfem::dimension::type::dim2>(
-        mesh.mesh_instance(), quadrature, sources, receivers, {}, 1.0, 0.0, 1,
+        *mesh.mesh_instance(), quadrature, sources, receivers, {}, 1.0, 0.0, 1,
         1, 1, specfem::simulation::type::forward, false, nullptr);
+  }
+  static std::string description() {
+    return std::string("Mesh-initialized assembly:\n  name: ") +
+           specfem::test_fixture::impl::name<Initializer>::get() +
+           "\n  description:\n" +
+           specfem::test_fixture::impl::description<Initializer>::get(4);
+  }
+  static std::string name() {
+    return std::string("FromMesh(") +
+           specfem::test_fixture::impl::name<Initializer>::get() + ")";
   }
 };
 } // namespace AssemblyInitializer2D

--- a/tests/unit-tests/utilities/include/fixture/impl/descriptions.hpp
+++ b/tests/unit-tests/utilities/include/fixture/impl/descriptions.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <regex>
+#include <string>
+#include <type_traits>
+
+namespace specfem::test_fixture::impl {
+
+template <typename T, typename = void> struct description {
+  static constexpr bool has = false;
+  static std::string get(const int &indent = 0) {
+    std::string indent_str(indent, ' ');
+    return indent_str = "<no description>";
+  }
+};
+
+template <typename T>
+struct description<
+    T, std::enable_if_t<std::is_same_v<decltype(T::description()), std::string>,
+                        void> > {
+  static constexpr bool has = true;
+  static std::string get(const int &indent = 0) {
+    std::string indent_str(indent, ' ');
+    return std::regex_replace(
+        T::description(), std::regex("^(.+)$", std::regex_constants::multiline),
+        indent_str + "$&");
+  }
+};
+
+template <typename T, typename = void> struct name {
+  static constexpr bool has = false;
+  static std::string get() { return "<unnamed>"; }
+};
+
+template <typename T>
+struct name<T, std::enable_if_t<
+                   std::is_same_v<decltype(T::name()), std::string>, void> > {
+  static constexpr bool has = true;
+  static std::string get() { return T::name(); }
+};
+} // namespace specfem::test_fixture::impl

--- a/tests/unit-tests/utilities/include/fixture/mesh.hpp
+++ b/tests/unit-tests/utilities/include/fixture/mesh.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+namespace specfem::test_fixture {
+
+/**
+ * @brief Constructs a test mesh given a compile-time initializer.
+ *
+ * @tparam MeshInitializer2D initializer, of type
+ * MeshInitializer2D::MeshInitializer2D
+ */
+template <typename MeshInitializer2D> struct Mesh2D;
+
+/**
+ * @brief Initializes Mesh2D, a mesh fixture
+ *
+ */
+namespace MeshInitializer2D {
+struct MeshInitializer2D {};
+} // namespace MeshInitializer2D
+
+/**
+ * @brief Provides helper functions for an element (control nodes -> elements,
+ * etc.)
+ *
+ */
+template <typename MeshElementInit2D> struct MeshElement2D;
+/**
+ * @brief Gives the quadrature points for a particular rule.
+ *
+ */
+namespace MeshElementType2D {
+struct MeshElementType2D {};
+} // namespace MeshElementType2D
+} // namespace specfem::test_fixture
+
+#include "mesh/element_2d.hpp"
+#include "mesh/mesh.hpp"

--- a/tests/unit-tests/utilities/include/fixture/mesh/element_2d.hpp
+++ b/tests/unit-tests/utilities/include/fixture/mesh/element_2d.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "../mesh.hpp"
+#include "enumerations/dimension.hpp"
+#include "specfem/point.hpp"
+
+namespace specfem::test_fixture {
+
+template <typename MeshElementInit2D> struct MeshElement2D {
+  static_assert(std::is_base_of_v<MeshElementType2D::MeshElementType2D,
+                                  MeshElementInit2D>,
+                "MeshElement2D template parameter expects MeshElementType2D!");
+};
+
+namespace MeshElementType2D {
+constexpr specfem::dimension::type DimensionTag =
+    specfem::dimension::type::dim2;
+constexpr int ndim = specfem::dimension::dimension<DimensionTag>::dim;
+
+/**
+ * @brief ngnod = 4 reference element [-1,1]^2
+ *
+ */
+struct Reference {
+  static constexpr int ngnod = 4;
+  static constexpr std::array<std::array<type_real, ndim>, 4> control_nodes = {
+    std::array<type_real, ndim>{ -1, -1 }, std::array<type_real, ndim>{ 1, -1 },
+    std::array<type_real, ndim>{ 1, 1 }, std::array<type_real, ndim>{ -1, 1 }
+  };
+  static std::string description() { return "ngnod = 4 reference element"; }
+};
+} // namespace MeshElementType2D
+} // namespace specfem::test_fixture

--- a/tests/unit-tests/utilities/include/fixture/mesh/mesh.hpp
+++ b/tests/unit-tests/utilities/include/fixture/mesh/mesh.hpp
@@ -16,14 +16,16 @@ template <typename Initializer> struct Mesh2D {
   static_assert(
       std::is_base_of_v<MeshInitializer2D::MeshInitializer2D, Initializer>,
       "Mesh2D template parameter expects MeshInitializer2D!");
+  using MeshInitializer = Initializer;
   static constexpr specfem::dimension::type DimensionTag =
       specfem::dimension::type::dim2;
   static constexpr int ndim = specfem::dimension::dimension<DimensionTag>::dim;
 
 private:
-  inline static std::unique_ptr<specfem::mesh::mesh<DimensionTag> >
-      _mesh_instance = nullptr;
-  inline static int refcount = 0;
+  inline static std::shared_ptr<specfem::mesh::mesh<DimensionTag> >
+      _global_mesh_instance = nullptr;
+
+  std::shared_ptr<specfem::mesh::mesh<DimensionTag> > _mesh_instance;
 
   template <typename dummy, typename = void>
   struct is_from_file_t : std::false_type {};
@@ -36,37 +38,50 @@ public:
   static constexpr bool is_from_file = is_from_file_t<int>::value;
 
   Mesh2D() {
-    if (_mesh_instance == nullptr) {
+    if (_global_mesh_instance == nullptr) {
       if constexpr (is_from_file) {
+        SPECFEMEnvironment::get_mpi()->cout(
+            std::string("[Mesh2D] Initializing mesh: ") +
+            Initializer::get_filename() + "\n");
         specfem::MPI::MPI *mpi = SPECFEMEnvironment::get_mpi();
 
-        _mesh_instance = std::make_unique<specfem::mesh::mesh<DimensionTag> >(
-            specfem::io::read_2d_mesh(
-                Initializer::get_filename(), specfem::enums::elastic_wave::psv,
-                specfem::enums::electromagnetic_wave::te, mpi));
+        _global_mesh_instance =
+            std::make_shared<specfem::mesh::mesh<DimensionTag> >(
+                specfem::io::read_2d_mesh(
+                    Initializer::get_filename(),
+                    specfem::enums::elastic_wave::psv,
+                    specfem::enums::electromagnetic_wave::te, mpi));
 
       } else {
         throw std::runtime_error("Mesh2D from internal variables (not from a "
                                  "database file) not yet implemented.");
       }
     }
-    ++refcount;
+    _mesh_instance = _global_mesh_instance;
   }
   ~Mesh2D() {
-    --refcount;
-    if (refcount == 0) {
-      _mesh_instance = nullptr;
+    _mesh_instance = nullptr;
+    if (_global_mesh_instance.use_count() == 1) {
+      SPECFEMEnvironment::get_mpi()->cout(
+          std::string("[Mesh2D] Destructing mesh: ") +
+          Initializer::get_filename() + "\n");
+      _global_mesh_instance = nullptr;
     }
   }
 
-  const specfem::mesh::mesh<DimensionTag> &mesh_instance() const {
-    return *_mesh_instance;
+  std::shared_ptr<const specfem::mesh::mesh<DimensionTag> >
+  mesh_instance() const {
+    return _global_mesh_instance;
   }
 };
 
 namespace MeshInitializer2D {
 struct ThreeElementNonconforming : MeshInitializer2D {
-  static std::string description() { return "3 element nonconforming grid"; }
+  static std::string description() {
+    return std::string("3 element nonconforming grid (\"") + get_filename() +
+           "\")";
+  }
+  static std::string name() { return "3_elem_nonconforming"; }
   static constexpr specfem::enums::elastic_wave elastic_wave_type =
       specfem::enums::elastic_wave::psv;
   static constexpr specfem::enums::electromagnetic_wave

--- a/tests/unit-tests/utilities/include/fixture/mesh/mesh.hpp
+++ b/tests/unit-tests/utilities/include/fixture/mesh/mesh.hpp
@@ -21,15 +21,19 @@ template <typename Initializer> struct Mesh2D {
   static constexpr int ndim = specfem::dimension::dimension<DimensionTag>::dim;
 
 private:
-  static std::unique_ptr<specfem::mesh::mesh<DimensionTag> > _mesh_instance;
+  inline static std::unique_ptr<specfem::mesh::mesh<DimensionTag> >
+      _mesh_instance = nullptr;
+  inline static int refcount = 0;
 
-  template <typename = void> struct is_from_file_t : std::false_type {};
-  template <>
-  struct is_from_file_t<std::enable_if_t<Initializer::is_from_file, void> >
+  template <typename dummy, typename = void>
+  struct is_from_file_t : std::false_type {};
+  template <typename dummy>
+  struct is_from_file_t<dummy,
+                        std::enable_if_t<Initializer::is_from_file, void> >
       : std::true_type {};
 
 public:
-  static constexpr bool is_from_file = is_from_file_t<>::type;
+  static constexpr bool is_from_file = is_from_file_t<int>::value;
 
   Mesh2D() {
     if (_mesh_instance == nullptr) {
@@ -46,6 +50,13 @@ public:
                                  "database file) not yet implemented.");
       }
     }
+    ++refcount;
+  }
+  ~Mesh2D() {
+    --refcount;
+    if (refcount == 0) {
+      _mesh_instance = nullptr;
+    }
   }
 
   const specfem::mesh::mesh<DimensionTag> &mesh_instance() const {
@@ -54,7 +65,7 @@ public:
 };
 
 namespace MeshInitializer2D {
-struct ThreeElementNonconforming {
+struct ThreeElementNonconforming : MeshInitializer2D {
   static std::string description() { return "3 element nonconforming grid"; }
   static constexpr specfem::enums::elastic_wave elastic_wave_type =
       specfem::enums::elastic_wave::psv;

--- a/tests/unit-tests/utilities/include/fixture/mesh/mesh.hpp
+++ b/tests/unit-tests/utilities/include/fixture/mesh/mesh.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "../../../../SPECFEM_Environment.hpp"
+#include "../mesh.hpp"
+#include "enumerations/dimension.hpp"
+#include "io/interface.hpp"
+#include "mesh/mesh.hpp"
+
+#include <memory>
+#include <stdexcept>
+#include <type_traits>
+
+namespace specfem::test_fixture {
+
+template <typename Initializer> struct Mesh2D {
+  static_assert(
+      std::is_base_of_v<MeshInitializer2D::MeshInitializer2D, Initializer>,
+      "Mesh2D template parameter expects MeshInitializer2D!");
+  static constexpr specfem::dimension::type DimensionTag =
+      specfem::dimension::type::dim2;
+  static constexpr int ndim = specfem::dimension::dimension<DimensionTag>::dim;
+
+private:
+  static std::unique_ptr<specfem::mesh::mesh<DimensionTag> > _mesh_instance;
+
+  template <typename = void> struct is_from_file_t : std::false_type {};
+  template <>
+  struct is_from_file_t<std::enable_if_t<Initializer::is_from_file, void> >
+      : std::true_type {};
+
+public:
+  static constexpr bool is_from_file = is_from_file_t<>::type;
+
+  Mesh2D() {
+    if (_mesh_instance == nullptr) {
+      if constexpr (is_from_file) {
+        specfem::MPI::MPI *mpi = SPECFEMEnvironment::get_mpi();
+
+        _mesh_instance = std::make_unique<specfem::mesh::mesh<DimensionTag> >(
+            specfem::io::read_2d_mesh(
+                Initializer::get_filename(), specfem::enums::elastic_wave::psv,
+                specfem::enums::electromagnetic_wave::te, mpi));
+
+      } else {
+        throw std::runtime_error("Mesh2D from internal variables (not from a "
+                                 "database file) not yet implemented.");
+      }
+    }
+  }
+
+  const specfem::mesh::mesh<DimensionTag> &mesh_instance() const {
+    return *_mesh_instance;
+  }
+};
+
+namespace MeshInitializer2D {
+struct ThreeElementNonconforming {
+  static std::string description() { return "3 element nonconforming grid"; }
+  static constexpr specfem::enums::elastic_wave elastic_wave_type =
+      specfem::enums::elastic_wave::psv;
+  static constexpr specfem::enums::electromagnetic_wave
+      electromagnetic_wave_type = specfem::enums::electromagnetic_wave::te;
+
+  static constexpr bool is_from_file = true;
+  static std::string get_filename() {
+    return "data/dim2/3_elem_nonconforming/database.bin";
+  }
+};
+} // namespace MeshInitializer2D
+} // namespace specfem::test_fixture


### PR DESCRIPTION
## Description

Please describe the changes/features in this pull request.
- adds `coupling_integral.hpp` to `unit-tests/algorithms/dim2`
- provides `assembly` and `mesh` `test_fixture`s (currently, only `3_elem_nonconforming`).
- improves prints by splitting `description` into `name` (single-line, used for test name generators) and `description` (multi-line verbose). Backwards compatible with prior fixtures (nonconforming_interface), but strings may want to be updated later.

## Issue Number

If there is an issue created for these changes, link it here

#1342

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
