### PR TITLE
Flux-scheme parameter in `specfem_config.yaml` + `assembly`-constructor pass

### DIFF
--- a/core/specfem/assembly/assembly/dim2/assembly.cpp
+++ b/core/specfem/assembly/assembly/dim2/assembly.cpp
@@ -17,7 +17,9 @@ specfem::assembly::assembly<specfem::element::dimension_tag::dim2>::assembly(
     const int nsteps_between_samples,
     const specfem::simulation::type simulation,
     const bool allocate_boundary_values,
-    const std::shared_ptr<specfem::io::reader> &property_reader) {
+    const std::shared_ptr<specfem::io::reader> &property_reader,
+    const specfem::element_coupling::flux_scheme_configuration
+        &flux_scheme_config) {
   this->mesh = { mesh.tags, mesh.control_nodes, quadratures,
                  mesh.adjacency_graph };
   this->element_types = { this->mesh.nspec, this->mesh.element_grid.ngllz,

--- a/core/specfem/assembly/assembly/dim2/assembly.hpp
+++ b/core/specfem/assembly/assembly/dim2/assembly.hpp
@@ -18,6 +18,7 @@
 #include "specfem/enums.hpp"
 #include "specfem/mesh.hpp"
 #include "specfem/receivers.hpp"
+#include "specfem/runtime_configuration/flux_schemes.hpp"
 #include "specfem/source.hpp"
 
 namespace specfem::io {
@@ -182,6 +183,7 @@ template <> struct assembly<specfem::element::dimension_tag::dim2> {
    * @param write_wavefield Whether to write wavefield
    * @param property_reader Reader for GLL model (skip material property
    * assignment if exists)
+   * @param flux_scheme_config Flux scheme rules for nonconforming interfaces
    */
   assembly(
       const specfem::mesh::mesh<dimension_tag> &mesh,
@@ -196,7 +198,10 @@ template <> struct assembly<specfem::element::dimension_tag::dim2> {
       const int nsteps_between_samples,
       const specfem::simulation::type simulation,
       const bool allocate_boundary_values,
-      const std::shared_ptr<specfem::io::reader> &property_reader);
+      const std::shared_ptr<specfem::io::reader> &property_reader,
+      const specfem::element_coupling::flux_scheme_configuration
+          &flux_scheme_config =
+              specfem::element_coupling::flux_scheme_configuration());
 
   /**
    * @brief Maps the component of wavefield on the entire spectral element grid

--- a/core/specfem/element_coupling/flux_scheme_configuration.hpp
+++ b/core/specfem/element_coupling/flux_scheme_configuration.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "specfem/constants.hpp"
+#include "specfem/element_coupling.hpp"
+namespace specfem::element_coupling {
+
+struct flux_scheme_configuration {
+  specfem::element_coupling::flux_scheme_tag flux_scheme_tag;
+  std::vector<type_real> scheme_parameters;
+
+  flux_scheme_configuration()
+      : flux_scheme_tag(specfem::element_coupling::flux_scheme_tag::natural) {}
+};
+} // namespace specfem::element_coupling

--- a/core/specfem/runtime_configuration/flux_schemes.cpp
+++ b/core/specfem/runtime_configuration/flux_schemes.cpp
@@ -11,107 +11,42 @@ specfem::runtime_configuration::flux_schemes::flux_schemes(
     throw std::runtime_error("flux-scheme YAML node must be a sequence.");
   }
 
-  for (const YAML::Node entry : this->flux_schemes_node) {
+  // multi-rules in commit 4a27c96cde7e8548556da6caf628eda034fd35b3
 
+  if (const YAML::Node &flux_scheme_type_node = flux_schemes_node["type"]) {
     specfem::element_coupling::flux_scheme_tag flux_scheme_tag;
-
-    // for now, we will only assume this is a singleton with "interface"
-    // identifier and not "material<1/2>". This code should work if generalized,
-    // but has not been verified.
-    if (const YAML::Node &flux_scheme_type_node = entry["type"]) {
-      try {
-        const auto flux_scheme_type = flux_scheme_type_node.as<std::string>();
-
-        // TODO flux_scheme_tag from_string() function?
-        if (flux_scheme_type == std::string("natural")) {
-          flux_scheme_tag = specfem::element_coupling::flux_scheme_tag::natural;
-        } else {
-          throw std::runtime_error(std::string("Unrecognized flux scheme: \"") +
-                                   flux_scheme_type + "\"");
-        }
-
-        // two cases: interface specification or material specification -- only
-        // one can be set for a given rule
-        const YAML::Node &interface_identifier_node = entry["interface"];
-        const YAML::Node &material1_identifier_node = entry["material1"];
-        const YAML::Node &material2_identifier_node = entry["material2"];
-        bool is_interface_defined = interface_identifier_node.IsDefined();
-        bool is_material_defined = material1_identifier_node.IsDefined() ||
-                                   material2_identifier_node.IsDefined();
-
-        if (is_interface_defined) {
-          if (is_material_defined) {
-            throw std::runtime_error(
-                "Flux-scheme entry has both \"interface\"-specification and "
-                "\"material1/2\"-specification. Only one is permitted.");
-          }
-          try {
-            const auto interface_identifier =
-                interface_identifier_node.as<std::string>();
-
-            // TODO interface_tag from_string() function?
-            specfem::element_coupling::interface_tag interface_tag;
-            if (interface_identifier == std::string("acoustic_elastic") ||
-                interface_identifier == std::string("elastic_acoustic")) {
-              interface_tag =
-                  specfem::element_coupling::interface_tag::acoustic_elastic;
-            } else {
-              throw std::runtime_error(
-                  std::string("Unrecognized interface tag: \"") +
-                  interface_identifier + "\"");
-            }
-
-            // append entry
-            this->per_interface_configs[interface_tag] =
-                std::make_pair(flux_scheme_tag, entry);
-
-          } catch (YAML::InvalidNode &e) {
-            throw std::runtime_error("Flux-scheme entry has \"type\" node, "
-                                     "but it is not a string!");
-          }
-          continue;
-        }
-
-        if (is_material_defined) {
-          if ((!material1_identifier_node.IsDefined()) ||
-              (!material2_identifier_node.IsDefined())) {
-            throw std::runtime_error(
-                "When a flux-scheme entry uses a "
-                "\"material1/2\"-specification, both \"material1\" and "
-                "\"material2\" must be specified!");
-          }
-          try {
-            int material1 = material1_identifier_node.as<int>();
-            int material2 = material2_identifier_node.as<int>();
-
-            // use lowest number first:
-            if (material1 > material2) {
-              std::swap(material1, material2);
-            }
-
-            // append entry
-            this->per_material_configs[std::make_pair(material1, material2)] =
-                std::make_pair(flux_scheme_tag, entry);
-
-          } catch (YAML::InvalidNode &e) {
-            throw std::runtime_error("Flux-scheme entry has \"type\" node, "
-                                     "but it is not a string!");
-          }
-          continue;
-        }
-
-        // no specification made
-        throw std::runtime_error(
-            "Flux-scheme needs either \"interface\"-specification or "
-            "\"material1/2\"-specification.");
-      } catch (YAML::InvalidNode &e) {
-        throw std::runtime_error(
-            "Flux-scheme entry has \"type\" node, but it is not a string!");
-      }
-    } else {
+    std::string flux_scheme_str;
+    try {
+      flux_scheme_str = flux_scheme_type_node.as<std::string>();
+    } catch (YAML::InvalidNode &e) {
       throw std::runtime_error(
-          "Flux-scheme entry must have a \"type\" string specified.");
+          "Flux-scheme entry has \"type\" node, but it is not a string!");
     }
+
+    // === parse flux scheme string to tag and verify necessary parameters ===
+
+    // TODO flux_scheme_tag from_string() function?
+    if (flux_scheme_str == std::string("natural")) {
+      flux_scheme_tag = specfem::element_coupling::flux_scheme_tag::natural;
+    } else if (flux_scheme_str == std::string("symmetric_interior_penalty")) {
+      flux_scheme_tag = specfem::element_coupling::flux_scheme_tag::
+          symmetric_interior_penalty;
+      throw std::runtime_error(
+          "symmetric_interior_penalty not yet supported. Do not set this "
+          "scheme in your specfem configuration.");
+    } else {
+      throw std::runtime_error(std::string("Unrecognized flux scheme: \"") +
+                               flux_scheme_str + "\"");
+    }
+
+    // === set config ===
+    per_interface_configs
+        [specfem::element_coupling::interface_tag::acoustic_elastic] =
+            std::make_pair(flux_scheme_tag, flux_schemes_node);
+
+  } else {
+    throw std::runtime_error(
+        "Flux-scheme entry must have a \"type\" string specified.");
   }
 }
 

--- a/core/specfem/runtime_configuration/flux_schemes.cpp
+++ b/core/specfem/runtime_configuration/flux_schemes.cpp
@@ -1,0 +1,141 @@
+#include "flux_schemes.hpp"
+#include "specfem/element_coupling.hpp"
+#include <stdexcept>
+#include <utility>
+#include <yaml-cpp/exceptions.h>
+
+specfem::runtime_configuration::flux_schemes::flux_schemes(
+    const YAML::Node &Node)
+    : flux_schemes_node(Node) {
+  if (!this->flux_schemes_node.IsSequence()) {
+    throw std::runtime_error("flux-scheme YAML node must be a sequence.");
+  }
+
+  for (const YAML::Node entry : this->flux_schemes_node) {
+
+    specfem::element_coupling::flux_scheme_tag flux_scheme_tag;
+
+    // for now, we will only assume this is a singleton with "interface"
+    // identifier and not "material<1/2>". This code should work if generalized,
+    // but has not been verified.
+    if (const YAML::Node &flux_scheme_type_node = entry["type"]) {
+      try {
+        const auto flux_scheme_type = flux_scheme_type_node.as<std::string>();
+
+        // TODO flux_scheme_tag from_string() function?
+        if (flux_scheme_type == std::string("natural")) {
+          flux_scheme_tag = specfem::element_coupling::flux_scheme_tag::natural;
+        } else {
+          throw std::runtime_error(std::string("Unrecognized flux scheme: \"") +
+                                   flux_scheme_type + "\"");
+        }
+
+        // two cases: interface specification or material specification -- only
+        // one can be set for a given rule
+        const YAML::Node &interface_identifier_node = entry["interface"];
+        const YAML::Node &material1_identifier_node = entry["material1"];
+        const YAML::Node &material2_identifier_node = entry["material2"];
+        bool is_interface_defined = interface_identifier_node.IsDefined();
+        bool is_material_defined = material1_identifier_node.IsDefined() ||
+                                   material2_identifier_node.IsDefined();
+
+        if (is_interface_defined) {
+          if (is_material_defined) {
+            throw std::runtime_error(
+                "Flux-scheme entry has both \"interface\"-specification and "
+                "\"material1/2\"-specification. Only one is permitted.");
+          }
+          try {
+            const auto interface_identifier =
+                interface_identifier_node.as<std::string>();
+
+            // TODO interface_tag from_string() function?
+            specfem::element_coupling::interface_tag interface_tag;
+            if (interface_identifier == std::string("acoustic_elastic") ||
+                interface_identifier == std::string("elastic_acoustic")) {
+              interface_tag =
+                  specfem::element_coupling::interface_tag::acoustic_elastic;
+            } else {
+              throw std::runtime_error(
+                  std::string("Unrecognized interface tag: \"") +
+                  interface_identifier + "\"");
+            }
+
+            // append entry
+            this->per_interface_configs[interface_tag] =
+                std::make_pair(flux_scheme_tag, entry);
+
+          } catch (YAML::InvalidNode &e) {
+            throw std::runtime_error("Flux-scheme entry has \"type\" node, "
+                                     "but it is not a string!");
+          }
+          continue;
+        }
+
+        if (is_material_defined) {
+          if ((!material1_identifier_node.IsDefined()) ||
+              (!material2_identifier_node.IsDefined())) {
+            throw std::runtime_error(
+                "When a flux-scheme entry uses a "
+                "\"material1/2\"-specification, both \"material1\" and "
+                "\"material2\" must be specified!");
+          }
+          try {
+            int material1 = material1_identifier_node.as<int>();
+            int material2 = material2_identifier_node.as<int>();
+
+            // use lowest number first:
+            if (material1 > material2) {
+              std::swap(material1, material2);
+            }
+
+            // append entry
+            this->per_material_configs[std::make_pair(material1, material2)] =
+                std::make_pair(flux_scheme_tag, entry);
+
+          } catch (YAML::InvalidNode &e) {
+            throw std::runtime_error("Flux-scheme entry has \"type\" node, "
+                                     "but it is not a string!");
+          }
+          continue;
+        }
+
+        // no specification made
+        throw std::runtime_error(
+            "Flux-scheme needs either \"interface\"-specification or "
+            "\"material1/2\"-specification.");
+      } catch (YAML::InvalidNode &e) {
+        throw std::runtime_error(
+            "Flux-scheme entry has \"type\" node, but it is not a string!");
+      }
+    } else {
+      throw std::runtime_error(
+          "Flux-scheme entry must have a \"type\" string specified.");
+    }
+  }
+}
+
+specfem::element_coupling::flux_scheme_configuration
+specfem::runtime_configuration::flux_schemes::generate_configuration() {
+  specfem::element_coupling::flux_scheme_configuration config;
+
+  // for now, we will only assume this is a singleton with "interface"
+  // identifier and not "material<1/2>". runtime_configuration::flux_schemes
+  // should work with multiple, but element_coupling::flux_scheme_configuration
+  // has not been implemented, so catch multiple-case here here.
+
+  if (per_material_configs.size() > 0) {
+    throw std::runtime_error(
+        "Per-material flux-scheme configuration not implemented.");
+  }
+  if (per_interface_configs.size() > 1) {
+    throw std::runtime_error(
+        "Per-interface flux-scheme configuration only supports 1 type.");
+  }
+
+  if (per_interface_configs.size() == 1) {
+    const auto config_entry = per_interface_configs.begin()->second;
+    config.flux_scheme_tag = config_entry.first;
+  }
+  return config;
+}

--- a/core/specfem/runtime_configuration/flux_schemes.cpp
+++ b/core/specfem/runtime_configuration/flux_schemes.cpp
@@ -7,9 +7,6 @@
 specfem::runtime_configuration::flux_schemes::flux_schemes(
     const YAML::Node &Node)
     : flux_schemes_node(Node) {
-  if (!this->flux_schemes_node.IsSequence()) {
-    throw std::runtime_error("flux-scheme YAML node must be a sequence.");
-  }
 
   // multi-rules in commit 4a27c96cde7e8548556da6caf628eda034fd35b3
 

--- a/core/specfem/runtime_configuration/flux_schemes.hpp
+++ b/core/specfem/runtime_configuration/flux_schemes.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "specfem/constants.hpp"
+#include "specfem/element_coupling.hpp"
+#include "specfem/element_coupling/flux_scheme_configuration.hpp"
+
+#include "yaml-cpp/yaml.h"
+#include <map>
+#include <string>
+#include <utility>
+
+namespace specfem {
+namespace runtime_configuration {
+
+/**
+ * @brief class to read flux-scheme information
+ *
+ */
+class flux_schemes {
+public:
+  flux_schemes(const YAML::Node &Node);
+
+private:
+  bool config_provided;
+  YAML::Node flux_schemes_node; /// Node that contains flux scheme information
+
+  std::map<specfem::element_coupling::interface_tag,
+           std::pair<specfem::element_coupling::flux_scheme_tag, YAML::Node> >
+      per_interface_configs;
+
+  std::map<std::pair<int, int>,
+           std::pair<specfem::element_coupling::flux_scheme_tag, YAML::Node> >
+      per_material_configs;
+
+public:
+  specfem::element_coupling::flux_scheme_configuration generate_configuration();
+};
+} // namespace runtime_configuration
+} // namespace specfem

--- a/core/specfem/runtime_configuration/setup.cpp
+++ b/core/specfem/runtime_configuration/setup.cpp
@@ -4,9 +4,11 @@
 #include <chrono>
 #include <ctime>
 #include <iostream>
+#include <memory>
 #include <ostream>
 #include <sys/stat.h>
 #include <tuple>
+#include <yaml-cpp/exceptions.h>
 
 void create_folder_if_not_exists(const std::string &folder_name) {
   struct stat info;
@@ -50,6 +52,13 @@ specfem::runtime_configuration::setup::setup(const YAML::Node &parameter_dict) {
         std::make_unique<specfem::runtime_configuration::sources>(source_node);
   } else {
     throw std::runtime_error("Error reading specfem source configuration.");
+  }
+
+  // Get flux scheme info (optional)
+  if (const YAML::Node &flux_schemes_node = simulation_setup["flux-schemes"]) {
+    this->flux_schemes =
+        std::make_unique<specfem::runtime_configuration::flux_schemes>(
+            flux_schemes_node);
   }
 
   // Get Elastic Wave type Default is P_SV

--- a/core/specfem/runtime_configuration/setup.cpp
+++ b/core/specfem/runtime_configuration/setup.cpp
@@ -55,7 +55,7 @@ specfem::runtime_configuration::setup::setup(const YAML::Node &parameter_dict) {
   }
 
   // Get flux scheme info (optional)
-  if (const YAML::Node &flux_schemes_node = simulation_setup["flux-schemes"]) {
+  if (const YAML::Node &flux_schemes_node = simulation_setup["flux-scheme"]) {
     this->flux_schemes =
         std::make_unique<specfem::runtime_configuration::flux_schemes>(
             flux_schemes_node);

--- a/core/specfem/runtime_configuration/setup.hpp
+++ b/core/specfem/runtime_configuration/setup.hpp
@@ -3,6 +3,7 @@
 #include "database_configuration.hpp"
 #include "elastic_wave.hpp"
 #include "electromagnetic_wave.hpp"
+#include "flux_schemes.hpp"
 #include "header.hpp"
 #include "quadrature.hpp"
 #include "receivers.hpp"
@@ -357,6 +358,15 @@ public:
                                                          time_scheme, tasks);
   }
 
+  specfem::element_coupling::flux_scheme_configuration
+  instantiate_flux_scheme_configuration() {
+    if (this->flux_schemes) {
+      return this->flux_schemes->generate_configuration();
+    } else {
+      return specfem::element_coupling::flux_scheme_configuration();
+    }
+  }
+
   /**
    * @brief Get total number of time steps.
    *
@@ -418,6 +428,8 @@ private:
       databases; ///< Database file path configuration
   std::unique_ptr<specfem::runtime_configuration::solver>
       solver; ///< Solver algorithm configuration
+  std::unique_ptr<specfem::runtime_configuration::flux_schemes>
+      flux_schemes; ///< flux-scheme configuration
 };
 } // namespace runtime_configuration
 } // namespace specfem


### PR DESCRIPTION
## Description

Please describe the changes/features in this pull request.
- provides `flux-scheme` support in `runtime_configuration`
- adds configuration struct to pass into `assembly` constructor (currently unused).

## Issue Number

If there is an issue created for these changes, link it here

#1654

#1655

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
