### PR TITLE
Test Fixtures: Split Description -> Description + Name

### DIFF
--- a/tests/unit-tests/algorithms/dim2/transfer.cpp
+++ b/tests/unit-tests/algorithms/dim2/transfer.cpp
@@ -325,7 +325,20 @@ using TransferFunctionTestTypes2D = ::testing::Types<
             AnalyticalFunctionType::Power<5>,
             QuadraturePoints::Asymm5Point> > >;
 
-TYPED_TEST_SUITE(TransferFunctionTest2D, TransferFunctionTestTypes2D);
+/* for test naming
+ * https://google.github.io/googletest/reference/testing.html#TYPED_TEST_SUITE
+ */
+struct TransferFunctionTest2DNames {
+  template <typename TestingTypes> static std::string GetName(int) {
+    using TestType = TransferFunctionTest2D<TestingTypes>;
+    return std::string("TransferFunctionTest2D(") +
+           TestType::TransferFunctionInitializer::name() + ", " +
+           TestType::FunctionInitializer::name() + ")";
+  }
+};
+
+TYPED_TEST_SUITE(TransferFunctionTest2D, TransferFunctionTestTypes2D,
+                 TransferFunctionTest2DNames);
 
 TYPED_TEST(TransferFunctionTest2D, ExecuteTransferFunction) {
   execute(this->transfer_function, this->function);

--- a/tests/unit-tests/algorithms/dim2/transfer.cpp
+++ b/tests/unit-tests/algorithms/dim2/transfer.cpp
@@ -1,4 +1,3 @@
-
 #include <array>
 #include <stdexcept>
 #include <tuple>
@@ -264,85 +263,81 @@ void execute(const TransferFunction2D &transfer_function,
 using namespace specfem::algorithms_test;
 
 /**
- * @brief Test fixture for 2D transfer function algorithms.
- * @tparam TestingTypes Tuple of (TransferFunctionInitializer,
- * FunctionInitializer)
+ * @brief Test parameter struct for parameterized tests
  */
-template <typename TestingTypes>
-struct TransferFunctionTest2D : public ::testing::Test {
-  using TransferFunctionInitializer = std::tuple_element_t<0, TestingTypes>;
-  using FunctionInitializer = std::tuple_element_t<1, TestingTypes>;
-
-  /**
-   * @brief Set up test with initialized transfer function and field.
-   */
-  TransferFunctionTest2D()
-      : transfer_function(TransferFunctionInitializer()),
-        function(FunctionInitializer()) {}
-
-  specfem::test_fixture::TransferFunction2D<TransferFunctionInitializer>
-      transfer_function;                                               /**< Test
-                                                  transfer
-                                                  function
-                                                */
-  specfem::test_fixture::EdgeFunction2D<FunctionInitializer> function; /**<
-                                                                           Test
-                                                                           field
-                                                                         */
+struct TransferFunctionTestParam {
+  std::function<void()> execute_test;
+  std::string name;
 };
+
+// Custom PrintTo to suppress verbose parameter output
+void PrintTo(const TransferFunctionTestParam &, std::ostream *os) { *os << ""; }
+
+/**
+ * @brief Test fixture for 2D transfer function algorithms using value
+ * parameters
+ */
+class TransferFunctionTest2D
+    : public ::testing::TestWithParam<TransferFunctionTestParam> {};
+
+TEST_P(TransferFunctionTest2D, ExecuteTransferFunction) {
+  GetParam().execute_test();
+}
+
 using namespace specfem::test_fixture;
 
-/** Test type combinations for parameterized testing */
-using TransferFunctionTestTypes2D = ::testing::Types<
-    std::tuple<specfem::test_fixture::TransferFunctionInitializer2D::Zero,
-               specfem::test_fixture::EdgeFunctionInitializer2D::Uniform>,
-    std::tuple<TransferFunctionInitializer2D::FromQuadratureRules<
-                   QuadraturePoints::GLL1, QuadraturePoints::GLL2>,
-               EdgeFunctionInitializer2D::FromAnalyticalFunction<
-                   AnalyticalFunctionType::Power<0>, QuadraturePoints::GLL1> >,
-    std::tuple<TransferFunctionInitializer2D::FromQuadratureRules<
-                   QuadraturePoints::GLL2, QuadraturePoints::GLL1>,
-               EdgeFunctionInitializer2D::FromAnalyticalFunction<
-                   AnalyticalFunctionType::Power<1>, QuadraturePoints::GLL2> >,
-    std::tuple<TransferFunctionInitializer2D::FromQuadratureRules<
-                   QuadraturePoints::GLL2, QuadraturePoints::GLL2>,
-               EdgeFunctionInitializer2D::FromAnalyticalFunction<
-                   AnalyticalFunctionType::Power<2>, QuadraturePoints::GLL2> >,
-    std::tuple<
-        TransferFunctionInitializer2D::FromQuadratureRules<
-            QuadraturePoints::Asymm4Point, QuadraturePoints::Asymm5Point>,
-        EdgeFunctionInitializer2D::FromAnalyticalFunction<
-            AnalyticalFunctionType::Power<3>, QuadraturePoints::Asymm4Point> >,
-    std::tuple<
-        TransferFunctionInitializer2D::FromQuadratureRules<
-            QuadraturePoints::Asymm5Point, QuadraturePoints::Asymm4Point>,
-        EdgeFunctionInitializer2D::FromAnalyticalFunction<
-            AnalyticalFunctionType::Power<4>, QuadraturePoints::Asymm5Point> >,
-    std::tuple<
-        TransferFunctionInitializer2D::FromQuadratureRules<
-            QuadraturePoints::Asymm5Point, QuadraturePoints::Asymm5Point>,
-        EdgeFunctionInitializer2D::FromAnalyticalFunction<
-            AnalyticalFunctionType::Power<5>,
-            QuadraturePoints::Asymm5Point> > >;
-
-/* for test naming
- * https://google.github.io/googletest/reference/testing.html#TYPED_TEST_SUITE
- */
-struct TransferFunctionTest2DNames {
-  template <typename TestingTypes> static std::string GetName(int) {
-    using TestType = TransferFunctionTest2D<TestingTypes>;
-    return std::string("TransferFunctionTest2D(") +
-           TestType::TransferFunctionInitializer::name() + ", " +
-           TestType::FunctionInitializer::name() + ")";
-  }
-};
-
-TYPED_TEST_SUITE(TransferFunctionTest2D, TransferFunctionTestTypes2D,
-                 TransferFunctionTest2DNames);
-
-TYPED_TEST(TransferFunctionTest2D, ExecuteTransferFunction) {
-  execute(this->transfer_function, this->function);
+// Helper template to create test execution lambdas
+template <typename TFInit, typename EFInit>
+TransferFunctionTestParam make_test_param(const std::string &name) {
+  return { []() {
+            auto transfer_function = TransferFunction2D<TFInit>(TFInit());
+            auto function = EdgeFunction2D<EFInit>(EFInit());
+            execute(transfer_function, function);
+          },
+           name };
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    TransferFunction2DTests, TransferFunctionTest2D,
+    ::testing::Values(
+        make_test_param<TransferFunctionInitializer2D::Zero,
+                        EdgeFunctionInitializer2D::Uniform>("Zero_Uniform"),
+        make_test_param<TransferFunctionInitializer2D::FromQuadratureRules<
+                            QuadraturePoints::GLL1, QuadraturePoints::GLL2>,
+                        EdgeFunctionInitializer2D::FromAnalyticalFunction<
+                            AnalyticalFunctionType::Power<0>,
+                            QuadraturePoints::GLL1> >("GLL1_GLL2_Pow0"),
+        make_test_param<TransferFunctionInitializer2D::FromQuadratureRules<
+                            QuadraturePoints::GLL2, QuadraturePoints::GLL1>,
+                        EdgeFunctionInitializer2D::FromAnalyticalFunction<
+                            AnalyticalFunctionType::Power<1>,
+                            QuadraturePoints::GLL2> >("GLL2_GLL1_Pow1"),
+        make_test_param<TransferFunctionInitializer2D::FromQuadratureRules<
+                            QuadraturePoints::GLL2, QuadraturePoints::GLL2>,
+                        EdgeFunctionInitializer2D::FromAnalyticalFunction<
+                            AnalyticalFunctionType::Power<2>,
+                            QuadraturePoints::GLL2> >("GLL2_GLL2_Pow2"),
+        make_test_param<
+            TransferFunctionInitializer2D::FromQuadratureRules<
+                QuadraturePoints::Asymm4Point, QuadraturePoints::Asymm5Point>,
+            EdgeFunctionInitializer2D::FromAnalyticalFunction<
+                AnalyticalFunctionType::Power<3>,
+                QuadraturePoints::Asymm4Point> >("Asymm4_Asymm5_Pow3"),
+        make_test_param<
+            TransferFunctionInitializer2D::FromQuadratureRules<
+                QuadraturePoints::Asymm5Point, QuadraturePoints::Asymm4Point>,
+            EdgeFunctionInitializer2D::FromAnalyticalFunction<
+                AnalyticalFunctionType::Power<4>,
+                QuadraturePoints::Asymm5Point> >("Asymm5_Asymm4_Pow4"),
+        make_test_param<
+            TransferFunctionInitializer2D::FromQuadratureRules<
+                QuadraturePoints::Asymm5Point, QuadraturePoints::Asymm5Point>,
+            EdgeFunctionInitializer2D::FromAnalyticalFunction<
+                AnalyticalFunctionType::Power<5>,
+                QuadraturePoints::Asymm5Point> >("Asymm5_Asymm5_Pow5")),
+    [](const ::testing::TestParamInfo<TransferFunctionTestParam> &info) {
+      return info.param.name;
+    });
 
 int main(int argc, char *argv[]) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/tests/unit-tests/utilities/include/fixture/impl/descriptions.hpp
+++ b/tests/unit-tests/utilities/include/fixture/impl/descriptions.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <regex>
+#include <string>
+#include <type_traits>
+
+namespace specfem::test_fixture::impl {
+
+/**
+ * @brief Simple identifier of a fixture (preferably one line).
+ */
+template <typename T, typename = void> struct name {
+  static constexpr bool has = false;
+  static std::string get() { return "<unnamed>"; }
+};
+
+template <typename T>
+struct name<T, std::enable_if_t<
+                   std::is_same_v<decltype(T::name()), std::string>, void> > {
+  static constexpr bool has = true;
+  static std::string get() { return T::name(); }
+};
+
+/**
+ * @brief Potentially multiple-line explanation of a given fixture.
+ */
+template <typename T, typename = void> struct description {
+  static constexpr bool has = false;
+  static std::string get(const int &indent = 0) {
+    std::string indent_str(indent, ' ');
+    using NameType = name<T>;
+    if constexpr (NameType::has) {
+      return indent_str + NameType::get();
+    }
+    return indent_str + "<no description>";
+  }
+};
+
+template <typename T>
+struct description<
+    T, std::enable_if_t<std::is_same_v<decltype(T::description()), std::string>,
+                        void> > {
+  static constexpr bool has = true;
+  static std::string get(const int &indent = 0) {
+    std::string indent_str(indent, ' ');
+    return std::regex_replace(
+        T::description(),
+        std::regex("^(.+)$", // capture each line individually (endl included in
+                             // capture group)
+                   std::regex_constants::multiline),
+        indent_str + "$&" // prepend indentation string to line
+    );
+  }
+};
+
+} // namespace specfem::test_fixture::impl

--- a/tests/unit-tests/utilities/include/fixture/nonconforming_interface/analytical_function.hpp
+++ b/tests/unit-tests/utilities/include/fixture/nonconforming_interface/analytical_function.hpp
@@ -20,7 +20,10 @@ template <int power> struct Power : AnalyticalFunctionType {
   }
 
   static std::string description() {
-    return std::string("xi^") + std::to_string(power);
+    return std::string("x^") + std::to_string(power);
+  }
+  static std::string name() {
+    return std::string("Pow(x,") + std::to_string(power) + ")";
   }
 };
 } // namespace AnalyticalFunctionType

--- a/tests/unit-tests/utilities/include/fixture/nonconforming_interface/edge_function.hpp
+++ b/tests/unit-tests/utilities/include/fixture/nonconforming_interface/edge_function.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../impl/descriptions.hpp"
 #include "initializers.hpp"
 #include "specfem_setup.hpp"
 
@@ -37,9 +38,8 @@ public:
     return edge_function;
   }
 
-  static std::string description() {
-    return std::string("ngll = 5 field of all ones");
-  }
+  static std::string description() { return "ngll = 5 field of all ones"; }
+  static std::string name() { return "Uniform(1,5,1)"; }
 };
 
 template <typename AnalyticalFunction, typename EdgePoints>
