### PR TITLE
Issue-1593 - 2 - Updates macros and containers

### DIFF
--- a/core/specfem/assembly/assembly/dim2/assembly.cpp
+++ b/core/specfem/assembly/assembly/dim2/assembly.cpp
@@ -109,14 +109,12 @@ specfem::assembly::assembly<specfem::dimension::type::dim2>::print() const {
   bool is_psv = false;
 
   FOR_EACH_IN_PRODUCT(
-      (DIMENSION_TAG(DIM2),
-       MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
-                  ELASTIC_PSV_T),
-       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
+      (DIMENSION_TAG(DIM2), MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC,
+                                       POROELASTIC, ELASTIC_PSV_T)),
       {
         // Getting the number of elements per medium
-        int n_elements = this->element_types.get_number_of_elements(
-            _medium_tag_, _property_tag_);
+        int n_elements =
+            this->element_types.get_number_of_elements(_medium_tag_);
 
         // Printing the number of elements if more than 0
         if (n_elements > 0) {
@@ -124,8 +122,8 @@ specfem::assembly::assembly<specfem::dimension::type::dim2>::print() const {
           total_elements += n_elements;
 
           message << "   Total number of elements of type "
-                  << specfem::element::to_string(_medium_tag_, _property_tag_)
-                  << " : " << n_elements << "\n";
+                  << specfem::element::to_string(_medium_tag_) << " : "
+                  << n_elements << "\n";
           if (_medium_tag_ == specfem::element::medium_tag::elastic_sh) {
             is_sh = true;
           } else if (_medium_tag_ ==

--- a/core/specfem/assembly/assembly/dim2/compute_wavefield/compute_wavefield.cpp
+++ b/core/specfem/assembly/assembly/dim2/compute_wavefield/compute_wavefield.cpp
@@ -91,7 +91,8 @@ specfem::assembly::assembly<specfem::dimension::type::dim2>::
       (DIMENSION_TAG(DIM2),
        MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
                   ELASTIC_PSV_T),
-       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
+       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+       ATTENUATION_TAG(NONE)),
       {
         if constexpr (_dimension_tag_ == specfem::dimension::type::dim2) {
           get_wavefield_on_entire_grid<_medium_tag_, _property_tag_>(

--- a/core/specfem/assembly/assembly/dim3/assembly.cpp
+++ b/core/specfem/assembly/assembly/dim3/assembly.cpp
@@ -87,24 +87,20 @@ specfem::assembly::assembly<specfem::dimension::type::dim3>::print() const {
 
   int total_elements = 0;
 
-  FOR_EACH_IN_PRODUCT(
-      (DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC, ACOUSTIC),
-       PROPERTY_TAG(ISOTROPIC)),
-      {
-        // Getting the number of elements per medium
-        int n_elements = this->element_types.get_number_of_elements(
-            _medium_tag_, _property_tag_);
+  FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC, ACOUSTIC)), {
+    // Getting the number of elements per medium
+    int n_elements = this->element_types.get_number_of_elements(_medium_tag_);
 
-        // Printing the number of elements if more than 0
-        if (n_elements > 0) {
-          // Adding the number of elements to the total
-          total_elements += n_elements;
+    // Printing the number of elements if more than 0
+    if (n_elements > 0) {
+      // Adding the number of elements to the total
+      total_elements += n_elements;
 
-          message << "   Total number of elements of type "
-                  << specfem::element::to_string(_medium_tag_, _property_tag_)
-                  << " : " << n_elements << "\n";
-        };
-      })
+      message << "   Total number of elements of type "
+              << specfem::element::to_string(_medium_tag_) << " : "
+              << n_elements << "\n";
+    };
+  })
 
   if (total_elements == mesh.nspec) {
     message << "  All elements accounted for.\n";

--- a/core/specfem/assembly/assembly/dim3/compute_wavefield/compute_wavefield.cpp
+++ b/core/specfem/assembly/assembly/dim3/compute_wavefield/compute_wavefield.cpp
@@ -90,7 +90,7 @@ specfem::assembly::assembly<specfem::dimension::type::dim3>::
 
   FOR_EACH_IN_PRODUCT(
       (DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC, ACOUSTIC),
-       PROPERTY_TAG(ISOTROPIC)),
+       PROPERTY_TAG(ISOTROPIC), ATTENUATION_TAG(NONE)),
       {
         if constexpr (_dimension_tag_ == specfem::dimension::type::dim3) {
           get_wavefield_on_entire_grid<_medium_tag_, _property_tag_>(

--- a/core/specfem/assembly/assembly/impl/helper.hpp
+++ b/core/specfem/assembly/assembly/impl/helper.hpp
@@ -88,8 +88,8 @@ public:
     // Get the element grid (ngllx, nglly, ngllz)
     const auto &element_grid = assembly.mesh.element_grid;
 
-    const auto elements =
-        assembly.element_types.get_elements_on_device(medium_tag, property_tag);
+    const auto elements = assembly.element_types.get_elements_on_device(
+        medium_tag, property_tag, specfem::element::attenuation_tag::none);
 
     const int nelements = elements.extent(0);
 

--- a/core/specfem/assembly/element_types/dim2/element_types.cpp
+++ b/core/specfem/assembly/element_types/dim2/element_types.cpp
@@ -7,12 +7,15 @@ specfem::assembly::element_types<specfem::dimension::type::dim2>::element_types(
     : nspec(nspec),
       medium_tags("specfem::assembly::element_types::medium_tags", nspec),
       property_tags("specfem::assembly::element_types::property_tags", nspec),
+      attenuation_tags("specfem::assembly::element_types::attenuation_tags",
+                       nspec),
       boundary_tags("specfem::assembly::element_types::boundary_tags", nspec) {
 
   for (int ispec = 0; ispec < nspec; ispec++) {
     const int ispec_mesh = mesh.compute_to_mesh(ispec);
     medium_tags(ispec) = tags.tags_container(ispec_mesh).medium_tag;
     property_tags(ispec) = tags.tags_container(ispec_mesh).property_tag;
+    attenuation_tags(ispec) = tags.tags_container(ispec_mesh).attenuation_tag;
     boundary_tags(ispec) = tags.tags_container(ispec_mesh).boundary_tag;
   }
 
@@ -43,31 +46,34 @@ specfem::assembly::element_types<specfem::dimension::type::dim2>::element_types(
       (DIMENSION_TAG(DIM2),
        MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
                   ELASTIC_PSV_T),
-       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
-      CAPTURE(elements, h_elements) {
+       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+       ATTENUATION_TAG(NONE, CONSTANT_ISOTROPIC)),
+      CAPTURE(material_elements, h_material_elements) {
         int count = 0;
         int index = 0;
 
         for (int ispec = 0; ispec < nspec; ispec++) {
           if (medium_tags(ispec) == _medium_tag_ &&
-              property_tags(ispec) == _property_tag_) {
+              property_tags(ispec) == _property_tag_ &&
+              attenuation_tags(ispec) == _attenuation_tag_) {
             count++;
           }
         }
 
-        _elements_ =
+        _material_elements_ =
             IndexViewType("specfem::assembly::element_types::elements", count);
-        _h_elements_ = Kokkos::create_mirror_view(_elements_);
+        _h_material_elements_ = Kokkos::create_mirror_view(_material_elements_);
 
         for (int ispec = 0; ispec < nspec; ispec++) {
           if (medium_tags(ispec) == _medium_tag_ &&
-              property_tags(ispec) == _property_tag_) {
-            _h_elements_(index) = ispec;
+              property_tags(ispec) == _property_tag_ &&
+              attenuation_tags(ispec) == _attenuation_tag_) {
+            _h_material_elements_(index) = ispec;
             index++;
           }
         }
 
-        Kokkos::deep_copy(_elements_, _h_elements_);
+        Kokkos::deep_copy(_material_elements_, _h_material_elements_);
       })
 
   FOR_EACH_IN_PRODUCT(
@@ -139,18 +145,21 @@ Kokkos::View<int *, Kokkos::DefaultExecutionSpace> specfem::assembly::
 Kokkos::View<int *, Kokkos::DefaultHostExecutionSpace> specfem::assembly::
     element_types<specfem::dimension::type::dim2>::get_elements_on_host(
         const specfem::element::medium_tag medium_tag,
-        const specfem::element::property_tag property_tag) const {
+        const specfem::element::property_tag property_tag,
+        const specfem::element::attenuation_tag attenuation_tag) const {
 
-  FOR_EACH_IN_PRODUCT(
-      (DIMENSION_TAG(DIM2),
-       MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
-                  ELASTIC_PSV_T),
-       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
-      CAPTURE(h_elements) {
-        if (_medium_tag_ == medium_tag && _property_tag_ == property_tag) {
-          return _h_elements_;
-        }
-      })
+  FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM2),
+                       MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC,
+                                  POROELASTIC, ELASTIC_PSV_T),
+                       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+                       ATTENUATION_TAG(NONE, CONSTANT_ISOTROPIC)),
+                      CAPTURE(h_material_elements) {
+                        if (_medium_tag_ == medium_tag &&
+                            _property_tag_ == property_tag &&
+                            _attenuation_tag_ == attenuation_tag) {
+                          return _h_material_elements_;
+                        }
+                      })
 
   throw std::runtime_error("Medium tag or property tag not found");
 }
@@ -158,18 +167,21 @@ Kokkos::View<int *, Kokkos::DefaultHostExecutionSpace> specfem::assembly::
 Kokkos::View<int *, Kokkos::DefaultExecutionSpace> specfem::assembly::
     element_types<specfem::dimension::type::dim2>::get_elements_on_device(
         const specfem::element::medium_tag medium_tag,
-        const specfem::element::property_tag property_tag) const {
+        const specfem::element::property_tag property_tag,
+        const specfem::element::attenuation_tag attenuation_tag) const {
 
-  FOR_EACH_IN_PRODUCT(
-      (DIMENSION_TAG(DIM2),
-       MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
-                  ELASTIC_PSV_T),
-       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
-      CAPTURE(elements) {
-        if (_medium_tag_ == medium_tag && _property_tag_ == property_tag) {
-          return _elements_;
-        }
-      })
+  FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM2),
+                       MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC,
+                                  POROELASTIC, ELASTIC_PSV_T),
+                       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+                       ATTENUATION_TAG(NONE, CONSTANT_ISOTROPIC)),
+                      CAPTURE(material_elements) {
+                        if (_medium_tag_ == medium_tag &&
+                            _property_tag_ == property_tag &&
+                            _attenuation_tag_ == attenuation_tag) {
+                          return _material_elements_;
+                        }
+                      })
 
   throw std::runtime_error("Medium tag or property tag not found");
 }

--- a/core/specfem/assembly/element_types/dim2/element_types.hpp
+++ b/core/specfem/assembly/element_types/dim2/element_types.hpp
@@ -77,6 +77,17 @@ protected:
                                         Kokkos::DefaultHostExecutionSpace>;
 
   /**
+   * @brief Kokkos view type for storing attenuation tags in host memory.
+   *
+   * Stores the attenuation type (none, constant_isotropic, etc.) for each
+   * spectral element. Host storage enables efficient attenuation property setup
+   * and validation.
+   */
+  using AttenuationTagViewType =
+      Kokkos::View<specfem::element::attenuation_tag *,
+                   Kokkos::DefaultHostExecutionSpace>;
+
+  /**
    * @brief Kokkos view type for storing element indices in device memory.
    *
    * Stores integer indices of spectral elements for device-side computations.
@@ -93,9 +104,10 @@ public:
   constexpr static auto dimension_tag =
       specfem::dimension::type::dim2; ///< Dimension tag
 
-  MediumTagViewType medium_tags;     ///< View to store medium tags
-  PropertyTagViewType property_tags; ///< View to store property tags
-  BoundaryViewType boundary_tags;    ///< View to store boundary tags
+  MediumTagViewType medium_tags;           ///< View to store medium tags
+  PropertyTagViewType property_tags;       ///< View to store property tags
+  BoundaryViewType boundary_tags;          ///< View to store boundary tags
+  AttenuationTagViewType attenuation_tags; ///< View to store attenuation tags
 
   /**
    * @brief Default constructor.
@@ -164,9 +176,10 @@ public:
    * @param property Property type (isotropic, anisotropic, isotropic_cosserat)
    * @return Kokkos view containing element indices for host access
    */
-  Kokkos::View<int *, Kokkos::DefaultHostExecutionSpace>
-  get_elements_on_host(const specfem::element::medium_tag tag,
-                       const specfem::element::property_tag property) const;
+  Kokkos::View<int *, Kokkos::DefaultHostExecutionSpace> get_elements_on_host(
+      const specfem::element::medium_tag tag,
+      const specfem::element::property_tag property,
+      const specfem::element::attenuation_tag attenuation) const;
 
   /**
    * @brief Get count of elements with specified medium and property types.
@@ -177,8 +190,9 @@ public:
    */
   int get_number_of_elements(
       const specfem::element::medium_tag tag,
-      const specfem::element::property_tag property) const {
-    return get_elements_on_host(tag, property).extent(0);
+      const specfem::element::property_tag property,
+      const specfem::element::attenuation_tag attenuation) const {
+    return get_elements_on_host(tag, property, attenuation).extent(0);
   }
 
   /**
@@ -189,9 +203,10 @@ public:
    * @param property Property type (isotropic, anisotropic, isotropic_cosserat)
    * @return Kokkos view containing element indices for device access
    */
-  Kokkos::View<int *, Kokkos::DefaultExecutionSpace>
-  get_elements_on_device(const specfem::element::medium_tag tag,
-                         const specfem::element::property_tag property) const;
+  Kokkos::View<int *, Kokkos::DefaultExecutionSpace> get_elements_on_device(
+      const specfem::element::medium_tag tag,
+      const specfem::element::property_tag property,
+      const specfem::element::attenuation_tag attenuation) const;
 
   /**
    * @brief Get elements with specified medium, property, and boundary types in
@@ -270,6 +285,10 @@ public:
     return boundary_tags(ispec);
   }
 
+  specfem::element::attenuation_tag get_attenuation_tag(const int ispec) const {
+    return attenuation_tags(ispec);
+  }
+
 private:
   FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM2),
                        MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC,
@@ -280,10 +299,15 @@ private:
   FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM2),
                        MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC,
                                   POROELASTIC, ELASTIC_PSV_T),
-                       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC,
-                                    ISOTROPIC_COSSERAT)),
-                      DECLARE((IndexViewType, elements),
-                              (IndexViewType::HostMirror, h_elements)))
+                       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+                       ATTENUATION_TAG(NONE, CONSTANT_ISOTROPIC)),
+                      DECLARE((IndexViewType, material_elements),
+                              (IndexViewType::HostMirror,
+                               h_material_elements))) /// This is a temporary
+                                                      /// fix since none
+                                                      /// attenuation tag
+                                                      /// conflicts with none
+                                                      /// boundary tag
 
   FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM2),
                        MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC,

--- a/core/specfem/assembly/element_types/dim3/element_types.cpp
+++ b/core/specfem/assembly/element_types/dim3/element_types.cpp
@@ -7,11 +7,14 @@ specfem::assembly::element_types<specfem::dimension::type::dim3>::element_types(
     : nspec(nspec),
       medium_tags("specfem::assembly::element_types::medium_tags", nspec),
       property_tags("specfem::assembly::element_types::property_tags", nspec),
+      attenuation_tags("specfem::assembly::element_types::attenuation_tags",
+                       nspec),
       boundary_tags("specfem::assembly::element_types::boundary_tags", nspec) {
 
   for (int ispec = 0; ispec < nspec; ispec++) {
     medium_tags(ispec) = tags.tags_container(ispec).medium_tag;
     property_tags(ispec) = tags.tags_container(ispec).property_tag;
+    attenuation_tags(ispec) = tags.tags_container(ispec).attenuation_tag;
     boundary_tags(ispec) = tags.tags_container(ispec).boundary_tag;
   }
 
@@ -39,31 +42,33 @@ specfem::assembly::element_types<specfem::dimension::type::dim3>::element_types(
 
   FOR_EACH_IN_PRODUCT(
       (DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC, ACOUSTIC),
-       PROPERTY_TAG(ISOTROPIC)),
-      CAPTURE(elements, h_elements) {
+       PROPERTY_TAG(ISOTROPIC), ATTENUATION_TAG(NONE)),
+      CAPTURE(material_elements, h_material_elements) {
         int count = 0;
         int index = 0;
 
         for (int ispec = 0; ispec < nspec; ispec++) {
           if (medium_tags(ispec) == _medium_tag_ &&
-              property_tags(ispec) == _property_tag_) {
+              property_tags(ispec) == _property_tag_ &&
+              attenuation_tags(ispec) == _attenuation_tag_) {
             count++;
           }
         }
 
-        _elements_ =
+        _material_elements_ =
             IndexViewType("specfem::assembly::element_types::elements", count);
-        _h_elements_ = Kokkos::create_mirror_view(_elements_);
+        _h_material_elements_ = Kokkos::create_mirror_view(_material_elements_);
 
         for (int ispec = 0; ispec < nspec; ispec++) {
           if (medium_tags(ispec) == _medium_tag_ &&
-              property_tags(ispec) == _property_tag_) {
-            _h_elements_(index) = ispec;
+              property_tags(ispec) == _property_tag_ &&
+              attenuation_tags(ispec) == _attenuation_tag_) {
+            _h_material_elements_(index) = ispec;
             index++;
           }
         }
 
-        Kokkos::deep_copy(_elements_, _h_elements_);
+        Kokkos::deep_copy(_material_elements_, _h_material_elements_);
       })
 
   FOR_EACH_IN_PRODUCT(
@@ -101,8 +106,7 @@ specfem::assembly::element_types<specfem::dimension::type::dim3>::element_types(
 Kokkos::View<int *, Kokkos::DefaultHostExecutionSpace>
 specfem::assembly::element_types<specfem::dimension::type::dim3>::
     get_elements_on_host(const specfem::element::medium_tag medium_tag) const {
-  FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC, ACOUSTIC),
-                       PROPERTY_TAG(ISOTROPIC), BOUNDARY_TAG(NONE)),
+  FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC, ACOUSTIC)),
                       CAPTURE(h_elements) {
                         if (_medium_tag_ == medium_tag) {
                           return _h_elements_;
@@ -115,8 +119,7 @@ specfem::assembly::element_types<specfem::dimension::type::dim3>::
 Kokkos::View<int *, Kokkos::DefaultExecutionSpace> specfem::assembly::
     element_types<specfem::dimension::type::dim3>::get_elements_on_device(
         const specfem::element::medium_tag medium_tag) const {
-  FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC, ACOUSTIC),
-                       PROPERTY_TAG(ISOTROPIC), BOUNDARY_TAG(NONE)),
+  FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC, ACOUSTIC)),
                       CAPTURE(elements) {
                         if (_medium_tag_ == medium_tag) {
                           return _elements_;
@@ -129,14 +132,16 @@ Kokkos::View<int *, Kokkos::DefaultExecutionSpace> specfem::assembly::
 Kokkos::View<int *, Kokkos::DefaultHostExecutionSpace> specfem::assembly::
     element_types<specfem::dimension::type::dim3>::get_elements_on_host(
         const specfem::element::medium_tag medium_tag,
-        const specfem::element::property_tag property_tag) const {
+        const specfem::element::property_tag property_tag,
+        const specfem::element::attenuation_tag attenuation_tag) const {
 
   FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC, ACOUSTIC),
-                       PROPERTY_TAG(ISOTROPIC), BOUNDARY_TAG(NONE)),
-                      CAPTURE(h_elements) {
+                       PROPERTY_TAG(ISOTROPIC), ATTENUATION_TAG(NONE)),
+                      CAPTURE(h_material_elements) {
                         if (_medium_tag_ == medium_tag &&
-                            _property_tag_ == property_tag) {
-                          return _h_elements_;
+                            _property_tag_ == property_tag &&
+                            _attenuation_tag_ == attenuation_tag) {
+                          return _h_material_elements_;
                         }
                       })
 
@@ -146,14 +151,16 @@ Kokkos::View<int *, Kokkos::DefaultHostExecutionSpace> specfem::assembly::
 Kokkos::View<int *, Kokkos::DefaultExecutionSpace> specfem::assembly::
     element_types<specfem::dimension::type::dim3>::get_elements_on_device(
         const specfem::element::medium_tag medium_tag,
-        const specfem::element::property_tag property_tag) const {
+        const specfem::element::property_tag property_tag,
+        const specfem::element::attenuation_tag attenuation_tag) const {
 
   FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC, ACOUSTIC),
-                       PROPERTY_TAG(ISOTROPIC), BOUNDARY_TAG(NONE)),
-                      CAPTURE(elements) {
+                       PROPERTY_TAG(ISOTROPIC), ATTENUATION_TAG(NONE)),
+                      CAPTURE(material_elements) {
                         if (_medium_tag_ == medium_tag &&
-                            _property_tag_ == property_tag) {
-                          return _elements_;
+                            _property_tag_ == property_tag &&
+                            _attenuation_tag_ == attenuation_tag) {
+                          return _material_elements_;
                         }
                       })
 

--- a/core/specfem/assembly/element_types/dim3/element_types.hpp
+++ b/core/specfem/assembly/element_types/dim3/element_types.hpp
@@ -83,6 +83,15 @@ protected:
   using BoundaryViewType = Kokkos::View<specfem::element::boundary_tag *,
                                         Kokkos::DefaultHostExecutionSpace>;
 
+  /** * @brief Kokkos view type for storing 3D attenuation tags in host memory.
+   *
+   * Stores the attenuation type (none, constant_isotropic, etc.) for each
+   * 3D spectral element. Host storage enables efficient attenuation property
+   * setup and validation.
+   */
+  using AttenuationTagViewType =
+      Kokkos::View<specfem::element::attenuation_tag *,
+                   Kokkos::DefaultHostExecutionSpace>;
   /**
    * @brief Kokkos view type for storing 3D element indices in device memory.
    *
@@ -101,9 +110,10 @@ public:
   constexpr static auto dimension_tag =
       specfem::dimension::type::dim3; ///< Dimension tag
 
-  MediumTagViewType medium_tags;     ///< View to store medium tags
-  PropertyTagViewType property_tags; ///< View to store property tags
-  BoundaryViewType boundary_tags;    ///< View to store boundary tags
+  MediumTagViewType medium_tags;           ///< View to store medium tags
+  PropertyTagViewType property_tags;       ///< View to store property tags
+  BoundaryViewType boundary_tags;          ///< View to store boundary tags
+  AttenuationTagViewType attenuation_tags; ///< View to store attenuation tags
 
   /**
    * @brief Default constructor.
@@ -169,9 +179,10 @@ public:
    * @param property Property type (isotropic, anisotropic, isotropic_cosserat)
    * @return Kokkos view containing 3D element indices for host access
    */
-  Kokkos::View<int *, Kokkos::DefaultHostExecutionSpace>
-  get_elements_on_host(const specfem::element::medium_tag tag,
-                       const specfem::element::property_tag property) const;
+  Kokkos::View<int *, Kokkos::DefaultHostExecutionSpace> get_elements_on_host(
+      const specfem::element::medium_tag tag,
+      const specfem::element::property_tag property,
+      const specfem::element::attenuation_tag attenuation) const;
 
   /**
    * @brief Get count of 3D elements with specified medium and property types.
@@ -182,8 +193,9 @@ public:
    */
   int get_number_of_elements(
       const specfem::element::medium_tag tag,
-      const specfem::element::property_tag property) const {
-    return get_elements_on_host(tag, property).extent(0);
+      const specfem::element::property_tag property,
+      const specfem::element::attenuation_tag attenuation) const {
+    return get_elements_on_host(tag, property, attenuation).extent(0);
   }
 
   /**
@@ -194,9 +206,10 @@ public:
    * @param property Property type (isotropic, anisotropic, isotropic_cosserat)
    * @return Kokkos view containing 3D element indices for device access
    */
-  Kokkos::View<int *, Kokkos::DefaultExecutionSpace>
-  get_elements_on_device(const specfem::element::medium_tag tag,
-                         const specfem::element::property_tag property) const;
+  Kokkos::View<int *, Kokkos::DefaultExecutionSpace> get_elements_on_device(
+      const specfem::element::medium_tag tag,
+      const specfem::element::property_tag property,
+      const specfem::element::attenuation_tag attenuation) const;
 
   /**
    * @brief Get 3D elements with specified medium, property, and boundary types
@@ -272,16 +285,20 @@ public:
     return boundary_tags(ispec);
   }
 
+  specfem::element::attenuation_tag get_attenuation_tag(const int ispec) const {
+    return attenuation_tags(ispec);
+  }
+
 private:
   FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC, ACOUSTIC)),
                       DECLARE((IndexViewType, elements),
                               (IndexViewType::HostMirror, h_elements)))
 
   FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC, ACOUSTIC),
-                       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC,
-                                    ISOTROPIC_COSSERAT)),
-                      DECLARE((IndexViewType, elements),
-                              (IndexViewType::HostMirror, h_elements)))
+                       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+                       ATTENUATION_TAG(NONE, CONSTANT_ISOTROPIC)),
+                      DECLARE((IndexViewType, material_elements),
+                              (IndexViewType::HostMirror, h_material_elements)))
 
   FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC, ACOUSTIC),
                        PROPERTY_TAG(ISOTROPIC), BOUNDARY_TAG(NONE)),

--- a/core/specfem/assembly/impl/domain_properties.tpp
+++ b/core/specfem/assembly/impl/domain_properties.tpp
@@ -26,7 +26,7 @@ specfem::assembly::impl::domain_properties<specfem::dimension::type::dim2, Mediu
         for (int ix = 0; ix < ngllx; ++ix) {
           // Get the material at index from mesh::materials
           auto material =
-              materials.template get_material<medium_tag, property_tag>(
+              materials.template get_material<medium_tag, property_tag, specfem::element::attenuation_tag::none>(
                   mesh_ispec);
 
           // Assign the material property to the property container
@@ -72,7 +72,7 @@ specfem::assembly::impl::domain_properties<specfem::dimension::type::dim3, Mediu
             property_tag == specfem::element::property_tag::isotropic) {
           // Handle the specific case
           const auto point_property =
-              materials.template get_properties<medium_tag, property_tag>(
+              materials.template get_properties<medium_tag, property_tag, specfem::element::attenuation_tag::none>(
                   ispec);
           this->store_host_values(
               specfem::point::index<dimension_tag, false>(count, iz, iy, ix),

--- a/core/specfem/assembly/impl/value_containers/dim2/value_containers.hpp
+++ b/core/specfem/assembly/impl/value_containers/dim2/value_containers.hpp
@@ -39,8 +39,8 @@ struct value_containers<specfem::dimension::type::dim2, containers_type> {
   FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM2),
                        MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC,
                                   POROELASTIC, ELASTIC_PSV_T),
-                       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC,
-                                    ISOTROPIC_COSSERAT)),
+                       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+                       ATTENUATION_TAG(NONE)),
                       DECLARE(((containers_type, (_DIMENSION_TAG_, _MEDIUM_TAG_,
                                                   _PROPERTY_TAG_)),
                                value)))
@@ -70,7 +70,8 @@ struct value_containers<specfem::dimension::type::dim2, containers_type> {
         (DIMENSION_TAG(DIM2),
          MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
                     ELASTIC_PSV_T),
-         PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
+         PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+         ATTENUATION_TAG(NONE)),
         CAPTURE(value) {
           if constexpr (_medium_tag_ == MediumTag &&
                         _property_tag_ == PropertyTag) {
@@ -95,7 +96,8 @@ struct value_containers<specfem::dimension::type::dim2, containers_type> {
         (DIMENSION_TAG(DIM2),
          MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
                     ELASTIC_PSV_T),
-         PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
+         PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+         ATTENUATION_TAG(NONE)),
         CAPTURE(value) { _value_.copy_to_host(); })
   }
 
@@ -105,7 +107,8 @@ struct value_containers<specfem::dimension::type::dim2, containers_type> {
         (DIMENSION_TAG(DIM2),
          MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
                     ELASTIC_PSV_T),
-         PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
+         PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+         ATTENUATION_TAG(NONE)),
         CAPTURE(value) { _value_.copy_to_device(); })
   }
 };

--- a/core/specfem/assembly/impl/value_containers/dim3/value_containers.hpp
+++ b/core/specfem/assembly/impl/value_containers/dim3/value_containers.hpp
@@ -37,7 +37,7 @@ struct value_containers<specfem::dimension::type::dim3, containers_type> {
   }
 
   FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC, ACOUSTIC),
-                       PROPERTY_TAG(ISOTROPIC)),
+                       PROPERTY_TAG(ISOTROPIC), ATTENUATION_TAG(NONE)),
                       DECLARE(((containers_type, (_DIMENSION_TAG_, _MEDIUM_TAG_,
                                                   _PROPERTY_TAG_)),
                                value)))
@@ -64,7 +64,7 @@ struct value_containers<specfem::dimension::type::dim3, containers_type> {
       get_container() const {
 
     FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC, ACOUSTIC),
-                         PROPERTY_TAG(ISOTROPIC)),
+                         PROPERTY_TAG(ISOTROPIC), ATTENUATION_TAG(NONE)),
                         CAPTURE(value) {
                           if constexpr (_medium_tag_ == MediumTag &&
                                         _property_tag_ == PropertyTag) {
@@ -89,14 +89,14 @@ struct value_containers<specfem::dimension::type::dim3, containers_type> {
   void copy_to_host() {
     Kokkos::deep_copy(h_property_index_mapping, property_index_mapping);
     FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC, ACOUSTIC),
-                         PROPERTY_TAG(ISOTROPIC)),
+                         PROPERTY_TAG(ISOTROPIC), ATTENUATION_TAG(NONE)),
                         CAPTURE(value) { _value_.copy_to_host(); })
   }
 
   void copy_to_device() {
     Kokkos::deep_copy(property_index_mapping, h_property_index_mapping);
     FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC, ACOUSTIC),
-                         PROPERTY_TAG(ISOTROPIC)),
+                         PROPERTY_TAG(ISOTROPIC), ATTENUATION_TAG(NONE)),
                         CAPTURE(value) { _value_.copy_to_device(); })
   }
 };

--- a/core/specfem/assembly/kernels/dim2/kernels.cpp
+++ b/core/specfem/assembly/kernels/dim2/kernels.cpp
@@ -24,11 +24,13 @@ specfem::assembly::kernels<specfem::dimension::type::dim2>::kernels(
       (DIMENSION_TAG(DIM2),
        MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
                   ELASTIC_PSV_T),
-       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
+       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+       ATTENUATION_TAG(NONE)),
       CAPTURE(value) {
         _value_ = specfem::assembly::impl::domain_kernels<
             _dimension_tag_, _medium_tag_, _property_tag_>(
-            element_types.get_elements_on_host(_medium_tag_, _property_tag_),
+            element_types.get_elements_on_host(_medium_tag_, _property_tag_,
+                                               _attenuation_tag_),
             ngllz, ngllx, h_property_index_mapping);
       })
 

--- a/core/specfem/assembly/kernels/dim3/kernels.cpp
+++ b/core/specfem/assembly/kernels/dim3/kernels.cpp
@@ -23,11 +23,12 @@ specfem::assembly::kernels<specfem::dimension::type::dim3>::kernels(
 
   FOR_EACH_IN_PRODUCT(
       (DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC, ACOUSTIC),
-       PROPERTY_TAG(ISOTROPIC)),
+       PROPERTY_TAG(ISOTROPIC), ATTENUATION_TAG(NONE)),
       CAPTURE(value) {
         _value_ = specfem::assembly::impl::domain_kernels<
             _dimension_tag_, _medium_tag_, _property_tag_>(
-            element_types.get_elements_on_host(_medium_tag_, _property_tag_),
+            element_types.get_elements_on_host(_medium_tag_, _property_tag_,
+                                               _attenuation_tag_),
             nglly, ngllz, ngllx, h_property_index_mapping);
       })
 

--- a/core/specfem/assembly/properties/dim2/properties.cpp
+++ b/core/specfem/assembly/properties/dim2/properties.cpp
@@ -30,11 +30,13 @@ specfem::assembly::properties<specfem::dimension::type::dim2>::properties(
       (DIMENSION_TAG(DIM2),
        MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
                   ELASTIC_PSV_T),
-       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
+       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+       ATTENUATION_TAG(NONE)),
       CAPTURE(value) {
         _value_ = specfem::assembly::impl::domain_properties<
             _dimension_tag_, _medium_tag_, _property_tag_>(
-            element_types.get_elements_on_host(_medium_tag_, _property_tag_),
+            element_types.get_elements_on_host(_medium_tag_, _property_tag_,
+                                               _attenuation_tag_),
             mesh, ngllz, ngllx, materials, has_gll_model,
             h_property_index_mapping);
       })

--- a/core/specfem/assembly/properties/dim3/properties.cpp
+++ b/core/specfem/assembly/properties/dim3/properties.cpp
@@ -25,11 +25,12 @@ specfem::assembly::properties<specfem::dimension::type::dim3>::properties(
 
   FOR_EACH_IN_PRODUCT(
       (DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC, ACOUSTIC),
-       PROPERTY_TAG(ISOTROPIC)),
+       PROPERTY_TAG(ISOTROPIC), ATTENUATION_TAG(NONE)),
       CAPTURE(value) {
         _value_ = specfem::assembly::impl::domain_properties<
             _dimension_tag_, _medium_tag_, _property_tag_>(
-            element_types.get_elements_on_host(_medium_tag_, _property_tag_),
+            element_types.get_elements_on_host(_medium_tag_, _property_tag_,
+                                               _attenuation_tag_),
             nspec, ngllz, nglly, ngllx, materials, h_property_index_mapping);
       })
 

--- a/core/specfem/assembly/receivers/dim2/receivers.cpp
+++ b/core/specfem/assembly/receivers/dim2/receivers.cpp
@@ -107,7 +107,8 @@ specfem::assembly::receivers<specfem::dimension::type::dim2>::receivers(
       (DIMENSION_TAG(DIM2),
        MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
                   ELASTIC_PSV_T),
-       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
+       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+       ATTENUATION_TAG(NONE)),
       CAPTURE(elements, h_elements, receiver_indices, h_receiver_indices) {
         int count = 0;
         int index = 0;
@@ -115,7 +116,8 @@ specfem::assembly::receivers<specfem::dimension::type::dim2>::receivers(
         for (int ireceiver = 0; ireceiver < h_elements.extent(0); ++ireceiver) {
           int ispec = h_elements(ireceiver);
           if (element_types.get_medium_tag(ispec) == _medium_tag_ &&
-              element_types.get_property_tag(ispec) == _property_tag_) {
+              element_types.get_property_tag(ispec) == _property_tag_ &&
+              element_types.get_attenuation_tag(ispec) == _attenuation_tag_) {
             count++;
           }
         }
@@ -130,7 +132,8 @@ specfem::assembly::receivers<specfem::dimension::type::dim2>::receivers(
         for (int ireceiver = 0; ireceiver < h_elements.extent(0); ++ireceiver) {
           int ispec = h_elements(ireceiver);
           if (element_types.get_medium_tag(ispec) == _medium_tag_ &&
-              element_types.get_property_tag(ispec) == _property_tag_) {
+              element_types.get_property_tag(ispec) == _property_tag_ &&
+              element_types.get_attenuation_tag(ispec) == _attenuation_tag_) {
             _h_elements_(index) = ispec;
             _h_receiver_indices_(index) = ireceiver;
             index++;
@@ -152,15 +155,18 @@ std::tuple<Kokkos::View<int *, Kokkos::DefaultHostExecutionSpace>,
 specfem::assembly::receivers<specfem::dimension::type::dim2>::
     get_indices_on_host(
         const specfem::element::medium_tag medium_tag,
-        const specfem::element::property_tag property_tag) const {
+        const specfem::element::property_tag property_tag,
+        const specfem::element::attenuation_tag attenuation_tag) const {
 
   FOR_EACH_IN_PRODUCT(
       (DIMENSION_TAG(DIM2),
        MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
                   ELASTIC_PSV_T),
-       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
+       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+       ATTENUATION_TAG(NONE)),
       CAPTURE(h_elements, h_receiver_indices) {
-        if (medium_tag == _medium_tag_ && property_tag == _property_tag_) {
+        if (medium_tag == _medium_tag_ && property_tag == _property_tag_ &&
+            attenuation_tag == _attenuation_tag_) {
           return std::make_tuple(_h_elements_, _h_receiver_indices_);
         }
       })
@@ -177,15 +183,18 @@ std::tuple<Kokkos::View<int *, Kokkos::DefaultExecutionSpace>,
 specfem::assembly::receivers<specfem::dimension::type::dim2>::
     get_indices_on_device(
         const specfem::element::medium_tag medium_tag,
-        const specfem::element::property_tag property_tag) const {
+        const specfem::element::property_tag property_tag,
+        const specfem::element::attenuation_tag attenuation_tag) const {
 
   FOR_EACH_IN_PRODUCT(
       (DIMENSION_TAG(DIM2),
        MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
                   ELASTIC_PSV_T),
-       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
+       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+       ATTENUATION_TAG(NONE)),
       CAPTURE(elements, receiver_indices) {
-        if (medium_tag == _medium_tag_ && property_tag == _property_tag_) {
+        if (medium_tag == _medium_tag_ && property_tag == _property_tag_ &&
+            attenuation_tag == _attenuation_tag_) {
           return std::make_tuple(_elements_, _receiver_indices_);
         }
       })

--- a/core/specfem/assembly/receivers/dim2/receivers.hpp
+++ b/core/specfem/assembly/receivers/dim2/receivers.hpp
@@ -95,8 +95,10 @@ public:
    */
   std::tuple<Kokkos::View<int *, Kokkos::DefaultExecutionSpace>,
              Kokkos::View<int *, Kokkos::DefaultExecutionSpace> >
-  get_indices_on_device(const specfem::element::medium_tag medium,
-                        const specfem::element::property_tag property) const;
+  get_indices_on_device(
+      const specfem::element::medium_tag medium,
+      const specfem::element::property_tag property,
+      const specfem::element::attenuation_tag attenuation) const;
 
   /**
    * @brief Get the spectral element indices in which the receivers are located
@@ -111,8 +113,10 @@ public:
    */
   std::tuple<Kokkos::View<int *, Kokkos::DefaultHostExecutionSpace>,
              Kokkos::View<int *, Kokkos::DefaultHostExecutionSpace> >
-  get_indices_on_host(const specfem::element::medium_tag medium,
-                      const specfem::element::property_tag property) const;
+  get_indices_on_host(
+      const specfem::element::medium_tag medium,
+      const specfem::element::property_tag property,
+      const specfem::element::attenuation_tag attenuation) const;
 
   /**
    * @brief Get the seismogram types
@@ -150,8 +154,8 @@ private:
   FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM2),
                        MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC,
                                   POROELASTIC, ELASTIC_PSV_T),
-                       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC,
-                                    ISOTROPIC_COSSERAT)),
+                       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+                       ATTENUATION_TAG(NONE)),
                       DECLARE((IndexViewType, receiver_indices),
                               (IndexViewType::HostMirror, h_receiver_indices),
                               (IndexViewType, elements),

--- a/core/specfem/assembly/receivers/dim3/receivers.cpp
+++ b/core/specfem/assembly/receivers/dim3/receivers.cpp
@@ -120,7 +120,7 @@ specfem::assembly::receivers<specfem::dimension::type::dim3>::receivers(
 
   FOR_EACH_IN_PRODUCT(
       (DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC, ACOUSTIC),
-       PROPERTY_TAG(ISOTROPIC)),
+       PROPERTY_TAG(ISOTROPIC), ATTENUATION_TAG(NONE)),
       CAPTURE(elements, h_elements, receiver_indices, h_receiver_indices) {
         int count = 0;
         int index = 0;
@@ -128,7 +128,8 @@ specfem::assembly::receivers<specfem::dimension::type::dim3>::receivers(
         for (int ireceiver = 0; ireceiver < h_elements.extent(0); ++ireceiver) {
           int ispec = h_elements(ireceiver);
           if (element_types.get_medium_tag(ispec) == _medium_tag_ &&
-              element_types.get_property_tag(ispec) == _property_tag_) {
+              element_types.get_property_tag(ispec) == _property_tag_ &&
+              element_types.get_attenuation_tag(ispec) == _attenuation_tag_) {
             count++;
           }
         }
@@ -143,7 +144,8 @@ specfem::assembly::receivers<specfem::dimension::type::dim3>::receivers(
         for (int ireceiver = 0; ireceiver < h_elements.extent(0); ++ireceiver) {
           int ispec = h_elements(ireceiver);
           if (element_types.get_medium_tag(ispec) == _medium_tag_ &&
-              element_types.get_property_tag(ispec) == _property_tag_) {
+              element_types.get_property_tag(ispec) == _property_tag_ &&
+              element_types.get_attenuation_tag(ispec) == _attenuation_tag_) {
             _h_elements_(index) = ispec;
             _h_receiver_indices_(index) = ireceiver;
             index++;
@@ -165,13 +167,16 @@ std::tuple<Kokkos::View<int *, Kokkos::DefaultHostExecutionSpace>,
 specfem::assembly::receivers<specfem::dimension::type::dim3>::
     get_indices_on_host(
         const specfem::element::medium_tag medium_tag,
-        const specfem::element::property_tag property_tag) const {
+        const specfem::element::property_tag property_tag,
+        const specfem::element::attenuation_tag attenuation_tag) const {
 
   FOR_EACH_IN_PRODUCT(
       (DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC, ACOUSTIC, POROELASTIC),
-       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
+       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+       ATTENUATION_TAG(NONE)),
       CAPTURE(h_elements, h_receiver_indices) {
-        if (medium_tag == _medium_tag_ && property_tag == _property_tag_) {
+        if (medium_tag == _medium_tag_ && property_tag == _property_tag_ &&
+            attenuation_tag == _attenuation_tag_) {
           return std::make_tuple(_h_elements_, _h_receiver_indices_);
         }
       })
@@ -188,13 +193,16 @@ std::tuple<Kokkos::View<int *, Kokkos::DefaultExecutionSpace>,
 specfem::assembly::receivers<specfem::dimension::type::dim3>::
     get_indices_on_device(
         const specfem::element::medium_tag medium_tag,
-        const specfem::element::property_tag property_tag) const {
+        const specfem::element::property_tag property_tag,
+        const specfem::element::attenuation_tag attenuation_tag) const {
 
   FOR_EACH_IN_PRODUCT(
       (DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC, ACOUSTIC, POROELASTIC),
-       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
+       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+       ATTENUATION_TAG(NONE)),
       CAPTURE(elements, receiver_indices) {
-        if (medium_tag == _medium_tag_ && property_tag == _property_tag_) {
+        if (medium_tag == _medium_tag_ && property_tag == _property_tag_ &&
+            attenuation_tag == _attenuation_tag_) {
           return std::make_tuple(_elements_, _receiver_indices_);
         }
       })

--- a/core/specfem/assembly/receivers/dim3/receivers.hpp
+++ b/core/specfem/assembly/receivers/dim3/receivers.hpp
@@ -80,8 +80,10 @@ public:
    */
   std::tuple<Kokkos::View<int *, Kokkos::DefaultExecutionSpace>,
              Kokkos::View<int *, Kokkos::DefaultExecutionSpace> >
-  get_indices_on_device(const specfem::element::medium_tag medium,
-                        const specfem::element::property_tag property) const;
+  get_indices_on_device(
+      const specfem::element::medium_tag medium,
+      const specfem::element::property_tag property,
+      const specfem::element::attenuation_tag attenuation) const;
 
   /**
    * @brief Get the spectral element indices in which the receivers are located
@@ -96,8 +98,10 @@ public:
    */
   std::tuple<Kokkos::View<int *, Kokkos::DefaultHostExecutionSpace>,
              Kokkos::View<int *, Kokkos::DefaultHostExecutionSpace> >
-  get_indices_on_host(const specfem::element::medium_tag medium,
-                      const specfem::element::property_tag property) const;
+  get_indices_on_host(
+      const specfem::element::medium_tag medium,
+      const specfem::element::property_tag property,
+      const specfem::element::attenuation_tag attenuation) const;
 
   /**
    * @brief Get the seismogram types
@@ -145,7 +149,7 @@ private:
                                                                  ///< types
 
   FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ELASTIC, ACOUSTIC),
-                       PROPERTY_TAG(ISOTROPIC)),
+                       PROPERTY_TAG(ISOTROPIC), ATTENUATION_TAG(NONE)),
                       DECLARE((IndexViewType, receiver_indices),
                               (IndexViewType::HostMirror, h_receiver_indices),
                               (IndexViewType, elements),

--- a/core/specfem/compute/compute_derivatives.hpp
+++ b/core/specfem/compute/compute_derivatives.hpp
@@ -24,7 +24,7 @@ void compute_derivatives(
   FOR_EACH_IN_PRODUCT(
       (DIMENSION_TAG(DIM2),
        MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC),
-       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC)),
+       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC), ATTENUATION_TAG(NONE)),
       {
         if constexpr (DimensionTag == _dimension_tag_) {
           impl::compute_material_derivatives<DimensionTag, NGLL, _medium_tag_,

--- a/core/specfem/compute/compute_seismograms.hpp
+++ b/core/specfem/compute/compute_seismograms.hpp
@@ -26,7 +26,8 @@ void compute_seismograms(specfem::assembly::assembly<DimensionTag> &assembly,
       (DIMENSION_TAG(DIM2, DIM3),
        MEDIUM_TAG(ELASTIC, ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
                   ELASTIC_PSV_T),
-       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
+       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+       ATTENUATION_TAG(NONE)),
       {
         if constexpr (DimensionTag == _dimension_tag_) {
           impl::compute_seismograms<WavefieldType, DimensionTag, NGLL,

--- a/core/specfem/compute/impl/compute_material_derivatives.tpp
+++ b/core/specfem/compute/impl/compute_material_derivatives.tpp
@@ -24,7 +24,7 @@ void specfem::compute::impl::compute_material_derivatives(
   auto &jacobian_matrix = assembly.jacobian_matrix;
 
   const auto elements =
-      assembly.element_types.get_elements_on_device(MediumTag, PropertyTag);
+      assembly.element_types.get_elements_on_device(MediumTag, PropertyTag, specfem::element::attenuation_tag::none);
 
   const int nelements = elements.extent(0);
 

--- a/core/specfem/compute/impl/compute_seismograms.tpp
+++ b/core/specfem/compute/impl/compute_seismograms.tpp
@@ -30,7 +30,7 @@ void specfem::compute::impl::compute_seismograms(
   constexpr int ngll = NGLL;
 
   const auto [elements, receiver_indices] =
-      assembly.receivers.get_indices_on_device(medium_tag, property_tag);
+      assembly.receivers.get_indices_on_device(medium_tag, property_tag, specfem::element::attenuation_tag::none);
 
   // Get the element grid (ngllx, ngllz)
   const auto &element_grid = assembly.mesh.element_grid;

--- a/core/specfem/macros/enum_tags.hpp
+++ b/core/specfem/macros/enum_tags.hpp
@@ -62,4 +62,6 @@
  */
 #define _ENUM_ID_FLUX_SCHEME_TAG 6
 
+#define _ENUM_ID_ATTENUATION_TAG 7
+
 /** @} */ // end of material_iterator_enum_tags

--- a/core/specfem/macros/macros_impl/utils.hpp
+++ b/core/specfem/macros/macros_impl/utils.hpp
@@ -38,9 +38,9 @@
 
 #define _SEQ_FOR_TAGS_2 MEDIUM_TAGS
 
-#define _SEQ_FOR_TAGS_3 MATERIAL_SYSTEMS
+#define _SEQ_FOR_TAGS_3
 
-#define _SEQ_FOR_TAGS_4 ELEMENT_TYPES EDGES
+#define _SEQ_FOR_TAGS_4 ELEMENT_TYPES EDGES MATERIAL_SYSTEMS
 
 #define _SEQ_FOR_TAGS_5 EDGES_AND_FLUX_SCHEME
 
@@ -166,7 +166,7 @@
 #define _WRITE_TAGS_1(data) _WRITE_TAG(_dimension_tag_, data, 0)
 #define _WRITE_TAGS_2(data) _WRITE_TAGS_1(data) _WRITE_TAG(_medium_tag_, data, 1) _WRITE_TAG(_connection_tag_, data, 1)
 #define _WRITE_TAGS_3(data) _WRITE_TAGS_2(data) _WRITE_TAG(_property_tag_, data, 2) _WRITE_TAG(_interface_tag_, data, 2)
-#define _WRITE_TAGS_4(data) _WRITE_TAGS_3(data) _WRITE_TAG(_boundary_tag_, data, 3)
+#define _WRITE_TAGS_4(data) _WRITE_TAGS_3(data) _WRITE_TAG(_attenuation_tag_, data, 3) _WRITE_TAG(_boundary_tag_, data, 3)
 #define _WRITE_TAGS_5(data) _WRITE_TAGS_4(data) _WRITE_TAG(_flux_scheme_tag_, data, 4)
 // clang-format on
 

--- a/core/specfem/macros/material_iterators.hpp
+++ b/core/specfem/macros/material_iterators.hpp
@@ -109,6 +109,13 @@
    _ENUM_ID_PROPERTY_TAG)
 /** @} */
 
+#define ATTENUATION_TAG_NONE                                                   \
+  (0, specfem::element::attenuation_tag::none, none, _ENUM_ID_ATTENUATION_TAG)
+
+#define ATTENUATION_TAG_CONSTANT_ISOTROPIC                                     \
+  (1, specfem::element::attenuation_tag::constant_isotropic,                   \
+   constant_isotropic, _ENUM_ID_ATTENUATION_TAG)
+
 /**
  * @defgroup boundary_tag_macros Boundary Tag Macros
  * @brief Macros for boundary tags.
@@ -169,20 +176,45 @@
  *
  */
 #define MATERIAL_SYSTEMS_DIM2                                                  \
-  ((DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_PSV, PROPERTY_TAG_ISOTROPIC))(      \
-      (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_PSV, PROPERTY_TAG_ANISOTROPIC))( \
-      (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_SH, PROPERTY_TAG_ISOTROPIC))(    \
-      (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_SH, PROPERTY_TAG_ANISOTROPIC))(  \
-      (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_PSV_T,                           \
-       PROPERTY_TAG_ISOTROPIC_COSSERAT))(                                      \
-      (DIMENSION_TAG_DIM2, MEDIUM_TAG_ACOUSTIC, PROPERTY_TAG_ISOTROPIC))(      \
-      (DIMENSION_TAG_DIM2, MEDIUM_TAG_POROELASTIC, PROPERTY_TAG_ISOTROPIC))(   \
+  ((DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_PSV, PROPERTY_TAG_ISOTROPIC,        \
+    ATTENUATION_TAG_NONE))((DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_PSV,        \
+                            PROPERTY_TAG_ANISOTROPIC, ATTENUATION_TAG_NONE))(  \
+      (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_SH, PROPERTY_TAG_ISOTROPIC,      \
+       ATTENUATION_TAG_NONE))(                                                 \
+      (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_SH, PROPERTY_TAG_ANISOTROPIC,    \
+       ATTENUATION_TAG_NONE))((DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_PSV_T,   \
+                               PROPERTY_TAG_ISOTROPIC_COSSERAT,                \
+                               ATTENUATION_TAG_NONE))(                         \
+      (DIMENSION_TAG_DIM2, MEDIUM_TAG_ACOUSTIC, PROPERTY_TAG_ISOTROPIC,        \
+       ATTENUATION_TAG_NONE))((DIMENSION_TAG_DIM2, MEDIUM_TAG_POROELASTIC,     \
+                               PROPERTY_TAG_ISOTROPIC, ATTENUATION_TAG_NONE))( \
       (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELECTROMAGNETIC_TE,                      \
-       PROPERTY_TAG_ISOTROPIC))
+       PROPERTY_TAG_ISOTROPIC, ATTENUATION_TAG_NONE))(                         \
+      (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_PSV, PROPERTY_TAG_ISOTROPIC,     \
+       ATTENUATION_TAG_CONSTANT_ISOTROPIC))(                                   \
+      (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_PSV, PROPERTY_TAG_ANISOTROPIC,   \
+       ATTENUATION_TAG_CONSTANT_ISOTROPIC))(                                   \
+      (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_SH, PROPERTY_TAG_ISOTROPIC,      \
+       ATTENUATION_TAG_CONSTANT_ISOTROPIC))(                                   \
+      (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_SH, PROPERTY_TAG_ANISOTROPIC,    \
+       ATTENUATION_TAG_CONSTANT_ISOTROPIC))(                                   \
+      (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELASTIC_PSV_T,                           \
+       PROPERTY_TAG_ISOTROPIC_COSSERAT, ATTENUATION_TAG_CONSTANT_ISOTROPIC))(  \
+      (DIMENSION_TAG_DIM2, MEDIUM_TAG_ACOUSTIC, PROPERTY_TAG_ISOTROPIC,        \
+       ATTENUATION_TAG_CONSTANT_ISOTROPIC))(                                   \
+      (DIMENSION_TAG_DIM2, MEDIUM_TAG_POROELASTIC, PROPERTY_TAG_ISOTROPIC,     \
+       ATTENUATION_TAG_CONSTANT_ISOTROPIC))(                                   \
+      (DIMENSION_TAG_DIM2, MEDIUM_TAG_ELECTROMAGNETIC_TE,                      \
+       PROPERTY_TAG_ISOTROPIC, ATTENUATION_TAG_CONSTANT_ISOTROPIC))
 
 #define MATERIAL_SYSTEMS_DIM3                                                  \
