### PR TITLE
Repo File Fix

### DIFF
--- a/docs/_ext/repo_file.py
+++ b/docs/_ext/repo_file.py
@@ -1,0 +1,63 @@
+import subprocess
+from docutils import nodes
+from sphinx.util.docutils import SphinxRole
+
+
+class RepoFileRole(SphinxRole):
+    """Role for linking to files in the GitHub repository.
+
+    Usage:
+        :repo-file:`path/to/file.cpp`
+
+    This will create a link to the file in the GitHub repository
+    on the current git branch.
+    """
+
+    def run(self):
+        # Access config values (github_url registered in conf.py)
+        github_url = self.env.config.github_url
+        git_branch = self.env.config.git_branch
+
+        print(f"DEBUG: RepoFileRole using branch: {git_branch} for file: {self.text}")
+
+        url = f"{github_url}/blob/{git_branch}/{self.text}"
+        node = nodes.reference("", "", internal=False, refuri=url)
+        node += nodes.literal(self.text, self.text)
+        return [node], []
+
+
+def get_git_branch(confdir):
+    """Get the current git branch name."""
+    try:
+        git_branch = (
+            subprocess.check_output(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                cwd=confdir,
+                stderr=subprocess.STDOUT,
+            )
+            .decode("utf-8")
+            .strip()
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        # Fallback to main if git command fails
+        git_branch = "main"
+    return git_branch
+
+
+def setup(app):
+    # Detect the current git branch
+    git_branch = get_git_branch(app.confdir)
+
+    print(f"DEBUG: Detected git branch: {git_branch}")
+
+    # Register config value - can be overridden in conf.py
+    app.add_config_value("git_branch", git_branch, "html")
+
+    # Register the custom role
+    app.add_role("repo-file", RepoFileRole())
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/_ext/repo_file.py
+++ b/docs/_ext/repo_file.py
@@ -31,14 +31,17 @@ def get_git_branch(confdir):
     """Get the current git branch name.
 
     Handles both local development and ReadTheDocs builds.
-    On ReadTheDocs, uses READTHEDOCS_VERSION which is the branch/tag being built.
+    On ReadTheDocs, uses READTHEDOCS_GIT_IDENTIFIER which contains the actual
+    branch name or commit SHA even for PR builds.
     Locally, uses git command.
     """
     # Check if we're on ReadTheDocs
-    rtd_version = os.environ.get("READTHEDOCS_VERSION")
-    if rtd_version:
-        # On ReadTheDocs, use the version being built (branch or tag name)
-        return rtd_version
+    # READTHEDOCS_GIT_IDENTIFIER contains the actual branch/commit, even for PRs
+    # READTHEDOCS_VERSION may contain PR number (e.g., "123") for PR builds
+    rtd_identifier = os.environ.get("READTHEDOCS_GIT_IDENTIFIER")
+    if rtd_identifier:
+        # On ReadTheDocs, use the git identifier (branch name or commit SHA)
+        return rtd_identifier
 
     # Local development: try to get branch from git
     try:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,8 +13,6 @@
 import os
 import sys
 import subprocess
-from docutils import nodes
-from sphinx.util.docutils import SphinxRole
 
 # Add the _ext directory to the path add path to include custom extensions
 sys.path.insert(0, os.path.abspath("_ext"))
@@ -72,7 +70,8 @@ extensions = [
     "sphinx_design",
     "breathe",
     "sphinx_copybutton",
-    "download_folder",
+    "download_folder",  # Local extension to add download buttons to code blocks
+    "repo_file",  # Local extension to add links to GitHub source files
 ]
 
 # Adding this to avoid the WARNING: duplicate label warning
@@ -120,19 +119,9 @@ extlinks = {
 }
 
 
-class RepoFileRole(SphinxRole):
-    """Role for linking to files in the GitHub repository."""
-
-    def run(self):
-        url = f"{github_url}/blob/main/{self.text}"
-        node = nodes.reference("", "", internal=False, refuri=url)
-        node += nodes.literal(self.text, self.text)
-        return [node], []
-
-
-# Register the custom role
+# Register custom config values
 def setup(app):
-    app.add_role("repo-file", RepoFileRole())
+    app.add_config_value("github_url", github_url, "html")
 
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION

## Description

If `:repo-file:` role is used in the sphinx docs, it will point to the file in the branch that the docs have been built with.

### Commits

- Updated repo-file and conf.py to allow for branch detection (1cb299357)

## Issue Number

-/-

## Checklist

Please make sure to check developer documentation on specfem docs.

- [x] I ran the code through pre-commit to check style
- [x] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [x] I have added labels to the PR (see right hand side of the PR page)
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
