### PR TITLE
Fixes OpenMP slow down on 

### DIFF
--- a/core/specfem/assembly/jacobian_matrix/dim2/impl_load.hpp
+++ b/core/specfem/assembly/jacobian_matrix/dim2/impl_load.hpp
@@ -87,28 +87,12 @@ KOKKOS_FORCEINLINE_FUNCTION void impl_load(const IndexType &index,
   const std::size_t _index = mapping(ispec, iz, ix);
 
   if constexpr (on_device) {
-    Kokkos::View<const type_real *, Kokkos::DefaultExecutionSpace::memory_space,
-                 Kokkos::MemoryTraits<Kokkos::RandomAccess> >
-        xix = container.xix.get_base_view();
-    Kokkos::View<const type_real *, Kokkos::DefaultExecutionSpace::memory_space,
-                 Kokkos::MemoryTraits<Kokkos::RandomAccess> >
-        gammax = container.gammax.get_base_view();
-    Kokkos::View<const type_real *, Kokkos::DefaultExecutionSpace::memory_space,
-                 Kokkos::MemoryTraits<Kokkos::RandomAccess> >
-        xiz = container.xiz.get_base_view();
-    Kokkos::View<const type_real *, Kokkos::DefaultExecutionSpace::memory_space,
-                 Kokkos::MemoryTraits<Kokkos::RandomAccess> >
-        gammaz = container.gammaz.get_base_view();
-    Kokkos::View<const type_real *, Kokkos::DefaultExecutionSpace::memory_space,
-                 Kokkos::MemoryTraits<Kokkos::RandomAccess> >
-        jacobian = container.jacobian.get_base_view();
-
-    point.xix = xix(_index);
-    point.gammax = gammax(_index);
-    point.xiz = xiz(_index);
-    point.gammaz = gammaz(_index);
+    point.xix = container.xix.get_base_view().data()[_index];
+    point.gammax = container.gammax.get_base_view().data()[_index];
+    point.xiz = container.xiz.get_base_view().data()[_index];
+    point.gammaz = container.gammaz.get_base_view().data()[_index];
     if constexpr (StoreJacobian) {
-      point.jacobian = jacobian(_index);
+      point.jacobian = container.jacobian.get_base_view().data()[_index];
     }
   } else {
     point.xix = container.h_xix[_index];

--- a/core/specfem/assembly/jacobian_matrix/load_on_device.hpp
+++ b/core/specfem/assembly/jacobian_matrix/load_on_device.hpp
@@ -66,7 +66,7 @@ KOKKOS_FORCEINLINE_FUNCTION void load_on_device(const IndexType &index,
                                                PointType>;
   static_assert(compatibility::value, "Incompatible types");
 
-  impl_load<trtimue>(index, container, point);
+  impl_load<true>(index, container, point);
 }
 
 } // namespace specfem::assembly

--- a/core/specfem/assembly/jacobian_matrix/load_on_device.hpp
+++ b/core/specfem/assembly/jacobian_matrix/load_on_device.hpp
@@ -66,7 +66,7 @@ KOKKOS_FORCEINLINE_FUNCTION void load_on_device(const IndexType &index,
                                                PointType>;
   static_assert(compatibility::value, "Incompatible types");
 
-  impl_load<true>(index, container, point);
+  impl_load<trtimue>(index, container, point);
 }
 
 } // namespace specfem::assembly

--- a/core/specfem/macros/data_container.hpp
+++ b/core/specfem/macros/data_container.hpp
@@ -11,9 +11,10 @@
 #define _ACCESS_ELEMENT_ON_HOST(elem, index)                                   \
   BOOST_PP_CAT(h_, BOOST_PP_SEQ_ELEM(0, elem))[index]
 
-#define _CALL_FUNCTOR_ON_DEVICE_CONST(r, data, elem)                           \
-  BOOST_PP_TUPLE_ELEM(0, data)                                                 \
-  (BOOST_PP_SEQ_ELEM(0, elem)[BOOST_PP_TUPLE_ELEM(1, data)],                   \
+#define _CALL_FUNCTOR_ON_DEVICE_CONST(r, _d, elem)                             \
+  BOOST_PP_TUPLE_ELEM(0, _d)                                                   \
+  (BOOST_PP_SEQ_ELEM(0, elem).get_base_view().data()[BOOST_PP_TUPLE_ELEM(1,    \
+                                                                         _d)], \
    static_cast<std::size_t>(BOOST_PP_SEQ_ELEM(1, elem)));
 
 #define _CALL_FUNCTOR_ON_DEVICE(r, data, elem)                                 \

--- a/core/specfem/macros/data_container.hpp
+++ b/core/specfem/macros/data_container.hpp
@@ -12,12 +12,8 @@
   BOOST_PP_CAT(h_, BOOST_PP_SEQ_ELEM(0, elem))[index]
 
 #define _CALL_FUNCTOR_ON_DEVICE_CONST(r, data, elem)                           \
-  Kokkos::View<const type_real *, Kokkos::DefaultExecutionSpace::memory_space, \
-               Kokkos::MemoryTraits<Kokkos::RandomAccess> >                    \
-      BOOST_PP_CAT(_, BOOST_PP_SEQ_ELEM(0, elem)) =                            \
-          BOOST_PP_SEQ_ELEM(0, elem).get_base_view();                          \
   BOOST_PP_TUPLE_ELEM(0, data)                                                 \
-  (_ACCESS_ELEMENT_ON_DEVICE_CONST(elem, BOOST_PP_TUPLE_ELEM(1, data)),        \
+  (BOOST_PP_SEQ_ELEM(0, elem)[BOOST_PP_TUPLE_ELEM(1, data)],                   \
    static_cast<std::size_t>(BOOST_PP_SEQ_ELEM(1, elem)));
 
 #define _CALL_FUNCTOR_ON_DEVICE(r, data, elem)                                 \

--- a/include/domain_view.hpp
+++ b/include/domain_view.hpp
@@ -219,7 +219,7 @@ public:
   }
 
   KOKKOS_INLINE_FUNCTION
-  base_type get_base_view() const {
+  const base_type &get_base_view() const {
     return static_cast<const base_type &>(*this);
   }
 


### PR DESCRIPTION
## Description

Intermittent View creation caused  `Kokkos::Impl::SharedAllocationRecord<..>::increment and decrement` per gll point.

Original PR: Using the operator `[ ]` directly, omitting the view creation, avoid the increment and decrement, and reestablishes correct scaling with increase in threads.

***Update***: Instead of using the operator, I updated the get_base_view operator so that a reference instead of a copy is returned, which is removes dependency on `DomainView::operator[]`

**Note**: Apple silicon chip has 4 performance and 4 energy saving threads, so a total of 8 threads. This means, up to NUM_THREADS=4 everything scales as expected, but if you set NUM_THREADS higher than 4 and performance degrades.

## Issue Number

Closes #1633

## Checklist

Please make sure to check developer documentation on specfem docs.

- [x] I ran the code through pre-commit to check style
- [x] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [x] I have added labels to the PR (see right hand side of the PR page)
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