-  ((DIMENSION_TAG_DIM3, MEDIUM_TAG_ELASTIC, PROPERTY_TAG_ISOTROPIC))(          \
-      (DIMENSION_TAG_DIM3, MEDIUM_TAG_ACOUSTIC, PROPERTY_TAG_ISOTROPIC))
+  ((DIMENSION_TAG_DIM3, MEDIUM_TAG_ELASTIC, PROPERTY_TAG_ISOTROPIC,            \
+    ATTENUATION_TAG_NONE))((DIMENSION_TAG_DIM3, MEDIUM_TAG_ACOUSTIC,           \
+                            PROPERTY_TAG_ISOTROPIC, ATTENUATION_TAG_NONE))(    \
+      (DIMENSION_TAG_DIM3, MEDIUM_TAG_ELASTIC, PROPERTY_TAG_ISOTROPIC,         \
+       ATTENUATION_TAG_CONSTANT_ISOTROPIC))(                                   \
+      (DIMENSION_TAG_DIM3, MEDIUM_TAG_ACOUSTIC, PROPERTY_TAG_ISOTROPIC,        \
+       ATTENUATION_TAG_CONSTANT_ISOTROPIC))
 
 #define MATERIAL_SYSTEMS MATERIAL_SYSTEMS_DIM2 MATERIAL_SYSTEMS_DIM3
 
