### PR TITLE
Issue 1594 Part 2 Implementing integration factor computation & updates point types

### DIFF
--- a/core/specfem/attenuation.hpp
+++ b/core/specfem/attenuation.hpp
@@ -2,6 +2,7 @@
 
 #include "attenuation/compute_band.hpp"
 #include "attenuation/compute_factors.hpp"
+#include "attenuation/compute_integration_factors.hpp"
 #include "attenuation/compute_tau_eps.hpp"
 #include "attenuation/compute_tau_sigma.hpp"
 #include "attenuation/maxwell.hpp"

--- a/core/specfem/attenuation/compute_band.hpp
+++ b/core/specfem/attenuation/compute_band.hpp
@@ -10,24 +10,42 @@ namespace attenuation {
 /**
  * @brief Compute the attenuation period band from the minimum resolved period.
  *
- * The minimum attenuation period is set equal to @p min_resolved_period.
- * The maximum attenuation period is
+ * The attenuation band defines the frequency range over which viscoelastic
+ * attenuation is computed using standard linear solids (SLS). The minimum
+ * attenuation period is set equal to @p min_resolved_period, while the maximum
+ * period is determined by empirically optimized decade-width values.
+ *
+ * The maximum attenuation period is computed as:
  * @f[
  *   T_{\text{max}} = T_{\text{min}} \times 10^{\Theta(N\_SLS)}
  * @f]
  * where @f$\Theta@f$ are empirically determined decade-width values that
  * minimise the spectral flatness of the absorption band for each SLS count:
  *
- * | N_SLS | @f$\Theta@f$ |
- * |-------|-------------|
- * | 2     | 0.75        |
- * | 3     | 1.75        |
- * | 4     | 2.25        |
- * | 5     | 2.85        |
+ * | N_SLS | @f$\Theta@f$ | Max/Min Ratio |
+ * |-------|--------------|---------------|
+ * | 2     | 0.75        | ~5.6          |
+ * | 3     | 1.75        | ~56           |
+ * | 4     | 2.25        | ~178          |
+ * | 5     | 2.85        | ~708          |
  *
  * @tparam N_SLS Number of standard linear solids (must be 2–5)
- * @param min_resolved_period Minimum period resolved by the mesh (s)
- * @return FrequencyBand with @c min_period and @c max_period
+ * @param min_resolved_period Minimum period resolved by the mesh (seconds)
+ * @return FrequencyBand containing the computed attenuation band limits
+ *
+ * @code
+ * // Compute attenuation band for 3 SLS mechanisms
+ * constexpr type_real min_period = 0.5; // seconds
+ * auto band = specfem::attenuation::compute_band<3>(min_period);
+ *
+ * // Access band limits
+ * type_real f_min = band.min_frequency();
+ * type_real f_max = band.max_frequency();
+ * type_real T_min = band.min_period();  // equals min_period
+ * type_real T_max = band.max_period();  // min_period * 10^1.75
+ * @endcode
+ *
+ * @see tests/unit-tests/attenuation/compute_band_tests.cpp for usage examples
  */
 template <int N_SLS>
 specfem::utilities::FrequencyBand compute_band(type_real min_resolved_period);

--- a/core/specfem/attenuation/compute_integration_factors.hpp
+++ b/core/specfem/attenuation/compute_integration_factors.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "specfem/constants.hpp"
+#include "specfem/setup.hpp"
+#include <Kokkos_Core.hpp>
+
+namespace specfem {
+namespace attenuation {
+
+/**
+ * @brief Runge-Kutta memory-variable update coefficients per SLS mechanism.
+ *
+ * Holds the three coefficient arrays @f$ \alpha_j @f$, @f$ \beta_j @f$,
+ * @f$ \gamma_j @f$ that advance each standard linear solid one time step
+ * via the low-storage fourth-order Runge-Kutta scheme of
+ * Savage et al. (BSSA 2010, eq. 11).
+ *
+ * @tparam N_SLS Number of standard linear solids
+ */
+template <int N_SLS> struct IntegrationFactors {
+  Kokkos::View<type_real[N_SLS], Kokkos::LayoutRight, Kokkos::HostSpace> alpha;
+  Kokkos::View<type_real[N_SLS], Kokkos::LayoutRight, Kokkos::HostSpace> beta;
+  Kokkos::View<type_real[N_SLS], Kokkos::LayoutRight, Kokkos::HostSpace> gamma;
+};
+
+/**
+ * @brief Compute Runge-Kutta coefficients for memory-variable time stepping.
+ *
+ * Translates the Fortran routine @c get_attenuation_memory_values from
+ * @c get_attenuation_model.f90 (Savage et al. BSSA 2010, eq. 11).
+ *
+ * For each SLS mechanism @f$ j @f$ with relaxation time
+ * @f$ \tau_{\sigma,j} @f$ the coefficients are
+ * @f[
+ *   \tau_{\text{inv},j} = -1/\tau_{\sigma,j}   \quad \text{(negative sign,
+ *                         Fortran convention)}
+ * @f]
+ * @f[
+ *   \alpha_j = 1 + \Delta t\,\tau_{\text{inv}}
+ *                + \tfrac{1}{2}(\Delta t)^2\,\tau_{\text{inv}}^2
+ *                + \tfrac{1}{6}(\Delta t)^3\,\tau_{\text{inv}}^3
+ *                + \tfrac{1}{24}(\Delta t)^4\,\tau_{\text{inv}}^4
+ * @f]
+ * @f[
+ *   \beta_j  = \tfrac{\Delta t}{2}
+ *              + \tfrac{1}{3}(\Delta t)^2\,\tau_{\text{inv}}
+ *              + \tfrac{1}{8}(\Delta t)^3\,\tau_{\text{inv}}^2
+ *              + \tfrac{1}{24}(\Delta t)^4\,\tau_{\text{inv}}^3
+ * @f]
+ * @f[
+ *   \gamma_j = \tfrac{\Delta t}{2}
+ *              + \tfrac{1}{6}(\Delta t)^2\,\tau_{\text{inv}}
+ *              + \tfrac{1}{24}(\Delta t)^3\,\tau_{\text{inv}}^2
+ * @f]
+ *
+ * @tparam N_SLS Number of standard linear solids
+ * @param tau_sigma Stress relaxation times @f$ \tau_\sigma @f$ (positive,
+ *                  in seconds)
+ * @param deltat    Time step @f$ \Delta t @f$ (seconds)
+ * @return IntegrationFactors containing the three coefficient arrays
+ */
+template <int N_SLS>
+IntegrationFactors<N_SLS> compute_integration_factors(
+    Kokkos::View<type_real[N_SLS], Kokkos::LayoutRight, Kokkos::HostSpace>
+        tau_sigma,
+    type_real deltat);
+
+} // namespace attenuation
+} // namespace specfem
+
+#include "compute_integration_factors.tpp"

--- a/core/specfem/attenuation/compute_integration_factors.hpp
+++ b/core/specfem/attenuation/compute_integration_factors.hpp
@@ -15,49 +15,91 @@ namespace attenuation {
  * via the low-storage fourth-order Runge-Kutta scheme of
  * Savage et al. (BSSA 2010, eq. 11).
  *
+ * The coefficients are used to update memory variables in the attenuation
+ * implementation, providing stable time integration of the viscoelastic
+ * stress-strain relationships.
+ *
  * @tparam N_SLS Number of standard linear solids
+ *
+ * @code
+ * // Example usage with computed integration factors
+ * constexpr int N_SLS = 3;
+ * auto factors = compute_integration_factors<N_SLS>(tau_sigma, dt);
+ *
+ * // Access coefficient arrays
+ * for (int j = 0; j < N_SLS; ++j) {
+ *   type_real alpha_j = factors.alpha(j);
+ *   type_real beta_j  = factors.beta(j);
+ *   type_real gamma_j = factors.gamma(j);
+ * }
+ * @endcode
  */
 template <int N_SLS> struct IntegrationFactors {
-  Kokkos::View<type_real[N_SLS], Kokkos::LayoutRight, Kokkos::HostSpace> alpha;
-  Kokkos::View<type_real[N_SLS], Kokkos::LayoutRight, Kokkos::HostSpace> beta;
-  Kokkos::View<type_real[N_SLS], Kokkos::LayoutRight, Kokkos::HostSpace> gamma;
+  Kokkos::View<type_real[N_SLS], Kokkos::LayoutRight, Kokkos::HostSpace>
+      alpha; ///< Fourth-order alpha coefficients
+  Kokkos::View<type_real[N_SLS], Kokkos::LayoutRight, Kokkos::HostSpace>
+      beta; ///< Fourth-order beta coefficients
+  Kokkos::View<type_real[N_SLS], Kokkos::LayoutRight, Kokkos::HostSpace>
+      gamma; ///< Fourth-order gamma coefficients
 };
 
 /**
  * @brief Compute Runge-Kutta coefficients for memory-variable time stepping.
  *
- * Translates the Fortran routine @c get_attenuation_memory_values from
- * @c get_attenuation_model.f90 (Savage et al. BSSA 2010, eq. 11).
+ * Computes the fourth-order Runge-Kutta integration coefficients used to
+ * advance memory variables for viscoelastic attenuation. This function
+ * implements the computation of the integration coefficients (Savage et al.
+ * BSSA 2010, eq. 11).
  *
- * For each SLS mechanism @f$ j @f$ with relaxation time
- * @f$ \tau_{\sigma,j} @f$ the coefficients are
- * @f[
- *   \tau_{\text{inv},j} = -1/\tau_{\sigma,j}   \quad \text{(negative sign,
- *                         Fortran convention)}
+ * For each SLS mechanism @f$ j @f$ with stress relaxation time
+ * @f$ \tau_{\sigma,j} @f$, the coefficients are computed as:
+ * @f[ \alpha_j = 1 - \frac{\Delta t}{\tau_{\sigma,j}}
+ *   + \frac{(\Delta t)^2}{2\,\tau_{\sigma,j}^2}
+ *   - \frac{(\Delta t)^3}{6\,\tau_{\sigma,j}^3}
+ *   + \frac{(\Delta t)^4}{24\,\tau_{\sigma,j}^4}
  * @f]
- * @f[
- *   \alpha_j = 1 + \Delta t\,\tau_{\text{inv}}
- *                + \tfrac{1}{2}(\Delta t)^2\,\tau_{\text{inv}}^2
- *                + \tfrac{1}{6}(\Delta t)^3\,\tau_{\text{inv}}^3
- *                + \tfrac{1}{24}(\Delta t)^4\,\tau_{\text{inv}}^4
+ * @f[ \beta_j  = \frac{\Delta t}{2}
+ *   - \frac{(\Delta t)^2}{3\,\tau_{\sigma,j}}
+ *   + \frac{(\Delta t)^3}{8\,\tau_{\sigma,j}^2}
+ *   - \frac{(\Delta t)^4}{24\,\tau_{\sigma,j}^3}
  * @f]
- * @f[
- *   \beta_j  = \tfrac{\Delta t}{2}
- *              + \tfrac{1}{3}(\Delta t)^2\,\tau_{\text{inv}}
- *              + \tfrac{1}{8}(\Delta t)^3\,\tau_{\text{inv}}^2
- *              + \tfrac{1}{24}(\Delta t)^4\,\tau_{\text{inv}}^3
+ * @f[ \gamma_j = \frac{\Delta t}{2}
+ *   - \frac{(\Delta t)^2}{6\,\tau_{\sigma,j}}
+ *   + \frac{(\Delta t)^3}{24\,\tau_{\sigma,j}^2}
  * @f]
- * @f[
- *   \gamma_j = \tfrac{\Delta t}{2}
- *              + \tfrac{1}{6}(\Delta t)^2\,\tau_{\text{inv}}
- *              + \tfrac{1}{24}(\Delta t)^3\,\tau_{\text{inv}}^2
- * @f]
+ *
+ * This notation is a departure from the Fortran implementation (and Savage et
+ * al. 2010), which sets the `tauinv` variable to @f$ - 1 / \tau_{\sigma,j} @f$
+ * so that the sign switch is absorbed. Here, we follow a more standard
+ * mathematical convention where @f$ 1/\tau_{\sigma,j} @f$ remains positive, and
+ * the negative signs are explicitly included in the formula for the
+ * coefficients.
  *
  * @tparam N_SLS Number of standard linear solids
- * @param tau_sigma Stress relaxation times @f$ \tau_\sigma @f$ (positive,
- *                  in seconds)
+ * @param tau_sigma Stress relaxation times @f$ \tau_\sigma @f$ (positive
+ * values, seconds)
  * @param deltat    Time step @f$ \Delta t @f$ (seconds)
  * @return IntegrationFactors containing the three coefficient arrays
+ *
+ * @code
+ * // Setup relaxation times and time step constexpr int N_SLS = 3;
+ * Kokkos::View<type_real[N_SLS], Kokkos::LayoutRight, Kokkos::HostSpace>
+ * tau_sigma("tau_sigma"); tau_sigma(0) = 1.0;  // 1 second tau_sigma(1) = 2.0;
+ * // 2 seconds
+ * tau_sigma(2) = 5.0;  // 5 seconds
+ *
+ * type_real dt = 0.01; // 10 ms time step
+ *
+ * // Compute integration factors auto factors =
+ * specfem::attenuation::compute_integration_factors<N_SLS>( tau_sigma, dt);
+ *
+ * // Use coefficients in time stepping for (int j = 0; j < N_SLS; ++j) { //
+ * Apply Runge-Kutta update using factors.alpha(j), beta(j), gamma(j)
+ * }
+ * @endcode
+ *
+ * @see tests/unit-tests/attenuation/compute_integration_factors_tests.cpp for
+ * detailed examples
  */
 template <int N_SLS>
 IntegrationFactors<N_SLS> compute_integration_factors(

--- a/core/specfem/attenuation/compute_integration_factors.tpp
+++ b/core/specfem/attenuation/compute_integration_factors.tpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "compute_integration_factors.hpp"
+#include "specfem/setup.hpp"
+#include <Kokkos_Core.hpp>
+
+namespace specfem {
+namespace attenuation {
+
+template <int N_SLS>
+IntegrationFactors<N_SLS> compute_integration_factors(
+    Kokkos::View<type_real[N_SLS], Kokkos::LayoutRight, Kokkos::HostSpace>
+        tau_sigma,
+    type_real deltat) {
+
+  IntegrationFactors<N_SLS> result;
+  result.alpha =
+      Kokkos::View<type_real[N_SLS], Kokkos::LayoutRight, Kokkos::HostSpace>(
+          "alpha_rk");
+  result.beta =
+      Kokkos::View<type_real[N_SLS], Kokkos::LayoutRight, Kokkos::HostSpace>(
+          "beta_rk");
+  result.gamma =
+      Kokkos::View<type_real[N_SLS], Kokkos::LayoutRight, Kokkos::HostSpace>(
+          "gamma_rk");
+
+  const type_real dt = deltat;
+  const type_real dt2 = dt * dt;
+  const type_real dt3 = dt2 * dt;
+  const type_real dt4 = dt3 * dt;
+
+  for (int j = 0; j < N_SLS; ++j) {
+    // Negative sign follows Fortran convention in get_attenuation_model.f90
+    const type_real tauinv  = -1.0 / tau_sigma(j);
+    const type_real tauinv2 = tauinv * tauinv;
+    const type_real tauinv3 = tauinv2 * tauinv;
+    const type_real tauinv4 = tauinv3 * tauinv;
+
+    // Savage et al. BSSA 2010, eq. (11)
+    result.alpha(j) = 1.0
+                    + dt  * tauinv
+                    + dt2 * tauinv2 / 2.0
+                    + dt3 * tauinv3 / 6.0
+                    + dt4 * tauinv4 / 24.0;
+
+    result.beta(j)  = dt  / 2.0
+                    + dt2 * tauinv  / 3.0
+                    + dt3 * tauinv2 / 8.0
+                    + dt4 * tauinv3 / 24.0;
+
+    result.gamma(j) = dt  / 2.0
+                    + dt2 * tauinv  / 6.0
+                    + dt3 * tauinv2 / 24.0;
+  }
+
+  return result;
+}
+
+} // namespace attenuation
+} // namespace specfem

--- a/core/specfem/attenuation/compute_integration_factors.tpp
+++ b/core/specfem/attenuation/compute_integration_factors.tpp
@@ -30,26 +30,27 @@ IntegrationFactors<N_SLS> compute_integration_factors(
   const type_real dt4 = dt3 * dt;
 
   for (int j = 0; j < N_SLS; ++j) {
-    // Negative sign follows Fortran convention in get_attenuation_model.f90
-    const type_real tauinv  = -1.0 / tau_sigma(j);
+
+    const type_real tauinv  = 1.0 / tau_sigma(j);
     const type_real tauinv2 = tauinv * tauinv;
     const type_real tauinv3 = tauinv2 * tauinv;
     const type_real tauinv4 = tauinv3 * tauinv;
 
-    // Savage et al. BSSA 2010, eq. (11)
+    // Taylor expansion of e^{-dt/tau_sigma} to 4th order
+    // (Savage et al. BSSA 2010, eq. 11)
     result.alpha(j) = 1.0
-                    + dt  * tauinv
+                    - dt  * tauinv
                     + dt2 * tauinv2 / 2.0
-                    + dt3 * tauinv3 / 6.0
+                    - dt3 * tauinv3 / 6.0
                     + dt4 * tauinv4 / 24.0;
 
     result.beta(j)  = dt  / 2.0
-                    + dt2 * tauinv  / 3.0
+                    - dt2 * tauinv  / 3.0
                     + dt3 * tauinv2 / 8.0
-                    + dt4 * tauinv3 / 24.0;
+                    - dt4 * tauinv3 / 24.0;
 
     result.gamma(j) = dt  / 2.0
-                    + dt2 * tauinv  / 6.0
+                    - dt2 * tauinv  / 6.0
                     + dt3 * tauinv2 / 24.0;
   }
 

--- a/core/specfem/point/attenuation.hpp
+++ b/core/specfem/point/attenuation.hpp
@@ -3,6 +3,7 @@
 #include "specfem/constants.hpp"
 #include "specfem/data_access/accessor.hpp"
 #include "specfem/element.hpp"
+#include "specfem/utilities/is_close.hpp"
 #include <sstream>
 
 namespace specfem::point {
@@ -64,8 +65,6 @@ public:
   // -----------------------------------------------------------------------
   using simd = typename base_type::template simd<type_real>;
   using value_type = typename base_type::template vector_type<type_real, N_SLS>;
-  using common_factor_type =
-      typename base_type::template vector_type<type_real, N_SLS>;
 
   // -----------------------------------------------------------------------
   // Constructors
@@ -118,18 +117,18 @@ public:
   // Type aliases
   // -----------------------------------------------------------------------
   using simd = typename base_type::template simd<type_real>;
-  using common_factor_type =
-      typename base_type::template vector_type<type_real, N_SLS>;
   using value_type = typename base_type::template vector_type<type_real, N_SLS>;
 
   // -----------------------------------------------------------------------
   // Data members — attenuation factors
   // -----------------------------------------------------------------------
-  common_factor_type kappa_common_factor;
-  common_factor_type mu_common_factor;
-  type_real alpha_rk;
-  type_real beta_rk;
-  type_real gamma_rk;
+  value_type kappa_common_factor;
+  value_type mu_common_factor;
+  /// Runge-Kutta coefficients; one entry per SLS mechanism (computed from
+  /// tau_sigma and deltat; constant throughout a run).
+  value_type alpha_rk;
+  value_type beta_rk;
+  value_type gamma_rk;
 
   // -----------------------------------------------------------------------
   // Data members — memory variables (dim2)
@@ -153,19 +152,19 @@ public:
    *
    * @param kappa_common_factor Common factor for kappa attenuation
    * @param mu_common_factor    Common factor for mu attenuation
-   * @param alpha_rk            Runge-Kutta alpha factor
-   * @param beta_rk             Runge-Kutta beta factor
-   * @param gamma_rk            Runge-Kutta gamma factor
+   * @param alpha_rk            Runge-Kutta alpha factors (per SLS)
+   * @param beta_rk             Runge-Kutta beta factors (per SLS)
+   * @param gamma_rk            Runge-Kutta gamma factors (per SLS)
    * @param Rxx                 Memory variable R_xx
    * @param Rxz                 Memory variable R_xz
    * @param Rkappa              Memory variable R_kappa
    */
   KOKKOS_FUNCTION
-  attenuation(const common_factor_type &kappa_common_factor,
-              const common_factor_type &mu_common_factor,
-              const type_real &alpha_rk, const type_real &beta_rk,
-              const type_real &gamma_rk, const value_type &Rxx,
-              const value_type &Rxz, const value_type &Rkappa)
+  attenuation(const value_type &kappa_common_factor,
+              const value_type &mu_common_factor, const value_type &alpha_rk,
+              const value_type &beta_rk, const value_type &gamma_rk,
+              const value_type &Rxx, const value_type &Rxz,
+              const value_type &Rkappa)
       : kappa_common_factor(kappa_common_factor),
         mu_common_factor(mu_common_factor), alpha_rk(alpha_rk),
         beta_rk(beta_rk), gamma_rk(gamma_rk), Rxx(Rxx), Rxz(Rxz),
@@ -183,7 +182,7 @@ public:
     this->Rkappa = value_type(typename value_type::value_type(0));
   }
 
-  /** @brief Component-wise addition on R fields. */
+  /** @brief Component-wise addition on R fields; RK/common factors copied. */
   KOKKOS_FUNCTION attenuation operator+(const attenuation &rhs) const {
     attenuation result;
     result.kappa_common_factor = this->kappa_common_factor;
@@ -211,7 +210,7 @@ public:
     return *this;
   }
 
-  /** @brief Scalar multiplication on R fields. */
+  /** @brief Scalar multiplication on R fields; RK/common factors copied. */
   KOKKOS_FUNCTION attenuation operator*(const type_real &rhs) const {
     attenuation result;
     result.kappa_common_factor = this->kappa_common_factor;
@@ -231,11 +230,26 @@ public:
   /** @brief Equality — compares all fields (factors and R). */
   KOKKOS_INLINE_FUNCTION
   bool operator==(const attenuation &other) const {
-    return kappa_common_factor == other.kappa_common_factor &&
-           mu_common_factor == other.mu_common_factor &&
-           alpha_rk == other.alpha_rk && beta_rk == other.beta_rk &&
-           gamma_rk == other.gamma_rk && Rxx == other.Rxx && Rxz == other.Rxz &&
-           Rkappa == other.Rkappa;
+    constexpr int N = specfem::constants::N_SLS;
+    if (!(kappa_common_factor == other.kappa_common_factor))
+      return false;
+    if (!(mu_common_factor == other.mu_common_factor))
+      return false;
+    for (int i = 0; i < N; ++i) {
+      if (!specfem::utilities::is_close(alpha_rk(i), other.alpha_rk(i)))
+        return false;
+      if (!specfem::utilities::is_close(beta_rk(i), other.beta_rk(i)))
+        return false;
+      if (!specfem::utilities::is_close(gamma_rk(i), other.gamma_rk(i)))
+        return false;
+      if (!specfem::utilities::is_close(Rxx(i), other.Rxx(i)))
+        return false;
+      if (!specfem::utilities::is_close(Rxz(i), other.Rxz(i)))
+        return false;
+      if (!specfem::utilities::is_close(Rkappa(i), other.Rkappa(i)))
+        return false;
+    }
+    return true;
   }
 
   /** @brief String representation (non-SIMD only). */
@@ -248,9 +262,12 @@ public:
     for (int i = 0; i < N_SLS; ++i)
       oss << "  mu_common_factor(" << i << ") = " << mu_common_factor(i)
           << "\n";
-    oss << "  alpha_rk = " << alpha_rk << "\n";
-    oss << "  beta_rk = " << beta_rk << "\n";
-    oss << "  gamma_rk = " << gamma_rk << "\n";
+    for (int i = 0; i < N_SLS; ++i)
+      oss << "  alpha_rk(" << i << ") = " << alpha_rk(i) << "\n";
+    for (int i = 0; i < N_SLS; ++i)
+      oss << "  beta_rk(" << i << ") = " << beta_rk(i) << "\n";
+    for (int i = 0; i < N_SLS; ++i)
+      oss << "  gamma_rk(" << i << ") = " << gamma_rk(i) << "\n";
     oss << "Memory Variables (dim2):\n";
     for (int i = 0; i < N_SLS; ++i)
       oss << "  Rxx(" << i << ") = " << Rxx(i) << "\n";
@@ -305,18 +322,18 @@ public:
   // Type aliases
   // -----------------------------------------------------------------------
   using simd = typename base_type::template simd<type_real>;
-  using common_factor_type =
-      typename base_type::template vector_type<type_real, N_SLS>;
   using value_type = typename base_type::template vector_type<type_real, N_SLS>;
 
   // -----------------------------------------------------------------------
   // Data members — attenuation factors
   // -----------------------------------------------------------------------
-  common_factor_type kappa_common_factor;
-  common_factor_type mu_common_factor;
-  type_real alpha_rk;
-  type_real beta_rk;
-  type_real gamma_rk;
+  value_type kappa_common_factor;
+  value_type mu_common_factor;
+  /// Runge-Kutta coefficients; one entry per SLS mechanism (computed from
+  /// tau_sigma and deltat; constant throughout a run).
+  value_type alpha_rk;
+  value_type beta_rk;
+  value_type gamma_rk;
 
   // -----------------------------------------------------------------------
   // Data members — memory variables (dim3)
@@ -343,9 +360,9 @@ public:
    *
    * @param kappa_common_factor Common factor for kappa attenuation
    * @param mu_common_factor    Common factor for mu attenuation
-   * @param alpha_rk            Runge-Kutta alpha factor
-   * @param beta_rk             Runge-Kutta beta factor
-   * @param gamma_rk            Runge-Kutta gamma factor
+   * @param alpha_rk            Runge-Kutta alpha factors (per SLS)
+   * @param beta_rk             Runge-Kutta beta factors (per SLS)
+   * @param gamma_rk            Runge-Kutta gamma factors (per SLS)
    * @param Rxx                 Memory variable R_xx
    * @param Ryy                 Memory variable R_yy
    * @param Rxy                 Memory variable R_xy
@@ -354,13 +371,12 @@ public:
    * @param Rkappa              Memory variable R_kappa
    */
   KOKKOS_FUNCTION
-  attenuation(const common_factor_type &kappa_common_factor,
-              const common_factor_type &mu_common_factor,
-              const type_real &alpha_rk, const type_real &beta_rk,
-              const type_real &gamma_rk, const value_type &Rxx,
-              const value_type &Ryy, const value_type &Rxy,
-              const value_type &Rxz, const value_type &Ryz,
-              const value_type &Rkappa)
+  attenuation(const value_type &kappa_common_factor,
+              const value_type &mu_common_factor, const value_type &alpha_rk,
+              const value_type &beta_rk, const value_type &gamma_rk,
+              const value_type &Rxx, const value_type &Ryy,
+              const value_type &Rxy, const value_type &Rxz,
+              const value_type &Ryz, const value_type &Rkappa)
       : kappa_common_factor(kappa_common_factor),
         mu_common_factor(mu_common_factor), alpha_rk(alpha_rk),
         beta_rk(beta_rk), gamma_rk(gamma_rk), Rxx(Rxx), Ryy(Ryy), Rxy(Rxy),
@@ -381,7 +397,7 @@ public:
     this->Rkappa = value_type(typename value_type::value_type(0));
   }
 
-  /** @brief Component-wise addition on R fields. */
+  /** @brief Component-wise addition on R fields; RK/common factors copied. */
   KOKKOS_FUNCTION attenuation operator+(const attenuation &rhs) const {
     attenuation result;
     result.kappa_common_factor = this->kappa_common_factor;
@@ -415,7 +431,7 @@ public:
     return *this;
   }
 
-  /** @brief Scalar multiplication on R fields. */
+  /** @brief Scalar multiplication on R fields; RK/common factors copied. */
   KOKKOS_FUNCTION attenuation operator*(const type_real &rhs) const {
     attenuation result;
     result.kappa_common_factor = this->kappa_common_factor;
@@ -438,12 +454,32 @@ public:
   /** @brief Equality — compares all fields (factors and R). */
   KOKKOS_INLINE_FUNCTION
   bool operator==(const attenuation &other) const {
-    return kappa_common_factor == other.kappa_common_factor &&
-           mu_common_factor == other.mu_common_factor &&
-           alpha_rk == other.alpha_rk && beta_rk == other.beta_rk &&
-           gamma_rk == other.gamma_rk && Rxx == other.Rxx && Ryy == other.Ryy &&
-           Rxy == other.Rxy && Rxz == other.Rxz && Ryz == other.Ryz &&
-           Rkappa == other.Rkappa;
+    constexpr int N = specfem::constants::N_SLS;
+    if (!(kappa_common_factor == other.kappa_common_factor))
+      return false;
+    if (!(mu_common_factor == other.mu_common_factor))
+      return false;
+    for (int i = 0; i < N; ++i) {
+      if (!specfem::utilities::is_close(alpha_rk(i), other.alpha_rk(i)))
+        return false;
+      if (!specfem::utilities::is_close(beta_rk(i), other.beta_rk(i)))
+        return false;
+      if (!specfem::utilities::is_close(gamma_rk(i), other.gamma_rk(i)))
+        return false;
+      if (!specfem::utilities::is_close(Rxx(i), other.Rxx(i)))
+        return false;
+      if (!specfem::utilities::is_close(Ryy(i), other.Ryy(i)))
+        return false;
+      if (!specfem::utilities::is_close(Rxy(i), other.Rxy(i)))
+        return false;
+      if (!specfem::utilities::is_close(Rxz(i), other.Rxz(i)))
+        return false;
+      if (!specfem::utilities::is_close(Ryz(i), other.Ryz(i)))
+        return false;
+      if (!specfem::utilities::is_close(Rkappa(i), other.Rkappa(i)))
+        return false;
+    }
+    return true;
   }
 
   /** @brief String representation (non-SIMD only). */
@@ -456,9 +492,12 @@ public:
     for (int i = 0; i < N_SLS; ++i)
       oss << "  mu_common_factor(" << i << ") = " << mu_common_factor(i)
           << "\n";
-    oss << "  alpha_rk = " << alpha_rk << "\n";
-    oss << "  beta_rk = " << beta_rk << "\n";
-    oss << "  gamma_rk = " << gamma_rk << "\n";
+    for (int i = 0; i < N_SLS; ++i)
+      oss << "  alpha_rk(" << i << ") = " << alpha_rk(i) << "\n";
+    for (int i = 0; i < N_SLS; ++i)
+      oss << "  beta_rk(" << i << ") = " << beta_rk(i) << "\n";
+    for (int i = 0; i < N_SLS; ++i)
+      oss << "  gamma_rk(" << i << ") = " << gamma_rk(i) << "\n";
     oss << "Memory Variables (dim3):\n";
     for (int i = 0; i < N_SLS; ++i)
       oss << "  Rxx(" << i << ") = " << Rxx(i) << "\n";

--- a/docs/sections/api/specfem/attenuation/compute_band.rst
+++ b/docs/sections/api/specfem/attenuation/compute_band.rst
@@ -1,0 +1,7 @@
+``specfem::attenuation::compute_band``
+======================================
+
+.. doxygenfunction:: specfem::attenuation::compute_band
+
+.. doxygenstruct:: specfem::utilities::FrequencyBand
+    :members:

--- a/docs/sections/api/specfem/attenuation/compute_integration_factors.rst
+++ b/docs/sections/api/specfem/attenuation/compute_integration_factors.rst
@@ -1,0 +1,7 @@
+``specfem::attenuation::compute_integration_factors``
+=====================================================
+
+.. doxygenfunction:: specfem::attenuation::compute_integration_factors
+
+.. doxygenstruct:: specfem::attenuation::IntegrationFactors
+    :members:

--- a/docs/sections/api/specfem/attenuation/index.rst
+++ b/docs/sections/api/specfem/attenuation/index.rst
@@ -10,5 +10,7 @@
     tau_sigma.rst
     compute_tau_eps.rst
     compute_factors.rst
+    compute_band.rst
+    compute_integration_factors.rst
     maxwell.rst
     optimization.rst

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -134,6 +134,7 @@ add_executable(
   attenuation/maxwell_tests.cpp
   attenuation/compute_tau_eps_tests.cpp
   attenuation/compute_factors_tests.cpp
+  attenuation/compute_integration_factors_tests.cpp
 )
 
 target_link_libraries(

--- a/tests/unit-tests/attenuation/compute_integration_factors_tests.cpp
+++ b/tests/unit-tests/attenuation/compute_integration_factors_tests.cpp
@@ -14,21 +14,21 @@ using specfem::utilities::is_close;
 // The three Runge-Kutta coefficients for mechanism j are
 // (Savage et al. BSSA 2010, eq. 11):
 //
-//   tauinv = -1 / tau_sigma[j]
-//
-//   alpha[j] = 1 + dt*tauinv
-//                + dt^2*tauinv^2 / 2
-//                + dt^3*tauinv^3 / 6
-//                + dt^4*tauinv^4 / 24
+//   alpha[j] = 1 - dt/tau_sigma
+//                + dt^2 / (2*tau_sigma^2)
+//                - dt^3 / (6*tau_sigma^3)
+//                + dt^4 / (24*tau_sigma^4)
 //
 //   beta[j]  = dt/2
-//                + dt^2*tauinv / 3
-//                + dt^3*tauinv^2 / 8
-//                + dt^4*tauinv^3 / 24
+//                - dt^2 / (3*tau_sigma)
+//                + dt^3 / (8*tau_sigma^2)
+//                - dt^4 / (24*tau_sigma^3)
 //
 //   gamma[j] = dt/2
-//                + dt^2*tauinv / 6
-//                + dt^3*tauinv^2 / 24
+//                - dt^2 / (6*tau_sigma)
+//                + dt^3 / (24*tau_sigma^2)
+//
+// The alternating signs are the Taylor expansion of e^{-dt/tau_sigma}.
 // =============================================================================
 
 // Zero timestep:
@@ -65,8 +65,7 @@ TEST(Attenuation_IntegrationFactors, ZeroTimestep) {
   }
 }
 
-// Single SLS, dt = 1, tau_sigma = 1  (product dt/tau_sigma = 1):
-//   tauinv = -1
+// Single SLS, dt = 1, tau_sigma = 1  (dt/tau_sigma = 1):
 //   alpha = 1 - 1 + 1/2 - 1/6 + 1/24 = 9/24 = 3/8
 //   beta  = 1/2 - 1/3 + 1/8 - 1/24   = 6/24 = 1/4
 //   gamma = 1/2 - 1/6 + 1/24          = 9/24 = 3/8
@@ -87,8 +86,8 @@ TEST(Attenuation_IntegrationFactors, SingleSLS_UnitTauUnitDt) {
       << expected_got(static_cast<type_real>(3.0 / 8.0), result.gamma(0));
 }
 
-// Single SLS, dt = 2, tau_sigma = 1  (product dt/tau_sigma = 2):
-//   tauinv = -1, dt=2, dt^2=4, dt^3=8, dt^4=16
+// Single SLS, dt = 2, tau_sigma = 1  (dt/tau_sigma = 2):
+//   dt=2, dt^2=4, dt^3=8, dt^4=16, 1/tau_sigma=1
 //   alpha = 1 - 2 + 4/2 - 8/6 + 16/24 = 1 - 2 + 2 - 4/3 + 2/3 = 1/3
 //   beta  = 1 - 4/3 + 8/8 - 16/24     = 1 - 4/3 + 1 - 2/3 = 0
 //   gamma = 1 - 4/6 + 8/24             = 1 - 2/3 + 1/3     = 2/3
@@ -110,17 +109,16 @@ TEST(Attenuation_IntegrationFactors, SingleSLS_DoubleDt) {
 }
 
 // Three SLS, all identical tau_sigma = 0.1, dt = 0.1
-//   (product dt/tau_sigma = 1 for every mechanism =>
+//   (dt/tau_sigma = 1 for every mechanism =>
 //    same Taylor coefficients as SingleSLS_UnitTauUnitDt, but scaled):
 //
-//   tauinv = -10, dt = 0.1 => dt*tauinv = -1
+//   1/tau_sigma = 10, dt = 0.1 => dt/tau_sigma = 1
 //
-//   alpha[j] = 0.1*(−1) summed as above with 24 denom:
-//     = 1 - 1 + 0.5 - 1/6 + 1/24       = 9/24 = 3/8
+//   alpha[j] = 1 - 1 + 1/2 - 1/6 + 1/24  = 9/24 = 3/8
 //   beta[j]  = 0.1*(1/2 - 1/3 + 1/8 - 1/24)
-//     = 0.1 * 6/24 = 0.1/4              = 1/40
+//     = 0.1 * 6/24 = 0.1/4               = 1/40
 //   gamma[j] = 0.1*(1/2 - 1/6 + 1/24)
-//     = 0.1 * 9/24 = 0.1 * 3/8          = 3/80
+//     = 0.1 * 9/24 = 0.1 * 3/8           = 3/80
 TEST(Attenuation_IntegrationFactors, ThreeSLS_UniformTau) {
   constexpr int N_SLS = 3;
 
@@ -156,7 +154,7 @@ TEST(Attenuation_IntegrationFactors, ThreeSLS_UniformTau) {
 //     beta[0]  = 1/40
 //     gamma[0] = 3/80
 //
-//   Mechanism 1 (tau=1.0, tauinv=-1):
+//   Mechanism 1 (tau=1.0, 1/tau=1):
 //     dt=0.1, dt^2=0.01, dt^3=0.001, dt^4=0.0001
 //     alpha[1] = 1 - 0.1 + 0.01/2 - 0.001/6 + 0.0001/24
 //              = (240000 - 24000 + 1200 - 40 + 1) / 240000
@@ -200,17 +198,17 @@ TEST(Attenuation_IntegrationFactors, TwoSLS_DistinctTau) {
                       result.gamma(1));
 }
 
-// Five SLS with N_SLS=5, dt=1, all tau_sigma=2  (product dt/tau=0.5):
-//   tauinv = -0.5
-//   alpha = 1 + (-0.5) + 0.25/2 + (-0.125)/6 + 0.0625/24
+// Five SLS with N_SLS=5, dt=1, all tau_sigma=2  (dt/tau_sigma=0.5):
+//   1/tau_sigma = 0.5
+//   alpha = 1 - 0.5 + 0.25/2 - 0.125/6 + 0.0625/24
 //         = 1 - 1/2 + 1/8 - 1/48 + 1/384
 //         = (384 - 192 + 48 - 8 + 1) / 384
 //         = 233/384
-//   beta  = 1/2 + (-0.5)/3 + 0.25/8 + (-0.125)/24
+//   beta  = 1/2 - 0.5/3 + 0.25/8 - 0.125/24
 //         = 1/2 - 1/6 + 1/32 - 1/192
 //         = (96 - 32 + 6 - 1) / 192
 //         = 69/192 = 23/64
-//   gamma = 1/2 + (-0.5)/6 + 0.25/24
+//   gamma = 1/2 - 0.5/6 + 0.25/24
 //         = 1/2 - 1/12 + 1/96
 //         = (48 - 8 + 1) / 96
 //         = 41/96

--- a/tests/unit-tests/attenuation/compute_integration_factors_tests.cpp
+++ b/tests/unit-tests/attenuation/compute_integration_factors_tests.cpp
@@ -1,0 +1,243 @@
+#include "specfem/attenuation/compute_integration_factors.hpp"
+#include "specfem/utilities/is_close.hpp"
+#include "test_macros.hpp"
+#include <gtest/gtest.h>
+
+using specfem::attenuation::compute_integration_factors;
+using specfem::utilities::is_close;
+
+// =============================================================================
+// compute_integration_factors tests
+//
+// All tests use hand-picked values with analytically known results.
+//
+// The three Runge-Kutta coefficients for mechanism j are
+// (Savage et al. BSSA 2010, eq. 11):
+//
+//   tauinv = -1 / tau_sigma[j]
+//
+//   alpha[j] = 1 + dt*tauinv
+//                + dt^2*tauinv^2 / 2
+//                + dt^3*tauinv^3 / 6
+//                + dt^4*tauinv^4 / 24
+//
+//   beta[j]  = dt/2
+//                + dt^2*tauinv / 3
+//                + dt^3*tauinv^2 / 8
+//                + dt^4*tauinv^3 / 24
+//
+//   gamma[j] = dt/2
+//                + dt^2*tauinv / 6
+//                + dt^3*tauinv^2 / 24
+// =============================================================================
+
+// Zero timestep:
+//   dt = 0 => all dt terms vanish.
+//   alpha[j] = 1 for all j
+//   beta[j]  = 0 for all j
+//   gamma[j] = 0 for all j
+TEST(Attenuation_IntegrationFactors, ZeroTimestep) {
+  constexpr int N_SLS = 3;
+
+  Kokkos::View<type_real[N_SLS], Kokkos::LayoutRight, Kokkos::HostSpace>
+      tau_sigma("tau_sigma");
+
+  tau_sigma(0) = 1.0;
+  tau_sigma(1) = 2.0;
+  tau_sigma(2) = 5.0;
+
+  auto result = compute_integration_factors<N_SLS>(tau_sigma, 0.0);
+
+  EXPECT_EQ(result.alpha.extent(0), N_SLS);
+  EXPECT_EQ(result.beta.extent(0), N_SLS);
+  EXPECT_EQ(result.gamma.extent(0), N_SLS);
+
+  for (int j = 0; j < N_SLS; ++j) {
+    EXPECT_TRUE(is_close(result.alpha(j), static_cast<type_real>(1.0)))
+        << "alpha(" << j
+        << "): " << expected_got(static_cast<type_real>(1.0), result.alpha(j));
+    EXPECT_TRUE(is_close(result.beta(j), static_cast<type_real>(0.0)))
+        << "beta(" << j
+        << "): " << expected_got(static_cast<type_real>(0.0), result.beta(j));
+    EXPECT_TRUE(is_close(result.gamma(j), static_cast<type_real>(0.0)))
+        << "gamma(" << j
+        << "): " << expected_got(static_cast<type_real>(0.0), result.gamma(j));
+  }
+}
+
+// Single SLS, dt = 1, tau_sigma = 1  (product dt/tau_sigma = 1):
+//   tauinv = -1
+//   alpha = 1 - 1 + 1/2 - 1/6 + 1/24 = 9/24 = 3/8
+//   beta  = 1/2 - 1/3 + 1/8 - 1/24   = 6/24 = 1/4
+//   gamma = 1/2 - 1/6 + 1/24          = 9/24 = 3/8
+TEST(Attenuation_IntegrationFactors, SingleSLS_UnitTauUnitDt) {
+  constexpr int N_SLS = 1;
+
+  Kokkos::View<type_real[N_SLS], Kokkos::LayoutRight, Kokkos::HostSpace>
+      tau_sigma("tau_sigma");
+  tau_sigma(0) = 1.0;
+
+  auto result = compute_integration_factors<N_SLS>(tau_sigma, 1.0);
+
+  EXPECT_TRUE(is_close(result.alpha(0), static_cast<type_real>(3.0 / 8.0)))
+      << expected_got(static_cast<type_real>(3.0 / 8.0), result.alpha(0));
+  EXPECT_TRUE(is_close(result.beta(0), static_cast<type_real>(1.0 / 4.0)))
+      << expected_got(static_cast<type_real>(1.0 / 4.0), result.beta(0));
+  EXPECT_TRUE(is_close(result.gamma(0), static_cast<type_real>(3.0 / 8.0)))
+      << expected_got(static_cast<type_real>(3.0 / 8.0), result.gamma(0));
+}
+
+// Single SLS, dt = 2, tau_sigma = 1  (product dt/tau_sigma = 2):
+//   tauinv = -1, dt=2, dt^2=4, dt^3=8, dt^4=16
+//   alpha = 1 - 2 + 4/2 - 8/6 + 16/24 = 1 - 2 + 2 - 4/3 + 2/3 = 1/3
+//   beta  = 1 - 4/3 + 8/8 - 16/24     = 1 - 4/3 + 1 - 2/3 = 0
+//   gamma = 1 - 4/6 + 8/24             = 1 - 2/3 + 1/3     = 2/3
+TEST(Attenuation_IntegrationFactors, SingleSLS_DoubleDt) {
+  constexpr int N_SLS = 1;
+
+  Kokkos::View<type_real[N_SLS], Kokkos::LayoutRight, Kokkos::HostSpace>
+      tau_sigma("tau_sigma");
+  tau_sigma(0) = 1.0;
+
+  auto result = compute_integration_factors<N_SLS>(tau_sigma, 2.0);
+
+  EXPECT_TRUE(is_close(result.alpha(0), static_cast<type_real>(1.0 / 3.0)))
+      << expected_got(static_cast<type_real>(1.0 / 3.0), result.alpha(0));
+  EXPECT_TRUE(is_close(result.beta(0), static_cast<type_real>(0.0)))
+      << expected_got(static_cast<type_real>(0.0), result.beta(0));
+  EXPECT_TRUE(is_close(result.gamma(0), static_cast<type_real>(2.0 / 3.0)))
+      << expected_got(static_cast<type_real>(2.0 / 3.0), result.gamma(0));
+}
+
+// Three SLS, all identical tau_sigma = 0.1, dt = 0.1
+//   (product dt/tau_sigma = 1 for every mechanism =>
+//    same Taylor coefficients as SingleSLS_UnitTauUnitDt, but scaled):
+//
+//   tauinv = -10, dt = 0.1 => dt*tauinv = -1
+//
+//   alpha[j] = 0.1*(−1) summed as above with 24 denom:
+//     = 1 - 1 + 0.5 - 1/6 + 1/24       = 9/24 = 3/8
+//   beta[j]  = 0.1*(1/2 - 1/3 + 1/8 - 1/24)
+//     = 0.1 * 6/24 = 0.1/4              = 1/40
+//   gamma[j] = 0.1*(1/2 - 1/6 + 1/24)
+//     = 0.1 * 9/24 = 0.1 * 3/8          = 3/80
+TEST(Attenuation_IntegrationFactors, ThreeSLS_UniformTau) {
+  constexpr int N_SLS = 3;
+
+  Kokkos::View<type_real[N_SLS], Kokkos::LayoutRight, Kokkos::HostSpace>
+      tau_sigma("tau_sigma");
+  for (int j = 0; j < N_SLS; ++j)
+    tau_sigma(j) = 0.1;
+
+  auto result = compute_integration_factors<N_SLS>(tau_sigma, 0.1);
+
+  EXPECT_EQ(result.alpha.extent(0), N_SLS);
+  EXPECT_EQ(result.beta.extent(0), N_SLS);
+  EXPECT_EQ(result.gamma.extent(0), N_SLS);
+
+  for (int j = 0; j < N_SLS; ++j) {
+    EXPECT_TRUE(is_close(result.alpha(j), static_cast<type_real>(3.0 / 8.0)))
+        << "alpha(" << j << "): "
+        << expected_got(static_cast<type_real>(3.0 / 8.0), result.alpha(j));
+    EXPECT_TRUE(is_close(result.beta(j), static_cast<type_real>(1.0 / 40.0)))
+        << "beta(" << j << "): "
+        << expected_got(static_cast<type_real>(1.0 / 40.0), result.beta(j));
+    EXPECT_TRUE(is_close(result.gamma(j), static_cast<type_real>(3.0 / 80.0)))
+        << "gamma(" << j << "): "
+        << expected_got(static_cast<type_real>(3.0 / 80.0), result.gamma(j));
+  }
+}
+
+// Two SLS with distinct tau_sigma, dt = 0.1:
+//   tau_sigma = [0.1, 1.0]
+//
+//   Mechanism 0 (tau=0.1, product dt/tau=1 — same as ThreeSLS_UniformTau):
+//     alpha[0] = 3/8
+//     beta[0]  = 1/40
+//     gamma[0] = 3/80
+//
+//   Mechanism 1 (tau=1.0, tauinv=-1):
+//     dt=0.1, dt^2=0.01, dt^3=0.001, dt^4=0.0001
+//     alpha[1] = 1 - 0.1 + 0.01/2 - 0.001/6 + 0.0001/24
+//              = (240000 - 24000 + 1200 - 40 + 1) / 240000
+//              = 217161 / 240000
+//     beta[1]  = 0.05 - 0.01/3 + 0.001/8 - 0.0001/24
+//              = (12000 - 800 + 30 - 1) / 240000
+//              = 11229 / 240000
+//     gamma[1] = 0.05 - 0.01/6 + 0.001/24
+//              = (1200 - 40 + 1) / 24000
+//              = 1161 / 24000
+TEST(Attenuation_IntegrationFactors, TwoSLS_DistinctTau) {
+  constexpr int N_SLS = 2;
+
+  Kokkos::View<type_real[N_SLS], Kokkos::LayoutRight, Kokkos::HostSpace>
+      tau_sigma("tau_sigma");
+  tau_sigma(0) = 0.1;
+  tau_sigma(1) = 1.0;
+
+  auto result = compute_integration_factors<N_SLS>(tau_sigma, 0.1);
+
+  // Mechanism 0
+  EXPECT_TRUE(is_close(result.alpha(0), static_cast<type_real>(3.0 / 8.0)))
+      << expected_got(static_cast<type_real>(3.0 / 8.0), result.alpha(0));
+  EXPECT_TRUE(is_close(result.beta(0), static_cast<type_real>(1.0 / 40.0)))
+      << expected_got(static_cast<type_real>(1.0 / 40.0), result.beta(0));
+  EXPECT_TRUE(is_close(result.gamma(0), static_cast<type_real>(3.0 / 80.0)))
+      << expected_got(static_cast<type_real>(3.0 / 80.0), result.gamma(0));
+
+  // Mechanism 1
+  EXPECT_TRUE(
+      is_close(result.alpha(1), static_cast<type_real>(217161.0 / 240000.0)))
+      << expected_got(static_cast<type_real>(217161.0 / 240000.0),
+                      result.alpha(1));
+  EXPECT_TRUE(
+      is_close(result.beta(1), static_cast<type_real>(11229.0 / 240000.0)))
+      << expected_got(static_cast<type_real>(11229.0 / 240000.0),
+                      result.beta(1));
+  EXPECT_TRUE(
+      is_close(result.gamma(1), static_cast<type_real>(1161.0 / 24000.0)))
+      << expected_got(static_cast<type_real>(1161.0 / 24000.0),
+                      result.gamma(1));
+}
+
+// Five SLS with N_SLS=5, dt=1, all tau_sigma=2  (product dt/tau=0.5):
+//   tauinv = -0.5
+//   alpha = 1 + (-0.5) + 0.25/2 + (-0.125)/6 + 0.0625/24
+//         = 1 - 1/2 + 1/8 - 1/48 + 1/384
+//         = (384 - 192 + 48 - 8 + 1) / 384
+//         = 233/384
+//   beta  = 1/2 + (-0.5)/3 + 0.25/8 + (-0.125)/24
+//         = 1/2 - 1/6 + 1/32 - 1/192
+//         = (96 - 32 + 6 - 1) / 192
+//         = 69/192 = 23/64
+//   gamma = 1/2 + (-0.5)/6 + 0.25/24
+//         = 1/2 - 1/12 + 1/96
+//         = (48 - 8 + 1) / 96
+//         = 41/96
+TEST(Attenuation_IntegrationFactors, FiveSLS_UniformTauHalf) {
+  constexpr int N_SLS = 5;
+
+  Kokkos::View<type_real[N_SLS], Kokkos::LayoutRight, Kokkos::HostSpace>
+      tau_sigma("tau_sigma");
+  for (int j = 0; j < N_SLS; ++j)
+    tau_sigma(j) = 2.0;
+
+  auto result = compute_integration_factors<N_SLS>(tau_sigma, 1.0);
+
+  EXPECT_EQ(result.alpha.extent(0), N_SLS);
+  EXPECT_EQ(result.beta.extent(0), N_SLS);
+  EXPECT_EQ(result.gamma.extent(0), N_SLS);
+
+  for (int j = 0; j < N_SLS; ++j) {
+    EXPECT_TRUE(
+        is_close(result.alpha(j), static_cast<type_real>(233.0 / 384.0)))
+        << "alpha(" << j << "): "
+        << expected_got(static_cast<type_real>(233.0 / 384.0), result.alpha(j));
+    EXPECT_TRUE(is_close(result.beta(j), static_cast<type_real>(23.0 / 64.0)))
+        << "beta(" << j << "): "
+        << expected_got(static_cast<type_real>(23.0 / 64.0), result.beta(j));
+    EXPECT_TRUE(is_close(result.gamma(j), static_cast<type_real>(41.0 / 96.0)))
+        << "gamma(" << j << "): "
+        << expected_got(static_cast<type_real>(41.0 / 96.0), result.gamma(j));
+  }
+}

--- a/tests/unit-tests/point/attenuation_tests.cpp
+++ b/tests/unit-tests/point/attenuation_tests.cpp
@@ -113,12 +113,13 @@ TYPED_TEST(PointAttenuationTest, ValueConstructor2D) {
       element::dimension_tag::dim2, element::medium_tag::elastic_psv,
       element::attenuation_tag::constant_isotropic, using_simd>;
 
-  typename att_type::common_factor_type kappa_val(1.5);
-  typename att_type::common_factor_type mu_val(2.5);
-  type_real alpha = 0.5, beta = 0.3, gamma = 0.1;
+  typename att_type::value_type kappa_val(1.5);
+  typename att_type::value_type mu_val(2.5);
+  typename att_type::value_type alpha_val(0.5), beta_val(0.3), gamma_val(0.1);
   typename att_type::value_type rxx_val(1.0), rxz_val(2.0), rk_val(3.0);
 
-  att_type att(kappa_val, mu_val, alpha, beta, gamma, rxx_val, rxz_val, rk_val);
+  att_type att(kappa_val, mu_val, alpha_val, beta_val, gamma_val, rxx_val,
+               rxz_val, rk_val);
 
   for (int i = 0; i < N; ++i) {
     EXPECT_TRUE(
@@ -135,13 +136,15 @@ TYPED_TEST(PointAttenuationTest, ValueConstructor2D) {
         << "Rxz(" << i << "): " << ExpectedGot(rxz_val(i), att.Rxz(i));
     EXPECT_TRUE(specfem::utilities::is_close(att.Rkappa(i), rk_val(i)))
         << "Rkappa(" << i << "): " << ExpectedGot(rk_val(i), att.Rkappa(i));
+    EXPECT_TRUE(specfem::utilities::is_close(att.alpha_rk(i), alpha_val(i)))
+        << "alpha_rk(" << i
+        << "): " << ExpectedGot(alpha_val(i), att.alpha_rk(i));
+    EXPECT_TRUE(specfem::utilities::is_close(att.beta_rk(i), beta_val(i)))
+        << "beta_rk(" << i << "): " << ExpectedGot(beta_val(i), att.beta_rk(i));
+    EXPECT_TRUE(specfem::utilities::is_close(att.gamma_rk(i), gamma_val(i)))
+        << "gamma_rk(" << i
+        << "): " << ExpectedGot(gamma_val(i), att.gamma_rk(i));
   }
-  EXPECT_TRUE(specfem::utilities::is_close(att.alpha_rk, alpha))
-      << ExpectedGot(alpha, att.alpha_rk);
-  EXPECT_TRUE(specfem::utilities::is_close(att.beta_rk, beta))
-      << ExpectedGot(beta, att.beta_rk);
-  EXPECT_TRUE(specfem::utilities::is_close(att.gamma_rk, gamma))
-      << ExpectedGot(gamma, att.gamma_rk);
 }
 
 // ============================================================
@@ -156,14 +159,14 @@ TYPED_TEST(PointAttenuationTest, ValueConstructor3D) {
       element::dimension_tag::dim3, element::medium_tag::elastic,
       element::attenuation_tag::constant_isotropic, using_simd>;
 
-  typename att_type::common_factor_type kappa_val(3.0);
-  typename att_type::common_factor_type mu_val(4.0);
-  type_real alpha = 0.7, beta = 0.2, gamma = 0.1;
+  typename att_type::value_type kappa_val(3.0);
+  typename att_type::value_type mu_val(4.0);
+  typename att_type::value_type alpha_val(0.7), beta_val(0.2), gamma_val(0.1);
   typename att_type::value_type rxx(1.0), ryy(2.0), rxy(3.0), rxz(4.0),
       ryz(5.0), rk(6.0);
 
-  att_type att(kappa_val, mu_val, alpha, beta, gamma, rxx, ryy, rxy, rxz, ryz,
-               rk);
+  att_type att(kappa_val, mu_val, alpha_val, beta_val, gamma_val, rxx, ryy, rxy,
+               rxz, ryz, rk);
 
   for (int i = 0; i < N; ++i) {
     EXPECT_TRUE(
@@ -176,10 +179,10 @@ TYPED_TEST(PointAttenuationTest, ValueConstructor3D) {
     EXPECT_TRUE(specfem::utilities::is_close(att.Rxz(i), rxz(i)));
     EXPECT_TRUE(specfem::utilities::is_close(att.Ryz(i), ryz(i)));
     EXPECT_TRUE(specfem::utilities::is_close(att.Rkappa(i), rk(i)));
+    EXPECT_TRUE(specfem::utilities::is_close(att.alpha_rk(i), alpha_val(i)));
+    EXPECT_TRUE(specfem::utilities::is_close(att.beta_rk(i), beta_val(i)));
+    EXPECT_TRUE(specfem::utilities::is_close(att.gamma_rk(i), gamma_val(i)));
   }
-  EXPECT_TRUE(specfem::utilities::is_close(att.alpha_rk, alpha));
-  EXPECT_TRUE(specfem::utilities::is_close(att.beta_rk, beta));
-  EXPECT_TRUE(specfem::utilities::is_close(att.gamma_rk, gamma));
 }
 
 // ============================================================
@@ -194,12 +197,13 @@ TYPED_TEST(PointAttenuationTest, InitMethod2D) {
       element::dimension_tag::dim2, element::medium_tag::elastic_psv,
       element::attenuation_tag::constant_isotropic, using_simd>;
 
-  typename att_type::common_factor_type kappa_val(1.0);
-  typename att_type::common_factor_type mu_val(2.0);
+  typename att_type::value_type kappa_val(1.0);
+  typename att_type::value_type mu_val(2.0);
   typename att_type::value_type const_val(5.0);
   typename att_type::value_type zero(0.0);
 
-  att_type att(kappa_val, mu_val, 0.5, 0.3, 0.1, const_val, const_val,
+  typename att_type::value_type rk_val(0.5);
+  att_type att(kappa_val, mu_val, rk_val, rk_val, rk_val, const_val, const_val,
                const_val);
   att.init();
 
@@ -218,12 +222,13 @@ TYPED_TEST(PointAttenuationTest, InitMethod3D) {
       element::dimension_tag::dim3, element::medium_tag::elastic,
       element::attenuation_tag::constant_isotropic, using_simd>;
 
-  typename att_type::common_factor_type kappa_val(1.0);
-  typename att_type::common_factor_type mu_val(2.0);
+  typename att_type::value_type kappa_val(1.0);
+  typename att_type::value_type mu_val(2.0);
   typename att_type::value_type const_val(7.0);
   typename att_type::value_type zero(0.0);
 
-  att_type att(kappa_val, mu_val, 0.5, 0.3, 0.1, const_val, const_val,
+  typename att_type::value_type rk_val(0.5);
+  att_type att(kappa_val, mu_val, rk_val, rk_val, rk_val, const_val, const_val,
                const_val, const_val, const_val, const_val);
   att.init();
 
@@ -249,13 +254,14 @@ TYPED_TEST(PointAttenuationTest, Addition2D) {
       element::dimension_tag::dim2, element::medium_tag::elastic_psv,
       element::attenuation_tag::constant_isotropic, using_simd>;
 
-  typename att_type::common_factor_type kf(1.0);
-  typename att_type::common_factor_type mf(2.0);
+  typename att_type::value_type kf(1.0);
+  typename att_type::value_type mf(2.0);
   typename att_type::value_type a_rxx(1.0), a_rxz(2.0), a_rk(3.0);
   typename att_type::value_type b_rxx(10.0), b_rxz(20.0), b_rk(30.0);
 
-  att_type a(kf, mf, 0.5, 0.3, 0.1, a_rxx, a_rxz, a_rk);
-  att_type b(kf, mf, 0.5, 0.3, 0.1, b_rxx, b_rxz, b_rk);
+  typename att_type::value_type alpha_rk(0.5), beta_rk(0.3), gamma_rk(0.1);
+  att_type a(kf, mf, alpha_rk, beta_rk, gamma_rk, a_rxx, a_rxz, a_rk);
+  att_type b(kf, mf, alpha_rk, beta_rk, gamma_rk, b_rxx, b_rxz, b_rk);
   att_type c = a + b;
 
   for (int i = 0; i < N; ++i) {
@@ -277,13 +283,14 @@ TYPED_TEST(PointAttenuationTest, AdditionAssignment2D) {
       element::dimension_tag::dim2, element::medium_tag::elastic_psv,
       element::attenuation_tag::constant_isotropic, using_simd>;
 
-  typename att_type::common_factor_type kf(1.0);
-  typename att_type::common_factor_type mf(2.0);
+  typename att_type::value_type kf(1.0);
+  typename att_type::value_type mf(2.0);
   typename att_type::value_type a_rxx(1.0), a_rxz(2.0), a_rk(3.0);
   typename att_type::value_type b_rxx(10.0), b_rxz(20.0), b_rk(30.0);
 
-  att_type a(kf, mf, 0.5, 0.3, 0.1, a_rxx, a_rxz, a_rk);
-  att_type b(kf, mf, 0.5, 0.3, 0.1, b_rxx, b_rxz, b_rk);
+  typename att_type::value_type alpha_rk(0.5), beta_rk(0.3), gamma_rk(0.1);
+  att_type a(kf, mf, alpha_rk, beta_rk, gamma_rk, a_rxx, a_rxz, a_rk);
+  att_type b(kf, mf, alpha_rk, beta_rk, gamma_rk, b_rxx, b_rxz, b_rk);
   a += b;
 
   for (int i = 0; i < N; ++i) {
@@ -306,12 +313,13 @@ TYPED_TEST(PointAttenuationTest, ScalarMultiplication2D) {
       element::attenuation_tag::constant_isotropic, using_simd>;
 
   if constexpr (!using_simd) {
-    typename att_type::common_factor_type kf(1.0);
-    typename att_type::common_factor_type mf(2.0);
+    typename att_type::value_type kf(1.0);
+    typename att_type::value_type mf(2.0);
     typename att_type::value_type rxx_val(1.0), rxz_val(2.0), rk_val(3.0);
+    typename att_type::value_type alpha_rk(0.5), beta_rk(0.3), gamma_rk(0.1);
     type_real scalar = 2.5;
 
-    att_type att(kf, mf, 0.5, 0.3, 0.1, rxx_val, rxz_val, rk_val);
+    att_type att(kf, mf, alpha_rk, beta_rk, gamma_rk, rxx_val, rxz_val, rk_val);
     att_type result = att * scalar;
 
     for (int i = 0; i < N; ++i) {
@@ -337,15 +345,18 @@ TYPED_TEST(PointAttenuationTest, Addition3D) {
       element::dimension_tag::dim3, element::medium_tag::elastic,
       element::attenuation_tag::constant_isotropic, using_simd>;
 
-  typename att_type::common_factor_type kf(1.0);
-  typename att_type::common_factor_type mf(2.0);
+  typename att_type::value_type kf(1.0);
+  typename att_type::value_type mf(2.0);
   typename att_type::value_type a_rxx(1.0), a_ryy(2.0), a_rxy(3.0), a_rxz(4.0),
       a_ryz(5.0), a_rk(6.0);
   typename att_type::value_type b_rxx(10.0), b_ryy(20.0), b_rxy(30.0),
       b_rxz(40.0), b_ryz(50.0), b_rk(60.0);
 
-  att_type a(kf, mf, 0.5, 0.3, 0.1, a_rxx, a_ryy, a_rxy, a_rxz, a_ryz, a_rk);
-  att_type b(kf, mf, 0.5, 0.3, 0.1, b_rxx, b_ryy, b_rxy, b_rxz, b_ryz, b_rk);
+  typename att_type::value_type alpha_rk(0.5), beta_rk(0.3), gamma_rk(0.1);
+  att_type a(kf, mf, alpha_rk, beta_rk, gamma_rk, a_rxx, a_ryy, a_rxy, a_rxz,
+             a_ryz, a_rk);
+  att_type b(kf, mf, alpha_rk, beta_rk, gamma_rk, b_rxx, b_ryy, b_rxy, b_rxz,
+             b_ryz, b_rk);
   att_type c = a + b;
 
   for (int i = 0; i < N; ++i) {
@@ -370,15 +381,18 @@ TYPED_TEST(PointAttenuationTest, AdditionAssignment3D) {
       element::dimension_tag::dim3, element::medium_tag::elastic,
       element::attenuation_tag::constant_isotropic, using_simd>;
 
-  typename att_type::common_factor_type kf(1.0);
-  typename att_type::common_factor_type mf(2.0);
+  typename att_type::value_type kf(1.0);
+  typename att_type::value_type mf(2.0);
   typename att_type::value_type a_rxx(1.0), a_ryy(2.0), a_rxy(3.0), a_rxz(4.0),
       a_ryz(5.0), a_rk(6.0);
   typename att_type::value_type b_rxx(10.0), b_ryy(20.0), b_rxy(30.0),
       b_rxz(40.0), b_ryz(50.0), b_rk(60.0);
 
-  att_type a(kf, mf, 0.5, 0.3, 0.1, a_rxx, a_ryy, a_rxy, a_rxz, a_ryz, a_rk);
-  att_type b(kf, mf, 0.5, 0.3, 0.1, b_rxx, b_ryy, b_rxy, b_rxz, b_ryz, b_rk);
+  typename att_type::value_type alpha_rk(0.5), beta_rk(0.3), gamma_rk(0.1);
+  att_type a(kf, mf, alpha_rk, beta_rk, gamma_rk, a_rxx, a_ryy, a_rxy, a_rxz,
+             a_ryz, a_rk);
+  att_type b(kf, mf, alpha_rk, beta_rk, gamma_rk, b_rxx, b_ryy, b_rxy, b_rxz,
+             b_ryz, b_rk);
   a += b;
 
   for (int i = 0; i < N; ++i) {
@@ -404,13 +418,15 @@ TYPED_TEST(PointAttenuationTest, ScalarMultiplication3D) {
       element::attenuation_tag::constant_isotropic, using_simd>;
 
   if constexpr (!using_simd) {
-    typename att_type::common_factor_type kf(1.0);
-    typename att_type::common_factor_type mf(2.0);
+    typename att_type::value_type kf(1.0);
+    typename att_type::value_type mf(2.0);
     typename att_type::value_type rxx(1.0), ryy(2.0), rxy(3.0), rxz(4.0),
         ryz(5.0), rk(6.0);
+    typename att_type::value_type alpha_rk(0.5), beta_rk(0.3), gamma_rk(0.1);
     type_real scalar = 2.5;
 
-    att_type att(kf, mf, 0.5, 0.3, 0.1, rxx, ryy, rxy, rxz, ryz, rk);
+    att_type att(kf, mf, alpha_rk, beta_rk, gamma_rk, rxx, ryy, rxy, rxz, ryz,
+                 rk);
     att_type result = att * scalar;
 
     for (int i = 0; i < N; ++i) {
@@ -436,17 +452,17 @@ TYPED_TEST(PointAttenuationTest, EqualityOperator2D) {
       element::dimension_tag::dim2, element::medium_tag::elastic_psv,
       element::attenuation_tag::constant_isotropic, using_simd>;
 
-  typename att_type::common_factor_type kappa_val(1.0);
-  typename att_type::common_factor_type mu_val(2.0);
-  type_real alpha = 0.5, beta = 0.3, gamma = 0.1;
+  typename att_type::value_type kappa_val(1.0);
+  typename att_type::value_type mu_val(2.0);
+  typename att_type::value_type alpha(0.5), beta(0.3), gamma(0.1);
   typename att_type::value_type rxx(1.0), rxz(2.0), rk(3.0);
   typename att_type::value_type rxx_alt(9.0);
+  typename att_type::value_type alpha_alt(0.6);
 
   att_type att1(kappa_val, mu_val, alpha, beta, gamma, rxx, rxz, rk);
   att_type att2(kappa_val, mu_val, alpha, beta, gamma, rxx, rxz, rk);
   // Different alpha_rk
-  att_type att3(kappa_val, mu_val, alpha + static_cast<type_real>(0.1), beta,
-                gamma, rxx, rxz, rk);
+  att_type att3(kappa_val, mu_val, alpha_alt, beta, gamma, rxx, rxz, rk);
   // Different Rxx
   att_type att4(kappa_val, mu_val, alpha, beta, gamma, rxx_alt, rxz, rk);
 
@@ -466,9 +482,9 @@ TYPED_TEST(PointAttenuationTest, EqualityOperator3D) {
       element::dimension_tag::dim3, element::medium_tag::elastic,
       element::attenuation_tag::constant_isotropic, using_simd>;
 
-  typename att_type::common_factor_type kappa_val(1.0);
-  typename att_type::common_factor_type mu_val(2.0);
-  type_real alpha = 0.5, beta = 0.3, gamma = 0.1;
+  typename att_type::value_type kappa_val(1.0);
+  typename att_type::value_type mu_val(2.0);
+  typename att_type::value_type alpha(0.5), beta(0.3), gamma(0.1);
   typename att_type::value_type rxx(1.0), ryy(2.0), rxy(3.0), rxz(4.0),
       ryz(5.0), rk(6.0);
   typename att_type::value_type ryy_alt(9.0);
@@ -496,10 +512,10 @@ TYPED_TEST(PointAttenuationTest, PrintMethod2D) {
       element::attenuation_tag::constant_isotropic, using_simd>;
 
   if constexpr (!using_simd) {
-    typename att_type::common_factor_type kappa_val(1.0);
-    typename att_type::common_factor_type mu_val(2.0);
+    typename att_type::value_type kappa_val(1.0);
+    typename att_type::value_type mu_val(2.0);
     typename att_type::value_type rxx(1.0), rxz(2.0), rk(3.0);
-    type_real alpha = 0.5, beta = 0.3, gamma = 0.1;
+    typename att_type::value_type alpha(0.5), beta(0.3), gamma(0.1);
 
     att_type att(kappa_val, mu_val, alpha, beta, gamma, rxx, rxz, rk);
     std::string s = att.print();


### PR DESCRIPTION

## Description

- Updated formulation of the integration factor computation since
  tau_inv was being set to negative which did not make sense this
  means that the formulation is also not 100% clear in Savage 2010,
  which upon rereading suggests that there is exponential growth in
  the memory variable.
- Updates attenuation point type since it had float only for attenuation
- Updates docs for everything


### Commits

- Updated the documentation AND implementation for the integration factors to be more consistent with RK integration. (7263f212b)
- Added integration factor computation and tests (c6309c4b5)

## Issue Number

Updates #1594 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [x] I ran the code through pre-commit to check style
- [x] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [x] I have added labels to the PR (see right hand side of the PR page)
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