@@ -61,8 +61,20 @@ struct FromAnalyticalFunction : EdgeFunctionInitializer2D {
       EdgeQuadraturePoints::quadrature_points;
 
   static std::string description() {
-    return std::string("EdgeField-initialized function (description: \"") +
-           AnalyticalFunction::description() + "\")";
+    /*    Format:
+     *
+     * Edge Function from analytical function:
+     *   AnalyticalFunction description with this indent
+     *
+     */
+    return std::string("Edge Function from analytical function:\n") +
+           specfem::test_fixture::impl::description<
+               AnalyticalFunctionType>::get(2);
+  }
+  static std::string name() {
+    return std::string("FromAnalytical(") +
+           specfem::test_fixture::impl::name<AnalyticalFunctionType>::get() +
+           ")";
   }
 
 private:
@@ -107,7 +119,12 @@ public:
   static constexpr int nquad_edge = Initializer::nquad_edge;
   using memory_space = Kokkos::DefaultExecutionSpace::memory_space;
 
-  static std::string description() { return Initializer::description(); }
+  static std::string description(const int &indent = 0) {
+    return specfem::test_fixture::impl::description<Initializer>::get(indent);
+  }
+  static std::string initializer_name() {
+    return specfem::test_fixture::impl::name<Initializer>::get();
+  }
 
 private:
   std::array<std::array<std::array<type_real, num_components>, nquad_edge>,

--- a/tests/unit-tests/utilities/include/fixture/nonconforming_interface/quadrature.hpp
+++ b/tests/unit-tests/utilities/include/fixture/nonconforming_interface/quadrature.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../impl/descriptions.hpp"
 #include "initializers.hpp"
 #include "specfem_setup.hpp"
 
@@ -12,7 +13,7 @@ template <typename QuadraturePointsType> struct QuadratureRule {
   static_assert(std::is_base_of_v<QuadraturePoints::QuadraturePoints,
                                   QuadraturePointsType>,
                 "QuadratureRule template parameter expects QuadraturePoints!");
-
+  using QuadraturePoints = QuadraturePointsType;
   static constexpr int nquad = QuadraturePointsType::nquad;
   static constexpr std::array<double, nquad> quadrature_points =
       QuadraturePointsType::quadrature_points;
@@ -28,6 +29,14 @@ template <typename QuadraturePointsType> struct QuadratureRule {
     }
     return (type_real)val;
   }
+
+  static std::string description(const int &indent = 0) {
+    return specfem::test_fixture::impl::description<QuadraturePoints>::get(
+        indent);
+  }
+  static std::string quadrature_name() {
+    return specfem::test_fixture::impl::name<QuadraturePoints>::get();
+  }
 };
 namespace QuadraturePoints {
 
@@ -35,12 +44,20 @@ struct GLL1 : QuadraturePoints {
   static constexpr int nquad = 2;
   static constexpr std::array<double, nquad> quadrature_points = { -1, 1 };
 
-  static std::string description() { return "GLL1 (-1, 1)"; }
+  static std::string name() { return "GLL1"; }
+  static std::string description() {
+    return ("2-point GLL quadrature (exactness to x^1)\n"
+            "  points = [-1, 1]");
+  }
 };
 struct GLL2 : QuadraturePoints {
   static constexpr int nquad = 3;
   static constexpr std::array<double, nquad> quadrature_points = { -1, 0, 1 };
-  static std::string description() { return "GLL2 (-1, 0, 1)"; }
+  static std::string name() { return "GLL2"; }
+  static std::string description() {
+    return ("3-point GLL quadrature (exactness to x^3)\n"
+            "  points = [-1, 0, 1]");
+  }
 };
 
 struct Asymm5Point : QuadraturePoints {
@@ -48,18 +65,22 @@ struct Asymm5Point : QuadraturePoints {
   static constexpr std::array<double, nquad> quadrature_points = { -1, -0.8,
                                                                    -0.5, 0.2,
                                                                    0.7 };
+  static std::string name() { return "Asymm5"; }
   static std::string description() {
-    return "5 point asymmetric (low exactness interpolating quadrature for "
-           "testing)";
+    return ("5 point asymmetric quadrature rule (low exactness interpolating "
+            "quadrature for testing)\n"
+            "  points = [-1, -0.8, -0.5, 0.2, 0.7]");
   }
 };
 struct Asymm4Point : QuadraturePoints {
   static constexpr int nquad = 4;
   static constexpr std::array<double, nquad> quadrature_points = { -0.3, 0, 0.4,
                                                                    0.6 };
+  static std::string name() { return "Asymm4"; }
   static std::string description() {
-    return "4 point asymmetric (low exactness interpolating quadrature for "
-           "testing)";
+    return ("4 point asymmetric quadrature rule (low exactness interpolating "
+            "quadrature for testing)\n"
+            "  points = [-0.3, 0, 0.4, -0.6]");
   }
 };
 

--- a/tests/unit-tests/utilities/include/fixture/nonconforming_interface/transfer_function.hpp
+++ b/tests/unit-tests/utilities/include/fixture/nonconforming_interface/transfer_function.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../impl/descriptions.hpp"
 #include "initializers.hpp"
 #include "specfem_setup.hpp"
 
@@ -28,8 +29,9 @@ private:
 public:
   static ArrayType init_transfer_function() { return { 0 }; }
 
+  static std::string name() { return "Zero(1,5,5)"; }
   static std::string description() {
-    return "A blank transfer function. This should zero out all values";
+    return "A blank transfer function. This should zero out all values.";
   }
 };
 
@@ -69,8 +71,22 @@ public:
     }
     return transfer_function;
   }