@@ -237,6 +269,7 @@
 #define _DIMENSION_TAG_ BOOST_PP_SEQ_TO_LIST((0))
 #define _MEDIUM_TAG_ BOOST_PP_SEQ_TO_LIST((1))
 #define _PROPERTY_TAG_ BOOST_PP_SEQ_TO_LIST((2))
+#define _ATTENUATION_TAG_ BOOST_PP_SEQ_TO_LIST((3))
 #define _BOUNDARY_TAG_ BOOST_PP_SEQ_TO_LIST((3))
 
 /**
@@ -279,6 +312,10 @@
 
 #define BOUNDARY_TAG(...)                                                      \
   BOOST_PP_SEQ_TRANSFORM(_TRANSFORM_TAGS, BOUNDARY_TAG_,                       \
+                         BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))
+
+#define ATTENUATION_TAG(...)                                                   \
+  BOOST_PP_SEQ_TRANSFORM(_TRANSFORM_TAGS, ATTENUATION_TAG_,                    \
                          BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))
 
 #define FOR_EACH_IN_PRODUCT(seq, ...)                                          \

--- a/core/specfem/mesh/dim2/materials/materials.hpp
+++ b/core/specfem/mesh/dim2/materials/materials.hpp
@@ -21,9 +21,10 @@ template <> struct materials<specfem::dimension::type::dim2> {
       specfem::dimension::type::dim2; ///< Dimension type
 
   struct material_specification {
-    specfem::element::medium_tag type;       ///< Type of element
-    specfem::element::property_tag property; ///< Property of element
-    int index;                               ///< Index of material property
+    specfem::element::medium_tag type;             ///< Type of element
+    specfem::element::property_tag property;       ///< Property of element
+    specfem::element::attenuation_tag attenuation; ///< Attenuation type
+    int index;          ///< Index of material property
     int database_index; ///< Index of material property in the database
 
     /**
@@ -40,27 +41,28 @@ template <> struct materials<specfem::dimension::type::dim2> {
      * @param index Index of material property
      */
     material_specification(specfem::element::medium_tag type,
-                           specfem::element::property_tag property, int index,
-                           int database_index)
-        : type(type), property(property), index(index),
-          database_index(database_index) {};
+                           specfem::element::property_tag property,
+                           specfem::element::attenuation_tag attenuation,
+                           int index, int database_index)
+        : type(type), property(property), attenuation(attenuation),
+          index(index), database_index(database_index) {};
   };
 
   template <specfem::element::medium_tag type,
