### PR TITLE
Update the gradient algorithm to return the jacobian if the callable …

### DIFF
--- a/core/specfem/algorithms/gradient.hpp
+++ b/core/specfem/algorithms/gradient.hpp
@@ -203,14 +203,26 @@ gradient(const ChunkIndexType &chunk_index,
 
   using datatype = typename VectorFieldType::simd::datatype;
 
-  static_assert(
+  using JacobianWithJacobianType =
+      specfem::point::jacobian_matrix<specfem::element::dimension_tag::dim2,
+                                      true, using_simd>;
+
+  // If the callback accepts a third argument (the point jacobian matrix with
+  // jacobian scalar), load with store_jacobian=true and forward it — avoids a
+  // redundant load_on_device call inside the callback.
+  constexpr bool pass_jacobian =
       std::is_invocable_v<CallbackFunctor,
                           typename ChunkIndexType::iterator_type::index_type,
-                          TensorPointViewType>,
-      "CallbackFunctor must be invocable with the following signature: "
-      "void(const int, const specfem::point::index, const "
-      "specfem::kokkos::array_type<type_real, components>, const "
-      "specfem::kokkos::array_type<type_real, components>)");
+                          TensorPointViewType, JacobianWithJacobianType>;
+
+  static_assert(
+      pass_jacobian || std::is_invocable_v<
+                           CallbackFunctor,
+                           typename ChunkIndexType::iterator_type::index_type,
+                           TensorPointViewType>,
+      "CallbackFunctor must be invocable with signature: "
+      "void(iterator_index, TensorPointViewType) or "
+      "void(iterator_index, TensorPointViewType, point_jacobian_matrix)");
 
   specfem::execution::for_each_level(
       chunk_index.get_iterator(),
@@ -220,17 +232,26 @@ gradient(const ChunkIndexType &chunk_index,
         const auto local_index = iterator_index.get_local_index();
         datatype df_dxi[components] = { 0.0 };
         datatype df_dgamma[components] = { 0.0 };
-        specfem::point::jacobian_matrix<specfem::element::dimension_tag::dim2,
-                                        false, using_simd>
-            point_jacobian_matrix;
 
-        specfem::assembly::load_on_device(index, jacobian_matrix,
-                                          point_jacobian_matrix);
-
-        const auto df =
-            impl::element_gradient(f, local_index, point_jacobian_matrix,
-                                   quadrature, df_dxi, df_dgamma);
-        callback(iterator_index, df);
+        if constexpr (pass_jacobian) {
+          JacobianWithJacobianType point_jacobian_matrix;
+          specfem::assembly::load_on_device(index, jacobian_matrix,
+                                            point_jacobian_matrix);
+          const auto df =
+              impl::element_gradient(f, local_index, point_jacobian_matrix,
+                                     quadrature, df_dxi, df_dgamma);
+          callback(iterator_index, df, point_jacobian_matrix);
+        } else {
+          specfem::point::jacobian_matrix<specfem::element::dimension_tag::dim2,
+                                          false, using_simd>
+              point_jacobian_matrix;
+          specfem::assembly::load_on_device(index, jacobian_matrix,
+                                            point_jacobian_matrix);
+          const auto df =
+              impl::element_gradient(f, local_index, point_jacobian_matrix,
+                                     quadrature, df_dxi, df_dgamma);
+          callback(iterator_index, df);
+        }
       });
 
   return;
@@ -362,15 +383,23 @@ gradient(const ChunkIndexType &chunk_index,
 
   using datatype = typename VectorFieldType::simd::datatype;
 
-  static_assert(
+  using JacobianWithJacobianType =
+      specfem::point::jacobian_matrix<specfem::element::dimension_tag::dim3,
+                                      true, using_simd>;
+
+  constexpr bool pass_jacobian =
       std::is_invocable_v<CallbackFunctor,
                           typename ChunkIndexType::iterator_type::index_type,
-                          TensorPointViewType>,
-      "CallbackFunctor must be invocable with the following signature: "
-      "void(const int, const specfem::point::index, const "
-      "specfem::kokkos::array_type<type_real, components>, const "
-      "specfem::kokkos::array_type<type_real, components>, const "
-      "specfem::kokkos::array_type<type_real, components>)");
+                          TensorPointViewType, JacobianWithJacobianType>;
+
+  static_assert(
+      pass_jacobian || std::is_invocable_v<
+                           CallbackFunctor,
+                           typename ChunkIndexType::iterator_type::index_type,
+                           TensorPointViewType>,
+      "CallbackFunctor must be invocable with signature: "
+      "void(iterator_index, TensorPointViewType) or "
+      "void(iterator_index, TensorPointViewType, point_jacobian_matrix)");
 
   specfem::execution::for_each_level(
       chunk_index.get_iterator(),
@@ -381,17 +410,26 @@ gradient(const ChunkIndexType &chunk_index,
         datatype df_dxi[components] = { 0.0 };
         datatype df_deta[components] = { 0.0 };
         datatype df_dgamma[components] = { 0.0 };
-        specfem::point::jacobian_matrix<specfem::element::dimension_tag::dim3,
-                                        false, using_simd>
-            point_jacobian_matrix;
 
-        specfem::assembly::load_on_device(index, jacobian_matrix,
-                                          point_jacobian_matrix);
-
-        const auto df =
-            impl::element_gradient(f, local_index, point_jacobian_matrix,
-                                   quadrature, df_dxi, df_deta, df_dgamma);
-        callback(iterator_index, df);
+        if constexpr (pass_jacobian) {
+          JacobianWithJacobianType point_jacobian_matrix;
+          specfem::assembly::load_on_device(index, jacobian_matrix,
+                                            point_jacobian_matrix);
+          const auto df =
+              impl::element_gradient(f, local_index, point_jacobian_matrix,
+                                     quadrature, df_dxi, df_deta, df_dgamma);
+          callback(iterator_index, df, point_jacobian_matrix);
+        } else {
+          specfem::point::jacobian_matrix<specfem::element::dimension_tag::dim3,
+                                          false, using_simd>
+              point_jacobian_matrix;
+          specfem::assembly::load_on_device(index, jacobian_matrix,
+                                            point_jacobian_matrix);
+          const auto df =
+              impl::element_gradient(f, local_index, point_jacobian_matrix,
+                                     quadrature, df_dxi, df_deta, df_dgamma);
+          callback(iterator_index, df);
+        }
       });
 
   return;

--- a/core/specfem/compute/impl/compute_stiffness_interaction.tpp
+++ b/core/specfem/compute/impl/compute_stiffness_interaction.tpp
@@ -145,12 +145,10 @@ int specfem::compute::impl::compute_stiffness_interaction(
           specfem::algorithms::gradient(
               chunk_index, jacobian_matrix, lagrange_derivative, element_field,
               [&](const auto &iterator_index,
-                  const typename PointFieldDerivativesType::value_type &du) {
+                  const typename PointFieldDerivativesType::value_type &du,
+                  const PointJacobianMatrixType &point_jacobian_matrix) {
                 const auto &index = iterator_index.get_index();
                 const auto &local_index = iterator_index.get_local_index();
-                PointJacobianMatrixType point_jacobian_matrix;
-                specfem::assembly::load_on_device(index, jacobian_matrix,
-                                                  point_jacobian_matrix);
 
                 PointPropertyType point_property;
                 specfem::assembly::load_on_device(index, properties,


### PR DESCRIPTION
## Description

Another couple of percent of performance. This should affect GPU performance as well. Since it removes 4 type real loads

`specfem::algorithms::gradient` now optionally forwards the point Jacobian matrix to the callback                                                                                                  
   
The gradient algorithm previously always loaded a jacobian_matrix (without the Jacobian scalar) internally and passed only the gradient tensor df to the callback. Callers that also needed the Jacobian (e.g., to compute stress) had to perform a second redundant load_on_device call.

This commit uses if constexpr + std::is_invocable_v to detect at compile time whether the callback accepts a third argument of type point::jacobian_matrix<..., store_jacobian=true, ...>. If so, the gradient function loads the richer Jacobian type (with the scalar Jacobian) once and forwards it directly to the callback, eliminating the duplicate load.

The compute_stiffness_interaction caller is updated to use the new three-argument signature, removing its now-redundant load_on_device call. The two-argument signature remains fully supported, so existing callers are unaffected.

Applied to both the 2D and 3D overloads of gradient.

## Issue Number

-/-

## Checklist

Please make sure to check developer documentation on specfem docs.

- [x] I ran the code through pre-commit to check style
- [x] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [x] I have added labels to the PR (see right hand side of the PR page)
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
