### PR TITLE
Updated the inner loop of the divergence for fewer accesses.

### DIFF
--- a/core/specfem/algorithms/divergence.hpp
+++ b/core/specfem/algorithms/divergence.hpp
@@ -56,13 +56,11 @@ element_divergence(const TensorFieldType &f,
 
   /// We omit the divergence here since we multiplied it when computing F.
   for (int l = 0; l < ngll; ++l) {
+    const datatype wxi = lagrange_derivative.xi(l, ix) * weights(l);
+    const datatype wgamma = lagrange_derivative.gamma(l, iz) * weights(l);
     for (int icomp = 0; icomp < components; ++icomp) {
-      temp1l[icomp] += f(ielement, iz, l, icomp, 0) *
-                       lagrange_derivative.xi(l, ix) * weights(l);
-    }
-    for (int icomp = 0; icomp < components; ++icomp) {
-      temp2l[icomp] += f(ielement, l, ix, icomp, 1) *
-                       lagrange_derivative.gamma(l, iz) * weights(l);
+      temp1l[icomp] += f(ielement, iz, l, icomp, 0) * wxi;
+      temp2l[icomp] += f(ielement, l, ix, icomp, 1) * wgamma;
     }
   }
   VectorPointViewType result;
@@ -113,17 +111,17 @@ element_divergence(const TensorFieldType &f,
 
   /// We omit the divergence here since we multiplied it when computing F.
   for (int l = 0; l < ngll; ++l) {
+    const datatype wxi = lagrange_derivative.xi(l, ix) * weights(l);
+    const datatype weta = lagrange_derivative.eta(l, iy) * weights(l);
+    const datatype wgamma = lagrange_derivative.gamma(l, iz) * weights(l);
     for (int icomp = 0; icomp < components; ++icomp) {
-      temp1l[icomp] += f(ielement, iz, iy, l, icomp, 0) *
-                       lagrange_derivative.xi(l, ix) * weights(l);
+      temp1l[icomp] += f(ielement, iz, iy, l, icomp, 0) * wxi;
     }
     for (int icomp = 0; icomp < components; ++icomp) {
-      temp2l[icomp] += f(ielement, iz, l, ix, icomp, 1) *
-                       lagrange_derivative.eta(l, iy) * weights(l);
+      temp2l[icomp] += f(ielement, iz, l, ix, icomp, 1) * weta;
     }
     for (int icomp = 0; icomp < components; ++icomp) {
-      temp3l[icomp] += f(ielement, l, iy, ix, icomp, 2) *
-                       lagrange_derivative.gamma(l, iz) * weights(l);
+      temp3l[icomp] += f(ielement, l, iy, ix, icomp, 2) * wgamma;
     }
   }
   VectorPointViewType result;


### PR DESCRIPTION
## Description

Updated the inner divergence loop for another couple of percent of performance on Macos

Performance on CPU runtime should be almost 50% smaller. May have impact on GPU. 
But unclear.

## Issue Number

-/-

## Checklist

Please make sure to check developer documentation on specfem docs.

- [x] I ran the code through pre-commit to check style
- [x] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [x] I have added labels to the PR (see right hand side of the PR page)
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