-            specfem::element::property_tag property>
+            specfem::element::property_tag property,
+            specfem::element::attenuation_tag attenuation>
   struct material {
     int n_materials; ///< Number of elements
-    std::vector<specfem::medium_container::material<
-        dimension_tag, type, property,
-        specfem::element::attenuation_tag::none> >
+    std::vector<
+        specfem::medium_container::material<dimension_tag, type, property,
+                                            attenuation> >
         element_materials; ///< Material properties
 
     material() = default;
 
     material(const int n_materials,
              const std::vector<specfem::medium_container::material<
-                 dimension_tag, type, property,
-                 specfem::element::attenuation_tag::none> > &l_material);
+                 dimension_tag, type, property, attenuation> > &l_material);
   };
 
   int n_materials; ///< Total number of different materials
@@ -72,15 +74,11 @@ template <> struct materials<specfem::dimension::type::dim2> {
       (DIMENSION_TAG(DIM2),
        MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC, ELASTIC_PSV_T,
                   ELECTROMAGNETIC_TE),
-       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
+       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+       ATTENUATION_TAG(NONE)),
       DECLARE(((specfem::mesh::materials, (_DIMENSION_TAG_), ::material,
-                (_MEDIUM_TAG_, _PROPERTY_TAG_)),
+                (_MEDIUM_TAG_, _PROPERTY_TAG_, _ATTENUATION_TAG_)),
                material)))