+  static std::string name() {
+    return std::string("FromQuadratureRules(") +
+           specfem::test_fixture::impl::name<EdgeQuadraturePoints>::get() +
+           ", " +
+           specfem::test_fixture::impl::name<
+               IntersectionQuadraturePoints>::get() +
+           ")";
+  }
   static std::string description() {
-    return "GLL1 ({-1, 1} on the edge), GLL2 ({-1, 0, 1} on the intersection)";
+    return std::string(
+               "Transfer Function generated from quadrature rules\n- Edge:\n") +
+           specfem::test_fixture::impl::description<EdgeQuadraturePoints>::get(
+               4) +
+           "\n- Intersection:\n" +
+           specfem::test_fixture::impl::description<
+               IntersectionQuadraturePoints>::get(4);
   }
 };
 
@@ -101,7 +117,12 @@ public:
 
   static constexpr int nquad_intersection = Initializer::nquad_intersection;
 
-  static std::string description() { return Initializer::description(); }
+  static std::string description(const int &indent = 0) {
+    return specfem::test_fixture::impl::description<Initializer>::get(indent);
+  }
+  static std::string initializer_name() {
+    return specfem::test_fixture::impl::name<Initializer>::get();
+  }
 
 private:
   std::array<std::array<std::array<type_real, nquad_intersection>, nquad_edge>,


### PR DESCRIPTION
## Description

Please describe the changes/features in this pull request.
- For the `specfem:test_fixture` namespace, added descriptions (with indenting for recursive calls) and names (for shorter representations, test names, etc.)
- Provided a name generator to `transfer` test, according to above names.

## Issue Number

If there is an issue created for these changes, link it here

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
