### PR TITLE
Bug fix for transfer function tests

### DIFF
--- a/tests/unit-tests/utilities/include/fixture/nonconforming_interface/edge_function.hpp
+++ b/tests/unit-tests/utilities/include/fixture/nonconforming_interface/edge_function.hpp
@@ -149,13 +149,16 @@ public:
    */
   FieldView get_view() const {
     FieldView view("field_view");
+    auto host_view =
+        Kokkos::create_mirror_view(view); // Create host mirror to copy data
     for (size_t i = 0; i < num_edges; ++i) {
       for (size_t j = 0; j < nquad_edge; ++j) {
         for (size_t k = 0; k < num_components; ++k) {
-          view(i, j, k) = (*this)(i, j, k);
+          host_view(i, j, k) = (*this)(i, j, k);
         }
       }
     }
+    Kokkos::deep_copy(view, host_view);
     return view;
   }
 

--- a/tests/unit-tests/utilities/include/fixture/nonconforming_interface/intersection_function.hpp
+++ b/tests/unit-tests/utilities/include/fixture/nonconforming_interface/intersection_function.hpp
@@ -142,13 +142,16 @@ public:
    */
   FieldView get_view() const {
     FieldView view("field_view");
+    auto host_view =
+        Kokkos::create_mirror_view(view); // Create host mirror to copy data
     for (size_t i = 0; i < num_edges; ++i) {
       for (size_t j = 0; j < nquad_intersection; ++j) {
         for (size_t k = 0; k < num_components; ++k) {
-          view(i, j, k) = (*this)(i, j, k);
+          host_view(i, j, k) = (*this)(i, j, k);
         }
       }
     }
+    Kokkos::deep_copy(view, host_view);
     return view;
   }
 

--- a/tests/unit-tests/utilities/include/fixture/nonconforming_interface/transfer_function.hpp
+++ b/tests/unit-tests/utilities/include/fixture/nonconforming_interface/transfer_function.hpp
@@ -147,13 +147,17 @@ public:
    */
   TransferFunctionView get_view() const {
     TransferFunctionView view("transfer_function_view");
+    auto host_view =
+        Kokkos::create_mirror_view(view); // Create host mirror to copy data
     for (size_t i = 0; i < num_edges; ++i) {
       for (size_t j = 0; j < nquad_edge; ++j) {
         for (size_t k = 0; k < nquad_intersection; ++k) {
-          view(i, j, k) = (*this)(i, j, k);
+          host_view(i, j, k) = (*this)(i, j, k);
         }
       }
     }
+
+    Kokkos::deep_copy(view, host_view);
     return view;
   }
 


### PR DESCRIPTION
## Description

Please describe the changes/features in this pull request.

Update ``get_view`` methods to use host views of default mem space kokkos views during initialization

## Issue Number

If there is an issue created for these changes, link it here

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
