### PR TITLE
1064 Tags Part II - Refactor compute_damping

### DIFF
--- a/core/specfem/assembly/assembly/impl/helper.hpp
+++ b/core/specfem/assembly/assembly/impl/helper.hpp
@@ -131,9 +131,8 @@ public:
         Kokkos::DefaultExecutionSpace::scratch_memory_space,
         Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
 
-    using PointPropertyType =
-        specfem::point::properties<dimension_tag, medium_tag, property_tag,
-                                   false>;
+    using PointPropertyType = specfem::point::properties<
+        specfem::tags::Tags<dimension_tag, medium_tag, property_tag, false> >;
 
     using PointFieldDerivativesType =
         specfem::point::field_derivatives<dimension_tag, medium_tag, false>;

--- a/core/specfem/assembly/info.tpp
+++ b/core/specfem/assembly/info.tpp
@@ -91,8 +91,7 @@ void process_medium_elements(
         const auto point_index = iterator_index.get_index();
 
         // Create point property object
-        specfem::point::properties<dimension_tag, medium_tag, property_tag,
-                                   false>
+        specfem::point::properties<specfem::tags::Tags<dimension_tag, medium_tag, property_tag, false>>
             point_property;
         specfem::assembly::load_on_device(point_index, properties,
                                           point_property);

--- a/core/specfem/assembly/properties/dim2/properties.hpp
+++ b/core/specfem/assembly/properties/dim2/properties.hpp
@@ -116,7 +116,9 @@ struct properties<specfem::element::dimension_tag::dim2>
  * @code
  * // Find maximum density across elements 0-99
  * Kokkos::View<int*> elements("elements", 100);
- * specfem::point::properties<dim2, elastic, isotropic> max_props;
+ * specfem::point::properties<specfem::tags::Tags<
+ *     dim2, elastic, isotropic, false>>
+ *     max_props;
  * max(elements, assembly_props, max_props);
  * @endcode
  */

--- a/core/specfem/assembly/properties/load_on_device.hpp
+++ b/core/specfem/assembly/properties/load_on_device.hpp
@@ -38,7 +38,7 @@ namespace specfem::assembly {
  * @code
  * // Load elastic isotropic properties at a quadrature point
  * specfem::point::index<...> coord(ispec, iz, ix);
- * specfem::point::properties<...> props;
+ * specfem::point::properties<specfem::tags::Tags<...>> props;
  *
  * load_on_device(coord, assembly.properties, props);
  * @endcode

--- a/core/specfem/assembly/properties/load_on_host.hpp
+++ b/core/specfem/assembly/properties/load_on_host.hpp
@@ -33,7 +33,7 @@ namespace specfem::assembly {
  * @code
  * // Load elastic isotropic properties at a quadrature point
  * specfem::point::index<...> coord(ispec, iz, ix);
- * specfem::point::properties<...> props;
+ * specfem::point::properties<specfem::tags::Tags<...>> props;
  *
  * load_on_host(coord, assembly.properties, props);
  * @endcode

--- a/core/specfem/assembly/properties/store_on_host.hpp
+++ b/core/specfem/assembly/properties/store_on_host.hpp
@@ -33,7 +33,7 @@ namespace specfem::assembly {
  * @code
  * // Store modified elastic properties back to host memory
  * specfem::point::index<...> coord(ispec, iz, ix);
- * specfem::point::properties<...> props;
+ * specfem::point::properties<specfem::tags::Tags<...>> props;
  *
  * // Modify properties (e.g., after inversion or processing)
  * props.rho = updated_density;

--- a/core/specfem/compute/impl/compute_mass_matrix.tpp
+++ b/core/specfem/compute/impl/compute_mass_matrix.tpp
@@ -66,8 +66,7 @@ void specfem::compute::impl::compute_mass_matrix(
       specfem::point::mass_inverse<PointTags>;
 
   using PointPropertyType =
-      specfem::point::properties<dimension_tag, medium_tag, property_tag,
-                                 using_simd>;
+      specfem::point::properties<specfem::tags::Tags<dimension_tag, medium_tag, property_tag, using_simd>>;
 
   using PointJacobianMatrixType =
       specfem::point::jacobian_matrix<dimension_tag, true, using_simd>;

--- a/core/specfem/compute/impl/compute_material_derivatives.tpp
+++ b/core/specfem/compute/impl/compute_material_derivatives.tpp
@@ -79,8 +79,7 @@ void specfem::compute::impl::compute_material_derivatives(
       specfem::point::field_derivatives<dimension_tag, medium_tag, using_simd>;
 
   using PointPropertiesType =
-      specfem::point::properties<dimension_tag, medium_tag, property_tag,
-                                 using_simd>;
+      specfem::point::properties<specfem::tags::Tags<dimension_tag, medium_tag, property_tag, using_simd>>;
 
   int scratch_size = 2 * ChunkElementFieldType::shmem_size() +
                      ElementQuadratureType::shmem_size();

--- a/core/specfem/compute/impl/compute_source_interaction.tpp
+++ b/core/specfem/compute/impl/compute_source_interaction.tpp
@@ -53,7 +53,7 @@ void specfem::compute::impl::compute_source_interaction(
   using PointSourceType =
       specfem::point::source<dimension_tag, medium_tag, wavefield>;
   using PointPropertiesType =
-      specfem::point::properties<dimension_tag, medium_tag, property_tag, false>;
+      specfem::point::properties<specfem::tags::Tags<dimension_tag, medium_tag, property_tag, false>>;
   using PointBoundaryType =
       specfem::point::boundary<boundary_tag, dimension_tag, false>;
   using PointIndexType = specfem::point::mapped_index<dimension_tag, false>;

--- a/core/specfem/compute/impl/compute_stiffness_interaction.tpp
+++ b/core/specfem/compute/impl/compute_stiffness_interaction.tpp
@@ -95,8 +95,7 @@ int specfem::compute::impl::compute_stiffness_interaction(
   using PointJacobianMatrixType =
       specfem::point::jacobian_matrix<Tags::dimension_tag, true, using_simd>;
   using PointPropertyType =
-      specfem::point::properties<Tags::dimension_tag, Tags::medium_tag, Tags::property_tag,
-                                 using_simd>;
+      specfem::point::properties<specfem::tags::Tags<Tags::dimension_tag, Tags::medium_tag, Tags::property_tag, using_simd>>;
   using PointFieldDerivativesType =
       specfem::point::field_derivatives<Tags::dimension_tag, Tags::medium_tag, using_simd>;
 

--- a/core/specfem/element_connections.hpp
+++ b/core/specfem/element_connections.hpp
@@ -7,18 +7,10 @@
 #pragma once
 
 #include "specfem/element.hpp"
+#include "specfem/element_connections/tags.hpp"
 #include <string>
 
 namespace specfem::element_connections {
-
-/**
- * @brief Connection conformity types between mesh elements.
- */
-enum class type : int {
-  strongly_conforming = 1, ///< Nodes match exactly
-  weakly_conforming = 2, ///< Nodes match, shape functions may be discontinuous
-  nonconforming = 3      ///< No matching nodes, geometrically adjacent
-};
 
 /**
  * @brief Convert connection type to string.

--- a/core/specfem/element_connections/tags.hpp
+++ b/core/specfem/element_connections/tags.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace specfem::element_connections {
+
+/**
+ * @brief Connection conformity types between mesh elements.
+ */
+enum class type : int {
+  strongly_conforming = 1, ///< Nodes match exactly
+  weakly_conforming = 2, ///< Nodes match, shape functions may be discontinuous
+  nonconforming = 3      ///< No matching nodes, geometrically adjacent
+};
+
+} // namespace specfem::element_connections

--- a/core/specfem/element_coupling.hpp
+++ b/core/specfem/element_coupling.hpp
@@ -1,45 +1,14 @@
 #pragma once
 
 #include "specfem/element.hpp"
-#include "specfem/element_connections.hpp"
+#include "specfem/element_connections/tags.hpp"
+#include "specfem/element_coupling/tags.hpp"
+#include "specfem/point/acceleration.hpp"
+#include "specfem/point/displacement.hpp"
 #include "specfem/setup.hpp"
-
-namespace specfem::tags {
-template <auto... TagMembers> struct Tags;
-}
-
-namespace specfem::point {
-
-template <typename Tags> struct acceleration;
-
-template <typename Tags> struct displacement;
-
-} // namespace specfem::point
+#include "specfem/tags.hpp"
 
 namespace specfem::element_coupling {
-
-/**
- * @brief Interface coupling direction types.
- *
- * Directional coupling: elastic_acoustic (elastic→acoustic),
- * acoustic_elastic (acoustic→elastic).
- */
-enum class interface_tag {
-  elastic_acoustic, ///< Elastic to acoustic interface - elastic field couples
-                    ///< to acoustic
-  acoustic_elastic  ///< Acoustic to elastic interface - acoustic field couples
-                    ///< to elastic
-};
-
-/**
- * @brief Flux scheme used for a coupling
- */
-enum class flux_scheme_tag {
-  natural, ///< Original SPECFEM acoustic-elastic interface (Komatitsch et al.
-           ///< 2000)
-  symmetric_interior_penalty ///< SIPG (Grote et al., Riviere et al., Antonietti
-                             ///< et al., etc.)
-};
 
 /**
  * @brief Compile-time interface field type determination.
@@ -111,7 +80,7 @@ template <>
 struct attributes<specfem::element::dimension_tag::dim2,
                   specfem::element_coupling::interface_tag::elastic_acoustic>::
     self_field<specfem::element_connections::type::weakly_conforming> {
-  using type = specfem::point::acceleration<
+  using type = specfem::point::impl::acceleration<
       specfem::tags::Tags<specfem::element::dimension_tag::dim2,
                           specfem::element::medium_tag::elastic_psv,
                           false> >; ///< vector acceleration
@@ -124,7 +93,7 @@ template <>
 struct attributes<specfem::element::dimension_tag::dim2,
                   specfem::element_coupling::interface_tag::elastic_acoustic>::
     coupled_field<specfem::element_connections::type::weakly_conforming> {
-  using type = specfem::point::acceleration<
+  using type = specfem::point::impl::acceleration<
       specfem::tags::Tags<specfem::element::dimension_tag::dim2,
                           specfem::element::medium_tag::acoustic,
                           false> >; ///< scalar acceleration

--- a/core/specfem/element_coupling/tags.hpp
+++ b/core/specfem/element_coupling/tags.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+namespace specfem::element_coupling {
+
+/**
+ * @brief Interface coupling direction types.
+ *
+ * Directional coupling: elastic_acoustic (elastic→acoustic),
+ * acoustic_elastic (acoustic→elastic).
+ */
+enum class interface_tag {
+  elastic_acoustic, ///< Elastic to acoustic interface - elastic field couples
+                    ///< to acoustic
+  acoustic_elastic  ///< Acoustic to elastic interface - acoustic field couples
+                    ///< to elastic
+};
+
+/**
+ * @brief Flux scheme used for a coupling
+ */
+enum class flux_scheme_tag {
+  natural, ///< Original SPECFEM acoustic-elastic interface (Komatitsch et al.
+           ///< 2000)
+  symmetric_interior_penalty ///< SIPG (Grote et al., Riviere et al., Antonietti
+                             ///< et al., etc.)
+};
+
+} // namespace specfem::element_coupling

--- a/core/specfem/medium/dim2/acoustic/isotropic/mass_matrix.hpp
+++ b/core/specfem/medium/dim2/acoustic/isotropic/mass_matrix.hpp
@@ -33,9 +33,9 @@ template <specfem::element::dimension_tag DimensionTag, bool UseSIMD>
 KOKKOS_FUNCTION specfem::point::mass_inverse<specfem::tags::Tags<
     DimensionTag, specfem::element::medium_tag::acoustic, UseSIMD> >
 impl_mass_matrix_component(
-    const specfem::point::properties<
+    const specfem::point::properties<specfem::tags::Tags<
         DimensionTag, specfem::element::medium_tag::acoustic,
-        specfem::element::property_tag::isotropic, UseSIMD> &properties);
+        specfem::element::property_tag::isotropic, UseSIMD> > &properties);
 
 } // namespace medium_physics
 } // namespace specfem

--- a/core/specfem/medium/dim2/acoustic/isotropic/mass_matrix.tpp
+++ b/core/specfem/medium/dim2/acoustic/isotropic/mass_matrix.tpp
@@ -6,9 +6,7 @@ template <specfem::element::dimension_tag DimensionTag, bool UseSIMD>
 KOKKOS_FUNCTION specfem::point::mass_inverse<
     specfem::tags::Tags<DimensionTag, specfem::element::medium_tag::acoustic, UseSIMD>>
 specfem::medium_physics::impl_mass_matrix_component(
-    const specfem::point::properties<
-        DimensionTag, specfem::element::medium_tag::acoustic,
-        specfem::element::property_tag::isotropic, UseSIMD> &properties) {
+    const specfem::point::properties<specfem::tags::Tags<DimensionTag, specfem::element::medium_tag::acoustic, specfem::element::property_tag::isotropic, UseSIMD>> &properties) {
 
   return { static_cast<type_real>(1.0) / properties.kappa() };
 }

--- a/core/specfem/medium/dim2/acoustic/isotropic/material.hpp
+++ b/core/specfem/medium/dim2/acoustic/isotropic/material.hpp
@@ -2,6 +2,7 @@
 
 #include "specfem/element.hpp"
 #include "specfem/setup.hpp"
+#include "specfem/tags.hpp"
 #include <exception>
 #include <iostream>
 #include <ostream>
@@ -148,8 +149,8 @@ public:
   template <specfem::element::attenuation_tag T = AttenuationTag,
             typename =
                 std::enable_if_t<T == specfem::element::attenuation_tag::none> >
-  inline specfem::point::properties<dimension_tag, medium_tag, property_tag,
-                                    false>
+  inline specfem::point::properties<
+      specfem::tags::Tags<dimension_tag, medium_tag, property_tag, false> >
   get_properties() const {
     return { static_cast<type_real>(1.0) / static_cast<type_real>(density),
              this->kappa };

--- a/core/specfem/medium/dim2/acoustic/isotropic/stress.hpp
+++ b/core/specfem/medium/dim2/acoustic/isotropic/stress.hpp
@@ -31,17 +31,18 @@ namespace medium_physics {
  * @return 1x2 stress tensor [\f$\sigma_{xx}\f$, \f$\sigma_{zz}\f$]
  */
 template <bool UseSIMD>
-KOKKOS_INLINE_FUNCTION specfem::point::stress<
-    specfem::element::dimension_tag::dim2,
-    specfem::element::medium_tag::acoustic, UseSIMD>
-impl_compute_stress(
-    const specfem::point::properties<specfem::element::dimension_tag::dim2,
-                                     specfem::element::medium_tag::acoustic,
-                                     specfem::element::property_tag::isotropic,
-                                     UseSIMD> &properties,
-    const specfem::point::field_derivatives<
-        specfem::element::dimension_tag::dim2,
-        specfem::element::medium_tag::acoustic, UseSIMD> &field_derivatives) {
+KOKKOS_INLINE_FUNCTION
+    specfem::point::stress<specfem::element::dimension_tag::dim2,
+                           specfem::element::medium_tag::acoustic, UseSIMD>
+    impl_compute_stress(
+        const specfem::point::properties<specfem::tags::Tags<
+            specfem::element::dimension_tag::dim2,
+            specfem::element::medium_tag::acoustic,
+            specfem::element::property_tag::isotropic, UseSIMD> > &properties,
+        const specfem::point::field_derivatives<
+            specfem::element::dimension_tag::dim2,
+            specfem::element::medium_tag::acoustic, UseSIMD>
+            &field_derivatives) {
 
   const auto &du = field_derivatives.du;
 

--- a/core/specfem/medium/dim2/acoustic/isotropic/stress.hpp
+++ b/core/specfem/medium/dim2/acoustic/isotropic/stress.hpp
@@ -31,18 +31,17 @@ namespace medium_physics {
  * @return 1x2 stress tensor [\f$\sigma_{xx}\f$, \f$\sigma_{zz}\f$]
  */
 template <bool UseSIMD>
-KOKKOS_INLINE_FUNCTION
-    specfem::point::stress<specfem::element::dimension_tag::dim2,
-                           specfem::element::medium_tag::acoustic, UseSIMD>
-    impl_compute_stress(
-        const specfem::point::properties<specfem::tags::Tags<
-            specfem::element::dimension_tag::dim2,
-            specfem::element::medium_tag::acoustic,
-            specfem::element::property_tag::isotropic, UseSIMD> > &properties,
-        const specfem::point::field_derivatives<
-            specfem::element::dimension_tag::dim2,
-            specfem::element::medium_tag::acoustic, UseSIMD>
-            &field_derivatives) {
+KOKKOS_INLINE_FUNCTION specfem::point::stress<
+    specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                        specfem::element::medium_tag::acoustic, UseSIMD> >
+impl_compute_stress(
+    const specfem::point::properties<specfem::tags::Tags<
+        specfem::element::dimension_tag::dim2,
+        specfem::element::medium_tag::acoustic,
+        specfem::element::property_tag::isotropic, UseSIMD> > &properties,
+    const specfem::point::field_derivatives<
+        specfem::element::dimension_tag::dim2,
+        specfem::element::medium_tag::acoustic, UseSIMD> &field_derivatives) {
 
   const auto &du = field_derivatives.du;
 

--- a/core/specfem/medium/dim2/acoustic/isotropic/wavefield.hpp
+++ b/core/specfem/medium/dim2/acoustic/isotropic/wavefield.hpp
@@ -36,11 +36,10 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
                                         specfem::element::medium_tag::acoustic,
                                         false>;
 
-  using PointPropertyType =
-      specfem::point::properties<specfem::element::dimension_tag::dim2,
-                                 specfem::element::medium_tag::acoustic,
-                                 specfem::element::property_tag::isotropic,
-                                 false>;
+  using PointPropertyType = specfem::point::properties<
+      specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                          specfem::element::medium_tag::acoustic,
+                          specfem::element::property_tag::isotropic, false> >;
 
   const auto &properties = assembly.properties;
 

--- a/core/specfem/medium/dim2/elastic/anisotropic/mass_matrix.hpp
+++ b/core/specfem/medium/dim2/elastic/anisotropic/mass_matrix.hpp
@@ -14,10 +14,10 @@ namespace medium_physics {
 //                                       specfem::element::medium_tag::elastic_psv,
 //                                       false, false, false, true, UseSIMD>
 // impl_mass_matrix_component(
-//     const specfem::point::properties<specfem::element::dimension_tag::dim2,
-//                                      specfem::element::medium_tag::elastic_psv,
-//                                      PropertyTag, UseSIMD> &properties,
-//     const specfem::point::jacobian_matrix<
+//     const
+//     specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+//     // specfem::element::medium_tag::elastic_psv, // PropertyTag, UseSIMD>>
+//     &properties, const specfem::point::jacobian_matrix<
 //         specfem::element::dimension_tag::dim2, true, UseSIMD>
 //         &jacobian_matrix);
 

--- a/core/specfem/medium/dim2/elastic/anisotropic/mass_matrix.tpp
+++ b/core/specfem/medium/dim2/elastic/anisotropic/mass_matrix.tpp
@@ -10,9 +10,7 @@
 //                                       specfem::element::medium_tag::elastic,
 //                                       false, false, false, true, UseSIMD>
 // specfem::medium_physics::impl_mass_matrix_component(
-//     const specfem::point::properties<
-//         specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic,
-//         PropertyTag, UseSIMD> &properties,
+//     const specfem::point::properties<specfem::tags::Tags<//         specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic, //         PropertyTag, UseSIMD>> &properties,
 //     const specfem::point::jacobian_matrix<
 //         specfem::element::dimension_tag::dim2, true, UseSIMD> &jacobian_matrix) {
 

--- a/core/specfem/medium/dim2/elastic/anisotropic/material.hpp
+++ b/core/specfem/medium/dim2/elastic/anisotropic/material.hpp
@@ -2,6 +2,7 @@
 
 #include "specfem/enums.hpp"
 #include "specfem/setup.hpp"
+#include "specfem/tags.hpp"
 #include <exception>
 #include <iostream>
 #include <ostream>
@@ -139,8 +140,8 @@ public:
    *
    * @return specfem::point::properties Material properties
    */
-  inline specfem::point::properties<dimension_tag, medium_tag, property_tag,
-                                    false>
+  inline specfem::point::properties<
+      specfem::tags::Tags<dimension_tag, medium_tag, property_tag, false> >
   get_properties() const {
     return { c11, c13, c15, c33, c35, c55, c12, c23, c25, density };
   }

--- a/core/specfem/medium/dim2/elastic/anisotropic/stress.hpp
+++ b/core/specfem/medium/dim2/elastic/anisotropic/stress.hpp
@@ -44,10 +44,10 @@ KOKKOS_INLINE_FUNCTION
     specfem::point::stress<specfem::element::dimension_tag::dim2,
                            specfem::element::medium_tag::elastic_psv, UseSIMD>
     impl_compute_stress(
-        const specfem::point::properties<
+        const specfem::point::properties<specfem::tags::Tags<
             specfem::element::dimension_tag::dim2,
             specfem::element::medium_tag::elastic_psv,
-            specfem::element::property_tag::anisotropic, UseSIMD> &properties,
+            specfem::element::property_tag::anisotropic, UseSIMD> > &properties,
         const specfem::point::field_derivatives<
             specfem::element::dimension_tag::dim2,
             specfem::element::medium_tag::elastic_psv, UseSIMD>
@@ -107,10 +107,10 @@ KOKKOS_INLINE_FUNCTION
     specfem::point::stress<specfem::element::dimension_tag::dim2,
                            specfem::element::medium_tag::elastic_sh, UseSIMD>
     impl_compute_stress(
-        const specfem::point::properties<
+        const specfem::point::properties<specfem::tags::Tags<
             specfem::element::dimension_tag::dim2,
             specfem::element::medium_tag::elastic_sh,
-            specfem::element::property_tag::anisotropic, UseSIMD> &properties,
+            specfem::element::property_tag::anisotropic, UseSIMD> > &properties,
         const specfem::point::field_derivatives<
             specfem::element::dimension_tag::dim2,
             specfem::element::medium_tag::elastic_sh, UseSIMD>

--- a/core/specfem/medium/dim2/elastic/anisotropic/stress.hpp
+++ b/core/specfem/medium/dim2/elastic/anisotropic/stress.hpp
@@ -40,18 +40,18 @@ namespace medium_physics {
  * \sigma_{xz}, \sigma_{zz}\f$]
  */
 template <bool UseSIMD>
-KOKKOS_INLINE_FUNCTION
-    specfem::point::stress<specfem::element::dimension_tag::dim2,
-                           specfem::element::medium_tag::elastic_psv, UseSIMD>
-    impl_compute_stress(
-        const specfem::point::properties<specfem::tags::Tags<
-            specfem::element::dimension_tag::dim2,
-            specfem::element::medium_tag::elastic_psv,
-            specfem::element::property_tag::anisotropic, UseSIMD> > &properties,
-        const specfem::point::field_derivatives<
-            specfem::element::dimension_tag::dim2,
-            specfem::element::medium_tag::elastic_psv, UseSIMD>
-            &field_derivatives) {
+KOKKOS_INLINE_FUNCTION specfem::point::stress<
+    specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                        specfem::element::medium_tag::elastic_psv, UseSIMD> >
+impl_compute_stress(
+    const specfem::point::properties<specfem::tags::Tags<
+        specfem::element::dimension_tag::dim2,
+        specfem::element::medium_tag::elastic_psv,
+        specfem::element::property_tag::anisotropic, UseSIMD> > &properties,
+    const specfem::point::field_derivatives<
+        specfem::element::dimension_tag::dim2,
+        specfem::element::medium_tag::elastic_psv, UseSIMD>
+        &field_derivatives) {
 
   using datatype =
       typename specfem::datatype::simd<type_real, UseSIMD>::datatype;
@@ -103,18 +103,17 @@ KOKKOS_INLINE_FUNCTION
  * @return 1x2 shear stress tensor [\f$\sigma_{xy}\f$, \f$\sigma_{zy}\f$]
  */
 template <bool UseSIMD>
-KOKKOS_INLINE_FUNCTION
-    specfem::point::stress<specfem::element::dimension_tag::dim2,
-                           specfem::element::medium_tag::elastic_sh, UseSIMD>
-    impl_compute_stress(
-        const specfem::point::properties<specfem::tags::Tags<
-            specfem::element::dimension_tag::dim2,
-            specfem::element::medium_tag::elastic_sh,
-            specfem::element::property_tag::anisotropic, UseSIMD> > &properties,
-        const specfem::point::field_derivatives<
-            specfem::element::dimension_tag::dim2,
-            specfem::element::medium_tag::elastic_sh, UseSIMD>
-            &field_derivatives) {
+KOKKOS_INLINE_FUNCTION specfem::point::stress<
+    specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                        specfem::element::medium_tag::elastic_sh, UseSIMD> >
+impl_compute_stress(
+    const specfem::point::properties<specfem::tags::Tags<
+        specfem::element::dimension_tag::dim2,
+        specfem::element::medium_tag::elastic_sh,
+        specfem::element::property_tag::anisotropic, UseSIMD> > &properties,
+    const specfem::point::field_derivatives<
+        specfem::element::dimension_tag::dim2,
+        specfem::element::medium_tag::elastic_sh, UseSIMD> &field_derivatives) {
 
   using datatype =
       typename specfem::datatype::simd<type_real, UseSIMD>::datatype;

--- a/core/specfem/medium/dim2/elastic/anisotropic/wavefield.hpp
+++ b/core/specfem/medium/dim2/elastic/anisotropic/wavefield.hpp
@@ -33,11 +33,10 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
       specfem::element::dimension_tag::dim2,
       specfem::element::medium_tag::elastic_psv, false>;
 
-  using PointPropertyType =
-      specfem::point::properties<specfem::element::dimension_tag::dim2,
-                                 specfem::element::medium_tag::elastic_psv,
-                                 specfem::element::property_tag::anisotropic,
-                                 false>;
+  using PointPropertyType = specfem::point::properties<
+      specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                          specfem::element::medium_tag::elastic_psv,
+                          specfem::element::property_tag::anisotropic, false> >;
 
   const auto &properties = assembly.properties;
 

--- a/core/specfem/medium/dim2/elastic/isotropic/mass_matrix.hpp
+++ b/core/specfem/medium/dim2/elastic/isotropic/mass_matrix.hpp
@@ -33,9 +33,10 @@ KOKKOS_FUNCTION specfem::point::mass_inverse<
     specfem::tags::Tags<specfem::element::dimension_tag::dim2,
                         specfem::element::medium_tag::elastic_psv, UseSIMD> >
 impl_mass_matrix_component(
-    const specfem::point::properties<specfem::element::dimension_tag::dim2,
-                                     specfem::element::medium_tag::elastic_psv,
-                                     PropertyTag, UseSIMD> &properties);
+    const specfem::point::properties<specfem::tags::Tags<
+        specfem::element::dimension_tag::dim2,
+        specfem::element::medium_tag::elastic_psv, PropertyTag, UseSIMD> >
+        &properties);
 
 /**
  * @ingroup specfem_medium_dim2_compute_mass_matrix_elastic
@@ -58,9 +59,10 @@ KOKKOS_FUNCTION specfem::point::mass_inverse<
     specfem::tags::Tags<specfem::element::dimension_tag::dim2,
                         specfem::element::medium_tag::elastic_sh, UseSIMD> >
 impl_mass_matrix_component(
-    const specfem::point::properties<specfem::element::dimension_tag::dim2,
-                                     specfem::element::medium_tag::elastic_sh,
-                                     PropertyTag, UseSIMD> &properties);
+    const specfem::point::properties<specfem::tags::Tags<
+        specfem::element::dimension_tag::dim2,
+        specfem::element::medium_tag::elastic_sh, PropertyTag, UseSIMD> >
+        &properties);
 
 } // namespace medium_physics
 } // namespace specfem

--- a/core/specfem/medium/dim2/elastic/isotropic/mass_matrix.tpp
+++ b/core/specfem/medium/dim2/elastic/isotropic/mass_matrix.tpp
@@ -7,9 +7,7 @@ KOKKOS_FUNCTION specfem::point::mass_inverse<
     specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic_psv,
     UseSIMD>>
 specfem::medium_physics::impl_mass_matrix_component(
-    const specfem::point::properties<specfem::element::dimension_tag::dim2,
-                                     specfem::element::medium_tag::elastic_psv,
-                                     PropertyTag, UseSIMD> &properties) {
+    const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic_psv, PropertyTag, UseSIMD>> &properties) {
 
   return { properties.rho(), properties.rho() };
 }
@@ -19,9 +17,7 @@ KOKKOS_FUNCTION specfem::point::mass_inverse<
     specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic_sh,
     UseSIMD>>
 specfem::medium_physics::impl_mass_matrix_component(
-    const specfem::point::properties<specfem::element::dimension_tag::dim2,
-                                     specfem::element::medium_tag::elastic_sh,
-                                     PropertyTag, UseSIMD> &properties) {
+    const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic_sh, PropertyTag, UseSIMD>> &properties) {
 
   return { properties.rho() }; ///< Mass matrix for SH waves is isotropic
 }

--- a/core/specfem/medium/dim2/elastic/isotropic/material.hpp
+++ b/core/specfem/medium/dim2/elastic/isotropic/material.hpp
@@ -2,6 +2,7 @@
 
 #include "specfem/element.hpp"
 #include "specfem/setup.hpp"
+#include "specfem/tags.hpp"
 #include <exception>
 #include <iostream>
 #include <ostream>
@@ -177,8 +178,8 @@ public:
    *
    * @return specfem::point::properties Material properties
    */
-  inline specfem::point::properties<dimension_tag, medium_tag, property_tag,
-                                    false>
+  inline specfem::point::properties<
+      specfem::tags::Tags<dimension_tag, medium_tag, property_tag, false> >
   get_properties() const {
     return { this->kappa, this->mu, this->density };
   }

--- a/core/specfem/medium/dim2/elastic/isotropic/stress.hpp
+++ b/core/specfem/medium/dim2/elastic/isotropic/stress.hpp
@@ -36,18 +36,18 @@ namespace medium_physics {
  * \f$\sigma_{xz}\f$, \f$\sigma_{zz}\f$]
  */
 template <bool UseSIMD>
-KOKKOS_INLINE_FUNCTION
-    specfem::point::stress<specfem::element::dimension_tag::dim2,
-                           specfem::element::medium_tag::elastic_psv, UseSIMD>
-    impl_compute_stress(
-        const specfem::point::properties<specfem::tags::Tags<
-            specfem::element::dimension_tag::dim2,
-            specfem::element::medium_tag::elastic_psv,
-            specfem::element::property_tag::isotropic, UseSIMD> > &properties,
-        const specfem::point::field_derivatives<
-            specfem::element::dimension_tag::dim2,
-            specfem::element::medium_tag::elastic_psv, UseSIMD>
-            &field_derivatives) {
+KOKKOS_INLINE_FUNCTION specfem::point::stress<
+    specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                        specfem::element::medium_tag::elastic_psv, UseSIMD> >
+impl_compute_stress(
+    const specfem::point::properties<specfem::tags::Tags<
+        specfem::element::dimension_tag::dim2,
+        specfem::element::medium_tag::elastic_psv,
+        specfem::element::property_tag::isotropic, UseSIMD> > &properties,
+    const specfem::point::field_derivatives<
+        specfem::element::dimension_tag::dim2,
+        specfem::element::medium_tag::elastic_psv, UseSIMD>
+        &field_derivatives) {
 
   using datatype =
       typename specfem::datatype::simd<type_real, UseSIMD>::datatype;
@@ -96,18 +96,17 @@ KOKKOS_INLINE_FUNCTION
  * @return 1x2 shear stress tensor [\f$\sigma_{xy}\f$, \f$\sigma_{zy}\f$]
  */
 template <bool UseSIMD>
-KOKKOS_INLINE_FUNCTION
-    specfem::point::stress<specfem::element::dimension_tag::dim2,
-                           specfem::element::medium_tag::elastic_sh, UseSIMD>
-    impl_compute_stress(
-        const specfem::point::properties<specfem::tags::Tags<
-            specfem::element::dimension_tag::dim2,
-            specfem::element::medium_tag::elastic_sh,
-            specfem::element::property_tag::isotropic, UseSIMD> > &properties,
-        const specfem::point::field_derivatives<
-            specfem::element::dimension_tag::dim2,
-            specfem::element::medium_tag::elastic_sh, UseSIMD>
-            &field_derivatives) {
+KOKKOS_INLINE_FUNCTION specfem::point::stress<
+    specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                        specfem::element::medium_tag::elastic_sh, UseSIMD> >
+impl_compute_stress(
+    const specfem::point::properties<specfem::tags::Tags<
+        specfem::element::dimension_tag::dim2,
+        specfem::element::medium_tag::elastic_sh,
+        specfem::element::property_tag::isotropic, UseSIMD> > &properties,
+    const specfem::point::field_derivatives<
+        specfem::element::dimension_tag::dim2,
+        specfem::element::medium_tag::elastic_sh, UseSIMD> &field_derivatives) {
 
   using datatype =
       typename specfem::datatype::simd<type_real, UseSIMD>::datatype;

--- a/core/specfem/medium/dim2/elastic/isotropic/stress.hpp
+++ b/core/specfem/medium/dim2/elastic/isotropic/stress.hpp
@@ -40,10 +40,10 @@ KOKKOS_INLINE_FUNCTION
     specfem::point::stress<specfem::element::dimension_tag::dim2,
                            specfem::element::medium_tag::elastic_psv, UseSIMD>
     impl_compute_stress(
-        const specfem::point::properties<
+        const specfem::point::properties<specfem::tags::Tags<
             specfem::element::dimension_tag::dim2,
             specfem::element::medium_tag::elastic_psv,
-            specfem::element::property_tag::isotropic, UseSIMD> &properties,
+            specfem::element::property_tag::isotropic, UseSIMD> > &properties,
         const specfem::point::field_derivatives<
             specfem::element::dimension_tag::dim2,
             specfem::element::medium_tag::elastic_psv, UseSIMD>
@@ -96,17 +96,18 @@ KOKKOS_INLINE_FUNCTION
  * @return 1x2 shear stress tensor [\f$\sigma_{xy}\f$, \f$\sigma_{zy}\f$]
  */
 template <bool UseSIMD>
-KOKKOS_INLINE_FUNCTION specfem::point::stress<
-    specfem::element::dimension_tag::dim2,
-    specfem::element::medium_tag::elastic_sh, UseSIMD>
-impl_compute_stress(
-    const specfem::point::properties<specfem::element::dimension_tag::dim2,
-                                     specfem::element::medium_tag::elastic_sh,
-                                     specfem::element::property_tag::isotropic,
-                                     UseSIMD> &properties,
-    const specfem::point::field_derivatives<
-        specfem::element::dimension_tag::dim2,
-        specfem::element::medium_tag::elastic_sh, UseSIMD> &field_derivatives) {
+KOKKOS_INLINE_FUNCTION
+    specfem::point::stress<specfem::element::dimension_tag::dim2,
+                           specfem::element::medium_tag::elastic_sh, UseSIMD>
+    impl_compute_stress(
+        const specfem::point::properties<specfem::tags::Tags<
+            specfem::element::dimension_tag::dim2,
+            specfem::element::medium_tag::elastic_sh,
+            specfem::element::property_tag::isotropic, UseSIMD> > &properties,
+        const specfem::point::field_derivatives<
+            specfem::element::dimension_tag::dim2,
+            specfem::element::medium_tag::elastic_sh, UseSIMD>
+            &field_derivatives) {
 
   using datatype =
       typename specfem::datatype::simd<type_real, UseSIMD>::datatype;

--- a/core/specfem/medium/dim2/elastic/isotropic/wavefield.hpp
+++ b/core/specfem/medium/dim2/elastic/isotropic/wavefield.hpp
@@ -34,11 +34,10 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
       specfem::element::dimension_tag::dim2,
       specfem::element::medium_tag::elastic_psv, false>;
 
-  using PointPropertyType =
-      specfem::point::properties<specfem::element::dimension_tag::dim2,
-                                 specfem::element::medium_tag::elastic_psv,
-                                 specfem::element::property_tag::isotropic,
-                                 false>;
+  using PointPropertyType = specfem::point::properties<
+      specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                          specfem::element::medium_tag::elastic_psv,
+                          specfem::element::property_tag::isotropic, false> >;
 
   const auto &properties = assembly.properties;
 

--- a/core/specfem/medium/dim2/elastic/isotropic_cosserat/mass_matrix.hpp
+++ b/core/specfem/medium/dim2/elastic/isotropic_cosserat/mass_matrix.hpp
@@ -40,11 +40,12 @@ template <bool UseSIMD>
 KOKKOS_FUNCTION specfem::point::mass_inverse<
     specfem::tags::Tags<specfem::element::dimension_tag::dim2,
                         specfem::element::medium_tag::elastic_psv_t, UseSIMD> >
-impl_mass_matrix_component(const specfem::point::properties<
-                           specfem::element::dimension_tag::dim2,
-                           specfem::element::medium_tag::elastic_psv_t,
-                           specfem::element::property_tag::isotropic_cosserat,
-                           UseSIMD> &properties);
+impl_mass_matrix_component(
+    const specfem::point::properties<specfem::tags::Tags<
+        specfem::element::dimension_tag::dim2,
+        specfem::element::medium_tag::elastic_psv_t,
+        specfem::element::property_tag::isotropic_cosserat, UseSIMD> >
+        &properties);
 
 } // namespace medium_physics
 } // namespace specfem

--- a/core/specfem/medium/dim2/elastic/isotropic_cosserat/mass_matrix.tpp
+++ b/core/specfem/medium/dim2/elastic/isotropic_cosserat/mass_matrix.tpp
@@ -8,10 +8,7 @@ KOKKOS_FUNCTION
                                  specfem::element::medium_tag::elastic_psv_t,
                                  UseSIMD>>
     specfem::medium_physics::impl_mass_matrix_component(
-        const specfem::point::properties<
-            specfem::element::dimension_tag::dim2,
-            specfem::element::medium_tag::elastic_psv_t,
-            specfem::element::property_tag::isotropic_cosserat, UseSIMD>
+        const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic_psv_t, specfem::element::property_tag::isotropic_cosserat, UseSIMD>>
             &properties) {
 
   return { properties.rho(), properties.rho(), properties.j() };

--- a/core/specfem/medium/dim2/elastic/isotropic_cosserat/material.hpp
+++ b/core/specfem/medium/dim2/elastic/isotropic_cosserat/material.hpp
@@ -3,6 +3,7 @@
 
 #include "specfem/element.hpp"
 #include "specfem/setup.hpp"
+#include "specfem/tags.hpp"
 #include <exception>
 #include <iostream>
 #include <ostream>
@@ -118,8 +119,8 @@ public:
    *
    * @return specfem::point::properties Material properties
    */
-  inline specfem::point::properties<dimension_tag, medium_tag, property_tag,
-                                    false>
+  inline specfem::point::properties<
+      specfem::tags::Tags<dimension_tag, medium_tag, property_tag, false> >
   get_properties() const {
     return { rho, kappa, mu, nu, j, lambda_c, mu_c, nu_c };
   }

--- a/core/specfem/medium/dim2/elastic/isotropic_cosserat/stress.hpp
+++ b/core/specfem/medium/dim2/elastic/isotropic_cosserat/stress.hpp
@@ -61,15 +61,16 @@ template <bool UseSIMD>
 KOKKOS_INLINE_FUNCTION
     specfem::point::stress<specfem::element::dimension_tag::dim2,
                            specfem::element::medium_tag::elastic_psv_t, UseSIMD>
-    impl_compute_stress(const specfem::point::properties<
-                            specfem::element::dimension_tag::dim2,
-                            specfem::element::medium_tag::elastic_psv_t,
-                            specfem::element::property_tag::isotropic_cosserat,
-                            UseSIMD> &properties,
-                        const specfem::point::field_derivatives<
-                            specfem::element::dimension_tag::dim2,
-                            specfem::element::medium_tag::elastic_psv_t,
-                            UseSIMD> &field_derivatives) {
+    impl_compute_stress(
+        const specfem::point::properties<specfem::tags::Tags<
+            specfem::element::dimension_tag::dim2,
+            specfem::element::medium_tag::elastic_psv_t,
+            specfem::element::property_tag::isotropic_cosserat, UseSIMD> >
+            &properties,
+        const specfem::point::field_derivatives<
+            specfem::element::dimension_tag::dim2,
+            specfem::element::medium_tag::elastic_psv_t, UseSIMD>
+            &field_derivatives) {
 
   using datatype =
       typename specfem::datatype::simd<type_real, UseSIMD>::datatype;

--- a/core/specfem/medium/dim2/elastic/isotropic_cosserat/stress.hpp
+++ b/core/specfem/medium/dim2/elastic/isotropic_cosserat/stress.hpp
@@ -58,19 +58,19 @@ namespace medium_physics {
  * @return 3x2 extended stress tensor (force + couple stresses)
  */
 template <bool UseSIMD>
-KOKKOS_INLINE_FUNCTION
-    specfem::point::stress<specfem::element::dimension_tag::dim2,
-                           specfem::element::medium_tag::elastic_psv_t, UseSIMD>
-    impl_compute_stress(
-        const specfem::point::properties<specfem::tags::Tags<
-            specfem::element::dimension_tag::dim2,
-            specfem::element::medium_tag::elastic_psv_t,
-            specfem::element::property_tag::isotropic_cosserat, UseSIMD> >
-            &properties,
-        const specfem::point::field_derivatives<
-            specfem::element::dimension_tag::dim2,
-            specfem::element::medium_tag::elastic_psv_t, UseSIMD>
-            &field_derivatives) {
+KOKKOS_INLINE_FUNCTION specfem::point::stress<
+    specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                        specfem::element::medium_tag::elastic_psv_t, UseSIMD> >
+impl_compute_stress(
+    const specfem::point::properties<specfem::tags::Tags<
+        specfem::element::dimension_tag::dim2,
+        specfem::element::medium_tag::elastic_psv_t,
+        specfem::element::property_tag::isotropic_cosserat, UseSIMD> >
+        &properties,
+    const specfem::point::field_derivatives<
+        specfem::element::dimension_tag::dim2,
+        specfem::element::medium_tag::elastic_psv_t, UseSIMD>
+        &field_derivatives) {
 
   using datatype =
       typename specfem::datatype::simd<type_real, UseSIMD>::datatype;

--- a/core/specfem/medium/dim2/elastic/isotropic_cosserat/wavefield.hpp
+++ b/core/specfem/medium/dim2/elastic/isotropic_cosserat/wavefield.hpp
@@ -35,10 +35,10 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
       specfem::element::dimension_tag::dim2,
       specfem::element::medium_tag::elastic_psv_t, false>;
 
-  using PointPropertyType = specfem::point::properties<
+  using PointPropertyType = specfem::point::properties<specfem::tags::Tags<
       specfem::element::dimension_tag::dim2,
       specfem::element::medium_tag::elastic_psv_t,
-      specfem::element::property_tag::isotropic_cosserat, false>;
+      specfem::element::property_tag::isotropic_cosserat, false> >;
 
   const auto &properties = assembly.properties;
 

--- a/core/specfem/medium/dim2/electromagnetic/isotropic/material.hpp
+++ b/core/specfem/medium/dim2/electromagnetic/isotropic/material.hpp
@@ -3,6 +3,7 @@
 
 #include "specfem/element.hpp"
 #include "specfem/setup.hpp"
+#include "specfem/tags.hpp"
 #include <exception>
 #include <iostream>
 #include <ostream>
@@ -119,8 +120,8 @@ public:
    *
    * @return specfem::point::properties Material properties
    */
-  inline specfem::point::properties<dimension_tag, medium_tag, property_tag,
-                                    false>
+  inline specfem::point::properties<
+      specfem::tags::Tags<dimension_tag, medium_tag, property_tag, false> >
   get_properties() const {
     return { static_cast<type_real>(1.0) / this->mu0, this->e0 * this->e11_e0,
              this->e0 * this->e33_e0, this->sig11, this->sig33 };

--- a/core/specfem/medium/dim2/poroelastic/isotropic/damping.hpp
+++ b/core/specfem/medium/dim2/poroelastic/isotropic/damping.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "specfem/element.hpp"
+#include "specfem/point.hpp"
 #include <Kokkos_Core.hpp>
 
 namespace specfem {
@@ -40,18 +41,17 @@ namespace medium_physics {
  * @param velocity Velocity field [u_x, u_z, w_x, w_z]
  * @param acceleration[in,out] Acceleration field (modified by damping)
  */
-template <typename T, typename PointPropertiesType, typename PointVelocityType,
-          typename PointAccelerationType>
-KOKKOS_FUNCTION void impl_compute_damping_force(
-    const std::true_type,
-    const std::integral_constant<specfem::element::dimension_tag,
-                                 specfem::element::dimension_tag::dim2>,
-    const std::integral_constant<specfem::element::medium_tag,
-                                 specfem::element::medium_tag::poroelastic>,
-    const std::integral_constant<specfem::element::property_tag,
-                                 specfem::element::property_tag::isotropic>,
-    const T factor, const PointPropertiesType &point_properties,
-    const PointVelocityType &velocity, PointAccelerationType &acceleration) {
+template <
+    typename T, typename Tags,
+    std::enable_if_t<
+        Tags::dimension_tag == specfem::element::dimension_tag::dim2 &&
+            Tags::medium_tag == specfem::element::medium_tag::poroelastic &&
+            Tags::property_tag == specfem::element::property_tag::isotropic,
+        int> = 0>
+KOKKOS_INLINE_FUNCTION void impl_compute_damping_force(
+    const T factor, const specfem::point::properties<Tags> &point_properties,
+    const specfem::point::velocity<Tags> &velocity,
+    specfem::point::acceleration<Tags> &acceleration) {
 
   // viscous damping
   const auto viscx =

--- a/core/specfem/medium/dim2/poroelastic/isotropic/mass_matrix.hpp
+++ b/core/specfem/medium/dim2/poroelastic/isotropic/mass_matrix.hpp
@@ -47,10 +47,10 @@ KOKKOS_FUNCTION specfem::point::mass_inverse<
     specfem::tags::Tags<specfem::element::dimension_tag::dim2,
                         specfem::element::medium_tag::poroelastic, UseSIMD> >
 impl_mass_matrix_component(
-    const specfem::point::properties<specfem::element::dimension_tag::dim2,
-                                     specfem::element::medium_tag::poroelastic,
-                                     specfem::element::property_tag::isotropic,
-                                     UseSIMD> &properties);
+    const specfem::point::properties<specfem::tags::Tags<
+        specfem::element::dimension_tag::dim2,
+        specfem::element::medium_tag::poroelastic,
+        specfem::element::property_tag::isotropic, UseSIMD> > &properties);
 
 } // namespace medium_physics
 } // namespace specfem

--- a/core/specfem/medium/dim2/poroelastic/isotropic/mass_matrix.tpp
+++ b/core/specfem/medium/dim2/poroelastic/isotropic/mass_matrix.tpp
@@ -6,10 +6,7 @@ template <bool UseSIMD>
 KOKKOS_FUNCTION specfem::point::mass_inverse<
     specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::poroelastic, UseSIMD>>
 specfem::medium_physics::impl_mass_matrix_component(
-    const specfem::point::properties<specfem::element::dimension_tag::dim2,
-                                     specfem::element::medium_tag::poroelastic,
-                                     specfem::element::property_tag::isotropic,
-                                     UseSIMD> &properties) {
+    const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::poroelastic, specfem::element::property_tag::isotropic, UseSIMD>> &properties) {
 
   const auto solid_component =
       (properties.rho_bar() -

--- a/core/specfem/medium/dim2/poroelastic/isotropic/material.hpp
+++ b/core/specfem/medium/dim2/poroelastic/isotropic/material.hpp
@@ -3,6 +3,7 @@
 
 #include "specfem/element.hpp"
 #include "specfem/setup.hpp"
+#include "specfem/tags.hpp"
 #include <exception>
 #include <iostream>
 #include <ostream>
@@ -144,8 +145,8 @@ public:
    *
    * @return specfem::point::properties Material properties
    */
-  inline specfem::point::properties<dimension_tag, medium_tag, property_tag,
-                                    false>
+  inline specfem::point::properties<
+      specfem::tags::Tags<dimension_tag, medium_tag, property_tag, false> >
   get_properties() const {
 
     const type_real phi = this->phi;

--- a/core/specfem/medium/dim2/poroelastic/isotropic/stress.hpp
+++ b/core/specfem/medium/dim2/poroelastic/isotropic/stress.hpp
@@ -59,10 +59,10 @@ KOKKOS_INLINE_FUNCTION
     specfem::point::stress<specfem::element::dimension_tag::dim2,
                            specfem::element::medium_tag::poroelastic, UseSIMD>
     impl_compute_stress(
-        const specfem::point::properties<
+        const specfem::point::properties<specfem::tags::Tags<
             specfem::element::dimension_tag::dim2,
             specfem::element::medium_tag::poroelastic,
-            specfem::element::property_tag::isotropic, UseSIMD> &properties,
+            specfem::element::property_tag::isotropic, UseSIMD> > &properties,
         const specfem::point::field_derivatives<
             specfem::element::dimension_tag::dim2,
             specfem::element::medium_tag::poroelastic, UseSIMD>

--- a/core/specfem/medium/dim2/poroelastic/isotropic/stress.hpp
+++ b/core/specfem/medium/dim2/poroelastic/isotropic/stress.hpp
@@ -55,18 +55,18 @@ namespace medium_physics {
  * @return 4x2 coupled stress tensor (solid + fluid)
  */
 template <bool UseSIMD>
-KOKKOS_INLINE_FUNCTION
-    specfem::point::stress<specfem::element::dimension_tag::dim2,
-                           specfem::element::medium_tag::poroelastic, UseSIMD>
-    impl_compute_stress(
-        const specfem::point::properties<specfem::tags::Tags<
-            specfem::element::dimension_tag::dim2,
-            specfem::element::medium_tag::poroelastic,
-            specfem::element::property_tag::isotropic, UseSIMD> > &properties,
-        const specfem::point::field_derivatives<
-            specfem::element::dimension_tag::dim2,
-            specfem::element::medium_tag::poroelastic, UseSIMD>
-            &field_derivatives) {
+KOKKOS_INLINE_FUNCTION specfem::point::stress<
+    specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                        specfem::element::medium_tag::poroelastic, UseSIMD> >
+impl_compute_stress(
+    const specfem::point::properties<specfem::tags::Tags<
+        specfem::element::dimension_tag::dim2,
+        specfem::element::medium_tag::poroelastic,
+        specfem::element::property_tag::isotropic, UseSIMD> > &properties,
+    const specfem::point::field_derivatives<
+        specfem::element::dimension_tag::dim2,
+        specfem::element::medium_tag::poroelastic, UseSIMD>
+        &field_derivatives) {
 
   using datatype =
       typename specfem::datatype::simd<type_real, UseSIMD>::datatype;

--- a/core/specfem/medium/dim2/poroelastic/isotropic/wavefield.hpp
+++ b/core/specfem/medium/dim2/poroelastic/isotropic/wavefield.hpp
@@ -34,11 +34,10 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
       specfem::element::dimension_tag::dim2,
       specfem::element::medium_tag::poroelastic, false>;
 
-  using PointPropertyType =
-      specfem::point::properties<specfem::element::dimension_tag::dim2,
-                                 specfem::element::medium_tag::poroelastic,
-                                 specfem::element::property_tag::isotropic,
-                                 false>;
+  using PointPropertyType = specfem::point::properties<
+      specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                          specfem::element::medium_tag::poroelastic,
+                          specfem::element::property_tag::isotropic, false> >;
 
   const auto &properties = assembly.properties;
 

--- a/core/specfem/medium/dim3/acoustic/isotropic/stress.hpp
+++ b/core/specfem/medium/dim3/acoustic/isotropic/stress.hpp
@@ -32,17 +32,18 @@ namespace specfem::medium_physics {
  * @return 1x3 stress tensor with diagonal components
  */
 template <bool UseSIMD>
-KOKKOS_INLINE_FUNCTION specfem::point::stress<
-    specfem::element::dimension_tag::dim3,
-    specfem::element::medium_tag::acoustic, UseSIMD>
-impl_compute_stress(
-    const specfem::point::properties<specfem::element::dimension_tag::dim3,
-                                     specfem::element::medium_tag::acoustic,
-                                     specfem::element::property_tag::isotropic,
-                                     UseSIMD> &properties,
-    const specfem::point::field_derivatives<
-        specfem::element::dimension_tag::dim3,
-        specfem::element::medium_tag::acoustic, UseSIMD> &field_derivatives) {
+KOKKOS_INLINE_FUNCTION
+    specfem::point::stress<specfem::element::dimension_tag::dim3,
+                           specfem::element::medium_tag::acoustic, UseSIMD>
+    impl_compute_stress(
+        const specfem::point::properties<specfem::tags::Tags<
+            specfem::element::dimension_tag::dim3,
+            specfem::element::medium_tag::acoustic,
+            specfem::element::property_tag::isotropic, UseSIMD> > &properties,
+        const specfem::point::field_derivatives<
+            specfem::element::dimension_tag::dim3,
+            specfem::element::medium_tag::acoustic, UseSIMD>
+            &field_derivatives) {
 
   const auto &du = field_derivatives.du;
 

--- a/core/specfem/medium/dim3/acoustic/isotropic/stress.hpp
+++ b/core/specfem/medium/dim3/acoustic/isotropic/stress.hpp
@@ -32,18 +32,17 @@ namespace specfem::medium_physics {
  * @return 1x3 stress tensor with diagonal components
  */
 template <bool UseSIMD>
-KOKKOS_INLINE_FUNCTION
-    specfem::point::stress<specfem::element::dimension_tag::dim3,
-                           specfem::element::medium_tag::acoustic, UseSIMD>
-    impl_compute_stress(
-        const specfem::point::properties<specfem::tags::Tags<
-            specfem::element::dimension_tag::dim3,
-            specfem::element::medium_tag::acoustic,
-            specfem::element::property_tag::isotropic, UseSIMD> > &properties,
-        const specfem::point::field_derivatives<
-            specfem::element::dimension_tag::dim3,
-            specfem::element::medium_tag::acoustic, UseSIMD>
-            &field_derivatives) {
+KOKKOS_INLINE_FUNCTION specfem::point::stress<
+    specfem::tags::Tags<specfem::element::dimension_tag::dim3,
+                        specfem::element::medium_tag::acoustic, UseSIMD> >
+impl_compute_stress(
+    const specfem::point::properties<specfem::tags::Tags<
+        specfem::element::dimension_tag::dim3,
+        specfem::element::medium_tag::acoustic,
+        specfem::element::property_tag::isotropic, UseSIMD> > &properties,
+    const specfem::point::field_derivatives<
+        specfem::element::dimension_tag::dim3,
+        specfem::element::medium_tag::acoustic, UseSIMD> &field_derivatives) {
 
   const auto &du = field_derivatives.du;
 

--- a/core/specfem/medium/dim3/acoustic/isotropic/wavefield.hpp
+++ b/core/specfem/medium/dim3/acoustic/isotropic/wavefield.hpp
@@ -37,11 +37,10 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
       specfem::point::field_derivatives<specfem::element::dimension_tag::dim3,
                                         specfem::element::medium_tag::acoustic,
                                         false>;
-  using PointPropertyType =
-      specfem::point::properties<specfem::element::dimension_tag::dim3,
-                                 specfem::element::medium_tag::acoustic,
-                                 specfem::element::property_tag::isotropic,
-                                 false>;
+  using PointPropertyType = specfem::point::properties<
+      specfem::tags::Tags<specfem::element::dimension_tag::dim3,
+                          specfem::element::medium_tag::acoustic,
+                          specfem::element::property_tag::isotropic, false> >;
 
   const auto &properties = assembly.properties;
   const auto &active_field = [&]() {

--- a/core/specfem/medium/dim3/elastic/isotropic/mass_matrix.hpp
+++ b/core/specfem/medium/dim3/elastic/isotropic/mass_matrix.hpp
@@ -32,8 +32,9 @@ KOKKOS_FUNCTION specfem::point::mass_inverse<
     specfem::tags::Tags<specfem::element::dimension_tag::dim3,
                         specfem::element::medium_tag::elastic, UseSIMD> >
 impl_mass_matrix_component(
-    const specfem::point::properties<specfem::element::dimension_tag::dim3,
-                                     specfem::element::medium_tag::elastic,
-                                     PropertyTag, UseSIMD> &properties);
+    const specfem::point::properties<specfem::tags::Tags<
+        specfem::element::dimension_tag::dim3,
+        specfem::element::medium_tag::elastic, PropertyTag, UseSIMD> >
+        &properties);
 } // namespace medium_physics
 } // namespace specfem

--- a/core/specfem/medium/dim3/elastic/isotropic/mass_matrix.tpp
+++ b/core/specfem/medium/dim3/elastic/isotropic/mass_matrix.tpp
@@ -6,8 +6,6 @@ template <specfem::element::property_tag PropertyTag, bool UseSIMD>
 KOKKOS_FUNCTION specfem::point::mass_inverse<
     specfem::tags::Tags<specfem::element::dimension_tag::dim3, specfem::element::medium_tag::elastic, UseSIMD>>
 specfem::medium_physics::impl_mass_matrix_component(
-    const specfem::point::properties<specfem::element::dimension_tag::dim3,
-                                     specfem::element::medium_tag::elastic,
-                                     PropertyTag, UseSIMD> &properties) {
+    const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim3, specfem::element::medium_tag::elastic, PropertyTag, UseSIMD>> &properties) {
   return { properties.rho(), properties.rho(), properties.rho() };
 }

--- a/core/specfem/medium/dim3/elastic/isotropic/stress.hpp
+++ b/core/specfem/medium/dim3/elastic/isotropic/stress.hpp
@@ -44,17 +44,18 @@ namespace medium_physics {
  * @return 3x3 symmetric stress tensor
  */
 template <bool UseSIMD>
-KOKKOS_INLINE_FUNCTION specfem::point::stress<
-    specfem::element::dimension_tag::dim3,
-    specfem::element::medium_tag::elastic, UseSIMD>
-impl_compute_stress(
-    const specfem::point::properties<specfem::element::dimension_tag::dim3,
-                                     specfem::element::medium_tag::elastic,
-                                     specfem::element::property_tag::isotropic,
-                                     UseSIMD> &properties,
-    const specfem::point::field_derivatives<
-        specfem::element::dimension_tag::dim3,
-        specfem::element::medium_tag::elastic, UseSIMD> &field_derivatives) {
+KOKKOS_INLINE_FUNCTION
+    specfem::point::stress<specfem::element::dimension_tag::dim3,
+                           specfem::element::medium_tag::elastic, UseSIMD>
+    impl_compute_stress(
+        const specfem::point::properties<specfem::tags::Tags<
+            specfem::element::dimension_tag::dim3,
+            specfem::element::medium_tag::elastic,
+            specfem::element::property_tag::isotropic, UseSIMD> > &properties,
+        const specfem::point::field_derivatives<
+            specfem::element::dimension_tag::dim3,
+            specfem::element::medium_tag::elastic, UseSIMD>
+            &field_derivatives) {
 
   using datatype =
       typename specfem::datatype::simd<type_real, UseSIMD>::datatype;

--- a/core/specfem/medium/dim3/elastic/isotropic/stress.hpp
+++ b/core/specfem/medium/dim3/elastic/isotropic/stress.hpp
@@ -44,18 +44,17 @@ namespace medium_physics {
  * @return 3x3 symmetric stress tensor
  */
 template <bool UseSIMD>
-KOKKOS_INLINE_FUNCTION
-    specfem::point::stress<specfem::element::dimension_tag::dim3,
-                           specfem::element::medium_tag::elastic, UseSIMD>
-    impl_compute_stress(
-        const specfem::point::properties<specfem::tags::Tags<
-            specfem::element::dimension_tag::dim3,
-            specfem::element::medium_tag::elastic,
-            specfem::element::property_tag::isotropic, UseSIMD> > &properties,
-        const specfem::point::field_derivatives<
-            specfem::element::dimension_tag::dim3,
-            specfem::element::medium_tag::elastic, UseSIMD>
-            &field_derivatives) {
+KOKKOS_INLINE_FUNCTION specfem::point::stress<
+    specfem::tags::Tags<specfem::element::dimension_tag::dim3,
+                        specfem::element::medium_tag::elastic, UseSIMD> >
+impl_compute_stress(
+    const specfem::point::properties<specfem::tags::Tags<
+        specfem::element::dimension_tag::dim3,
+        specfem::element::medium_tag::elastic,
+        specfem::element::property_tag::isotropic, UseSIMD> > &properties,
+    const specfem::point::field_derivatives<
+        specfem::element::dimension_tag::dim3,
+        specfem::element::medium_tag::elastic, UseSIMD> &field_derivatives) {
 
   using datatype =
       typename specfem::datatype::simd<type_real, UseSIMD>::datatype;

--- a/core/specfem/medium/dim3/elastic/isotropic/wavefield.hpp
+++ b/core/specfem/medium/dim3/elastic/isotropic/wavefield.hpp
@@ -35,11 +35,10 @@ KOKKOS_FUNCTION void impl_compute_wavefield(
                                         specfem::element::medium_tag::elastic,
                                         false>;
 
-  using PointPropertyType =
-      specfem::point::properties<specfem::element::dimension_tag::dim3,
-                                 specfem::element::medium_tag::elastic,
-                                 specfem::element::property_tag::isotropic,
-                                 false>;
+  using PointPropertyType = specfem::point::properties<
+      specfem::tags::Tags<specfem::element::dimension_tag::dim3,
+                          specfem::element::medium_tag::elastic,
+                          specfem::element::property_tag::isotropic, false> >;
 
   const auto &properties = assembly.properties;
 

--- a/core/specfem/medium_container/material.hpp
+++ b/core/specfem/medium_container/material.hpp
@@ -7,10 +7,7 @@
 #include <tuple>
 
 namespace specfem::point {
-template <specfem::element::dimension_tag Dimension,
-          specfem::element::medium_tag MediumTag,
-          specfem::element::property_tag PropertyTag, bool UseSIMD>
-struct properties;
+template <typename Tags> struct properties;
 } // namespace specfem::point
 
 namespace specfem::medium_container {

--- a/core/specfem/medium_physics/compute_damping_force.hpp
+++ b/core/specfem/medium_physics/compute_damping_force.hpp
@@ -3,113 +3,12 @@
 #include "specfem/data_access.hpp"
 #include "specfem/element.hpp"
 #include "specfem/medium/dim2/poroelastic/isotropic/damping.hpp"
+#include "specfem/point.hpp"
 #include "specfem/utilities.hpp"
 #include <Kokkos_Core.hpp>
 
-// Function that is called when the implementation is available
-template <typename T, typename PointPropertiesType, typename PointVelocityType,
-          typename PointAccelerationType>
-KOKKOS_INLINE_FUNCTION void assert_types(const std::true_type) {
-
-  constexpr auto DimensionTag = PointPropertiesType::dimension_tag;
-  constexpr auto MediumTag = PointPropertiesType::medium_tag;
-  constexpr auto PropertyTag = PointPropertiesType::property_tag;
-
-  static_assert(
-      specfem::data_access::is_point<PointPropertiesType>::value &&
-          specfem::data_access::is_properties<PointPropertiesType>::value,
-      "point_properties is not a point properties type");
-
-  // Check that the types are compatible
-  static_assert(std::is_same_v<T, typename PointPropertiesType::simd::datatype>,
-                "factor must have the same SIMD type as point_properties");
-
-  static_assert(specfem::data_access::is_point<PointVelocityType>::value &&
-                    specfem::data_access::is_field<PointVelocityType>::value,
-                "velocity is not a point field type");
-
-  static_assert(
-      specfem::data_access::is_point<PointAccelerationType>::value &&
-          specfem::data_access::is_field<PointAccelerationType>::value,
-      "acceleration is not a point field type");
-
-  static_assert(PointPropertiesType::dimension_tag ==
-                    PointVelocityType::dimension_tag,
-                "point_properties and velocity have different dimensions");
-
-  static_assert(PointPropertiesType::dimension_tag ==
-                    PointAccelerationType::dimension_tag,
-                "point_properties and acceleration have different dimensions");
-
-  static_assert(PointPropertiesType::medium_tag ==
-                    PointVelocityType::medium_tag,
-                "point_properties and velocity have different medium tags");
-
-  static_assert(PointPropertiesType::medium_tag ==
-                    PointAccelerationType::medium_tag,
-                "point_properties and acceleration have different medium tags");
-
-  static_assert(PointPropertiesType::simd::using_simd ==
-                    PointVelocityType::simd::using_simd,
-                "point_properties and velocity have different SIMD settings");
-
-  static_assert(
-      PointPropertiesType::simd::using_simd ==
-          PointAccelerationType::simd::using_simd,
-      "point_properties and acceleration have different SIMD settings");
-}
-
-// Function that is called when the implementation is not available
-template <typename T, typename PointPropertiesType, typename PointVelocityType,
-          typename PointAccelerationType>
-KOKKOS_INLINE_FUNCTION void assert_types(const std::false_type) {
-  // If the implementation is not available, we do nothing
-  return;
-}
-
 namespace specfem {
 namespace medium_physics {
-
-template <typename T, typename PointPropertiesType, typename PointVelocityType,
-          typename PointAccelerationType, typename DimensionTagType,
-          typename MediumTagType, typename PropertyTagType>
-KOKKOS_INLINE_FUNCTION void impl_compute_damping_force(
-    std::false_type, const DimensionTagType dimension_tag,
-    const MediumTagType medium_tag, const PropertyTagType property_tag,
-    const T factor, const PointPropertiesType &point_properties,
-    const PointVelocityType &velocity, PointAccelerationType &acceleration) {
-  // If the implementation is not available, we do nothing
-  return;
-}
-
-template <typename T, typename PointPropertiesType, typename PointVelocityType,
-          typename PointAccelerationType, typename DimensionTagType,
-          typename MediumTagType, typename PropertyTagType>
-KOKKOS_INLINE_FUNCTION void impl_compute_damping_force(
-    std::true_type, const DimensionTagType dimension_tag,
-    const MediumTagType medium_tag, const PropertyTagType property_tag,
-    const T factor, const PointPropertiesType &point_properties,
-    const PointVelocityType &velocity, PointAccelerationType &acceleration) {
-
-  // Extract actual tag types for the static_assert message
-  using ActualDimensionTag = typename DimensionTagType::type;
-  using ActualMediumTag = typename MediumTagType::type;
-  using ActualPropertyTag = typename PropertyTagType::type;
-
-  // The enumeration is set to true for damping force, but there is
-  // no implementation available for this dimension, medium and property
-  static_assert(specfem::utilities::always_false<ActualDimensionTag::value,
-                                                 ActualMediumTag::value,
-                                                 ActualPropertyTag::value>,
-                "\n\nDamping force is not implemented for this dimension, "
-                "medium, and property.\n"
-                "    --> Either deactivate damping force in "
-                " specfem/enums.hpp or \n"
-                "        implement the damping force in "
-                "medium/<dim>/<medium>/<property>/damping.hpp\n");
-  //  If the implementation is not available, we do nothing
-  return;
-}
 
 /**
  * @brief Compute damping force for wave attenuation.
@@ -131,40 +30,18 @@ KOKKOS_INLINE_FUNCTION void impl_compute_damping_force(
  * @param velocity Velocity field at point
  * @param acceleration[in,out] Acceleration field (modified by damping)
  */
-template <typename T, typename PointPropertiesType, typename PointVelocityType,
-          typename PointAccelerationType>
-KOKKOS_INLINE_FUNCTION void compute_damping_force(
-    const T factor, const PointPropertiesType &point_properties,
-    const PointVelocityType &velocity, PointAccelerationType &acceleration) {
+template <typename T, typename Tags>
+KOKKOS_INLINE_FUNCTION void
+compute_damping_force(const T factor,
+                      const specfem::point::properties<Tags> &point_properties,
+                      const specfem::point::velocity<Tags> &velocity,
+                      specfem::point::acceleration<Tags> &acceleration) {
 
-  constexpr auto DimensionTag = PointPropertiesType::dimension_tag;
-  constexpr auto MediumTag = PointPropertiesType::medium_tag;
-  constexpr auto PropertyTag = PointPropertiesType::property_tag;
-  constexpr bool has_damping_force =
-      specfem::element::attributes<DimensionTag, MediumTag>::has_damping_force;
-
-  using dimension_dispatch =
-      std::integral_constant<specfem::element::dimension_tag, DimensionTag>;
-
-  using medium_dispatch =
-      std::integral_constant<specfem::element::medium_tag, MediumTag>;
-
-  using property_dispatch =
-      std::integral_constant<specfem::element::property_tag, PropertyTag>;
-
-  using damping_force_dispatch =
-      std::integral_constant<bool, has_damping_force>;
-
-  // Check that the types are compatible
-  assert_types<T, PointPropertiesType, PointVelocityType,
-               PointAccelerationType>(damping_force_dispatch());
-
-  // If damping force is not available call empty function, else call the
-  // implementation
-  // Compute the damping force
-  specfem::medium_physics::impl_compute_damping_force(
-      damping_force_dispatch(), dimension_dispatch(), medium_dispatch(),
-      property_dispatch(), factor, point_properties, velocity, acceleration);
+  if constexpr (specfem::element::attributes<
+                    Tags::dimension_tag, Tags::medium_tag>::has_damping_force) {
+    impl_compute_damping_force<T>(factor, point_properties, velocity,
+                                  acceleration);
+  }
 }
 
 } // namespace medium_physics

--- a/core/specfem/medium_physics/compute_source_contribution.hpp
+++ b/core/specfem/medium_physics/compute_source_contribution.hpp
@@ -31,7 +31,7 @@ namespace medium_physics {
  * @code{.cpp}
  * // Example usage for 2D elastic isotropic medium
  * using Source     = specfem::point::source<dim2, elastic, false>;
- * using Properties = specfem::point::properties<dim2, elastic, isotropic, false>;
+ * using Properties = specfem::point::properties<specfem::tags::Tags<dim2, elastic, isotropic, false>>;
  *
  * Source     src   = ...;  // Initialize source parameters
  * Properties props = ...;  // Initialize material properties

--- a/core/specfem/medium_physics/compute_stress.hpp
+++ b/core/specfem/medium_physics/compute_stress.hpp
@@ -29,7 +29,7 @@ namespace medium_physics {
  *
  * @code{.cpp}
  * // Example usage for 2D elastic isotropic medium
- * using Properties = specfem::point::properties<dim2, elastic, isotropic, false>;
+ * using Properties = specfem::point::properties<specfem::tags::Tags<dim2, elastic, isotropic, false>>;
  * using FieldDerivatives = specfem::point::field_derivatives<dim2, elastic, false>;
  * Properties props = ...; // Initialize material properties
  * FieldDerivatives derivs = ...; // Initialize field derivatives

--- a/core/specfem/medium_physics/mass_matrix_component.hpp
+++ b/core/specfem/medium_physics/mass_matrix_component.hpp
@@ -30,7 +30,7 @@ namespace medium_physics {
  *
  * @code{.cpp}
  * // Example usage for 2D elastic isotropic medium
- * using Properties = specfem::point::properties<dim2, elastic, isotropic, false>;
+ * using Properties = specfem::point::properties<specfem::tags::Tags<dim2, elastic, isotropic, false>>;
  * Properties props = ...; // Initialize material properties
  * auto mass_inv = specfem::medium_physics::mass_matrix_component(props);
  * @endcode
@@ -42,8 +42,9 @@ template <specfem::element::dimension_tag DimensionTag,
 KOKKOS_INLINE_FUNCTION specfem::point::mass_inverse<
     specfem::tags::Tags<DimensionTag, MediumTag, UseSIMD> >
 mass_matrix_component(
-    const specfem::point::properties<DimensionTag, MediumTag, PropertyTag,
-                                     UseSIMD> &properties) {
+    const specfem::point::properties<
+        specfem::tags::Tags<DimensionTag, MediumTag, PropertyTag, UseSIMD> >
+        &properties) {
   return impl_mass_matrix_component(properties);
 }
 

--- a/core/specfem/mesh/dim3/materials/materials.hpp
+++ b/core/specfem/mesh/dim3/materials/materials.hpp
@@ -284,7 +284,8 @@ public:
   template <specfem::element::medium_tag MediumTag,
             specfem::element::property_tag PropertyTag,
             specfem::element::attenuation_tag AttenuationTag>
-  const specfem::point::properties<dimension_tag, MediumTag, PropertyTag, false>
+  const specfem::point::properties<
+      specfem::tags::Tags<dimension_tag, MediumTag, PropertyTag, false> >
   get_properties(const int index) const {
     const auto material =
         this->get_material<MediumTag, PropertyTag, AttenuationTag>(index);

--- a/core/specfem/mesh/dim3/tags/tags.cpp
+++ b/core/specfem/mesh/dim3/tags/tags.cpp
@@ -39,7 +39,8 @@ specfem::mesh::tags<specfem::element::dimension_tag::dim3>::tags(
         const auto boundary_tag = specfem::element::boundary_tag::none;
 
         this->tags_container(ispec) = { material_tag, property_tag,
-                                        attenuation_tag, boundary_tag };
+                                        attenuation_tag, boundary_tag,
+                                        mpi_tag };
       });
 
   return;

--- a/core/specfem/point/acceleration.hpp
+++ b/core/specfem/point/acceleration.hpp
@@ -5,6 +5,7 @@
 
 namespace specfem::point {
 
+namespace impl {
 /**
  * @brief Point acceleration field accessor for spectral element computations.
  *
@@ -94,5 +95,11 @@ public:
    */
   using base_type::base_type;
 };
+
+} // namespace impl
+
+template <typename Tags>
+using acceleration = impl::acceleration<specfem::tags::Tags<
+    Tags::dimension_tag, Tags::medium_tag, Tags::using_simd> >;
 
 } // namespace specfem::point

--- a/core/specfem/point/displacement.hpp
+++ b/core/specfem/point/displacement.hpp
@@ -62,6 +62,7 @@ namespace specfem::point {
  * @see specfem::point::acceleration for acceleration field accessor
  * @see specfem::point::mass_inverse for inverse mass matrix field accessor
  */
+namespace impl {
 template <typename Tags>
 class displacement
     : public impl::field<Tags,
@@ -89,5 +90,10 @@ public:
    */
   using base_type::base_type;
 };
+} // namespace impl
+
+template <typename Tags>
+using displacement = impl::displacement<specfem::tags::Tags<
+    Tags::dimension_tag, Tags::medium_tag, Tags::using_simd> >;
 
 } // namespace specfem::point

--- a/core/specfem/point/mass_inverse.hpp
+++ b/core/specfem/point/mass_inverse.hpp
@@ -69,6 +69,7 @@ namespace specfem::point {
  * @see specfem::point::velocity for velocity field accessor
  * @see specfem::point::acceleration for acceleration field accessor
  */
+namespace impl {
 template <typename Tags>
 class mass_inverse
     : public impl::field<Tags,
@@ -96,5 +97,10 @@ public:
    */
   using base_type::base_type;
 };
+} // namespace impl
+
+template <typename Tags>
+using mass_inverse = impl::mass_inverse<specfem::tags::Tags<
+    Tags::dimension_tag, Tags::medium_tag, Tags::using_simd> >;
 
 } // namespace specfem::point

--- a/core/specfem/point/properties.hpp
+++ b/core/specfem/point/properties.hpp
@@ -3,6 +3,7 @@
 #include "specfem/enums.hpp"
 #include "specfem/medium_container.hpp"
 #include "specfem/setup.hpp"
+#include "specfem/tags.hpp"
 
 namespace specfem {
 namespace point {
@@ -43,8 +44,9 @@ namespace point {
  * double mu = 10.0;
  * double rho = 2500.0;
  *
- * specfem::point::properties<dim, medium_tag::elastic, property_tag::isotropic,
- * use_simd> props(kappa, mu, rho);
+ * specfem::point::properties<specfem::tags::Tags<
+ *     dim, medium_tag::elastic, property_tag::isotropic, use_simd>>
+ *     props(kappa, mu, rho);
  *
  * // Access properties
  * double k = props.kappa();
@@ -59,14 +61,14 @@ namespace point {
  * - specfem::medium_container::properties::point_container
  * - specfem::compute::mass_matrix
  */
-template <specfem::element::dimension_tag Dimension,
-          specfem::element::medium_tag MediumTag,
-          specfem::element::property_tag PropertyTag, bool UseSIMD>
+template <typename Tags>
 struct properties : specfem::medium_container::properties::point_container<
-                        Dimension, MediumTag, PropertyTag, UseSIMD> {
+                        Tags::dimension_tag, Tags::medium_tag,
+                        Tags::property_tag, Tags::using_simd> {
 
   using base_type = specfem::medium_container::properties::point_container<
-      Dimension, MediumTag, PropertyTag, UseSIMD>;
+      Tags::dimension_tag, Tags::medium_tag, Tags::property_tag,
+      Tags::using_simd>;
 
   using value_type = typename base_type::value_type;
   using simd = typename base_type::simd;

--- a/core/specfem/point/stress.hpp
+++ b/core/specfem/point/stress.hpp
@@ -4,6 +4,7 @@
 #include "specfem/data_access.hpp"
 #include "specfem/datatype.hpp"
 #include "specfem/enums.hpp"
+#include "specfem/tags.hpp"
 #include <Kokkos_Core.hpp>
 
 namespace specfem {
@@ -25,17 +26,16 @@ namespace point {
  * vectorization support and efficient memory access patterns for
  * high-performance computing.
  *
- * @tparam DimensionTag Spatial dimension (dim2 or dim3)
- * @tparam MediumTag Physical medium type (acoustic, elastic_psv, elastic,
- * poroelastic)
- * @tparam UseSIMD Enable SIMD vectorization for performance optimization
+ * @tparam Tags A specfem::tags::Tags type containing dimension_tag (dim2 or
+ * dim3), medium_tag (acoustic, elastic_psv, elastic, poroelastic), and
+ * using_simd (enable SIMD vectorization)
  *
  * @code
  * // Example: Create stress tensor for 2D elastic medium
  * using stress_type =
- * specfem::point::stress<specfem::element::dimension_tag::dim2,
- *                                           specfem::element::medium_tag::elastic_psv,
- *                                           false>;
+ * specfem::point::stress<specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+ *                                            specfem::element::medium_tag::elastic_psv,
+ *                                            false>>;
  *
  * // Initialize stress components (2x2 tensor for 2D elastic)
  * typename stress_type::value_type T(1.1, 2.1,  // first column  (component 0,
@@ -49,17 +49,17 @@ namespace point {
  * @see specfem::point::jacobian_matrix
  * @see specfem::data_access::Accessor
  */
-template <specfem::element::dimension_tag DimensionTag,
-          specfem::element::medium_tag MediumTag, bool UseSIMD>
-struct stress
-    : public specfem::data_access::Accessor<
-          specfem::datatype::AccessorType::point,
-          specfem::data_access::DataClassType::stress, DimensionTag, UseSIMD> {
+template <typename Tags>
+struct stress : public specfem::data_access::Accessor<
+                    specfem::datatype::AccessorType::point,
+                    specfem::data_access::DataClassType::stress,
+                    Tags::dimension_tag, Tags::using_simd> {
 private:
   /** @brief Base accessor type for data access framework integration */
   using base_type = specfem::data_access::Accessor<
       specfem::datatype::AccessorType::point,
-      specfem::data_access::DataClassType::stress, DimensionTag, UseSIMD>;
+      specfem::data_access::DataClassType::stress, Tags::dimension_tag,
+      Tags::using_simd>;
 
 public:
   /**
@@ -69,20 +69,23 @@ public:
   ///@{
   /** @brief Spatial dimension (2 or 3) */
   constexpr static int dimension =
-      specfem::element::attributes<DimensionTag, MediumTag>::dimension;
+      specfem::element::attributes<Tags::dimension_tag,
+                                   Tags::medium_tag>::dimension;
 
   /** @brief Number of stress components based on medium type */
   constexpr static int components =
-      specfem::element::attributes<DimensionTag, MediumTag>::components;
+      specfem::element::attributes<Tags::dimension_tag,
+                                   Tags::medium_tag>::components;
 
   /** @brief Template parameter for spatial dimension */
-  constexpr static specfem::element::dimension_tag dimension_tag = DimensionTag;
+  constexpr static specfem::element::dimension_tag dimension_tag =
+      Tags::dimension_tag;
 
   /** @brief Template parameter for medium type */
-  constexpr static specfem::element::medium_tag medium_tag = MediumTag;
+  constexpr static specfem::element::medium_tag medium_tag = Tags::medium_tag;
 
   /** @brief Template parameter for SIMD usage */
-  constexpr static bool using_simd = UseSIMD;
+  constexpr static bool using_simd = Tags::using_simd;
   ///@}
 
   /**
@@ -166,8 +169,8 @@ public:
    */
   KOKKOS_INLINE_FUNCTION
   value_type operator*(const specfem::point::jacobian_matrix<
-                       specfem::element::dimension_tag::dim2, true, UseSIMD>
-                           &jacobian_matrix) const {
+                       specfem::element::dimension_tag::dim2, true,
+                       Tags::using_simd> &jacobian_matrix) const {
     value_type F;
 
     for (int icomponent = 0; icomponent < components; ++icomponent) {
@@ -216,8 +219,8 @@ public:
    */
   KOKKOS_INLINE_FUNCTION
   value_type operator*(const specfem::point::jacobian_matrix<
-                       specfem::element::dimension_tag::dim3, true, UseSIMD>
-                           &jacobian_matrix) const {
+                       specfem::element::dimension_tag::dim3, true,
+                       Tags::using_simd> &jacobian_matrix) const {
     value_type F;
 
     for (int icomponent = 0; icomponent < components; ++icomponent) {

--- a/core/specfem/point/velocity.hpp
+++ b/core/specfem/point/velocity.hpp
@@ -66,6 +66,7 @@ namespace specfem::point {
  * @see specfem::point::acceleration for acceleration field accessor
  * @see specfem::point::mass_inverse for inverse mass matrix field accessor
  */
+namespace impl {
 template <typename Tags>
 class velocity
     : public impl::field<Tags, specfem::data_access::DataClassType::velocity> {
@@ -92,5 +93,11 @@ public:
    */
   using base_type::base_type;
 };
+} // namespace impl
+
+template <typename Tags>
+using velocity =
+    impl::velocity<specfem::tags::Tags<Tags::dimension_tag, Tags::medium_tag,
+                                       Tags::using_simd> >;
 
 } // namespace specfem::point

--- a/core/specfem/tags.hpp
+++ b/core/specfem/tags.hpp
@@ -1,9 +1,8 @@
 #pragma once
 
-#include "specfem/datatype.hpp"
-#include "specfem/element.hpp"
-#include "specfem/element_connections.hpp"
-#include "specfem/element_coupling.hpp"
+#include "specfem/element/tags.hpp"
+#include "specfem/element_connections/tags.hpp"
+#include "specfem/element_coupling/tags.hpp"
 #include "specfem/simulation.hpp"
 
 namespace specfem::tags {
@@ -118,24 +117,5 @@ template <bool UseSIMD> struct TagMember<bool, UseSIMD> {
  */
 template <auto... TagMembers>
 struct Tags : TagMember<decltype(TagMembers), TagMembers>... {};
-
-// template <typename ParentTags>
-// using MediumTags = Tags<ParentTags::dimension_tag, ParentTags::medium_tag>;
-
-// template <typename ParentTags>
-// using PointMediumTags = Tags<ParentTags::dimension_tag,
-// ParentTags::medium_tag, ParentTags::using_simd>;
-
-// template <typename ParentTags>
-// using PropertyTags = Tags<ParentTags::dimension_tag, ParentTags::medium_tag,
-// ParentTags::property_tag>;
-
-// template <typename ParentTags>
-// using PointPropertyTags = Tags<ParentTags::dimension_tag,
-// ParentTags::medium_tag, ParentTags::property_tag, ParentTags::using_simd>;
-
-// template <typename ParentTags>
-// using BoundaryTags = Tags<ParentTags::dimension_tag, ParentTags::medium_tag,
-// ParentTags::boundary_tag>;
 
 } // namespace specfem::tags

--- a/properties_usages.txt
+++ b/properties_usages.txt
@@ -1,0 +1,134 @@
+core/specfem/mesh/dim3/materials/materials.hpp:  const specfem::point::properties<specfem::tags::Tags<dimension_tag, MediumTag, PropertyTag, false>>
+core/specfem/assembly/info.tpp:        specfem::point::properties<specfem::tags::Tags<dimension_tag, medium_tag, property_tag, false>>
+core/specfem/assembly/assembly/impl/helper.hpp:        specfem::point::properties<specfem::tags::Tags<dimension_tag, medium_tag, property_tag, false>>;
+core/specfem/assembly/properties/dim2/properties.hpp: * specfem::point::properties<dim2, elastic, isotropic> max_props;
+core/specfem/assembly/properties/load_on_host.hpp: * specfem::point::properties<...> props;
+core/specfem/assembly/properties/load_on_device.hpp: * specfem::point::properties<...> props;
+core/specfem/assembly/properties/store_on_host.hpp: * specfem::point::properties<...> props;
+core/specfem/point/properties.hpp: * specfem::point::properties<specfem::tags::Tags<
+core/specfem/medium/dim3/acoustic/isotropic/wavefield.hpp:      specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim3, specfem::element::medium_tag::acoustic, specfem::element::property_tag::isotropic, false>>;
+core/specfem/medium/dim3/acoustic/isotropic/stress.hpp:    const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim3, specfem::element::medium_tag::acoustic, specfem::element::property_tag::isotropic, UseSIMD>> &properties,
+core/specfem/medium/dim3/elastic/isotropic/mass_matrix.hpp:    const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim3, specfem::element::medium_tag::elastic, PropertyTag, UseSIMD>> &properties);
+core/specfem/medium/dim3/elastic/isotropic/wavefield.hpp:      specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim3, specfem::element::medium_tag::elastic, specfem::element::property_tag::isotropic, false>>;
+core/specfem/medium/dim3/elastic/isotropic/mass_matrix.tpp:    const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim3, specfem::element::medium_tag::elastic, PropertyTag, UseSIMD>> &properties) {
+core/specfem/medium/dim3/elastic/isotropic/stress.hpp:    const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim3, specfem::element::medium_tag::elastic, specfem::element::property_tag::isotropic, UseSIMD>> &properties,
+core/specfem/medium/dim2/acoustic/isotropic/material.hpp:  inline specfem::point::properties<specfem::tags::Tags<dimension_tag, medium_tag, property_tag, false>>
+core/specfem/medium/dim2/acoustic/isotropic/mass_matrix.hpp:    const specfem::point::properties<specfem::tags::Tags<DimensionTag, specfem::element::medium_tag::acoustic, specfem::element::property_tag::isotropic, UseSIMD>> &properties);
+core/specfem/medium/dim2/acoustic/isotropic/wavefield.hpp:      specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::acoustic, specfem::element::property_tag::isotropic, false>>;
+core/specfem/medium/dim2/acoustic/isotropic/mass_matrix.tpp:    const specfem::point::properties<specfem::tags::Tags<DimensionTag, specfem::element::medium_tag::acoustic, specfem::element::property_tag::isotropic, UseSIMD>> &properties) {
+core/specfem/medium/dim2/acoustic/isotropic/stress.hpp:    const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::acoustic, specfem::element::property_tag::isotropic, UseSIMD>> &properties,
+core/specfem/medium/dim2/elastic/anisotropic/material.hpp:  inline specfem::point::properties<specfem::tags::Tags<dimension_tag, medium_tag, property_tag, false>>
+core/specfem/medium/dim2/elastic/anisotropic/mass_matrix.hpp://     const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, //                                      specfem::element::medium_tag::elastic_psv, //                                      PropertyTag, UseSIMD>> &properties,
+core/specfem/medium/dim2/elastic/anisotropic/wavefield.hpp:      specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic_psv, specfem::element::property_tag::anisotropic, false>>;
+core/specfem/medium/dim2/elastic/anisotropic/mass_matrix.tpp://     const specfem::point::properties<specfem::tags::Tags<//         specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic, //         PropertyTag, UseSIMD>> &properties,
+core/specfem/medium/dim2/elastic/anisotropic/stress.hpp:        const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic_psv, specfem::element::property_tag::anisotropic, UseSIMD>> &properties,
+core/specfem/medium/dim2/elastic/anisotropic/stress.hpp:        const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic_sh, specfem::element::property_tag::anisotropic, UseSIMD>> &properties,
+core/specfem/medium/dim2/elastic/isotropic/material.hpp:  inline specfem::point::properties<specfem::tags::Tags<dimension_tag, medium_tag, property_tag, false>>
+core/specfem/medium/dim2/elastic/isotropic/mass_matrix.hpp:    const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic_psv, PropertyTag, UseSIMD>> &properties);
+core/specfem/medium/dim2/elastic/isotropic/mass_matrix.hpp:    const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic_sh, PropertyTag, UseSIMD>> &properties);
+core/specfem/medium/dim2/elastic/isotropic/wavefield.hpp:      specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic_psv, specfem::element::property_tag::isotropic, false>>;
+core/specfem/medium/dim2/elastic/isotropic/mass_matrix.tpp:    const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic_psv, PropertyTag, UseSIMD>> &properties) {
+core/specfem/medium/dim2/elastic/isotropic/mass_matrix.tpp:    const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic_sh, PropertyTag, UseSIMD>> &properties) {
+core/specfem/medium/dim2/elastic/isotropic/stress.hpp:        const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic_psv, specfem::element::property_tag::isotropic, UseSIMD>> &properties,
+core/specfem/medium/dim2/elastic/isotropic/stress.hpp:    const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic_sh, specfem::element::property_tag::isotropic, UseSIMD>> &properties,
+core/specfem/medium/dim2/elastic/isotropic_cosserat/material.hpp:  inline specfem::point::properties<specfem::tags::Tags<dimension_tag, medium_tag, property_tag, false>>
+core/specfem/medium/dim2/elastic/isotropic_cosserat/mass_matrix.hpp:impl_mass_matrix_component(const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic_psv_t, specfem::element::property_tag::isotropic_cosserat, UseSIMD>> &properties);
+core/specfem/medium/dim2/elastic/isotropic_cosserat/wavefield.hpp:  using PointPropertyType = specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic_psv_t, specfem::element::property_tag::isotropic_cosserat, false>>;
+core/specfem/medium/dim2/elastic/isotropic_cosserat/mass_matrix.tpp:        const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic_psv_t, specfem::element::property_tag::isotropic_cosserat, UseSIMD>>
+core/specfem/medium/dim2/elastic/isotropic_cosserat/stress.hpp:    impl_compute_stress(const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic_psv_t, specfem::element::property_tag::isotropic_cosserat, UseSIMD>> &properties,
+core/specfem/medium/dim2/electromagnetic/isotropic/material.hpp:  inline specfem::point::properties<specfem::tags::Tags<dimension_tag, medium_tag, property_tag, false>>
+core/specfem/medium/dim2/poroelastic/isotropic/material.hpp:  inline specfem::point::properties<specfem::tags::Tags<dimension_tag, medium_tag, property_tag, false>>
+core/specfem/medium/dim2/poroelastic/isotropic/mass_matrix.hpp:    const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::poroelastic, specfem::element::property_tag::isotropic, UseSIMD>> &properties);
+core/specfem/medium/dim2/poroelastic/isotropic/wavefield.hpp:      specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::poroelastic, specfem::element::property_tag::isotropic, false>>;
+core/specfem/medium/dim2/poroelastic/isotropic/mass_matrix.tpp:    const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::poroelastic, specfem::element::property_tag::isotropic, UseSIMD>> &properties) {
+core/specfem/medium/dim2/poroelastic/isotropic/stress.hpp:        const specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::poroelastic, specfem::element::property_tag::isotropic, UseSIMD>> &properties,
+core/specfem/compute/impl/compute_source_interaction.tpp:      specfem::point::properties<specfem::tags::Tags<dimension_tag, medium_tag, property_tag, false>>;
+core/specfem/compute/impl/compute_stiffness_interaction.tpp:      specfem::point::properties<specfem::tags::Tags<Tags::dimension_tag, Tags::medium_tag, Tags::property_tag, using_simd>>;
+core/specfem/compute/impl/compute_mass_matrix.tpp:      specfem::point::properties<specfem::tags::Tags<dimension_tag, medium_tag, property_tag, using_simd>>;
+core/specfem/compute/impl/compute_material_derivatives.tpp:      specfem::point::properties<specfem::tags::Tags<dimension_tag, medium_tag, property_tag, using_simd>>;
+core/specfem/medium_physics/compute_source_contribution.hpp: * using Properties = specfem::point::properties<specfem::tags::Tags<dim2, elastic, isotropic, false>>;
+core/specfem/medium_physics/compute_stress.hpp: * using Properties = specfem::point::properties<specfem::tags::Tags<dim2, elastic, isotropic, false>>;
+core/specfem/medium_physics/mass_matrix_component.hpp: * using Properties = specfem::point::properties<specfem::tags::Tags<dim2, elastic, isotropic, false>>;
+core/specfem/medium_physics/mass_matrix_component.hpp:    const specfem::point::properties<specfem::tags::Tags<DimensionTag, MediumTag, PropertyTag, UseSIMD>> &properties) {
+tests/unit-tests/mesh/dim2/materials/properties.cpp:        MaterialVectorType({ specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic_psv, specfem::element::property_tag::isotropic, false>>(
+tests/unit-tests/mesh/dim2/materials/properties.cpp:        MaterialVectorType({ specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic_sh, specfem::element::property_tag::isotropic, false>>(
+tests/unit-tests/mesh/dim2/materials/properties.cpp:        MaterialVectorType({ specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic_psv, specfem::element::property_tag::isotropic, false>>(
+tests/unit-tests/mesh/dim2/materials/properties.cpp:            { specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic_psv, specfem::element::property_tag::isotropic, false>>(
+tests/unit-tests/mesh/dim2/materials/properties.cpp:              specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::acoustic, specfem::element::property_tag::isotropic, false>>(
+tests/unit-tests/mesh/dim2/materials/properties.cpp:            { specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic_psv, specfem::element::property_tag::isotropic, false>>(
+tests/unit-tests/mesh/dim2/materials/properties.cpp:              specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::acoustic, specfem::element::property_tag::isotropic, false>>(
+tests/unit-tests/mesh/dim2/materials/properties.cpp:            { specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::acoustic, specfem::element::property_tag::isotropic, false>>(
+tests/unit-tests/mesh/dim2/materials/properties.cpp:              specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::acoustic, specfem::element::property_tag::isotropic, false>>(
+tests/unit-tests/mesh/dim2/materials/properties.cpp:        MaterialVectorType({ specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic_psv, specfem::element::property_tag::anisotropic, false>>(
+tests/unit-tests/mesh/dim2/materials/properties.cpp:        MaterialVectorType({ specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic_sh, specfem::element::property_tag::anisotropic, false>>(
+tests/unit-tests/mesh/dim2/materials/properties.cpp:        MaterialVectorType({ specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::poroelastic, specfem::element::property_tag::isotropic, false>>(
+tests/unit-tests/mesh/dim2/materials/properties.cpp:            specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::electromagnetic_te, specfem::element::property_tag::isotropic, false>>(
+tests/unit-tests/mesh/dim2/materials/properties.cpp:            specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::electromagnetic_te, specfem::element::property_tag::isotropic, false>>(
+tests/unit-tests/mesh/dim2/materials/properties.cpp:            specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic_psv_t, specfem::element::property_tag::isotropic_cosserat, false>>(
+tests/unit-tests/mesh/dim2/materials/properties.cpp:            const auto iexpected = std::any_cast<specfem::point::properties<specfem::tags::Tags<dimension, _medium_tag_, _property_tag_, false>> >(
+tests/unit-tests/assembly/dim3/properties/properties.cpp:                specfem::point::properties<specfem::tags::Tags<_dimension_tag_, _medium_tag_, _property_tag_, false>>
+tests/unit-tests/assembly/dim3/properties/properties.cpp:                  std::any_cast<specfem::point::properties<specfem::tags::Tags<_dimension_tag_, _medium_tag_, _property_tag_, false>> >(
+tests/unit-tests/assembly/dim3/properties/properties.cpp:                    specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim3, specfem::element::medium_tag::elastic, specfem::element::property_tag::isotropic, false>>(
+tests/unit-tests/assembly/properties/properties.cpp:      specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, MediumTag, PropertyTag, using_simd>>;
+tests/unit-tests/assembly/properties/properties.cpp:      specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, MediumTag, PropertyTag, using_simd>>;
+tests/unit-tests/assembly/properties/properties.cpp:      specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, MediumTag, PropertyTag, using_simd>>;
+tests/unit-tests/assembly/properties/properties.cpp:      specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, MediumTag, PropertyTag, false>>;
+tests/unit-tests/assembly/compute_wavefield/test_helper.hpp:        specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic_psv, specfem::element::property_tag::isotropic, false>>;
+tests/unit-tests/assembly/compute_wavefield/test_helper.hpp:        specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::acoustic, specfem::element::property_tag::isotropic, false>>;
+tests/unit-tests/assembly/compute_wavefield/test_helper.hpp:        specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::acoustic, specfem::element::property_tag::isotropic, false>>;
+tests/unit-tests/point/properties/dim3/elastic_isotropic.cpp:      specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim3, specfem::element::medium_tag::elastic, specfem::element::property_tag::isotropic, using_simd>>;
+tests/unit-tests/point/properties/dim2/acoustic_isotropic.cpp:      specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::acoustic, specfem::element::property_tag::isotropic, using_simd>>;
+tests/unit-tests/point/properties/dim2/electromagnetic_isotropic.cpp:      specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::electromagnetic, specfem::element::property_tag::isotropic, using_simd>>;
+tests/unit-tests/point/properties/dim2/elastic_anisotropic.cpp:      specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic, specfem::element::property_tag::anisotropic, using_simd>>;
+tests/unit-tests/point/properties/dim2/poroelastic_isotropic.cpp:      specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::poroelastic, specfem::element::property_tag::isotropic, using_simd>>;
+tests/unit-tests/point/properties/dim2/elastic_isotropic.cpp:      specfem::point::properties<specfem::tags::Tags<specfem::element::dimension_tag::dim2, specfem::element::medium_tag::elastic, specfem::element::property_tag::isotropic, using_simd>>;
+tests/unit-tests/medium/source/dim3/acoustic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, medium_tag, property_tag, false>>;
+tests/unit-tests/medium/source/dim3/acoustic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, medium_tag, property_tag, false>>;
+tests/unit-tests/medium/source/dim3/elastic_isotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, medium_tag, property_tag, false>>;
+tests/unit-tests/medium/source/dim3/elastic_isotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, medium_tag, property_tag, false>>;
+tests/unit-tests/medium/source/dim2/acoustic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, medium_tag, property_tag, false>>;
+tests/unit-tests/medium/source/dim2/acoustic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, medium_tag, property_tag, false>>;
+tests/unit-tests/medium/source/dim2/poroelastic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, medium_tag, property_tag, false>>;
+tests/unit-tests/medium/source/dim2/poroelastic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, medium_tag, property_tag, false>>;
+tests/unit-tests/medium/source/dim2/elastic_isotropic_cosserat.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, medium_tag, property_tag, false>>;
+tests/unit-tests/medium/source/dim2/elastic_isotropic_cosserat.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, medium_tag, property_tag, false>>;
+tests/unit-tests/medium/source/dim2/elastic_anisotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, medium_tag, property_tag, false>>;
+tests/unit-tests/medium/source/dim2/elastic_anisotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, medium_tag, property_tag, false>>;
+tests/unit-tests/medium/source/dim2/elastic_isotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, medium_tag, property_tag, false>>;
+tests/unit-tests/medium/source/dim2/elastic_isotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, medium_tag, property_tag, false>>;
+tests/unit-tests/medium/source/dim2/elastic_isotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, medium_tag, property_tag, false>>;
+tests/unit-tests/medium/mass_matrix/dim3/acoustic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, medium_tag, property_tag, false>>;
+tests/unit-tests/medium/mass_matrix/dim3/elastic_isotropic.cpp:  using PointPropertiesType = specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic, property_tag, false>>;
+tests/unit-tests/medium/mass_matrix/dim3/elastic_isotropic.cpp:  using PointPropertiesType = specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic, property_tag, false>>;
+tests/unit-tests/medium/mass_matrix/dim2/acoustic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, medium_tag, property_tag, false>>;
+tests/unit-tests/medium/mass_matrix/dim2/poroelastic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, medium_tag, property_tag, false>>;
+tests/unit-tests/medium/mass_matrix/dim2/poroelastic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, medium_tag, property_tag, false>>;
+tests/unit-tests/medium/mass_matrix/dim2/elastic_anisotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic_psv, property_tag, false>>;
+tests/unit-tests/medium/mass_matrix/dim2/elastic_anisotropic.cpp:  using PointSHPropertiesType = specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic_sh, property_tag, false>>;
+tests/unit-tests/medium/mass_matrix/dim2/elastic_anisotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic_psv, property_tag, false>>;
+tests/unit-tests/medium/mass_matrix/dim2/elastic_anisotropic.cpp:  using PointSHPropertiesType = specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic_sh, property_tag, false>>;
+tests/unit-tests/medium/mass_matrix/dim2/elastic_isotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic_psv, property_tag, false>>;
+tests/unit-tests/medium/mass_matrix/dim2/elastic_isotropic.cpp:  using PointSHPropertiesType = specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic_sh, property_tag, false>>;
+tests/unit-tests/medium/mass_matrix/dim2/elastic_isotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic_psv, property_tag, false>>;
+tests/unit-tests/medium/mass_matrix/dim2/elastic_isotropic.cpp:  using PointSHPropertiesType = specfem::point::properties<specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic_sh, property_tag, false>>;
+tests/unit-tests/medium/stress/dim3/acoustic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, medium_tag, property_tag, false>>;
+tests/unit-tests/medium/stress/dim3/acoustic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, medium_tag, property_tag, false>>;
+tests/unit-tests/medium/stress/dim3/elastic_isotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, elasticTag, property_tag, false>>;
+tests/unit-tests/medium/stress/dim3/elastic_isotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, elasticTag, property_tag, false>>;
+tests/unit-tests/medium/stress/dim2/acoustic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, medium_tag, property_tag, false>>;
+tests/unit-tests/medium/stress/dim2/acoustic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, medium_tag, property_tag, false>>;
+tests/unit-tests/medium/stress/dim2/elastic_isotropic_cosserat.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, CosseratTag, property_tag, false>>;
+tests/unit-tests/medium/stress/dim2/elastic_isotropic_cosserat.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, CosseratTag, property_tag, false>>;
+tests/unit-tests/medium/stress/dim2/elastic_isotropic_cosserat.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, CosseratTag, property_tag, false>>;
+tests/unit-tests/medium/stress/dim2/elastic_anisotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, PSVTag, property_tag, false>>;
+tests/unit-tests/medium/stress/dim2/elastic_anisotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, PSVTag, property_tag, false>>;
+tests/unit-tests/medium/stress/dim2/elastic_anisotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, PSVTag, property_tag, false>>;
+tests/unit-tests/medium/stress/dim2/elastic_anisotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, SHTag, property_tag, false>>;
+tests/unit-tests/medium/stress/dim2/elastic_anisotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, SHTag, property_tag, false>>;
+tests/unit-tests/medium/stress/dim2/elastic_anisotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, SHTag, property_tag, false>>;
+tests/unit-tests/medium/stress/dim2/poroelastic_isotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, PoroTag, property_tag, false>>;
+tests/unit-tests/medium/stress/dim2/poroelastic_isotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, PoroTag, property_tag, false>>;
+tests/unit-tests/medium/stress/dim2/elastic_isotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, PSVTag, property_tag, false>>;
+tests/unit-tests/medium/stress/dim2/elastic_isotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, PSVTag, property_tag, false>>;
+tests/unit-tests/medium/stress/dim2/elastic_isotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, SHTag, property_tag, false>>;
+tests/unit-tests/medium/stress/dim2/elastic_isotropic.cpp:      specfem::point::properties<specfem::tags::Tags<dimension, SHTag, property_tag, false>>;

--- a/tests/unit-tests/assembly/compute_wavefield/test_helper.hpp
+++ b/tests/unit-tests/assembly/compute_wavefield/test_helper.hpp
@@ -89,11 +89,10 @@ public:
     const int ngllz = assembly.mesh.element_grid.ngllz;
     const int ngllx = assembly.mesh.element_grid.ngllx;
 
-    using PointProperties =
-        specfem::point::properties<specfem::element::dimension_tag::dim2,
-                                   specfem::element::medium_tag::elastic_psv,
-                                   specfem::element::property_tag::isotropic,
-                                   false>;
+    using PointProperties = specfem::point::properties<
+        specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                            specfem::element::medium_tag::elastic_psv,
+                            specfem::element::property_tag::isotropic, false> >;
 
     for (int iz = 0; iz < ngllz; iz++) {
       for (int ix = 0; ix < ngllx; ix++) {
@@ -157,11 +156,10 @@ public:
     const int ngllz = assembly.mesh.element_grid.ngllz;
     const int ngllx = assembly.mesh.element_grid.ngllx;
 
-    using PointProperties =
-        specfem::point::properties<specfem::element::dimension_tag::dim2,
-                                   specfem::element::medium_tag::acoustic,
-                                   specfem::element::property_tag::isotropic,
-                                   false>;
+    using PointProperties = specfem::point::properties<
+        specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                            specfem::element::medium_tag::acoustic,
+                            specfem::element::property_tag::isotropic, false> >;
 
     for (int iz = 0; iz < ngllz; iz++) {
       for (int ix = 0; ix < ngllx; ix++) {
@@ -224,11 +222,10 @@ public:
     const int ngllz = assembly.mesh.element_grid.ngllz;
     const int ngllx = assembly.mesh.element_grid.ngllx;
 
-    using PointProperties =
-        specfem::point::properties<specfem::element::dimension_tag::dim2,
-                                   specfem::element::medium_tag::acoustic,
-                                   specfem::element::property_tag::isotropic,
-                                   false>;
+    using PointProperties = specfem::point::properties<
+        specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                            specfem::element::medium_tag::acoustic,
+                            specfem::element::property_tag::isotropic, false> >;
 
     for (int iz = 0; iz < ngllz; iz++) {
       for (int ix = 0; ix < ngllx; ix++) {

--- a/tests/unit-tests/assembly/dim3/properties/properties.cpp
+++ b/tests/unit-tests/assembly/dim3/properties/properties.cpp
@@ -207,8 +207,8 @@ struct ExpectedProperties3D {
 
               // Load computed property from assembly structure
               const auto computed_property = [&]() {
-                specfem::point::properties<_dimension_tag_, _medium_tag_,
-                                           _property_tag_, false>
+                specfem::point::properties<specfem::tags::Tags<
+                    _dimension_tag_, _medium_tag_, _property_tag_, false> >
                     prop_accessor;
                 specfem::assembly::load_on_host(index, properties,
                                                 prop_accessor);
@@ -217,8 +217,8 @@ struct ExpectedProperties3D {
 
               // Extract expected property from type-erased storage
               const auto expected_property =
-                  std::any_cast<specfem::point::properties<
-                      _dimension_tag_, _medium_tag_, _property_tag_, false> >(
+                  std::any_cast<specfem::point::properties<specfem::tags::Tags<
+                      _dimension_tag_, _medium_tag_, _property_tag_, false> > >(
                       expected.property);
 
               // Compare properties with detailed error reporting
@@ -268,10 +268,10 @@ std::unordered_map<std::string, ExpectedProperties3D>
                 Properties3D(
                     0, 0, 0, 0, specfem::element::medium_tag::elastic,
                     specfem::element::property_tag::isotropic,
-                    specfem::point::properties<
+                    specfem::point::properties<specfem::tags::Tags<
                         specfem::element::dimension_tag::dim3,
                         specfem::element::medium_tag::elastic,
-                        specfem::element::property_tag::isotropic, false>(
+                        specfem::element::property_tag::isotropic, false> >(
                         11.132e9, 5.175e9, 2300)) // κ, μ, ρ
                                                   // Add more GLL points as
                                                   // needed

--- a/tests/unit-tests/assembly/properties/properties.cpp
+++ b/tests/unit-tests/assembly/properties/properties.cpp
@@ -28,9 +28,9 @@ set_property_value(
 
   const auto &properties = assembly.properties;
 
-  using PointPropertiesType =
-      specfem::point::properties<specfem::element::dimension_tag::dim2,
-                                 MediumTag, PropertyTag, using_simd>;
+  using PointPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<specfem::element::dimension_tag::dim2, MediumTag,
+                          PropertyTag, using_simd> >;
   using PointType = typename PointPropertiesType::value_type;
 
   specfem::execution::ChunkedDomainIterator policy(
@@ -62,9 +62,9 @@ check_property_value(
 
   constexpr auto dimension = specfem::element::dimension_tag::dim2;
   const auto &properties = assembly.properties;
-  using PointType =
-      specfem::point::properties<specfem::element::dimension_tag::dim2,
-                                 MediumTag, PropertyTag, using_simd>;
+  using PointType = specfem::point::properties<
+      specfem::tags::Tags<specfem::element::dimension_tag::dim2, MediumTag,
+                          PropertyTag, using_simd> >;
 
   specfem::execution::ChunkedDomainIterator policy(
       ParallelConfig<using_simd, Kokkos::DefaultHostExecutionSpace>(), elements,
@@ -129,9 +129,9 @@ check_property_value(
   const int ngll = assembly.mesh.element_grid.ngllx;
   const auto &properties = assembly.properties;
 
-  using PointType =
-      specfem::point::properties<specfem::element::dimension_tag::dim2,
-                                 MediumTag, PropertyTag, using_simd>;
+  using PointType = specfem::point::properties<
+      specfem::tags::Tags<specfem::element::dimension_tag::dim2, MediumTag,
+                          PropertyTag, using_simd> >;
 
   Kokkos::View<PointType ***, Kokkos::DefaultExecutionSpace> point_view(
       "point_view", nspec, ngll, ngll);
@@ -210,9 +210,8 @@ void check_compute_to_mesh(
   const auto elements = element_types.get_elements_on_host(
       MediumTag, PropertyTag, specfem::element::attenuation_tag::none);
 
-  using PointType =
-      specfem::point::properties<specfem::element::dimension_tag::dim2,
-                                 MediumTag, PropertyTag, false>;
+  using PointType = specfem::point::properties<specfem::tags::Tags<
+      specfem::element::dimension_tag::dim2, MediumTag, PropertyTag, false> >;
 
   specfem::execution::ChunkedDomainIterator policy(
       ParallelConfig<false, Kokkos::DefaultHostExecutionSpace>(), elements,

--- a/tests/unit-tests/medium/mass_matrix/dim2/acoustic.cpp
+++ b/tests/unit-tests/medium/mass_matrix/dim2/acoustic.cpp
@@ -11,8 +11,8 @@ TEST(MassMatrix, AcousticIsotropic2D) {
 
   using PointJacobianMatrixType =
       specfem::point::jacobian_matrix<dimension, true, false>;
-  using PointPropertiesType =
-      specfem::point::properties<dimension, medium_tag, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointMassMatrixType = specfem::point::mass_inverse<
       specfem::tags::Tags<dimension, medium_tag, false> >;
 

--- a/tests/unit-tests/medium/mass_matrix/dim2/elastic_anisotropic.cpp
+++ b/tests/unit-tests/medium/mass_matrix/dim2/elastic_anisotropic.cpp
@@ -8,10 +8,9 @@ TEST(MassMatrix, ElasticPSVAnIsotropicTrivialSolution2D) {
   static constexpr auto property_tag =
       specfem::element::property_tag::anisotropic;
 
-  using PointPSVPropertiesType =
-      specfem::point::properties<dimension,
-                                 specfem::element::medium_tag::elastic_psv,
-                                 property_tag, false>;
+  using PointPSVPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic_psv,
+                          property_tag, false> >;
   using PointPSVMassMatrixType =
       specfem::point::mass_inverse<specfem::tags::Tags<
           dimension, specfem::element::medium_tag::elastic_psv, false> >;
@@ -33,7 +32,8 @@ TEST(MassMatrix, ElasticSHAnIsotropicTrivialSolution2D) {
       specfem::element::property_tag::anisotropic;
 
   using PointSHPropertiesType = specfem::point::properties<
-      dimension, specfem::element::medium_tag::elastic_sh, property_tag, false>;
+      specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic_sh,
+                          property_tag, false> >;
   using PointSHMassMatrixType =
       specfem::point::mass_inverse<specfem::tags::Tags<
           dimension, specfem::element::medium_tag::elastic_sh, false> >;
@@ -54,10 +54,9 @@ TEST(MassMatrix, ElasticPSVAnIsotropic2D) {
   static constexpr auto property_tag =
       specfem::element::property_tag::anisotropic;
 
-  using PointPSVPropertiesType =
-      specfem::point::properties<dimension,
-                                 specfem::element::medium_tag::elastic_psv,
-                                 property_tag, false>;
+  using PointPSVPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic_psv,
+                          property_tag, false> >;
   using PointPSVMassMatrixType =
       specfem::point::mass_inverse<specfem::tags::Tags<
           dimension, specfem::element::medium_tag::elastic_psv, false> >;
@@ -81,7 +80,8 @@ TEST(MassMatrix, ElasticSHAnIsotropic2D) {
       specfem::element::property_tag::anisotropic;
 
   using PointSHPropertiesType = specfem::point::properties<
-      dimension, specfem::element::medium_tag::elastic_sh, property_tag, false>;
+      specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic_sh,
+                          property_tag, false> >;
   using PointSHMassMatrixType =
       specfem::point::mass_inverse<specfem::tags::Tags<
           dimension, specfem::element::medium_tag::elastic_sh, false> >;

--- a/tests/unit-tests/medium/mass_matrix/dim2/elastic_isotropic.cpp
+++ b/tests/unit-tests/medium/mass_matrix/dim2/elastic_isotropic.cpp
@@ -8,10 +8,9 @@ TEST(MassMatrix, ElasticPSVIsotropicTrivialSolution2D) {
   static constexpr auto property_tag =
       specfem::element::property_tag::isotropic;
 
-  using PointPSVPropertiesType =
-      specfem::point::properties<dimension,
-                                 specfem::element::medium_tag::elastic_psv,
-                                 property_tag, false>;
+  using PointPSVPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic_psv,
+                          property_tag, false> >;
   using PointPSVMassMatrixType =
       specfem::point::mass_inverse<specfem::tags::Tags<
           dimension, specfem::element::medium_tag::elastic_psv, false> >;
@@ -32,7 +31,8 @@ TEST(MassMatrix, ElasticSHIsotropicTrivialSolution2D) {
       specfem::element::property_tag::isotropic;
 
   using PointSHPropertiesType = specfem::point::properties<
-      dimension, specfem::element::medium_tag::elastic_sh, property_tag, false>;
+      specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic_sh,
+                          property_tag, false> >;
   using PointSHMassMatrixType =
       specfem::point::mass_inverse<specfem::tags::Tags<
           dimension, specfem::element::medium_tag::elastic_sh, false> >;
@@ -52,10 +52,9 @@ TEST(MassMatrix, ElasticPSVIsotropic2D) {
   static constexpr auto property_tag =
       specfem::element::property_tag::isotropic;
 
-  using PointPSVPropertiesType =
-      specfem::point::properties<dimension,
-                                 specfem::element::medium_tag::elastic_psv,
-                                 property_tag, false>;
+  using PointPSVPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic_psv,
+                          property_tag, false> >;
   using PointPSVMassMatrixType =
       specfem::point::mass_inverse<specfem::tags::Tags<
           dimension, specfem::element::medium_tag::elastic_psv, false> >;
@@ -78,7 +77,8 @@ TEST(MassMatrix, ElasticSHIsotropic2D) {
       specfem::element::property_tag::isotropic;
 
   using PointSHPropertiesType = specfem::point::properties<
-      dimension, specfem::element::medium_tag::elastic_sh, property_tag, false>;
+      specfem::tags::Tags<dimension, specfem::element::medium_tag::elastic_sh,
+                          property_tag, false> >;
   using PointSHMassMatrixType =
       specfem::point::mass_inverse<specfem::tags::Tags<
           dimension, specfem::element::medium_tag::elastic_sh, false> >;

--- a/tests/unit-tests/medium/mass_matrix/dim2/poroelastic.cpp
+++ b/tests/unit-tests/medium/mass_matrix/dim2/poroelastic.cpp
@@ -12,8 +12,8 @@ TEST(MassMatrix, PoroelasticIsotropic2DZeroPorosity) {
 
   using PointJacobianMatrixType =
       specfem::point::jacobian_matrix<dimension, true, false>;
-  using PointPropertiesType =
-      specfem::point::properties<dimension, medium_tag, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointMassMatrixType = specfem::point::mass_inverse<
       specfem::tags::Tags<dimension, medium_tag, false> >;
 
@@ -50,8 +50,8 @@ TEST(MassMatrix, PoroelasticIsotropic2D) {
 
   using PointJacobianMatrixType =
       specfem::point::jacobian_matrix<dimension, true, false>;
-  using PointPropertiesType =
-      specfem::point::properties<dimension, medium_tag, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointMassMatrixType = specfem::point::mass_inverse<
       specfem::tags::Tags<dimension, medium_tag, false> >;
 

--- a/tests/unit-tests/medium/mass_matrix/dim3/acoustic.cpp
+++ b/tests/unit-tests/medium/mass_matrix/dim3/acoustic.cpp
@@ -11,8 +11,8 @@ TEST(MassMatrix, AcousticIsotropic3D) {
 
   using PointJacobianMatrixType =
       specfem::point::jacobian_matrix<dimension, true, false>;
-  using PointPropertiesType =
-      specfem::point::properties<dimension, medium_tag, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointMassMatrixType = specfem::point::mass_inverse<
       specfem::tags::Tags<dimension, medium_tag, false> >;
 

--- a/tests/unit-tests/medium/mass_matrix/dim3/elastic_isotropic.cpp
+++ b/tests/unit-tests/medium/mass_matrix/dim3/elastic_isotropic.cpp
@@ -8,8 +8,8 @@ TEST(MassMatrix, ElasticIsotropicTrivialSolution3D) {
   static constexpr auto property_tag =
       specfem::element::property_tag::isotropic;
 
-  using PointPropertiesType = specfem::point::properties<
-      dimension, specfem::element::medium_tag::elastic, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<specfem::tags::Tags<
+      dimension, specfem::element::medium_tag::elastic, property_tag, false> >;
   using PointMassMatrixType = specfem::point::mass_inverse<specfem::tags::Tags<
       dimension, specfem::element::medium_tag::elastic, false> >;
 
@@ -28,8 +28,8 @@ TEST(MassMatrix, ElasticIsotropic3D) {
   static constexpr auto property_tag =
       specfem::element::property_tag::isotropic;
 
-  using PointPropertiesType = specfem::point::properties<
-      dimension, specfem::element::medium_tag::elastic, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<specfem::tags::Tags<
+      dimension, specfem::element::medium_tag::elastic, property_tag, false> >;
   using PointMassMatrixType = specfem::point::mass_inverse<specfem::tags::Tags<
       dimension, specfem::element::medium_tag::elastic, false> >;
 

--- a/tests/unit-tests/medium/source/dim2/acoustic.cpp
+++ b/tests/unit-tests/medium/source/dim2/acoustic.cpp
@@ -12,8 +12,8 @@ TEST(Source, AcousticIsotropic2D) {
   static constexpr auto property_tag =
       specfem::element::property_tag::isotropic;
 
-  using PointPropertiesType =
-      specfem::point::properties<dimension, medium_tag, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointSourceType =
       specfem::point::source<dimension, medium_tag,
                              specfem::simulation::field_type::forward>;
@@ -50,8 +50,8 @@ TEST(Source, AcousticIsotropic2D_ZeroSource) {
   static constexpr auto property_tag =
       specfem::element::property_tag::isotropic;
 
-  using PointPropertiesType =
-      specfem::point::properties<dimension, medium_tag, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointSourceType =
       specfem::point::source<dimension, medium_tag,
                              specfem::simulation::field_type::forward>;

--- a/tests/unit-tests/medium/source/dim2/elastic_anisotropic.cpp
+++ b/tests/unit-tests/medium/source/dim2/elastic_anisotropic.cpp
@@ -12,8 +12,8 @@ TEST(Source, ElasticAnisotropicPSV2D) {
   static constexpr auto property_tag =
       specfem::element::property_tag::anisotropic;
 
-  using PointPropertiesType =
-      specfem::point::properties<dimension, medium_tag, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointSourceType =
       specfem::point::source<dimension, medium_tag,
                              specfem::simulation::field_type::forward>;
@@ -57,8 +57,8 @@ TEST(Source, ElasticAnisotropicSH2D) {
   static constexpr auto property_tag =
       specfem::element::property_tag::anisotropic;
 
-  using PointPropertiesType =
-      specfem::point::properties<dimension, medium_tag, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointSourceType =
       specfem::point::source<dimension, medium_tag,
                              specfem::simulation::field_type::forward>;

--- a/tests/unit-tests/medium/source/dim2/elastic_isotropic.cpp
+++ b/tests/unit-tests/medium/source/dim2/elastic_isotropic.cpp
@@ -12,8 +12,8 @@ TEST(Source, ElasticIsotropicPSV2D) {
   static constexpr auto property_tag =
       specfem::element::property_tag::isotropic;
 
-  using PointPropertiesType =
-      specfem::point::properties<dimension, medium_tag, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointSourceType =
       specfem::point::source<dimension, medium_tag,
                              specfem::simulation::field_type::forward>;
@@ -55,8 +55,8 @@ TEST(Source, ElasticIsotropicSH2D) {
   static constexpr auto property_tag =
       specfem::element::property_tag::isotropic;
 
-  using PointPropertiesType =
-      specfem::point::properties<dimension, medium_tag, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointSourceType =
       specfem::point::source<dimension, medium_tag,
                              specfem::simulation::field_type::forward>;
@@ -94,8 +94,8 @@ TEST(Source, ElasticIsotropicPSV2D_ZeroSource) {
   static constexpr auto property_tag =
       specfem::element::property_tag::isotropic;
 
-  using PointPropertiesType =
-      specfem::point::properties<dimension, medium_tag, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointSourceType =
       specfem::point::source<dimension, medium_tag,
                              specfem::simulation::field_type::forward>;

--- a/tests/unit-tests/medium/source/dim2/elastic_isotropic_cosserat.cpp
+++ b/tests/unit-tests/medium/source/dim2/elastic_isotropic_cosserat.cpp
@@ -13,8 +13,8 @@ TEST(Source, ElasticIsotropicCosserat2D) {
   static constexpr auto property_tag =
       specfem::element::property_tag::isotropic_cosserat;
 
-  using PointPropertiesType =
-      specfem::point::properties<dimension, medium_tag, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointSourceType =
       specfem::point::source<dimension, medium_tag,
                              specfem::simulation::field_type::forward>;
@@ -67,8 +67,8 @@ TEST(Source, ElasticIsotropicCosserat2D_ZeroSource) {
   static constexpr auto property_tag =
       specfem::element::property_tag::isotropic_cosserat;
 
-  using PointPropertiesType =
-      specfem::point::properties<dimension, medium_tag, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointSourceType =
       specfem::point::source<dimension, medium_tag,
                              specfem::simulation::field_type::forward>;

--- a/tests/unit-tests/medium/source/dim2/poroelastic.cpp
+++ b/tests/unit-tests/medium/source/dim2/poroelastic.cpp
@@ -12,8 +12,8 @@ TEST(Source, PoroelasticIsotropic2D) {
   static constexpr auto property_tag =
       specfem::element::property_tag::isotropic;
 
-  using PointPropertiesType =
-      specfem::point::properties<dimension, medium_tag, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointSourceType =
       specfem::point::source<dimension, medium_tag,
                              specfem::simulation::field_type::forward>;
@@ -72,8 +72,8 @@ TEST(Source, PoroelasticIsotropic2D_ZeroSource) {
   static constexpr auto property_tag =
       specfem::element::property_tag::isotropic;
 
-  using PointPropertiesType =
-      specfem::point::properties<dimension, medium_tag, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointSourceType =
       specfem::point::source<dimension, medium_tag,
                              specfem::simulation::field_type::forward>;

--- a/tests/unit-tests/medium/source/dim3/acoustic.cpp
+++ b/tests/unit-tests/medium/source/dim3/acoustic.cpp
@@ -12,8 +12,8 @@ TEST(Source, AcousticIsotropic3D) {
   static constexpr auto property_tag =
       specfem::element::property_tag::isotropic;
 
-  using PointPropertiesType =
-      specfem::point::properties<dimension, medium_tag, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointSourceType =
       specfem::point::source<dimension, medium_tag,
                              specfem::simulation::field_type::forward>;
@@ -49,8 +49,8 @@ TEST(Source, AcousticIsotropic3D_ZeroSource) {
   static constexpr auto property_tag =
       specfem::element::property_tag::isotropic;
 
-  using PointPropertiesType =
-      specfem::point::properties<dimension, medium_tag, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointSourceType =
       specfem::point::source<dimension, medium_tag,
                              specfem::simulation::field_type::forward>;

--- a/tests/unit-tests/medium/source/dim3/elastic_isotropic.cpp
+++ b/tests/unit-tests/medium/source/dim3/elastic_isotropic.cpp
@@ -12,8 +12,8 @@ TEST(Source, ElasticIsotropic3D) {
   static constexpr auto property_tag =
       specfem::element::property_tag::isotropic;
 
-  using PointPropertiesType =
-      specfem::point::properties<dimension, medium_tag, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointSourceType =
       specfem::point::source<dimension, medium_tag,
                              specfem::simulation::field_type::forward>;
@@ -59,8 +59,8 @@ TEST(Source, ElasticIsotropic3D_ZeroSource) {
   static constexpr auto property_tag =
       specfem::element::property_tag::isotropic;
 
-  using PointPropertiesType =
-      specfem::point::properties<dimension, medium_tag, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointSourceType =
       specfem::point::source<dimension, medium_tag,
                              specfem::simulation::field_type::forward>;

--- a/tests/unit-tests/medium/stress/dim2/acoustic.cpp
+++ b/tests/unit-tests/medium/stress/dim2/acoustic.cpp
@@ -16,7 +16,8 @@ TEST(Stress, AcousticIsotropic2D) {
       specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointFieldDerivativesType =
       specfem::point::field_derivatives<dimension, medium_tag, false>;
-  using PointStressType = specfem::point::stress<dimension, medium_tag, false>;
+  using PointStressType = specfem::point::stress<
+      specfem::tags::Tags<dimension, medium_tag, false> >;
   const type_real rho_inverse = 2.0;
   const type_real kappa = 10.0;
   const PointPropertiesType properties(rho_inverse, kappa);
@@ -50,7 +51,8 @@ TEST(Stress, AcousticIsotropic2D_ZeroDerivatives) {
       specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointFieldDerivativesType =
       specfem::point::field_derivatives<dimension, medium_tag, false>;
-  using PointStressType = specfem::point::stress<dimension, medium_tag, false>;
+  using PointStressType = specfem::point::stress<
+      specfem::tags::Tags<dimension, medium_tag, false> >;
   const type_real rho_inverse = 2.0;
   const type_real kappa = 10.0;
   const PointPropertiesType properties(rho_inverse, kappa);

--- a/tests/unit-tests/medium/stress/dim2/acoustic.cpp
+++ b/tests/unit-tests/medium/stress/dim2/acoustic.cpp
@@ -12,8 +12,8 @@ TEST(Stress, AcousticIsotropic2D) {
   static constexpr auto property_tag =
       specfem::element::property_tag::isotropic;
 
-  using PointPropertiesType =
-      specfem::point::properties<dimension, medium_tag, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointFieldDerivativesType =
       specfem::point::field_derivatives<dimension, medium_tag, false>;
   using PointStressType = specfem::point::stress<dimension, medium_tag, false>;
@@ -46,8 +46,8 @@ TEST(Stress, AcousticIsotropic2D_ZeroDerivatives) {
   static constexpr auto property_tag =
       specfem::element::property_tag::isotropic;
 
-  using PointPropertiesType =
-      specfem::point::properties<dimension, medium_tag, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointFieldDerivativesType =
       specfem::point::field_derivatives<dimension, medium_tag, false>;
   using PointStressType = specfem::point::stress<dimension, medium_tag, false>;

--- a/tests/unit-tests/medium/stress/dim2/elastic_anisotropic.cpp
+++ b/tests/unit-tests/medium/stress/dim2/elastic_anisotropic.cpp
@@ -16,7 +16,8 @@ TEST(Stress, ElasticAnisotropic2D_PSV_Basic) {
       specfem::tags::Tags<dimension, PSVTag, property_tag, false> >;
   using PSVFieldDerivativesType =
       specfem::point::field_derivatives<dimension, PSVTag, false>;
-  using PSVStressType = specfem::point::stress<dimension, PSVTag, false>;
+  using PSVStressType =
+      specfem::point::stress<specfem::tags::Tags<dimension, PSVTag, false> >;
   // c11, c13, c15, c33, c35, c55, rho
   const type_real c11 = 10.0, c13 = 2.0, c15 = 1.0;
   const type_real c33 = 20.0, c35 = 3.0, c55 = 5.0;
@@ -61,7 +62,8 @@ TEST(Stress, ElasticAnisotropic2D_PSV_ZeroDerivatives) {
       specfem::tags::Tags<dimension, PSVTag, property_tag, false> >;
   using PSVFieldDerivativesType =
       specfem::point::field_derivatives<dimension, PSVTag, false>;
-  using PSVStressType = specfem::point::stress<dimension, PSVTag, false>;
+  using PSVStressType =
+      specfem::point::stress<specfem::tags::Tags<dimension, PSVTag, false> >;
   const type_real c11 = 10.0, c13 = 2.0, c15 = 1.0;
   const type_real c33 = 20.0, c35 = 3.0, c55 = 5.0;
   const type_real rho = 4.0;
@@ -104,7 +106,8 @@ TEST(Stress, ElasticAnisotropic2D_PSV_IsotropicCoefficients) {
       specfem::tags::Tags<dimension, PSVTag, property_tag, false> >;
   using PSVFieldDerivativesType =
       specfem::point::field_derivatives<dimension, PSVTag, false>;
-  using PSVStressType = specfem::point::stress<dimension, PSVTag, false>;
+  using PSVStressType =
+      specfem::point::stress<specfem::tags::Tags<dimension, PSVTag, false> >;
   // Isotropic properties
   const type_real kappa = 7.0;
   const type_real mu = 3.0;
@@ -158,7 +161,8 @@ TEST(Stress, ElasticAnisotropic2D_SH_Basic) {
       specfem::tags::Tags<dimension, SHTag, property_tag, false> >;
   using SHFieldDerivativesType =
       specfem::point::field_derivatives<dimension, SHTag, false>;
-  using SHStressType = specfem::point::stress<dimension, SHTag, false>;
+  using SHStressType =
+      specfem::point::stress<specfem::tags::Tags<dimension, SHTag, false> >;
   const type_real c11 = 10.0, c13 = 2.0, c15 = 1.0;
   const type_real c33 = 20.0, c35 = 3.0, c55 = 5.0;
   const type_real rho = 4.0; // Density is not used in stress computation
@@ -195,7 +199,8 @@ TEST(Stress, ElasticAnisotropic2D_SH_ZeroDerivatives) {
       specfem::tags::Tags<dimension, SHTag, property_tag, false> >;
   using SHFieldDerivativesType =
       specfem::point::field_derivatives<dimension, SHTag, false>;
-  using SHStressType = specfem::point::stress<dimension, SHTag, false>;
+  using SHStressType =
+      specfem::point::stress<specfem::tags::Tags<dimension, SHTag, false> >;
   const type_real c11 = 10.0, c13 = 2.0, c15 = 1.0;
   const type_real c33 = 20.0, c35 = 3.0, c55 = 5.0;
   const type_real rho = 4.0; // Density is not used in stress computation
@@ -234,7 +239,8 @@ TEST(Stress, ElasticAnisotropic2D_SH_IsotropicCoefficients) {
       specfem::tags::Tags<dimension, SHTag, property_tag, false> >;
   using SHFieldDerivativesType =
       specfem::point::field_derivatives<dimension, SHTag, false>;
-  using SHStressType = specfem::point::stress<dimension, SHTag, false>;
+  using SHStressType =
+      specfem::point::stress<specfem::tags::Tags<dimension, SHTag, false> >;
   // Isotropic properties
   const type_real kappa = 7.0;
   const type_real mu = 3.0;

--- a/tests/unit-tests/medium/stress/dim2/elastic_anisotropic.cpp
+++ b/tests/unit-tests/medium/stress/dim2/elastic_anisotropic.cpp
@@ -12,8 +12,8 @@ TEST(Stress, ElasticAnisotropic2D_PSV_Basic) {
       specfem::element::property_tag::anisotropic;
   static constexpr auto PSVTag = specfem::element::medium_tag::elastic_psv;
 
-  using PSVPropertiesType =
-      specfem::point::properties<dimension, PSVTag, property_tag, false>;
+  using PSVPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, PSVTag, property_tag, false> >;
   using PSVFieldDerivativesType =
       specfem::point::field_derivatives<dimension, PSVTag, false>;
   using PSVStressType = specfem::point::stress<dimension, PSVTag, false>;
@@ -57,8 +57,8 @@ TEST(Stress, ElasticAnisotropic2D_PSV_ZeroDerivatives) {
       specfem::element::property_tag::anisotropic;
   static constexpr auto PSVTag = specfem::element::medium_tag::elastic_psv;
 
-  using PSVPropertiesType =
-      specfem::point::properties<dimension, PSVTag, property_tag, false>;
+  using PSVPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, PSVTag, property_tag, false> >;
   using PSVFieldDerivativesType =
       specfem::point::field_derivatives<dimension, PSVTag, false>;
   using PSVStressType = specfem::point::stress<dimension, PSVTag, false>;
@@ -100,8 +100,8 @@ TEST(Stress, ElasticAnisotropic2D_PSV_IsotropicCoefficients) {
       specfem::element::property_tag::anisotropic;
   static constexpr auto PSVTag = specfem::element::medium_tag::elastic_psv;
 
-  using PSVPropertiesType =
-      specfem::point::properties<dimension, PSVTag, property_tag, false>;
+  using PSVPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, PSVTag, property_tag, false> >;
   using PSVFieldDerivativesType =
       specfem::point::field_derivatives<dimension, PSVTag, false>;
   using PSVStressType = specfem::point::stress<dimension, PSVTag, false>;
@@ -154,8 +154,8 @@ TEST(Stress, ElasticAnisotropic2D_SH_Basic) {
       specfem::element::property_tag::anisotropic;
   static constexpr auto SHTag = specfem::element::medium_tag::elastic_sh;
 
-  using SHPropertiesType =
-      specfem::point::properties<dimension, SHTag, property_tag, false>;
+  using SHPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, SHTag, property_tag, false> >;
   using SHFieldDerivativesType =
       specfem::point::field_derivatives<dimension, SHTag, false>;
   using SHStressType = specfem::point::stress<dimension, SHTag, false>;
@@ -191,8 +191,8 @@ TEST(Stress, ElasticAnisotropic2D_SH_ZeroDerivatives) {
       specfem::element::property_tag::anisotropic;
   static constexpr auto SHTag = specfem::element::medium_tag::elastic_sh;
 
-  using SHPropertiesType =
-      specfem::point::properties<dimension, SHTag, property_tag, false>;
+  using SHPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, SHTag, property_tag, false> >;
   using SHFieldDerivativesType =
       specfem::point::field_derivatives<dimension, SHTag, false>;
   using SHStressType = specfem::point::stress<dimension, SHTag, false>;
@@ -230,8 +230,8 @@ TEST(Stress, ElasticAnisotropic2D_SH_IsotropicCoefficients) {
       specfem::element::property_tag::anisotropic;
   static constexpr auto SHTag = specfem::element::medium_tag::elastic_sh;
 
-  using SHPropertiesType =
-      specfem::point::properties<dimension, SHTag, property_tag, false>;
+  using SHPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, SHTag, property_tag, false> >;
   using SHFieldDerivativesType =
       specfem::point::field_derivatives<dimension, SHTag, false>;
   using SHStressType = specfem::point::stress<dimension, SHTag, false>;

--- a/tests/unit-tests/medium/stress/dim2/elastic_isotropic.cpp
+++ b/tests/unit-tests/medium/stress/dim2/elastic_isotropic.cpp
@@ -12,8 +12,8 @@ TEST(Stress, ElasticIsotropic2D_PSV_Basic) {
       specfem::element::property_tag::isotropic;
   static constexpr auto PSVTag = specfem::element::medium_tag::elastic_psv;
 
-  using PSVPropertiesType =
-      specfem::point::properties<dimension, PSVTag, property_tag, false>;
+  using PSVPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, PSVTag, property_tag, false> >;
   using PSVFieldDerivativesType =
       specfem::point::field_derivatives<dimension, PSVTag, false>;
   using PSVStressType = specfem::point::stress<dimension, PSVTag, false>;
@@ -53,8 +53,8 @@ TEST(Stress, ElasticIsotropic2D_PSV_ZeroDerivatives) {
       specfem::element::property_tag::isotropic;
   static constexpr auto PSVTag = specfem::element::medium_tag::elastic_psv;
 
-  using PSVPropertiesType =
-      specfem::point::properties<dimension, PSVTag, property_tag, false>;
+  using PSVPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, PSVTag, property_tag, false> >;
   using PSVFieldDerivativesType =
       specfem::point::field_derivatives<dimension, PSVTag, false>;
   using PSVStressType = specfem::point::stress<dimension, PSVTag, false>;
@@ -92,8 +92,8 @@ TEST(Stress, ElasticIsotropic2D_SH_Basic) {
       specfem::element::property_tag::isotropic;
   static constexpr auto SHTag = specfem::element::medium_tag::elastic_sh;
 
-  using SHPropertiesType =
-      specfem::point::properties<dimension, SHTag, property_tag, false>;
+  using SHPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, SHTag, property_tag, false> >;
   using SHFieldDerivativesType =
       specfem::point::field_derivatives<dimension, SHTag, false>;
   using SHStressType = specfem::point::stress<dimension, SHTag, false>;
@@ -127,8 +127,8 @@ TEST(Stress, ElasticIsotropic2D_SH_ZeroDerivatives) {
       specfem::element::property_tag::isotropic;
   static constexpr auto SHTag = specfem::element::medium_tag::elastic_sh;
 
-  using SHPropertiesType =
-      specfem::point::properties<dimension, SHTag, property_tag, false>;
+  using SHPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, SHTag, property_tag, false> >;
   using SHFieldDerivativesType =
       specfem::point::field_derivatives<dimension, SHTag, false>;
   using SHStressType = specfem::point::stress<dimension, SHTag, false>;

--- a/tests/unit-tests/medium/stress/dim2/elastic_isotropic.cpp
+++ b/tests/unit-tests/medium/stress/dim2/elastic_isotropic.cpp
@@ -16,7 +16,8 @@ TEST(Stress, ElasticIsotropic2D_PSV_Basic) {
       specfem::tags::Tags<dimension, PSVTag, property_tag, false> >;
   using PSVFieldDerivativesType =
       specfem::point::field_derivatives<dimension, PSVTag, false>;
-  using PSVStressType = specfem::point::stress<dimension, PSVTag, false>;
+  using PSVStressType =
+      specfem::point::stress<specfem::tags::Tags<dimension, PSVTag, false> >;
   const type_real kappa = 2.0;
   const type_real mu = 3.0;
   const type_real rho = 4.0; // Density is not used in stress computation
@@ -57,7 +58,8 @@ TEST(Stress, ElasticIsotropic2D_PSV_ZeroDerivatives) {
       specfem::tags::Tags<dimension, PSVTag, property_tag, false> >;
   using PSVFieldDerivativesType =
       specfem::point::field_derivatives<dimension, PSVTag, false>;
-  using PSVStressType = specfem::point::stress<dimension, PSVTag, false>;
+  using PSVStressType =
+      specfem::point::stress<specfem::tags::Tags<dimension, PSVTag, false> >;
   const type_real kappa = 2.0;
   const type_real mu = 3.0;
   const type_real rho = 4.0; // Density is not used in stress computation
@@ -96,7 +98,8 @@ TEST(Stress, ElasticIsotropic2D_SH_Basic) {
       specfem::tags::Tags<dimension, SHTag, property_tag, false> >;
   using SHFieldDerivativesType =
       specfem::point::field_derivatives<dimension, SHTag, false>;
-  using SHStressType = specfem::point::stress<dimension, SHTag, false>;
+  using SHStressType =
+      specfem::point::stress<specfem::tags::Tags<dimension, SHTag, false> >;
   const type_real kappa = 2.0;
   const type_real mu = 3.0;
   const type_real rho = 4.0; // Density is not used in stress computation
@@ -131,7 +134,8 @@ TEST(Stress, ElasticIsotropic2D_SH_ZeroDerivatives) {
       specfem::tags::Tags<dimension, SHTag, property_tag, false> >;
   using SHFieldDerivativesType =
       specfem::point::field_derivatives<dimension, SHTag, false>;
-  using SHStressType = specfem::point::stress<dimension, SHTag, false>;
+  using SHStressType =
+      specfem::point::stress<specfem::tags::Tags<dimension, SHTag, false> >;
   const type_real kappa = 2.0;
   const type_real mu = 3.0;
   const type_real rho = 4.0; // Density is not used in stress computation

--- a/tests/unit-tests/medium/stress/dim2/elastic_isotropic_cosserat.cpp
+++ b/tests/unit-tests/medium/stress/dim2/elastic_isotropic_cosserat.cpp
@@ -13,8 +13,8 @@ TEST(Stress, ElasticIsotropicCosserat2D_Basic) {
   static constexpr auto CosseratTag =
       specfem::element::medium_tag::elastic_psv_t;
 
-  using CosseratPropertiesType =
-      specfem::point::properties<dimension, CosseratTag, property_tag, false>;
+  using CosseratPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, CosseratTag, property_tag, false> >;
   using CosseratFieldDerivativesType =
       specfem::point::field_derivatives<dimension, CosseratTag, false>;
   using CosseratStressType =
@@ -79,8 +79,8 @@ TEST(Stress, ElasticIsotropicCosserat2D_ZeroDerivatives) {
   static constexpr auto CosseratTag =
       specfem::element::medium_tag::elastic_psv_t;
 
-  using CosseratPropertiesType =
-      specfem::point::properties<dimension, CosseratTag, property_tag, false>;
+  using CosseratPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, CosseratTag, property_tag, false> >;
   using CosseratFieldDerivativesType =
       specfem::point::field_derivatives<dimension, CosseratTag, false>;
   using CosseratStressType =
@@ -128,8 +128,8 @@ TEST(Stress, ElasticIsotropicCosserat2D_SymmetricWhenNuZero) {
   static constexpr auto CosseratTag =
       specfem::element::medium_tag::elastic_psv_t;
 
-  using CosseratPropertiesType =
-      specfem::point::properties<dimension, CosseratTag, property_tag, false>;
+  using CosseratPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, CosseratTag, property_tag, false> >;
   using CosseratFieldDerivativesType =
       specfem::point::field_derivatives<dimension, CosseratTag, false>;
   using CosseratStressType =

--- a/tests/unit-tests/medium/stress/dim2/elastic_isotropic_cosserat.cpp
+++ b/tests/unit-tests/medium/stress/dim2/elastic_isotropic_cosserat.cpp
@@ -17,8 +17,8 @@ TEST(Stress, ElasticIsotropicCosserat2D_Basic) {
       specfem::tags::Tags<dimension, CosseratTag, property_tag, false> >;
   using CosseratFieldDerivativesType =
       specfem::point::field_derivatives<dimension, CosseratTag, false>;
-  using CosseratStressType =
-      specfem::point::stress<dimension, CosseratTag, false>;
+  using CosseratStressType = specfem::point::stress<
+      specfem::tags::Tags<dimension, CosseratTag, false> >;
   // Set up properties (arbitrary but nonzero values)
   const type_real rho = 2.5;
   const type_real kappa = 7.0;
@@ -83,8 +83,8 @@ TEST(Stress, ElasticIsotropicCosserat2D_ZeroDerivatives) {
       specfem::tags::Tags<dimension, CosseratTag, property_tag, false> >;
   using CosseratFieldDerivativesType =
       specfem::point::field_derivatives<dimension, CosseratTag, false>;
-  using CosseratStressType =
-      specfem::point::stress<dimension, CosseratTag, false>;
+  using CosseratStressType = specfem::point::stress<
+      specfem::tags::Tags<dimension, CosseratTag, false> >;
   const type_real rho = 2.5;
   const type_real kappa = 7.0;
   const type_real mu = 3.0;
@@ -132,8 +132,8 @@ TEST(Stress, ElasticIsotropicCosserat2D_SymmetricWhenNuZero) {
       specfem::tags::Tags<dimension, CosseratTag, property_tag, false> >;
   using CosseratFieldDerivativesType =
       specfem::point::field_derivatives<dimension, CosseratTag, false>;
-  using CosseratStressType =
-      specfem::point::stress<dimension, CosseratTag, false>;
+  using CosseratStressType = specfem::point::stress<
+      specfem::tags::Tags<dimension, CosseratTag, false> >;
   const type_real rho = 2.5;
   const type_real kappa = 7.0;
   const type_real mu = 3.0;

--- a/tests/unit-tests/medium/stress/dim2/poroelastic_isotropic.cpp
+++ b/tests/unit-tests/medium/stress/dim2/poroelastic_isotropic.cpp
@@ -12,8 +12,8 @@ TEST(Stress, PoroelasticIsotropic2D_Basic) {
       specfem::element::property_tag::isotropic;
   static constexpr auto PoroTag = specfem::element::medium_tag::poroelastic;
 
-  using PoroPropertiesType =
-      specfem::point::properties<dimension, PoroTag, property_tag, false>;
+  using PoroPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, PoroTag, property_tag, false> >;
   using PoroFieldDerivativesType =
       specfem::point::field_derivatives<dimension, PoroTag, false>;
   using PoroStressType = specfem::point::stress<dimension, PoroTag, false>;
@@ -83,8 +83,8 @@ TEST(Stress, PoroelasticIsotropic2D_ZeroDerivatives) {
       specfem::element::property_tag::isotropic;
   static constexpr auto PoroTag = specfem::element::medium_tag::poroelastic;
 
-  using PoroPropertiesType =
-      specfem::point::properties<dimension, PoroTag, property_tag, false>;
+  using PoroPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, PoroTag, property_tag, false> >;
   using PoroFieldDerivativesType =
       specfem::point::field_derivatives<dimension, PoroTag, false>;
   using PoroStressType = specfem::point::stress<dimension, PoroTag, false>;

--- a/tests/unit-tests/medium/stress/dim2/poroelastic_isotropic.cpp
+++ b/tests/unit-tests/medium/stress/dim2/poroelastic_isotropic.cpp
@@ -16,7 +16,8 @@ TEST(Stress, PoroelasticIsotropic2D_Basic) {
       specfem::tags::Tags<dimension, PoroTag, property_tag, false> >;
   using PoroFieldDerivativesType =
       specfem::point::field_derivatives<dimension, PoroTag, false>;
-  using PoroStressType = specfem::point::stress<dimension, PoroTag, false>;
+  using PoroStressType =
+      specfem::point::stress<specfem::tags::Tags<dimension, PoroTag, false> >;
   // Set up properties (arbitrary but nonzero values)
   const type_real phi = 0.25;
   const type_real rho_s = 2.5;
@@ -87,7 +88,8 @@ TEST(Stress, PoroelasticIsotropic2D_ZeroDerivatives) {
       specfem::tags::Tags<dimension, PoroTag, property_tag, false> >;
   using PoroFieldDerivativesType =
       specfem::point::field_derivatives<dimension, PoroTag, false>;
-  using PoroStressType = specfem::point::stress<dimension, PoroTag, false>;
+  using PoroStressType =
+      specfem::point::stress<specfem::tags::Tags<dimension, PoroTag, false> >;
   const type_real phi = 0.25;
   const type_real rho_s = 2.5;
   const type_real rho_f = 1.2;

--- a/tests/unit-tests/medium/stress/dim3/acoustic.cpp
+++ b/tests/unit-tests/medium/stress/dim3/acoustic.cpp
@@ -12,8 +12,8 @@ TEST(Stress, AcousticIsotropic3D) {
   static constexpr auto property_tag =
       specfem::element::property_tag::isotropic;
 
-  using PointPropertiesType =
-      specfem::point::properties<dimension, medium_tag, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointFieldDerivativesType =
       specfem::point::field_derivatives<dimension, medium_tag, false>;
   using PointStressType = specfem::point::stress<dimension, medium_tag, false>;
@@ -48,8 +48,8 @@ TEST(Stress, AcousticIsotropic3D_ZeroDerivatives) {
   static constexpr auto property_tag =
       specfem::element::property_tag::isotropic;
 
-  using PointPropertiesType =
-      specfem::point::properties<dimension, medium_tag, property_tag, false>;
+  using PointPropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointFieldDerivativesType =
       specfem::point::field_derivatives<dimension, medium_tag, false>;
   using PointStressType = specfem::point::stress<dimension, medium_tag, false>;

--- a/tests/unit-tests/medium/stress/dim3/acoustic.cpp
+++ b/tests/unit-tests/medium/stress/dim3/acoustic.cpp
@@ -16,7 +16,8 @@ TEST(Stress, AcousticIsotropic3D) {
       specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointFieldDerivativesType =
       specfem::point::field_derivatives<dimension, medium_tag, false>;
-  using PointStressType = specfem::point::stress<dimension, medium_tag, false>;
+  using PointStressType = specfem::point::stress<
+      specfem::tags::Tags<dimension, medium_tag, false> >;
 
   const type_real rho_inverse = 2.0;
   const PointPropertiesType properties(rho_inverse);
@@ -52,7 +53,8 @@ TEST(Stress, AcousticIsotropic3D_ZeroDerivatives) {
       specfem::tags::Tags<dimension, medium_tag, property_tag, false> >;
   using PointFieldDerivativesType =
       specfem::point::field_derivatives<dimension, medium_tag, false>;
-  using PointStressType = specfem::point::stress<dimension, medium_tag, false>;
+  using PointStressType = specfem::point::stress<
+      specfem::tags::Tags<dimension, medium_tag, false> >;
 
   const type_real rho_inverse = 2.0;
   const PointPropertiesType properties(rho_inverse);

--- a/tests/unit-tests/medium/stress/dim3/elastic_isotropic.cpp
+++ b/tests/unit-tests/medium/stress/dim3/elastic_isotropic.cpp
@@ -12,8 +12,8 @@ TEST(Stress, ElasticIsotropic3D_Basic) {
       specfem::element::property_tag::isotropic;
   static constexpr auto elasticTag = specfem::element::medium_tag::elastic;
 
-  using PropertiesType =
-      specfem::point::properties<dimension, elasticTag, property_tag, false>;
+  using PropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, elasticTag, property_tag, false> >;
   using FieldDerivativesType =
       specfem::point::field_derivatives<dimension, elasticTag, false>;
   using StressType = specfem::point::stress<dimension, elasticTag, false>;
@@ -68,8 +68,8 @@ TEST(Stress, ElasticIsotropic3D_ZeroDerivatives) {
       specfem::element::property_tag::isotropic;
   static constexpr auto elasticTag = specfem::element::medium_tag::elastic;
 
-  using PropertiesType =
-      specfem::point::properties<dimension, elasticTag, property_tag, false>;
+  using PropertiesType = specfem::point::properties<
+      specfem::tags::Tags<dimension, elasticTag, property_tag, false> >;
   using FieldDerivativesType =
       specfem::point::field_derivatives<dimension, elasticTag, false>;
   using StressType = specfem::point::stress<dimension, elasticTag, false>;

--- a/tests/unit-tests/medium/stress/dim3/elastic_isotropic.cpp
+++ b/tests/unit-tests/medium/stress/dim3/elastic_isotropic.cpp
@@ -16,7 +16,8 @@ TEST(Stress, ElasticIsotropic3D_Basic) {
       specfem::tags::Tags<dimension, elasticTag, property_tag, false> >;
   using FieldDerivativesType =
       specfem::point::field_derivatives<dimension, elasticTag, false>;
-  using StressType = specfem::point::stress<dimension, elasticTag, false>;
+  using StressType = specfem::point::stress<
+      specfem::tags::Tags<dimension, elasticTag, false> >;
   const type_real kappa = 2.0;
   const type_real mu = 3.0;
   const type_real rho = 4.0; // Density is not used in stress computation
@@ -72,7 +73,8 @@ TEST(Stress, ElasticIsotropic3D_ZeroDerivatives) {
       specfem::tags::Tags<dimension, elasticTag, property_tag, false> >;
   using FieldDerivativesType =
       specfem::point::field_derivatives<dimension, elasticTag, false>;
-  using StressType = specfem::point::stress<dimension, elasticTag, false>;
+  using StressType = specfem::point::stress<
+      specfem::tags::Tags<dimension, elasticTag, false> >;
   const type_real kappa = 2.0;
   const type_real mu = 3.0;
   const type_real rho = 4.0; // Density is not used in stress computation

--- a/tests/unit-tests/mesh/dim2/materials/properties.cpp
+++ b/tests/unit-tests/mesh/dim2/materials/properties.cpp
@@ -14,73 +14,73 @@ constexpr static auto dimension = specfem::element::dimension_tag::dim2;
 const static std::unordered_map<std::string, MaterialVectorType>
     properties_ground_truth = {
       { "Simple mesh with flat topography (P_SV wave)",
-        MaterialVectorType({ specfem::point::properties<
+        MaterialVectorType({ specfem::point::properties<specfem::tags::Tags<
             dimension, specfem::element::medium_tag::elastic_psv,
-            specfem::element::property_tag::isotropic, false>(
+            specfem::element::property_tag::isotropic, false> >(
             static_cast<type_real>(13499997600.24),
             static_cast<type_real>(8100001799.82),
             static_cast<type_real>(2700.0)) }) },
       { "Simple mesh with flat topography (SH wave)",
-        MaterialVectorType({ specfem::point::properties<
+        MaterialVectorType({ specfem::point::properties<specfem::tags::Tags<
             dimension, specfem::element::medium_tag::elastic_sh,
-            specfem::element::property_tag::isotropic, false>(
+            specfem::element::property_tag::isotropic, false> >(
             static_cast<type_real>(13499997600.24),
             static_cast<type_real>(8100001799.82),
             static_cast<type_real>(2700.0)) }) },
       { "Simple mesh with curved topography",
-        MaterialVectorType({ specfem::point::properties<
+        MaterialVectorType({ specfem::point::properties<specfem::tags::Tags<
             dimension, specfem::element::medium_tag::elastic_psv,
-            specfem::element::property_tag::isotropic, false>(
+            specfem::element::property_tag::isotropic, false> >(
             static_cast<type_real>(13499997600.24),
             static_cast<type_real>(8100001799.82),
             static_cast<type_real>(2700.0)) }) },
       { "Simple mesh with flat ocean bottom",
         MaterialVectorType(
-            { specfem::point::properties<
+            { specfem::point::properties<specfem::tags::Tags<
                   dimension, specfem::element::medium_tag::elastic_psv,
-                  specfem::element::property_tag::isotropic, false>(
+                  specfem::element::property_tag::isotropic, false> >(
                   static_cast<type_real>(16055436666.666668),
                   static_cast<type_real>(9633422500.0),
                   static_cast<type_real>(2500.0)),
-              specfem::point::properties<
+              specfem::point::properties<specfem::tags::Tags<
                   dimension, specfem::element::medium_tag::acoustic,
-                  specfem::element::property_tag::isotropic, false>(
+                  specfem::element::property_tag::isotropic, false> >(
                   static_cast<type_real>(0.00098039215),
                   static_cast<type_real>(2295000000.0))
 
             }) },
       { "Simple mesh with curved ocean bottom",
         MaterialVectorType(
-            { specfem::point::properties<
+            { specfem::point::properties<specfem::tags::Tags<
                   dimension, specfem::element::medium_tag::elastic_psv,
-                  specfem::element::property_tag::isotropic, false>(
+                  specfem::element::property_tag::isotropic, false> >(
                   static_cast<type_real>(16055436666.666668),
                   static_cast<type_real>(9633422500.0),
                   static_cast<type_real>(2500.0)),
-              specfem::point::properties<
+              specfem::point::properties<specfem::tags::Tags<
                   dimension, specfem::element::medium_tag::acoustic,
-                  specfem::element::property_tag::isotropic, false>(
+                  specfem::element::property_tag::isotropic, false> >(
                   static_cast<type_real>(0.00098039215),
                   static_cast<type_real>(2295000000.0))
 
             }) },
       { "Gmesh Example",
         MaterialVectorType(
-            { specfem::point::properties<
+            { specfem::point::properties<specfem::tags::Tags<
                   dimension, specfem::element::medium_tag::acoustic,
-                  specfem::element::property_tag::isotropic, false>(
+                  specfem::element::property_tag::isotropic, false> >(
                   static_cast<type_real>(0.0005),
                   static_cast<type_real>(5644800000.0)),
-              specfem::point::properties<
+              specfem::point::properties<specfem::tags::Tags<
                   dimension, specfem::element::medium_tag::acoustic,
-                  specfem::element::property_tag::isotropic, false>(
+                  specfem::element::property_tag::isotropic, false> >(
                   static_cast<type_real>(0.001),
                   static_cast<type_real>(2181529000.0)) }) },
 
       { "Homogeneous Elastic Anisotropic Material (P_SV wave)",
-        MaterialVectorType({ specfem::point::properties<
+        MaterialVectorType({ specfem::point::properties<specfem::tags::Tags<
             dimension, specfem::element::medium_tag::elastic_psv,
-            specfem::element::property_tag::anisotropic, false>(
+            specfem::element::property_tag::anisotropic, false> >(
             static_cast<type_real>(24299994600.5),
             static_cast<type_real>(8099996400.35), static_cast<type_real>(0.0),
             static_cast<type_real>(24299994600.5), static_cast<type_real>(0.0),
@@ -89,9 +89,9 @@ const static std::unordered_map<std::string, MaterialVectorType>
             static_cast<type_real>(8099996400.35), static_cast<type_real>(0.0),
             static_cast<type_real>(2700.0)) }) },
       { "Homogeneous Elastic Anisotropic Material (SH wave)",
-        MaterialVectorType({ specfem::point::properties<
+        MaterialVectorType({ specfem::point::properties<specfem::tags::Tags<
             dimension, specfem::element::medium_tag::elastic_sh,
-            specfem::element::property_tag::anisotropic, false>(
+            specfem::element::property_tag::anisotropic, false> >(
             static_cast<type_real>(24299994600.5),
             static_cast<type_real>(8099996400.35), static_cast<type_real>(0.0),
             static_cast<type_real>(24299994600.5), static_cast<type_real>(0.0),
@@ -100,9 +100,9 @@ const static std::unordered_map<std::string, MaterialVectorType>
             static_cast<type_real>(8099996400.35), static_cast<type_real>(0.0),
             static_cast<type_real>(2700.0)) }) },
       { "Poroelastic mesh - Homogeneous isotropic material",
-        MaterialVectorType({ specfem::point::properties<
+        MaterialVectorType({ specfem::point::properties<specfem::tags::Tags<
             dimension, specfem::element::medium_tag::poroelastic,
-            specfem::element::property_tag::isotropic, false>(
+            specfem::element::property_tag::isotropic, false> >(
             static_cast<type_real>(0.1), static_cast<type_real>(2650.0),
             static_cast<type_real>(880.0), static_cast<type_real>(2.0),
             static_cast<type_real>(5.1e9),
@@ -113,17 +113,17 @@ const static std::unordered_map<std::string, MaterialVectorType>
             static_cast<type_real>(1.0e-9), static_cast<type_real>(0.0)) }) },
       { "Electro-magnetic mesh example from Morency 2020",
         MaterialVectorType({
-            specfem::point::properties<
+            specfem::point::properties<specfem::tags::Tags<
                 dimension, specfem::element::medium_tag::electromagnetic_te,
-                specfem::element::property_tag::isotropic, false>(
+                specfem::element::property_tag::isotropic, false> >(
                 static_cast<type_real>(1.0 / (12.566 * 1e-7)), // mu0_inv
                 static_cast<type_real>(5.0 * 8.85 * 1e-12),    // e0_e11
                 static_cast<type_real>(5.0 * 8.85 * 1e-12),    // e0_e33
                 static_cast<type_real>(2.0 * 1e-3),            // sig11
                 static_cast<type_real>(2.0 * 1e-3)),           // sig33
-            specfem::point::properties<
+            specfem::point::properties<specfem::tags::Tags<
                 dimension, specfem::element::medium_tag::electromagnetic_te,
-                specfem::element::property_tag::isotropic, false>(
+                specfem::element::property_tag::isotropic, false> >(
                 static_cast<type_real>(1.0 / (12.566 * 1e-7)), // mu0_inv
                 static_cast<type_real>(1.0 * 8.85 * 1e-12),    // e0_e11
                 static_cast<type_real>(1.0 * 8.85 * 1e-12),    // e0_e33
@@ -132,9 +132,9 @@ const static std::unordered_map<std::string, MaterialVectorType>
         }) },
       { "Elastic Isotropic Cosserat Medium - Homogeneous",
         MaterialVectorType({
-            specfem::point::properties<
+            specfem::point::properties<specfem::tags::Tags<
                 dimension, specfem::element::medium_tag::elastic_psv_t,
-                specfem::element::property_tag::isotropic_cosserat, false>(
+                specfem::element::property_tag::isotropic_cosserat, false> >(
                 static_cast<type_real>(2700.0),  // rho
                 static_cast<type_real>(13.5e9),  // kappa
                 static_cast<type_real>(8.1e9),   // mu
@@ -188,9 +188,10 @@ void check_property(
                                   _attenuation_tag_>(ispec)
                     .get_properties();
 
-            const auto iexpected = std::any_cast<specfem::point::properties<
-                dimension, _medium_tag_, _property_tag_, false> >(
-                expected[imaterial]);
+            const auto iexpected =
+                std::any_cast<specfem::point::properties<specfem::tags::Tags<
+                    dimension, _medium_tag_, _property_tag_, false> > >(
+                    expected[imaterial]);
             if (icomputed != iexpected) {
               std::ostringstream error_message;
               error_message << "Material " << index << " is not the same ["

--- a/tests/unit-tests/point/properties/dim2/acoustic_isotropic.cpp
+++ b/tests/unit-tests/point/properties/dim2/acoustic_isotropic.cpp
@@ -70,11 +70,10 @@ TYPED_TEST(PointPropertiesTest, AcousticIsotropic2D) {
   }
 
   // Create the properties object
-  using PointPropertiesType =
-      specfem::point::properties<specfem::element::dimension_tag::dim2,
-                                 specfem::element::medium_tag::acoustic,
-                                 specfem::element::property_tag::isotropic,
-                                 using_simd>;
+  using PointPropertiesType = specfem::point::properties<specfem::tags::Tags<
+      specfem::element::dimension_tag::dim2,
+      specfem::element::medium_tag::acoustic,
+      specfem::element::property_tag::isotropic, using_simd> >;
   PointPropertiesType props(rho_inv, kappa);
 
   EXPECT_TRUE(specfem::utilities::is_close(props.rho_inverse(), rho_inv))

--- a/tests/unit-tests/point/properties/dim2/elastic_anisotropic.cpp
+++ b/tests/unit-tests/point/properties/dim2/elastic_anisotropic.cpp
@@ -134,11 +134,10 @@ TYPED_TEST(PointPropertiesTest, ElasticAnisotropic2D) {
   }
 
   // Create the properties object
-  using PointPropertiesType =
-      specfem::point::properties<specfem::element::dimension_tag::dim2,
-                                 specfem::element::medium_tag::elastic,
-                                 specfem::element::property_tag::anisotropic,
-                                 using_simd>;
+  using PointPropertiesType = specfem::point::properties<specfem::tags::Tags<
+      specfem::element::dimension_tag::dim2,
+      specfem::element::medium_tag::elastic,
+      specfem::element::property_tag::anisotropic, using_simd> >;
   PointPropertiesType props(c11, c13, c15, c33, c35, c55, c12, c23, c25, rho);
 
   // Additional constructors and assignment tests

--- a/tests/unit-tests/point/properties/dim2/elastic_isotropic.cpp
+++ b/tests/unit-tests/point/properties/dim2/elastic_isotropic.cpp
@@ -126,11 +126,10 @@ TYPED_TEST(PointPropertiesTest, ElasticIsotropic2D) {
   }
 
   // Create the properties object
-  using PointPropertiesType =
-      specfem::point::properties<specfem::element::dimension_tag::dim2,
-                                 specfem::element::medium_tag::elastic,
-                                 specfem::element::property_tag::isotropic,
-                                 using_simd>;
+  using PointPropertiesType = specfem::point::properties<specfem::tags::Tags<
+      specfem::element::dimension_tag::dim2,
+      specfem::element::medium_tag::elastic,
+      specfem::element::property_tag::isotropic, using_simd> >;
   PointPropertiesType props(kappa, mu, rho);
 
   EXPECT_TRUE(specfem::utilities::is_close(props.kappa(), kappa))

--- a/tests/unit-tests/point/properties/dim2/electromagnetic_isotropic.cpp
+++ b/tests/unit-tests/point/properties/dim2/electromagnetic_isotropic.cpp
@@ -56,11 +56,10 @@ TYPED_TEST(PointPropertiesTest, ElectromagneticIsotropic2D) {
   }
 
   // Create the properties object
-  using PointPropertiesType =
-      specfem::point::properties<specfem::element::dimension_tag::dim2,
-                                 specfem::element::medium_tag::electromagnetic,
-                                 specfem::element::property_tag::isotropic,
-                                 using_simd>;
+  using PointPropertiesType = specfem::point::properties<specfem::tags::Tags<
+      specfem::element::dimension_tag::dim2,
+      specfem::element::medium_tag::electromagnetic,
+      specfem::element::property_tag::isotropic, using_simd> >;
   PointPropertiesType props(mu0_inv, eps11, eps33, sig11, sig33);
 
   EXPECT_TRUE(specfem::utilities::is_close(props.mu0_inv(), mu0_inv))

--- a/tests/unit-tests/point/properties/dim2/poroelastic_isotropic.cpp
+++ b/tests/unit-tests/point/properties/dim2/poroelastic_isotropic.cpp
@@ -169,11 +169,10 @@ TYPED_TEST(PointPropertiesTest, PoroelasticIsotropic2D) {
   }
 
   // Create the properties object
-  using PointPropertiesType =
-      specfem::point::properties<specfem::element::dimension_tag::dim2,
-                                 specfem::element::medium_tag::poroelastic,
-                                 specfem::element::property_tag::isotropic,
-                                 using_simd>;
+  using PointPropertiesType = specfem::point::properties<specfem::tags::Tags<
+      specfem::element::dimension_tag::dim2,
+      specfem::element::medium_tag::poroelastic,
+      specfem::element::property_tag::isotropic, using_simd> >;
   PointPropertiesType props(phi, rho_s, rho_f, tortuosity, mu_G, H_Biot, C_Biot,
                             M_Biot, permxx, permxz, permzz, eta_f);
 

--- a/tests/unit-tests/point/properties/dim3/elastic_isotropic.cpp
+++ b/tests/unit-tests/point/properties/dim3/elastic_isotropic.cpp
@@ -79,11 +79,10 @@ TYPED_TEST(PointPropertiesTest, ElasticIsotropic3D) {
   }
 
   // Create the properties object
-  using PointPropertiesType =
-      specfem::point::properties<specfem::element::dimension_tag::dim3,
-                                 specfem::element::medium_tag::elastic,
-                                 specfem::element::property_tag::isotropic,
-                                 using_simd>;
+  using PointPropertiesType = specfem::point::properties<specfem::tags::Tags<
+      specfem::element::dimension_tag::dim3,
+      specfem::element::medium_tag::elastic,
+      specfem::element::property_tag::isotropic, using_simd> >;
   PointPropertiesType props(kappa, mu, rho);
 
   EXPECT_TRUE(specfem::utilities::is_close(props.kappa(), kappa))

--- a/tests/unit-tests/point/stress_tests.cpp
+++ b/tests/unit-tests/point/stress_tests.cpp
@@ -2,6 +2,7 @@
 #include "specfem/point/jacobian_matrix.hpp"
 #include "specfem/point/stress.hpp"
 #include "specfem/setup.hpp"
+#include "specfem/tags.hpp"
 #include "specfem/utilities.hpp"
 #include "test_helper.hpp"
 #include "test_macros.hpp"
@@ -44,8 +45,9 @@ TYPED_TEST(PointStressTest, Stress2DAcoustic) {
       specfem::datatype::simd<type_real, using_simd>::size();
 
   // Define the stress type for 2D acoustic medium
-  using stress_type = point::stress<specfem::element::dimension_tag::dim2,
-                                    element::medium_tag::acoustic, using_simd>;
+  using stress_type = point::stress<
+      specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                          element::medium_tag::acoustic, using_simd> >;
 
   // Verify static properties
   constexpr int expected_dimension =
@@ -85,9 +87,9 @@ TYPED_TEST(PointStressTest, Stress2DElastic) {
       specfem::datatype::simd<type_real, using_simd>::size();
 
   // Define the stress type for 2D elastic medium
-  using stress_type =
-      point::stress<specfem::element::dimension_tag::dim2,
-                    element::medium_tag::elastic_psv, using_simd>;
+  using stress_type = point::stress<
+      specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                          element::medium_tag::elastic_psv, using_simd> >;
 
   // Verify static properties
   constexpr int expected_dimension =
@@ -141,9 +143,9 @@ TYPED_TEST(PointStressTest, Stress2DPoroelastic) {
       specfem::datatype::simd<type_real, using_simd>::size();
 
   // Define the stress type for 2D poroelastic medium
-  using stress_type =
-      point::stress<specfem::element::dimension_tag::dim2,
-                    element::medium_tag::poroelastic, using_simd>;
+  using stress_type = point::stress<
+      specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                          element::medium_tag::poroelastic, using_simd> >;
 
   // Verify static properties
   constexpr int expected_dimension =
@@ -196,8 +198,9 @@ TYPED_TEST(PointStressTest, Stress3DAcoustic) {
       specfem::datatype::simd<type_real, using_simd>::size();
 
   // Define the stress type for 3D acoustic medium
-  using stress_type = point::stress<specfem::element::dimension_tag::dim3,
-                                    element::medium_tag::acoustic, using_simd>;
+  using stress_type = point::stress<
+      specfem::tags::Tags<specfem::element::dimension_tag::dim3,
+                          element::medium_tag::acoustic, using_simd> >;
 
   // Verify static properties
   constexpr int expected_dimension =
@@ -240,8 +243,9 @@ TYPED_TEST(PointStressTest, Stress3DElastic) {
       specfem::datatype::simd<type_real, using_simd>::size();
 
   // Define the stress type for 3D elastic medium
-  using stress_type = point::stress<specfem::element::dimension_tag::dim3,
-                                    element::medium_tag::elastic, using_simd>;
+  using stress_type = point::stress<
+      specfem::tags::Tags<specfem::element::dimension_tag::dim3,
+                          element::medium_tag::elastic, using_simd> >;
 
   // Verify static properties
   constexpr int expected_dimension =
@@ -293,8 +297,9 @@ TYPED_TEST(PointStressTest, DefaultConstructor) {
       specfem::datatype::simd<type_real, using_simd>::size();
 
   // Define the stress type for 2D acoustic medium
-  using stress_type = point::stress<specfem::element::dimension_tag::dim2,
-                                    element::medium_tag::acoustic, using_simd>;
+  using stress_type = point::stress<
+      specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                          element::medium_tag::acoustic, using_simd> >;
 
   // Create a zero value for comparison
   typename specfem::datatype::simd<type_real, using_simd>::datatype zero_val{
@@ -316,9 +321,9 @@ TEST_F(PointStressTestSerial, StressOperatorMultiply2D) {
   constexpr bool using_simd = false;
 
   // Define the stress type for 2D elastic medium
-  using stress_type =
-      point::stress<specfem::element::dimension_tag::dim2,
-                    element::medium_tag::elastic_psv, using_simd>;
+  using stress_type = point::stress<
+      specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                          element::medium_tag::elastic_psv, using_simd> >;
 
   // Create test values
   typename specfem::datatype::simd<type_real, using_simd>::datatype val11;
@@ -373,8 +378,9 @@ TEST_F(PointStressTestSerial, StressOperatorMultiply2DAcoustic) {
   constexpr bool using_simd = false;
 
   // Define the stress type for 2D acoustic medium
-  using stress_type = point::stress<specfem::element::dimension_tag::dim2,
-                                    element::medium_tag::acoustic, using_simd>;
+  using stress_type = point::stress<
+      specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                          element::medium_tag::acoustic, using_simd> >;
 
   // Create a stress tensor with transposed indexing
   typename stress_type::value_type T(5.0, 6.0); // T(0,0)=5.0, T(0,1)=6.0
@@ -410,8 +416,9 @@ TEST_F(PointStressTestSerial, StressOperatorMultiply2DAcoustic) {
 TYPED_TEST(PointStressTest, AccessorBaseType) {
   constexpr bool using_simd = TypeParam::value;
 
-  using stress_type = point::stress<specfem::element::dimension_tag::dim2,
-                                    element::medium_tag::acoustic, using_simd>;
+  using stress_type = point::stress<
+      specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                          element::medium_tag::acoustic, using_simd> >;
 
   // Check if stress_type is derived from the correct base class
   bool is_accessor =
@@ -428,8 +435,9 @@ TYPED_TEST(PointStressTest, AccessorBaseType) {
 TYPED_TEST(PointStressTest, SIMDTypePropagation) {
   constexpr bool using_simd = TypeParam::value;
 
-  using stress_type = point::stress<specfem::element::dimension_tag::dim2,
-                                    element::medium_tag::acoustic, using_simd>;
+  using stress_type = point::stress<
+      specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                          element::medium_tag::acoustic, using_simd> >;
 
   using expected_simd_type = specfem::datatype::simd<type_real, using_simd>;
   using actual_simd_type = typename stress_type::simd;
@@ -452,17 +460,21 @@ TYPED_TEST(PointStressTest, TensorShape) {
   constexpr bool using_simd = TypeParam::value;
 
   // Test various element types and dimensions
-  using acoustic_2d = point::stress<specfem::element::dimension_tag::dim2,
-                                    element::medium_tag::acoustic, using_simd>;
-  using elastic_2d =
-      point::stress<specfem::element::dimension_tag::dim2,
-                    element::medium_tag::elastic_psv, using_simd>;
-  using acoustic_3d = point::stress<specfem::element::dimension_tag::dim3,
-                                    element::medium_tag::acoustic, using_simd>;
-  using elastic_3d = point::stress<specfem::element::dimension_tag::dim3,
-                                   element::medium_tag::elastic, using_simd>;
-  using poro_2d = point::stress<specfem::element::dimension_tag::dim2,
-                                element::medium_tag::poroelastic, using_simd>;
+  using acoustic_2d = point::stress<
+      specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                          element::medium_tag::acoustic, using_simd> >;
+  using elastic_2d = point::stress<
+      specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                          element::medium_tag::elastic_psv, using_simd> >;
+  using acoustic_3d = point::stress<
+      specfem::tags::Tags<specfem::element::dimension_tag::dim3,
+                          element::medium_tag::acoustic, using_simd> >;
+  using elastic_3d = point::stress<
+      specfem::tags::Tags<specfem::element::dimension_tag::dim3,
+                          element::medium_tag::elastic, using_simd> >;
+  using poro_2d = point::stress<
+      specfem::tags::Tags<specfem::element::dimension_tag::dim2,
+                          element::medium_tag::poroelastic, using_simd> >;
 
   // Verify tensor shapes
   EXPECT_EQ(acoustic_2d::dimension, 2);


### PR DESCRIPTION
## Description

- Use new syntax for specfem::point::properties
- Refactor compute_damping with Tags syntax

## Issue Number

Adds to #1064

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