-
-  specfem::mesh::materials<specfem::dimension::type::dim2>::material<
-      specfem::element::medium_tag::electromagnetic_te,
-      specfem::element::property_tag::isotropic>
-      electromagnetic_te_isotropic; ///< Electromagnetic material propertie TE
 
   /**
    * @name Constructors
@@ -105,16 +103,17 @@ template <> struct materials<specfem::dimension::type::dim2> {
   ///@}
 
 public:
-  template <specfem::element::medium_tag MediumTag,
-            specfem::element::property_tag PropertyTag>
   /**
    * @brief Material material at spectral element index
    *
    * @param index Spectral element index
    * @return std::variant Material properties
    */
+  template <specfem::element::medium_tag MediumTag,
+            specfem::element::property_tag PropertyTag,
+            specfem::element::attenuation_tag AttenuationTag>
   specfem::medium_container::material<dimension_tag, MediumTag, PropertyTag,
-                                      specfem::element::attenuation_tag::none>
+                                      AttenuationTag>
   get_material(const int index) const {
     const auto &material_specification = this->material_index_mapping(index);
 
@@ -122,10 +121,12 @@ public:
         (DIMENSION_TAG(DIM2),
          MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
                     ELASTIC_PSV_T, ELECTROMAGNETIC_TE),
-         PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
+         PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+         ATTENUATION_TAG(NONE)),
         CAPTURE(material) {
           if constexpr (MediumTag == _medium_tag_ &&
-                        PropertyTag == _property_tag_) {
+                        PropertyTag == _property_tag_ &&
+                        AttenuationTag == _attenuation_tag_) {
             return _material_.element_materials[material_specification.index];
           }
         })
@@ -143,18 +144,22 @@ public:
    * @return material<MediumTag, PropertyTag>& material container
    */
   template <specfem::element::medium_tag MediumTag,
-            specfem::element::property_tag PropertyTag>
-  specfem::mesh::materials<dimension_tag>::material<MediumTag, PropertyTag> &
+            specfem::element::property_tag PropertyTag,
+            specfem::element::attenuation_tag AttenuationTag>
+  specfem::mesh::materials<dimension_tag>::material<MediumTag, PropertyTag,
+                                                    AttenuationTag> &
   get_container() {
 
     FOR_EACH_IN_PRODUCT(
         (DIMENSION_TAG(DIM2),
          MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
                     ELASTIC_PSV_T, ELECTROMAGNETIC_TE),
-         PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
+         PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+         ATTENUATION_TAG(NONE)),
         CAPTURE(material) {
           if constexpr (_medium_tag_ == MediumTag &&
-                        _property_tag_ == PropertyTag) {
+                        _property_tag_ == PropertyTag &&
+                        _attenuation_tag_ == AttenuationTag) {
             return _material_;
           }
         })

--- a/core/specfem/mesh/dim2/materials/materials.tpp
+++ b/core/specfem/mesh/dim2/materials/materials.tpp
@@ -1,17 +1,17 @@
 #pragma once
 
 #include "enumerations/specfem_enums.hpp"
-#include "specfem/medium_container.hpp"
 #include "materials.hpp"
+#include "specfem/medium_container.hpp"
 #include <variant>
 #include <vector>
 
 template <specfem::element::medium_tag type,
-          specfem::element::property_tag property>
-          specfem::mesh::materials<specfem::dimension::type::dim2>::material<type, property>::material(
-    const int n_materials,
-    const std::vector<specfem::medium_container::material<dimension_tag, type, property,
-                                                specfem::element::attenuation_tag::none> >
-        &l_materials)
-    : n_materials(n_materials),
-    element_materials(l_materials) {}
+          specfem::element::property_tag property,
+          specfem::element::attenuation_tag attenuation>
+specfem::mesh::materials<specfem::dimension::type::dim2>::
+    material<type, property, attenuation>::material(
+        const int n_materials,
+        const std::vector<specfem::medium_container::material<
+            dimension_tag, type, property, attenuation> > &l_materials)
+    : n_materials(n_materials), element_materials(l_materials) {}

