### PR TITLE
Updated the get mask utility for ~10% performance gain on apple silicon

### DIFF
--- a/core/specfem/assembly/boundaries/dim2/impl/acoustic_free_surface.hpp
+++ b/core/specfem/assembly/boundaries/dim2/impl/acoustic_free_surface.hpp
@@ -244,7 +244,7 @@ public:
     using mask_type = typename simd::mask_type;
     using tag_type = typename simd::tag_type;
 
-    mask_type mask([&](std::size_t lane) { return index.mask(lane); });
+    const auto mask = index.template get_mask<simd>();
 
     for (int lane = 0; lane < mask_type::size(); ++lane) {
       if (index.mask(lane)) {
@@ -284,7 +284,7 @@ public:
     using mask_type = typename simd::mask_type;
     using tag_type = typename simd::tag_type;
 
-    mask_type mask([&](std::size_t lane) { return index.mask(lane); });
+    const auto mask = index.template get_mask<simd>();
 
     for (int lane = 0; lane < mask_type::size(); ++lane) {
       if (index.mask(lane)) {

--- a/core/specfem/assembly/boundaries/dim2/impl/stacey.hpp
+++ b/core/specfem/assembly/boundaries/dim2/impl/stacey.hpp
@@ -327,7 +327,7 @@ public:
     using mask_type = typename simd::mask_type;
     using tag_type = typename simd::tag_type;
 
-    mask_type mask([&](std::size_t lane) { return index.mask(lane); });
+    const auto mask = index.template get_mask<simd>();
 
     for (int lane = 0; lane < mask_type::size(); ++lane) {
       if (index.mask(lane)) {
@@ -375,7 +375,7 @@ public:
     using mask_type = typename simd::mask_type;
     using tag_type = typename simd::tag_type;
 
-    mask_type mask([&](std::size_t lane) { return index.mask(lane); });
+    const auto mask = index.template get_mask<simd>();
 
     for (int lane = 0; lane < mask_type::size(); ++lane) {
       if (index.mask(lane)) {
@@ -496,7 +496,7 @@ public:
     using mask_type = typename simd::mask_type;
     using tag_type = typename simd::tag_type;
 
-    mask_type mask([&](std::size_t lane) { return index.mask(lane); });
+    const auto mask = index.template get_mask<simd>();
 
     for (int lane = 0; lane < mask_type::size(); ++lane) {
       if (index.mask(lane)) {
@@ -546,7 +546,7 @@ public:
     using mask_type = typename simd::mask_type;
     using tag_type = typename simd::tag_type;
 
-    mask_type mask([&](std::size_t lane) { return index.mask(lane); });
+    const auto mask = index.template get_mask<simd>();
 
     for (int lane = 0; lane < mask_type::size(); ++lane) {
       if (index.mask(lane)) {

--- a/core/specfem/assembly/boundary_values/dim2/impl/boundary_medium_container.hpp
+++ b/core/specfem/assembly/boundary_values/dim2/impl/boundary_medium_container.hpp
@@ -116,7 +116,7 @@ public:
     using mask_type = typename simd::mask_type;
     using tag_type = typename simd::tag_type;
 
-    mask_type mask([&](std::size_t lane) { return index.mask(lane); });
+    const auto mask = index.template get_mask<simd>();
 
     for (int icomp = 0; icomp < components; ++icomp)
       Kokkos::Experimental::where(mask, acceleration(icomp))
@@ -144,7 +144,7 @@ public:
     using mask_type = typename simd::mask_type;
     using tag_type = typename simd::tag_type;
 
-    mask_type mask([&](std::size_t lane) { return index.mask(lane); });
+    const auto mask = index.template get_mask<simd>();
 
     for (int icomp = 0; icomp < components; ++icomp)
       Kokkos::Experimental::where(mask, acceleration(icomp))

--- a/core/specfem/assembly/boundary_values/dim3/impl/boundary_medium_container.hpp
+++ b/core/specfem/assembly/boundary_values/dim3/impl/boundary_medium_container.hpp
@@ -119,7 +119,7 @@ public:
     using mask_type = typename simd::mask_type;
     using tag_type = typename simd::tag_type;
 
-    mask_type mask([&](std::size_t lane) { return index.mask(lane); });
+    const auto mask = index.template get_mask<simd>();
 
     for (int icomp = 0; icomp < components; ++icomp)
       Kokkos::Experimental::where(mask, acceleration(icomp))
@@ -148,7 +148,7 @@ public:
     using mask_type = typename simd::mask_type;
     using tag_type = typename simd::tag_type;
 
-    mask_type mask([&](std::size_t lane) { return index.mask(lane); });
+    const auto mask = index.template get_mask<simd>();
 
     for (int icomp = 0; icomp < components; ++icomp)
       Kokkos::Experimental::where(mask, acceleration(icomp))

--- a/core/specfem/assembly/fields/impl/add_access_functions.hpp
+++ b/core/specfem/assembly/fields/impl/add_access_functions.hpp
@@ -75,9 +75,10 @@ KOKKOS_FORCEINLINE_FUNCTION void add_after_simd_dispatch(
 
   check_accessor_compatibility<AccessorTypes...>();
 
-  using mask_type = typename std::tuple_element_t<
-      0, std::tuple<AccessorTypes...> >::simd::mask_type;
-  mask_type mask([&](std::size_t lane) { return index.mask(lane); });
+  using simd =
+      typename std::tuple_element_t<0, std::tuple<AccessorTypes...> >::simd;
+  using mask_type = typename simd::mask_type;
+  const auto mask = index.template get_mask<simd>();
 
   const int iglob = index.iglob;
 

--- a/core/specfem/assembly/fields/impl/atomic_add_access_functions.hpp
+++ b/core/specfem/assembly/fields/impl/atomic_add_access_functions.hpp
@@ -89,9 +89,10 @@ KOKKOS_FORCEINLINE_FUNCTION void atomic_add_after_simd_dispatch(
 
   check_accessor_compatibility<AccessorTypes...>();
 
-  using mask_type = typename std::tuple_element_t<
-      0, std::tuple<AccessorTypes...> >::simd::mask_type;
-  mask_type mask([&](std::size_t lane) { return index.mask(lane); });
+  using simd =
+      typename std::tuple_element_t<0, std::tuple<AccessorTypes...> >::simd;
+  using mask_type = typename simd::mask_type;
+  const auto mask = index.template get_mask<simd>();
 
   const int iglob = index.iglob;
 

--- a/core/specfem/assembly/fields/impl/load_access_functions.hpp
+++ b/core/specfem/assembly/fields/impl/load_access_functions.hpp
@@ -89,9 +89,10 @@ KOKKOS_FORCEINLINE_FUNCTION void load_after_simd_dispatch(
 
   check_accessor_compatibility<AccessorTypes...>();
 
-  using mask_type = typename std::tuple_element_t<
-      0, std::tuple<AccessorTypes...> >::simd::mask_type;
-  mask_type mask([&](std::size_t lane) { return index.mask(lane); });
+  using simd =
+      typename std::tuple_element_t<0, std::tuple<AccessorTypes...> >::simd;
+  using mask_type = typename simd::mask_type;
+  const auto mask = index.template get_mask<simd>();
 
   const int iglob = index.iglob;
 

--- a/core/specfem/assembly/fields/impl/store_access_functions.hpp
+++ b/core/specfem/assembly/fields/impl/store_access_functions.hpp
@@ -71,9 +71,10 @@ KOKKOS_FORCEINLINE_FUNCTION void store_after_simd_dispatch(
 
   check_accessor_compatibility<AccessorTypes...>();
 
-  using mask_type = typename std::tuple_element_t<
-      0, std::tuple<AccessorTypes...> >::simd::mask_type;
-  mask_type mask([&](std::size_t lane) { return index.mask(lane); });
+  using simd =
+      typename std::tuple_element_t<0, std::tuple<AccessorTypes...> >::simd;
+  using mask_type = typename simd::mask_type;
+  const auto mask = index.template get_mask<simd>();
 
   const int iglob = index.iglob;
 

--- a/core/specfem/assembly/impl/domain_accessor.hpp
+++ b/core/specfem/assembly/impl/domain_accessor.hpp
@@ -54,7 +54,7 @@ private:
     using mask_type = typename simd::mask_type;
     using tag_type = typename simd::tag_type;
 
-    mask_type mask([&](std::size_t lane) { return index.mask(lane); });
+    const auto mask = index.template get_mask<simd>();
     static_cast<const DataContainer *>(this)->for_each_on_device(
         index, [&](const type_real &value, const std::size_t i) mutable {
           Kokkos::Experimental::where(mask, values[i])
@@ -70,7 +70,7 @@ private:
     using mask_type = typename simd::mask_type;
     using tag_type = typename simd::tag_type;
 
-    mask_type mask([&](std::size_t lane) { return index.mask(lane); });
+    const auto mask = index.template get_mask<simd>();
     static_cast<const DataContainer *>(this)->for_each_on_host(
         index, [&](const type_real &value, const std::size_t i) mutable {
           Kokkos::Experimental::where(mask, values[i])
@@ -104,7 +104,7 @@ private:
     using mask_type = typename simd::mask_type;
     using tag_type = typename simd::tag_type;
 
-    mask_type mask([&](std::size_t lane) { return index.mask(lane); });
+    const auto mask = index.template get_mask<simd>();
     static_cast<const DataContainer *>(this)->for_each_on_device(
         index, [&](type_real &value, const std::size_t i) {
           Kokkos::Experimental::where(mask, values[i])
@@ -120,7 +120,7 @@ private:
     using mask_type = typename simd::mask_type;
     using tag_type = typename simd::tag_type;
 
-    mask_type mask([&](std::size_t lane) { return index.mask(lane); });
+    const auto mask = index.template get_mask<simd>();
     static_cast<const DataContainer *>(this)->for_each_on_host(
         index, [&](type_real &value, const std::size_t i) {
           Kokkos::Experimental::where(mask, values[i])

--- a/core/specfem/assembly/jacobian_matrix/dim2/impl_load.hpp
+++ b/core/specfem/assembly/jacobian_matrix/dim2/impl_load.hpp
@@ -33,7 +33,7 @@ KOKKOS_FORCEINLINE_FUNCTION void impl_load(const IndexType &index,
   const auto &mapping = container.xix.get_mapping();
   const std::size_t _index = mapping(ispec, iz, ix);
 
-  mask_type mask([&](std::size_t lane) { return index.mask(lane); });
+  const auto mask = index.template get_mask<simd>();
 
   if constexpr (on_device) {
     Kokkos::Experimental::where(mask, point.xix)

--- a/core/specfem/assembly/jacobian_matrix/dim2/impl_store.hpp
+++ b/core/specfem/assembly/jacobian_matrix/dim2/impl_store.hpp
@@ -30,7 +30,7 @@ inline void impl_store(const IndexType &index, const ContainerType &derivatives,
   using mask_type = typename simd::mask_type;
   using tag_type = typename simd::tag_type;
 
-  mask_type mask([&](std::size_t lane) { return index.mask(lane); });
+  const auto mask = index.template get_mask<simd>();
 
   const auto &mapping = derivatives.xix.get_mapping();
   const std::size_t _index = mapping(ispec, iz, ix);

--- a/core/specfem/point/assembly_index.hpp
+++ b/core/specfem/point/assembly_index.hpp
@@ -108,6 +108,26 @@ struct assembly_index<true>
   bool mask(const std::size_t &lane) const { return int(lane) < number_points; }
 
   /**
+   * @brief Returns a SIMD mask for valid lanes.
+   *
+   * For full chunks (all lanes valid) returns an all-true mask using the cheap
+   * broadcast constructor, avoiding the per-lane generator. For the rare
+   * partial last chunk falls back to per-lane evaluation.
+   *
+   * @tparam simd_type SIMD wrapper type (e.g. specfem::datatype::simd<float,
+   * true>)
+   * @return SIMD mask with true for valid lanes
+   */
+  template <typename simd_type>
+  KOKKOS_INLINE_FUNCTION typename simd_type::mask_type get_mask() const {
+    if (number_points >= simd_type::size()) {
+      return typename simd_type::mask_type(true);
+    }
+    return typename simd_type::mask_type(
+        [&](std::size_t lane) { return int(lane) < number_points; });
+  }
+
+  /**
    * @name Constructors
    * @brief Constructors for initializing the SIMD assembly index.
    */

--- a/core/specfem/point/index.hpp
+++ b/core/specfem/point/index.hpp
@@ -164,6 +164,26 @@ struct index<specfem::element::dimension_tag::dim2, true>
   bool mask(const std::size_t &lane) const {
     return int(lane) < number_elements;
   }
+
+  /**
+   * @brief Returns a SIMD mask for valid lanes.
+   *
+   * For full chunks (all lanes valid) returns an all-true mask using the cheap
+   * broadcast constructor, avoiding the per-lane generator. For the rare
+   * partial last chunk falls back to per-lane evaluation.
+   *
+   * @tparam simd_type SIMD wrapper type (e.g. specfem::datatype::simd<float,
+   * true>)
+   * @return SIMD mask with true for valid lanes
+   */
+  template <typename simd_type>
+  KOKKOS_INLINE_FUNCTION typename simd_type::mask_type get_mask() const {
+    if (number_elements >= simd_type::size()) {
+      return typename simd_type::mask_type(true);
+    }
+    return typename simd_type::mask_type(
+        [&](std::size_t lane) { return int(lane) < number_elements; });
+  }
 };
 
 //-------------------------- 3D Specializations ------------------------------//
@@ -333,6 +353,26 @@ struct index<specfem::element::dimension_tag::dim3, true>
   KOKKOS_INLINE_FUNCTION
   bool mask(const std::size_t &lane) const {
     return int(lane) < number_elements;
+  }
+
+  /**
+   * @brief Returns a SIMD mask for valid lanes.
+   *
+   * For full chunks (all lanes valid) returns an all-true mask using the cheap
+   * broadcast constructor, avoiding the per-lane generator. For the rare
+   * partial last chunk falls back to per-lane evaluation.
+   *
+   * @tparam simd_type SIMD wrapper type (e.g. specfem::datatype::simd<float,
+   * true>)
+   * @return SIMD mask with true for valid lanes
+   */
+  template <typename simd_type>
+  KOKKOS_INLINE_FUNCTION typename simd_type::mask_type get_mask() const {
+    if (number_elements >= simd_type::size()) {
+      return typename simd_type::mask_type(true);
+    }
+    return typename simd_type::mask_type(
+        [&](std::size_t lane) { return int(lane) < number_elements; });
   }
 };
 


### PR DESCRIPTION
## Description

The mask is created for every single chunk/gll combination but for 99% of chunks the mask is true for all!


### Problem

Every masked SIMD kernel call constructed its mask via a per-lane lambda, even for the ~99% of chunks that are full and trivially all-true:

```cpp
// runs on every chunk — opaque to optimizer, can't constant-fold
mask_type mask([&](std::size_t lane) { return int(lane) < number_elements; });
```

This appeared hot in 13 call sites across field I/O, Jacobians, and boundary conditions.

### Fix

Added `get_mask<simd_type>()` to `point::index` and `point::assembly_index` to fast-path the common case:

```cpp
if (number_elements >= simd_type::size())
    return mask_type(true);  // single vmov.i32 on NEON; branch is ~always taken
return mask_type([&](std::size_t lane) { return int(lane) < number_elements; });
```

All 13 sites updated. Partial-chunk behavior is unchanged.

### Result

| | |
|---|---|
| Runtime (Apple M3, 2D fluid-solid benchmark) | **~10% faster** |
| Correctness impact | **None** |


## Issue Number

If there is an issue created for these changes, link it here

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
