### PR TITLE
Precompiled header would result in 23% speed up in compilation

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -187,6 +187,25 @@
         "SPECFEM_BUILD_BENCHMARKS": "ON",
         "SPECFEM_BENCHMARKS_BUILD_DIR": "${sourceDir}/benchmarks/build/release-mpi"
       }
+    },
+    {
+      "name": "profile-release",
+      "displayName": "Default Release -- SIMD enabled for Profiling",
+      "binaryDir": "build/profile-release",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/bin/profile-release",
+        "CMAKE_CXX_FLAGS": "-ftime-trace",
+        "Kokkos_ARCH_NATIVE": "ON",
+        "Kokkos_ENABLE_AGGRESSIVE_VECTORIZATION": "ON",
+        "Kokkos_ENABLE_ATOMICS_BYPASS": "ON",
+        "SPECFEM_INSTALL": "ON",
+        "SPECFEM_BUILD_TESTS": "ON",
+        "SPECFEM_ENABLE_SIMD": "ON",
+        "SPECFEM_BUILD_BENCHMARKS": "ON",
+        "SPECFEM_BENCHMARKS_BUILD_DIR": "${sourceDir}/benchmarks/build/profile-release"
+      }
     }
   ],
   "buildPresets": [
@@ -256,6 +275,13 @@
     {
       "name": "release-mpi",
       "configurePreset": "release-mpi",
+      "targets": [
+        "all"
+      ]
+    },
+    {
+      "name": "profile-release",
+      "configurePreset": "profile-release",
       "targets": [
         "all"
       ]

--- a/core/specfem/CMakeLists.txt
+++ b/core/specfem/CMakeLists.txt
@@ -1,3 +1,16 @@
+# Precompiled header library (third-party & stdlib headers)
+add_library(specfem_pch STATIC pch_stub.cpp)
+add_library(specfem::pch ALIAS specfem_pch)
+target_precompile_headers(specfem_pch
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/pch.hpp
+)
+target_link_libraries(specfem_pch
+    PUBLIC
+        Kokkos::kokkos
+        ${BOOST_LIBS}
+)
+
 # Add existing subdirectories
 add_subdirectory(algorithms)
 add_subdirectory(assembly)

--- a/core/specfem/assembly/CMakeLists.txt
+++ b/core/specfem/assembly/CMakeLists.txt
@@ -3,6 +3,8 @@ file(GLOB_RECURSE COMPUTE_SOURCE_FILES "*.cpp")
 add_library(assembly ${COMPUTE_SOURCE_FILES})
 add_library(specfem::assembly ALIAS assembly)
 
+target_precompile_headers(assembly REUSE_FROM specfem_pch)
+
 target_link_libraries(
         assembly
         PUBLIC

--- a/core/specfem/pch.hpp
+++ b/core/specfem/pch.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+// Heavy third-party headers
+#include <Kokkos_Core.hpp>
+
+// Boost headers used widely
+#include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
+
+// Standard library headers used everywhere
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>

--- a/core/specfem/pch_stub.cpp
+++ b/core/specfem/pch_stub.cpp
@@ -1,0 +1,2 @@
+// Stub file for precompiled header library.
+// This file intentionally left empty.

--- a/core/specfem/solver/CMakeLists.txt
+++ b/core/specfem/solver/CMakeLists.txt
@@ -6,6 +6,8 @@ add_library(
 )
 add_library(specfem::solver ALIAS specfem_solver)
 
+target_precompile_headers(specfem_solver REUSE_FROM specfem_pch)
+
 target_link_libraries(
         specfem_solver
         Kokkos::kokkos

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -352,6 +352,7 @@ target_link_libraries(
   -lpthread -lm
   gtest_main
 )
+target_precompile_headers(nonconforming_tests REUSE_FROM specfem_pch)
 
 # add_executable(
 #   compute_jacobian_matrix_tests
@@ -454,6 +455,7 @@ target_link_libraries(
   -lpthread -lm
   gtest_main
 )
+target_precompile_headers(nonconforming_assembly_tests REUSE_FROM specfem_pch)
 
 
 add_executable(
@@ -489,6 +491,7 @@ add_executable(
 #Set unity build off
 target_compile_definitions(assembly_tests PRIVATE TEST_OUTPUT_DIR=${TEST_OUTPUT_DIR})
 set_target_properties(assembly_tests PROPERTIES UNITY_BUILD OFF)
+target_precompile_headers(assembly_tests REUSE_FROM specfem_pch)
 
 target_link_libraries(
   assembly_tests
@@ -533,6 +536,7 @@ target_link_libraries(
   gtest_main
   -lpthread -lm
 )
+target_precompile_headers(assembly_receivers_tests REUSE_FROM specfem_pch)
 
 add_executable(
   io_tests
@@ -625,6 +629,7 @@ target_link_libraries(
 
 # Turn unity build off for gradient_tests
 set_target_properties(gradient_tests PROPERTIES UNITY_BUILD OFF)
+target_precompile_headers(gradient_tests REUSE_FROM specfem_pch)
 
 add_executable(
   transfer_tests
@@ -673,6 +678,7 @@ target_link_libraries(
   ${BOOST_LIBS}
   -lpthread -lm
 )
+target_precompile_headers(chunked_edge_tests REUSE_FROM specfem_pch)
 
 add_executable(
   chunked_face_tests
@@ -839,6 +845,7 @@ target_link_libraries(
   ${BOOST_LIBS}
   -lpthread -lm
 )
+target_precompile_headers(displacement_newmark_2d_tests REUSE_FROM specfem_pch)
 
 
 add_executable(
@@ -863,6 +870,7 @@ target_link_libraries(
   ${BOOST_LIBS}
   -lpthread -lm
 )
+target_precompile_headers(displacement_newmark_3d_tests REUSE_FROM specfem_pch)
 
 # add_executable(
 #   seismogram_elastic_tests


### PR DESCRIPTION
## Description

Not sure I like this but 25% is not insignificant.

## Issue Number

#1651 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [x] I ran the code through pre-commit to check style
- [x] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [x] I have added labels to the PR (see right hand side of the PR page)
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