--- a/core/specfem/mesh/dim2/tags/tags.cpp
+++ b/core/specfem/mesh/dim2/tags/tags.cpp
@@ -40,9 +40,11 @@ specfem::mesh::tags<specfem::dimension::type::dim2>::tags(
         materials.material_index_mapping(ispec);
     const auto medium_tag = material_specification.type;
     const auto property_tag = material_specification.property;
+    const auto attenuation_tag = material_specification.attenuation;
 
     this->tags_container(ispec).medium_tag = medium_tag;
     this->tags_container(ispec).property_tag = property_tag;
+    this->tags_container(ispec).attenuation_tag = attenuation_tag;
     this->tags_container(ispec).boundary_tag = boundary_tag[ispec].get_tag();
   }
 }

--- a/core/specfem/mesh/dim3/materials/materials.hpp
+++ b/core/specfem/mesh/dim3/materials/materials.hpp
@@ -71,6 +71,9 @@ template <> struct materials<specfem::dimension::type::dim3> {
     /** @brief Material property type (isotropic, anisotropic) */
     specfem::element::property_tag property;
 
+    /** @brief Attenuation type (none, constant_isotropic, etc.) */
+    specfem::element::attenuation_tag attenuation;
+
     /** @brief Local index within the type-specific material container */
     int index;
 
@@ -89,10 +92,11 @@ template <> struct materials<specfem::dimension::type::dim3> {
      * @param database_index Original MESHFEM3D database index
      */
     material_specification(specfem::element::medium_tag type,
-                           specfem::element::property_tag property, int index,
-                           int database_index)
-        : type(type), property(property), index(index),
-          database_index(database_index) {};
+                           specfem::element::property_tag property,
+                           specfem::element::attenuation_tag attenuation,
+                           int index, int database_index)
+        : type(type), property(property), attenuation(attenuation),
+          index(index), database_index(database_index) {};
   };
 
   /**
@@ -112,7 +116,8 @@ template <> struct materials<specfem::dimension::type::dim3> {
    * @tparam property Property type (isotropic, anisotropic)
    */
   template <specfem::element::medium_tag type,
-            specfem::element::property_tag property>
+            specfem::element::property_tag property,
+            specfem::element::attenuation_tag attenuation>
   struct material {
     /** @brief Number of materials stored in this container */
     int n_materials;
@@ -120,9 +125,8 @@ template <> struct materials<specfem::dimension::type::dim3> {
     /** @brief Storage for material objects of this type/property combination */
     std::vector<
 
-        specfem::medium_container::material<
-            dimension_tag, type, property,
-            specfem::element::attenuation_tag::none> >
+        specfem::medium_container::material<dimension_tag, type, property,
+                                            attenuation> >
         element_materials;
 
     /** @brief Default constructor creating empty container */
@@ -136,8 +140,7 @@ template <> struct materials<specfem::dimension::type::dim3> {
      */
     material(const int n_materials,
              const std::vector<specfem::medium_container::material<
-                 dimension_tag, type, property,
-                 specfem::element::attenuation_tag::none> > &l_material);
+                 dimension_tag, type, property, attenuation> > &l_material);
   };
 
   /** @name Core Data Members */
@@ -186,11 +189,12 @@ private:
    * - Efficient storage organization by material type
    * - Integration with SPECFEM++ template metaprogramming patterns
    */
-  FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ACOUSTIC, ELASTIC),
-                       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC)),
-                      DECLARE(((specfem::mesh::materials, (_DIMENSION_TAG_),
-                                ::material, (_MEDIUM_TAG_, _PROPERTY_TAG_)),
-                               material)))
+  FOR_EACH_IN_PRODUCT(
+      (DIMENSION_TAG(DIM3), MEDIUM_TAG(ACOUSTIC, ELASTIC),
+       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC), ATTENUATION_TAG(NONE)),
+      DECLARE(((specfem::mesh::materials, (_DIMENSION_TAG_), ::material,
+                (_MEDIUM_TAG_, _PROPERTY_TAG_, _ATTENUATION_TAG_)),
+               material)))
 
   /** @} */
 public:
@@ -239,9 +243,10 @@ public:
    * @endcode
    */
   template <specfem::element::medium_tag MediumTag,
-            specfem::element::property_tag PropertyTag>
+            specfem::element::property_tag PropertyTag,
+            specfem::element::attenuation_tag AttenuationTag>
   specfem::medium_container::material<dimension_tag, MediumTag, PropertyTag,
-                                      specfem::element::attenuation_tag::none>
+                                      AttenuationTag>
   get_material(const int index) const {
 #ifndef NDEBUG
     if (index < 0 || index >= this->nspec) {
@@ -252,17 +257,19 @@ public:
 
 #ifndef NDEBUG
     if (material_specification.type != MediumTag ||
-        material_specification.property != PropertyTag) {
+        material_specification.property != PropertyTag ||
+        material_specification.attenuation != AttenuationTag) {
       KOKKOS_ABORT_WITH_LOCATION("Material type mismatch in get_material");
     }
 #endif
 
     FOR_EACH_IN_PRODUCT(
         (DIMENSION_TAG(DIM3), MEDIUM_TAG(ACOUSTIC, ELASTIC),
-         PROPERTY_TAG(ISOTROPIC, ANISOTROPIC)),
+         PROPERTY_TAG(ISOTROPIC, ANISOTROPIC), ATTENUATION_TAG(NONE)),
         CAPTURE(material) {
           if constexpr (MediumTag == _medium_tag_ &&
-                        PropertyTag == _property_tag_) {
+                        PropertyTag == _property_tag_ &&
+                        AttenuationTag == _attenuation_tag_) {
             return _material_.element_materials[material_specification.index];
           }
         })
@@ -273,10 +280,12 @@ public:
   }
 
   template <specfem::element::medium_tag MediumTag,
-            specfem::element::property_tag PropertyTag>
+            specfem::element::property_tag PropertyTag,
+            specfem::element::attenuation_tag AttenuationTag>
   const specfem::point::properties<dimension_tag, MediumTag, PropertyTag, false>
   get_properties(const int index) const {
-    const auto material = this->get_material<MediumTag, PropertyTag>(index);
+    const auto material =
+        this->get_material<MediumTag, PropertyTag, AttenuationTag>(index);
     return material.get_properties();
   }
 
@@ -307,15 +316,19 @@ public:
    * @endcode
    */
   template <specfem::element::medium_tag MediumTag,
-            specfem::element::property_tag PropertyTag>
-  specfem::mesh::materials<dimension_tag>::material<MediumTag, PropertyTag> &
+            specfem::element::property_tag PropertyTag,
+            specfem::element::attenuation_tag AttenuationTag>
+  specfem::mesh::materials<dimension_tag>::material<MediumTag, PropertyTag,
+                                                    AttenuationTag> &
   get_container() {
 
     FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM3), MEDIUM_TAG(ACOUSTIC, ELASTIC),
-                         PROPERTY_TAG(ISOTROPIC, ANISOTROPIC)),
+                         PROPERTY_TAG(ISOTROPIC, ANISOTROPIC),
+                         ATTENUATION_TAG(NONE)),
                         CAPTURE(material) {
                           if constexpr (_medium_tag_ == MediumTag &&
-                                        _property_tag_ == PropertyTag) {
+                                        _property_tag_ == PropertyTag &&
+                                        _attenuation_tag_ == AttenuationTag) {
                             return _material_;
                           }
                         })
@@ -343,12 +356,14 @@ public:
    * @endcode
    */
   template <specfem::element::medium_tag MediumTag,
-            specfem::element::property_tag PropertyTag>
+            specfem::element::property_tag PropertyTag,
+            specfem::element::attenuation_tag AttenuationTag>
   int add_material(const specfem::medium_container::material<
-                   dimension_tag, MediumTag, PropertyTag,
-                   specfem::element::attenuation_tag::none> &new_material) {
+                   dimension_tag, MediumTag, PropertyTag, AttenuationTag>
+                       &new_material) {
     this->n_materials += 1;
-    auto &material_container = this->get_container<MediumTag, PropertyTag>();
+    auto &material_container =
+        this->get_container<MediumTag, PropertyTag, AttenuationTag>();
     material_container.element_materials.push_back(new_material);
     material_container.n_materials += 1;
 
@@ -375,7 +390,8 @@ public:
    * }
    * @endcode
    */
-  std::tuple<specfem::element::medium_tag, specfem::element::property_tag>
+  std::tuple<specfem::element::medium_tag, specfem::element::property_tag,
+             specfem::element::attenuation_tag>
   get_material_type(const int index) const {
 #ifndef NDEBUG
     if (index < 0 || index >= this->nspec) {
@@ -385,7 +401,8 @@ public:
 #endif
     const auto &material_specification = this->material_index_mapping[index];
     return std::make_tuple(material_specification.type,
-                           material_specification.property);
+                           material_specification.property,
+                           material_specification.attenuation);
   }
 
   /** @} */ // End Material Access Interface

--- a/core/specfem/mesh/dim3/mesh.cpp
+++ b/core/specfem/mesh/dim3/mesh.cpp
@@ -11,8 +11,9 @@ void specfem::mesh::mesh<
       const auto target = boost::target(e, graph);
       auto &edge_props = graph[e];
 
-      const auto [self_medium, self_property] = materials.get_material_type(v);
-      const auto [neighbor_medium, neighbor_property] =
+      const auto [self_medium, self_property, self_attenuation] =
+          materials.get_material_type(v);
+      const auto [neighbor_medium, neighbor_property, neighbor_attenuation] =
           materials.get_material_type(target);
       if ((self_medium != neighbor_medium) &&
           (edge_props.connection ==

--- a/core/specfem/mesh/dim3/tags/tags.cpp
+++ b/core/specfem/mesh/dim3/tags/tags.cpp
@@ -32,14 +32,14 @@ specfem::mesh::tags<specfem::dimension::type::dim3>::tags(
       "specfem::mesh::tags::copy_tags",
       Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0, nspec),
       [=, *this](const int ispec) {
-        const auto [material_tag, property_tag] =
+        const auto [material_tag, property_tag, attenuation_tag] =
             materials.get_material_type(ispec);
 
         // Set to none since other boundary conditions are not yet implemented
         const auto boundary_tag = specfem::element::boundary_tag::none;
 
         this->tags_container(ispec) = { material_tag, property_tag,
-                                        boundary_tag };
+                                        attenuation_tag, boundary_tag };
       });
 
   return;

--- a/core/specfem/mesh/impl/tags_container.hpp
+++ b/core/specfem/mesh/impl/tags_container.hpp
@@ -11,15 +11,17 @@ namespace impl {
  *
  */
 struct tags_container {
-  specfem::element::medium_tag medium_tag;     ///< Medium tag
-  specfem::element::property_tag property_tag; ///< Property tag
-  specfem::element::boundary_tag boundary_tag; ///< Boundary tag
+  specfem::element::medium_tag medium_tag;           ///< Medium tag
+  specfem::element::property_tag property_tag;       ///< Property tag
+  specfem::element::attenuation_tag attenuation_tag; ///< Attenuation tag
+  specfem::element::boundary_tag boundary_tag;       ///< Boundary tag
 
   tags_container(const specfem::element::medium_tag medium_tag_,
                  const specfem::element::property_tag property_tag_,
+                 const specfem::element::attenuation_tag attenuation_tag_,
                  const specfem::element::boundary_tag boundary_tag_)
       : medium_tag(medium_tag_), property_tag(property_tag_),
-        boundary_tag(boundary_tag_) {}
+        attenuation_tag(attenuation_tag_), boundary_tag(boundary_tag_) {}
 
   tags_container() = default;
 };

--- a/include/enumerations/medium.hpp
+++ b/include/enumerations/medium.hpp
@@ -282,7 +282,8 @@ const std::string to_string(const medium_tag &medium,
  * @return Combined string representation
  */
 const std::string to_string(const medium_tag &medium,
-                            const property_tag &property_tag);
+                            const property_tag &property_tag,
+                            const attenuation_tag &attenuation_tag);
 
 /**
  * @brief Convert medium tag to string.
@@ -307,6 +308,8 @@ const std::string to_string(const property_tag &property);
  * @return String representation
  */
 const std::string to_string(const boundary_tag &boundary);
+
+const std::string to_string(const attenuation_tag &attenuation);
 
 /**
  * @brief Type trait to identify elastic media.

--- a/include/enumerations/medium_tags.hpp
+++ b/include/enumerations/medium_tags.hpp
@@ -75,7 +75,8 @@ template <> constexpr auto material_systems<specfem::dimension::type::dim2>() {
       BOOST_PP_SEQ_SIZE(MATERIAL_SYSTEMS_DIM2);
   constexpr std::array<
       std::tuple<specfem::dimension::type, specfem::element::medium_tag,
-                 specfem::element::property_tag>,
+                 specfem::element::property_tag,
+                 specfem::element::attenuation_tag>,
       total_material_systems>
       material_systems{ _MAKE_CONSTEXPR_ARRAY(MATERIAL_SYSTEMS_DIM2) };
 
@@ -93,7 +94,8 @@ template <> constexpr auto material_systems<specfem::dimension::type::dim3>() {
       BOOST_PP_SEQ_SIZE(MATERIAL_SYSTEMS_DIM3);
   constexpr std::array<
       std::tuple<specfem::dimension::type, specfem::element::medium_tag,
-                 specfem::element::property_tag>,
+                 specfem::element::property_tag,
+                 specfem::element::attenuation_tag>,
       total_material_systems>
       material_systems{ _MAKE_CONSTEXPR_ARRAY(MATERIAL_SYSTEMS_DIM3) };
 

--- a/include/io/impl/medium_writer.tpp
+++ b/include/io/impl/medium_writer.tpp
@@ -1,20 +1,21 @@
 #pragma once
 
-#include "specfem/assembly.hpp"
 #include "domain_view.hpp"
 #include "enumerations/dimension.hpp"
-#include "specfem/macros.hpp"
-#include "specfem/logger.hpp"
 #include "enumerations/medium.hpp"
 #include "io/impl/medium_writer.hpp"
 #include "kokkos_abstractions.h"
+#include "specfem/assembly.hpp"
+#include "specfem/logger.hpp"
+#include "specfem/macros.hpp"
 #include <Kokkos_Core.hpp>
 
 template <typename OutputLibrary, typename ContainerType>
 void specfem::io::impl::write_container(
     const std::string &output_folder, const std::string &output_namespace,
     const specfem::assembly::mesh<specfem::dimension::type::dim2> &mesh,
-    const specfem::assembly::element_types<specfem::dimension::type::dim2> &element_types,
+    const specfem::assembly::element_types<specfem::dimension::type::dim2>
+        &element_types,
     ContainerType &container) {
   using DomainView =
       specfem::kokkos::DomainView2d<type_real, 3, Kokkos::HostSpace>;
@@ -33,14 +34,16 @@ void specfem::io::impl::write_container(
       (DIMENSION_TAG(DIM2),
        MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
                   ELASTIC_PSV_T),
-       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
+       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+       ATTENUATION_TAG(NONE)),
       {
         const std::string name =
             std::string("/") +
-            specfem::element::to_string(_medium_tag_, _property_tag_);
+            specfem::element::to_string(_medium_tag_, _property_tag_,
+                                       _attenuation_tag_);
         typename OutputLibrary::Group group = file.createGroup(name);
         const auto element_indices =
-            element_types.get_elements_on_host(_medium_tag_, _property_tag_);
+            element_types.get_elements_on_host(_medium_tag_, _property_tag_, _attenuation_tag_);
         const int n_elements = element_indices.size();
         n_written += n_elements;
         DomainView x("xcoordinates", n_elements, ngllz, ngllx);
@@ -59,6 +62,7 @@ void specfem::io::impl::write_container(
         auto data_container =
             container.template get_container<_medium_tag_, _property_tag_>();
 
+
         data_container.for_each_host_view(
             [&](const auto view, const std::string name) mutable {
               group.createDataset(name, view).write();
@@ -74,5 +78,6 @@ void specfem::io::impl::write_container(
     throw std::runtime_error(message.str());
   }
 
-  specfem::Logger::info(output_namespace + " written to " + output_folder + "/" + output_namespace);
+  specfem::Logger::info(output_namespace + " written to " + output_folder +
+                        "/" + output_namespace);
 }

--- a/src/enumerations/medium.cpp
+++ b/src/enumerations/medium.cpp
@@ -3,12 +3,14 @@
 
 const std::string specfem::element::to_string(
     const specfem::element::medium_tag &medium,
-    const specfem::element::property_tag &property_tag) {
+    const specfem::element::property_tag &property_tag,
+    const specfem::element::attenuation_tag &attenuation_tag) {
 
   std::string medium_string = specfem::element::to_string(medium);
   std::string property_string = specfem::element::to_string(property_tag);
+  std::string attenuation_string = specfem::element::to_string(attenuation_tag);
 
-  return medium_string + "_" + property_string;
+  return medium_string + "_" + property_string + "_" + attenuation_string;
 }
 
 const std::string
@@ -101,6 +103,26 @@ specfem::element::to_string(const specfem::element::boundary_tag &boundary) {
   }
 
   return boundary_string;
+}
+
+const std::string specfem::element::to_string(
+    const specfem::element::attenuation_tag &attenuation) {
+
+  std::string attenuation_string;
+
+  switch (attenuation) {
+  case specfem::element::attenuation_tag::none:
+    attenuation_string = "none";
+    break;
+  case specfem::element::attenuation_tag::constant_isotropic:
+    attenuation_string = "constant_isotropic";
+    break;
+  default:
+    attenuation_string = "unknown";
+    break;
+  }
+
+  return attenuation_string;
 }
 
 specfem::element::medium_tag

--- a/src/io/mesh/impl/fortran/dim2/mesh.cpp
+++ b/src/io/mesh/impl/fortran/dim2/mesh.cpp
@@ -174,10 +174,13 @@ specfem::mesh::mesh<specfem::dimension::type::dim2> specfem::io::read_2d_mesh(
       (DIMENSION_TAG(DIM2),
        MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC, ELASTIC_PSV_T,
                   ELECTROMAGNETIC_TE),
-       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
+       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+       ATTENUATION_TAG(NONE)),
       {
         for (const auto material :
-             mesh.materials.get_container<_medium_tag_, _property_tag_>()
+             mesh.materials
+                 .get_container<_medium_tag_, _property_tag_,
+                                _attenuation_tag_>()
                  .element_materials) {
           specfem::Logger::debug(material.print());
         }
@@ -189,11 +192,13 @@ specfem::mesh::mesh<specfem::dimension::type::dim2> specfem::io::read_2d_mesh(
       (DIMENSION_TAG(DIM2),
        MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC, ELASTIC_PSV_T,
                   ELECTROMAGNETIC_TE),
-       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
+       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+       ATTENUATION_TAG(NONE)),
       {
-        total_materials_read +=
-            mesh.materials.get_container<_medium_tag_, _property_tag_>()
-                .element_materials.size();
+        total_materials_read += mesh.materials
+                                    .get_container<_medium_tag_, _property_tag_,
+                                                   _attenuation_tag_>()
+                                    .element_materials.size();
       })
 
   if (total_materials_read != mesh.materials.n_materials) {

--- a/src/io/mesh/impl/fortran/dim2/read_material_properties.cpp
+++ b/src/io/mesh/impl/fortran/dim2/read_material_properties.cpp
@@ -40,21 +40,23 @@ read_materials(
     const specfem::enums::elastic_wave elastic_wave,
     const specfem::enums::electromagnetic_wave electromagnetic_wave,
     specfem::mesh::materials<specfem::dimension::type::dim2>::material<
-        acoustic, isotropic> &acoustic_isotropic,
+        acoustic, isotropic, no_attenuation> &acoustic_isotropic,
     specfem::mesh::materials<specfem::dimension::type::dim2>::material<
-        elastic_psv, isotropic> &elastic_psv_isotropic,
+        elastic_psv, isotropic, no_attenuation> &elastic_psv_isotropic,
     specfem::mesh::materials<specfem::dimension::type::dim2>::material<
-        elastic_sh, isotropic> &elastic_sh_isotropic,
+        elastic_sh, isotropic, no_attenuation> &elastic_sh_isotropic,
     specfem::mesh::materials<specfem::dimension::type::dim2>::material<
-        elastic_psv, anisotropic> &elastic_psv_anisotropic,
+        elastic_psv, anisotropic, no_attenuation> &elastic_psv_anisotropic,
     specfem::mesh::materials<specfem::dimension::type::dim2>::material<
-        elastic_sh, anisotropic> &elastic_sh_anisotropic,
+        elastic_sh, anisotropic, no_attenuation> &elastic_sh_anisotropic,
     specfem::mesh::materials<specfem::dimension::type::dim2>::material<
-        poroelastic, isotropic> &poroelastic_isotropic,
+        poroelastic, isotropic, no_attenuation> &poroelastic_isotropic,
     specfem::mesh::materials<specfem::dimension::type::dim2>::material<
-        electromagnetic_te, isotropic> &electromagnetic_te_isotropic,
+        electromagnetic_te, isotropic, no_attenuation>
+        &electromagnetic_te_isotropic,
     specfem::mesh::materials<specfem::dimension::type::dim2>::material<
-        elastic_psv_t, isotropic_cosserat> &elastic_psv_t_isotropic_cosserat) {
+        elastic_psv_t, isotropic_cosserat, no_attenuation>
+        &elastic_psv_t_isotropic_cosserat) {
 
   // Define the elastic medium tag based on input elastic wave type
   const specfem::element::medium_tag elastic = [elastic_wave]() {
@@ -205,6 +207,7 @@ read_materials(
               materials<specfem::dimension::type::dim2>::material_specification(
                   specfem::element::medium_tag::acoustic,
                   specfem::element::property_tag::isotropic,
+                  specfem::element::attenuation_tag::none,
                   index_acoustic_isotropic, read_values.n - 1);
 
           index_acoustic_isotropic++;
@@ -239,6 +242,7 @@ read_materials(
                     material_specification(
                         specfem::element::medium_tag::elastic_psv,
                         specfem::element::property_tag::isotropic,
+                        specfem::element::attenuation_tag::none,
                         index_elastic_isotropic, read_values.n - 1);
           } else {
             specfem::medium_container::material<specfem::dimension::type::dim2,
@@ -253,6 +257,7 @@ read_materials(
                     material_specification(
                         specfem::element::medium_tag::elastic_sh,
                         specfem::element::property_tag::isotropic,
+                        specfem::element::attenuation_tag::none,
                         index_elastic_isotropic, read_values.n - 1);
           }
 
@@ -299,6 +304,7 @@ read_materials(
               materials<specfem::dimension::type::dim2>::material_specification(
                   specfem::element::medium_tag::elastic_psv,
                   specfem::element::property_tag::anisotropic,
+                  specfem::element::attenuation_tag::none,
                   index_elastic_anisotropic, read_values.n - 1);
         } else {
 
@@ -314,6 +320,7 @@ read_materials(
               materials<specfem::dimension::type::dim2>::material_specification(
                   specfem::element::medium_tag::elastic_sh,
                   specfem::element::property_tag::anisotropic,
+                  specfem::element::attenuation_tag::none,
                   index_elastic_anisotropic, read_values.n - 1);
         }
 
@@ -354,6 +361,7 @@ read_materials(
             materials<specfem::dimension::type::dim2>::material_specification(
                 specfem::element::medium_tag::poroelastic,
                 specfem::element::property_tag::isotropic,
+                specfem::element::attenuation_tag::none,
                 index_poroelastic_isotropic, read_values.n - 1);
         index_poroelastic_isotropic++;
       } else {
@@ -388,6 +396,7 @@ read_materials(
             materials<specfem::dimension::type::dim2>::material_specification(
                 specfem::element::medium_tag::electromagnetic_te,
                 specfem::element::property_tag::isotropic,
+                specfem::element::attenuation_tag::none,
                 index_electromagnetic_te_isotropic, read_values.n - 1);
 
         index_electromagnetic_te_isotropic++;
@@ -422,6 +431,7 @@ read_materials(
             materials<specfem::dimension::type::dim2>::material_specification(
                 specfem::element::medium_tag::elastic_psv_t,
                 specfem::element::property_tag::isotropic_cosserat,
+                specfem::element::attenuation_tag::none,
                 index_elastic_psv_t_isotropic_cosserat, read_values.n - 1);
         index_elastic_psv_t_isotropic_cosserat++;
 
@@ -470,42 +480,43 @@ read_materials(
   // Create materials instances
   acoustic_isotropic =
       specfem::mesh::materials<specfem::dimension::type::dim2>::material<
-          acoustic, isotropic>(l_acoustic_isotropic.size(),
-                               l_acoustic_isotropic);
+          acoustic, isotropic, no_attenuation>(l_acoustic_isotropic.size(),
+                                               l_acoustic_isotropic);
 
   elastic_psv_isotropic =
       specfem::mesh::materials<specfem::dimension::type::dim2>::material<
-          elastic_psv, isotropic>(l_elastic_psv_isotropic.size(),
-                                  l_elastic_psv_isotropic);
+          elastic_psv, isotropic, no_attenuation>(
+          l_elastic_psv_isotropic.size(), l_elastic_psv_isotropic);
 
   elastic_sh_isotropic =
       specfem::mesh::materials<specfem::dimension::type::dim2>::material<
-          elastic_sh, isotropic>(l_elastic_sh_isotropic.size(),
-                                 l_elastic_sh_isotropic);
+          elastic_sh, isotropic, no_attenuation>(l_elastic_sh_isotropic.size(),
+                                                 l_elastic_sh_isotropic);
 
   elastic_psv_anisotropic =
       specfem::mesh::materials<specfem::dimension::type::dim2>::material<
-          elastic_psv, anisotropic>(l_elastic_psv_anisotropic.size(),
-                                    l_elastic_psv_anisotropic);
+          elastic_psv, anisotropic, no_attenuation>(
+          l_elastic_psv_anisotropic.size(), l_elastic_psv_anisotropic);
 
   elastic_sh_anisotropic =
       specfem::mesh::materials<specfem::dimension::type::dim2>::material<
-          elastic_sh, anisotropic>(l_elastic_sh_anisotropic.size(),
-                                   l_elastic_sh_anisotropic);
+          elastic_sh, anisotropic, no_attenuation>(
+          l_elastic_sh_anisotropic.size(), l_elastic_sh_anisotropic);
 
   poroelastic_isotropic =
       specfem::mesh::materials<specfem::dimension::type::dim2>::material<
-          poroelastic, isotropic>(l_poroelastic_isotropic.size(),
-                                  l_poroelastic_isotropic);
+          poroelastic, isotropic, no_attenuation>(
+          l_poroelastic_isotropic.size(), l_poroelastic_isotropic);
 
   electromagnetic_te_isotropic =
       specfem::mesh::materials<specfem::dimension::type::dim2>::material<
-          electromagnetic_te, isotropic>(l_electromagnetic_te_isotropic.size(),
-                                         l_electromagnetic_te_isotropic);
+          electromagnetic_te, isotropic, no_attenuation>(
+          l_electromagnetic_te_isotropic.size(),
+          l_electromagnetic_te_isotropic);
 
   elastic_psv_t_isotropic_cosserat =
       specfem::mesh::materials<specfem::dimension::type::dim2>::material<
-          elastic_psv_t, isotropic_cosserat>(
+          elastic_psv_t, isotropic_cosserat, no_attenuation>(
           l_elastic_psv_t_isotropic_cosserat.size(),
           l_elastic_psv_t_isotropic_cosserat);
   return index_mapping;
@@ -575,14 +586,15 @@ specfem::io::mesh::impl::fortran::dim2::read_material_properties(
   // Read material properties
   auto index_mapping = read_materials(
       stream, numat, elastic_wave, electromagnetic_wave,
-      materials.get_container<acoustic, isotropic>(),
-      materials.get_container<elastic_psv, isotropic>(),
-      materials.get_container<elastic_sh, isotropic>(),
-      materials.get_container<elastic_psv, anisotropic>(),
-      materials.get_container<elastic_sh, anisotropic>(),
-      materials.get_container<poroelastic, isotropic>(),
-      materials.get_container<electromagnetic_te, isotropic>(),
-      materials.get_container<elastic_psv_t, isotropic_cosserat>());
+      materials.get_container<acoustic, isotropic, no_attenuation>(),
+      materials.get_container<elastic_psv, isotropic, no_attenuation>(),
+      materials.get_container<elastic_sh, isotropic, no_attenuation>(),
+      materials.get_container<elastic_psv, anisotropic, no_attenuation>(),
+      materials.get_container<elastic_sh, anisotropic, no_attenuation>(),
+      materials.get_container<poroelastic, isotropic, no_attenuation>(),
+      materials.get_container<electromagnetic_te, isotropic, no_attenuation>(),
+      materials
+          .get_container<elastic_psv_t, isotropic_cosserat, no_attenuation>());
 
   // Read material indices
   read_material_indices(stream, nspec, numat, index_mapping,

--- a/src/io/mesh/impl/fortran/dim3/read_materials.cpp
+++ b/src/io/mesh/impl/fortran/dim3/read_materials.cpp
@@ -63,7 +63,8 @@ specfem::io::mesh::impl::fortran::dim3::read_materials(std::ifstream &stream,
             const int index = materials.add_material(material);
             mapping.push_back({ specfem::element::medium_tag::acoustic,
                                 specfem::element::property_tag::isotropic,
-                                index, imat });
+                                specfem::element::attenuation_tag::none, index,
+                                imat });
           } else {
             throw std::runtime_error(
                 "Attenuation not yet supported for acoustic materials in 3D");
@@ -88,7 +89,8 @@ specfem::io::mesh::impl::fortran::dim3::read_materials(std::ifstream &stream,
             const int index = materials.add_material(material);
             mapping.push_back({ specfem::element::medium_tag::elastic,
                                 specfem::element::property_tag::isotropic,
-                                index, imat });
+                                specfem::element::attenuation_tag::none, index,
+                                imat });
           } else {
             throw std::runtime_error(
                 "Attenuation not yet supported for elastic materials in 3D");

--- a/tests/unit-tests/assembly/compute_wavefield/generate_data.hpp
+++ b/tests/unit-tests/assembly/compute_wavefield/generate_data.hpp
@@ -19,8 +19,8 @@ void generate_data(
   const int ngllx = assembly.mesh.element_grid.ngllx;
   const int ngllz = assembly.mesh.element_grid.ngllz;
 
-  const auto elements =
-      assembly.element_types.get_elements_on_host(medium, property);
+  const auto elements = assembly.element_types.get_elements_on_host(
+      medium, property, specfem::element::attenuation_tag::none);
 
   constexpr int num_components =
       specfem::element::attributes<specfem::dimension::type::dim2,

--- a/tests/unit-tests/assembly/properties/properties.cpp
+++ b/tests/unit-tests/assembly/properties/properties.cpp
@@ -205,8 +205,8 @@ void check_compute_to_mesh(
   const auto &materials = mesh.materials;
 
   // Get all elements of the given type
-  const auto elements =
-      element_types.get_elements_on_host(MediumTag, PropertyTag);
+  const auto elements = element_types.get_elements_on_host(
+      MediumTag, PropertyTag, specfem::element::attenuation_tag::none);
 
   using PointType = specfem::point::properties<specfem::dimension::type::dim2,
                                                MediumTag, PropertyTag, false>;

--- a/tests/unit-tests/mesh/dim2/materials/materials.cpp
+++ b/tests/unit-tests/mesh/dim2/materials/materials.cpp
@@ -147,6 +147,7 @@ void check_material(
 
     const auto medium_tag = material_specification.type;
     const auto property_tag = material_specification.property;
+    const auto attenuation_tag = material_specification.attenuation;
     const int index = material_specification.index;
     const int imaterial = material_specification.database_index;
 
@@ -154,17 +155,19 @@ void check_material(
         (DIMENSION_TAG(DIM2),
          MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
                     ELASTIC_PSV_T, ELECTROMAGNETIC_TE),
-         PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
+         PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+         ATTENUATION_TAG(NONE)),
         {
           if ((medium_tag == _medium_tag_) &&
-              (property_tag == _property_tag_)) {
+              (property_tag == _property_tag_) &&
+              (attenuation_tag == _attenuation_tag_)) {
             const auto icomputed =
-                computed.get_material<_medium_tag_, _property_tag_>(ispec);
+                computed.get_material<_medium_tag_, _property_tag_,
+                                      _attenuation_tag_>(ispec);
             const auto iexpected =
                 std::any_cast<specfem::medium_container::material<
                     _dimension_tag_, _medium_tag_, _property_tag_,
-                    specfem::element::attenuation_tag::none> >(
-                    expected[imaterial]);
+                    _attenuation_tag_> >(expected[imaterial]);
             if (icomputed != iexpected) {
               std::ostringstream error_message;
               error_message << "Material " << index << " is not the same ["

--- a/tests/unit-tests/mesh/dim2/materials/properties.cpp
+++ b/tests/unit-tests/mesh/dim2/materials/properties.cpp
@@ -166,6 +166,7 @@ void check_property(
 
     const auto medium_tag = material_specification.type;
     const auto property_tag = material_specification.property;
+    const auto attenuation_tag = material_specification.attenuation;
     const int index = material_specification.index;
     const int imaterial = material_specification.database_index;
 
@@ -173,12 +174,16 @@ void check_property(
         (DIMENSION_TAG(DIM2),
          MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
                     ELASTIC_PSV_T, ELECTROMAGNETIC_TE),
-         PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
+         PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+         ATTENUATION_TAG(NONE)),
         {
           if ((medium_tag == _medium_tag_) &&
-              (property_tag == _property_tag_)) {
+              (property_tag == _property_tag_) &&
+              (attenuation_tag == _attenuation_tag_)) {
             const auto icomputed =
-                computed.get_material<_medium_tag_, _property_tag_>(ispec)
+                computed
+                    .get_material<_medium_tag_, _property_tag_,
+                                  _attenuation_tag_>(ispec)
                     .get_properties();
             const auto iexpected = std::any_cast<specfem::point::properties<
                 dimension, _medium_tag_, _property_tag_, false> >(

--- a/tests/unit-tests/mesh/dim3/materials.cpp
+++ b/tests/unit-tests/mesh/dim3/materials.cpp
@@ -80,7 +80,7 @@ struct ExpectedMaterials3D {
       }
 
       // Get the material type for the element and verify it matches expected
-      const auto [medium_tag, property_tag] =
+      const auto [medium_tag, property_tag, attenuation_tag] =
           materials.get_material_type(expected.element_id);
 
       if (medium_tag != expected.medium_tag ||

--- a/tests/unit-tests/mesh/dim3/tags.cpp
+++ b/tests/unit-tests/mesh/dim3/tags.cpp
@@ -46,6 +46,9 @@ struct ElementTags {
                                            ///< etc.)
   specfem::element::property_tag property_tag; ///< Property type (isotropic,
                                                ///< anisotropic)
+  specfem::element::attenuation_tag attenuation_tag; ///< Attenuation type
+                                                     ///< (none, constant
+                                                     ///< isotropic, etc.)
   specfem::element::boundary_tag boundary_tag; ///< Boundary condition (none,
                                                ///< stacey, etc.)
 
@@ -59,9 +62,11 @@ struct ElementTags {
    */
   ElementTags(int element_id, specfem::element::medium_tag medium_tag,
               specfem::element::property_tag property_tag,
+              specfem::element::attenuation_tag attenuation_tag,
               specfem::element::boundary_tag boundary_tag)
       : element_id(element_id), medium_tag(medium_tag),
-        property_tag(property_tag), boundary_tag(boundary_tag) {}
+        property_tag(property_tag), attenuation_tag(attenuation_tag),
+        boundary_tag(boundary_tag) {}
 };
 
 /**
@@ -117,20 +122,23 @@ struct ExpectedTags3D {
       }
 
       // Extract computed tags from mesh structure
-      const auto [medium_tag, property_tag, boundary_tag] =
+      const auto [medium_tag, property_tag, attenuation_tag, boundary_tag] =
           tags.tags_container(expected.element_id);
 
       // Compare all tag components with detailed error reporting
       if (medium_tag != expected.medium_tag ||
           property_tag != expected.property_tag ||
+          attenuation_tag != expected.attenuation_tag ||
           boundary_tag != expected.boundary_tag) {
         FAIL() << "Tag mismatch for element " << expected.element_id << ". "
                << "Expected: ("
                << specfem::element::to_string(expected.medium_tag) << ", "
                << specfem::element::to_string(expected.property_tag) << ", "
+               << specfem::element::to_string(expected.attenuation_tag) << ", "
                << specfem::element::to_string(expected.boundary_tag) << "), "
                << "Got: (" << specfem::element::to_string(medium_tag) << ", "
                << specfem::element::to_string(property_tag) << ", "
+               << specfem::element::to_string(attenuation_tag) << ", "
                << specfem::element::to_string(boundary_tag) << ")" << std::endl;
       }
     }
@@ -172,12 +180,15 @@ std::unordered_map<std::string, ExpectedTags3D> expected_tags_map = {
   { "EightNodeElastic",
     ExpectedTags3D(8, { ElementTags(0, specfem::element::medium_tag::elastic,
                                     specfem::element::property_tag::isotropic,
+                                    specfem::element::attenuation_tag::none,
                                     specfem::element::boundary_tag::none),
                         ElementTags(1, specfem::element::medium_tag::elastic,
                                     specfem::element::property_tag::isotropic,
+                                    specfem::element::attenuation_tag::none,
                                     specfem::element::boundary_tag::none),
                         ElementTags(5, specfem::element::medium_tag::elastic,
                                     specfem::element::property_tag::isotropic,
+                                    specfem::element::attenuation_tag::none,
                                     specfem::element::boundary_tag::none) }) }
   // Add more test cases as needed
 };


### PR DESCRIPTION
## Description

Please describe the changes/features in this pull request.

- [x] Updates material systems macros to include attenuation tag
- [x] Updates the macro calls throughout the code
- [x] Updates mesh materials so that attenuation can be stored and retrieved

The PR was reviewed but closed for some reason 

## Issue Number

If there is an issue created for these changes, link it here

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
