### PR TITLE
Fix Info Bug

### DIFF
--- a/core/specfem/assembly/info.cpp
+++ b/core/specfem/assembly/info.cpp
@@ -18,7 +18,7 @@ specfem::assembly::Info<specfem::element::dimension_tag::dim2>::string() const {
       << element_size.max << "]\n";
   oss << " GLL Distance: ........... [" << gll_distance.min << ", "
       << gll_distance.max << "]\n";
-  oss << " Largest Minimum Period: . " << largest_minimum_period << "\n";
+  oss << " Minimum Period: . " << largest_minimum_period << "\n";
   oss << " Suggested Time Step: .... " << suggested_time_step << "\n";
   return oss.str();
 }
@@ -42,7 +42,7 @@ specfem::assembly::Info<specfem::element::dimension_tag::dim3>::string() const {
       << element_size.max << "]\n";
   oss << " GLL Distance: ........... [" << gll_distance.min << ", "
       << gll_distance.max << "]\n";
-  oss << " Largest Minimum Period: . " << largest_minimum_period << "\n";
+  oss << " Minimum Period: . " << largest_minimum_period << "\n";
   oss << " Suggested Time Step: .... " << suggested_time_step << "\n";
   return oss.str();
 }

--- a/core/specfem/assembly/info.tpp
+++ b/core/specfem/assembly/info.tpp
@@ -62,7 +62,8 @@ struct InfoScatters {
 /// @tparam PropertyTag The property type (isotropic, anisotropic, etc.)
 template <specfem::element::dimension_tag DimensionTag,
           specfem::element::medium_tag MediumTag,
-          specfem::element::property_tag PropertyTag>
+          specfem::element::property_tag PropertyTag,
+          specfem::element::attenuation_tag AttenuationTag>
 void process_medium_elements(
     const specfem::assembly::mesh<DimensionTag> &mesh,
     const specfem::assembly::properties<DimensionTag> &properties,
@@ -72,9 +73,9 @@ void process_medium_elements(
   constexpr specfem::element::dimension_tag dimension_tag = DimensionTag;
   constexpr specfem::element::medium_tag medium_tag = MediumTag;
   constexpr specfem::element::property_tag property_tag = PropertyTag;
-
+  constexpr specfem::element::attenuation_tag attenuation_tag = AttenuationTag;
   auto elements =
-      element_types.get_elements_on_device(medium_tag, property_tag);
+      element_types.get_elements_on_device(medium_tag, property_tag, attenuation_tag);
 
   constexpr bool using_simd = false;
   using simd = specfem::datatype::simd<type_real, using_simd>;
@@ -214,20 +215,22 @@ specfem::assembly::Info<DimensionTag>::Info(
         (DIMENSION_TAG(DIM2),
          MEDIUM_TAG(ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
                     ELASTIC_PSV_T),
-         PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT)),
+         PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+        ATTENUATION_TAG(NONE)),
         {
           info::impl::process_medium_elements<_dimension_tag_, _medium_tag_,
-                                              _property_tag_>(
+                                              _property_tag_, _attenuation_tag_>(
               mesh, properties, element_types, scatters);
         };);
   } else {
     FOR_EACH_IN_PRODUCT(
         (DIMENSION_TAG(DIM3),
          MEDIUM_TAG(ELASTIC, ACOUSTIC),
-         PROPERTY_TAG(ISOTROPIC)),
+         PROPERTY_TAG(ISOTROPIC),
+         ATTENUATION_TAG(NONE)),
         {
           info::impl::process_medium_elements<_dimension_tag_, _medium_tag_,
-                                              _property_tag_>(
+                                              _property_tag_, _attenuation_tag_>(
               mesh, properties, element_types, scatters);
         };);
   };

--- a/core/specfem/point/global_coordinates.hpp
+++ b/core/specfem/point/global_coordinates.hpp
@@ -41,6 +41,10 @@ distance(const specfem::point::global_coordinates<DimensionTag> &p1,
  * Stores the physical coordinates (\f$x, z\f$) for a point in 2D space.
  */
 template <> struct global_coordinates<specfem::element::dimension_tag::dim2> {
+  constexpr static auto dimension_tag = specfem::element::dimension_tag::dim2;
+  constexpr static auto data_class =
+      specfem::data_access::DataClassType::global_coordinates;
+
   type_real x; ///< Global coordinate \f$ x \f$
   type_real z; ///< Global coordinate \f$ z \f$
 


### PR DESCRIPTION

## Description

- Fixed bug in the computation of the mesh information after attenuation tag was implemented. (98800cc70)

## Issue Number

-/-

## Checklist

Please make sure to check developer documentation on specfem docs.

- [x] I ran the code through pre-commit to check style
- [x] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [x] I have added labels to the PR (see right hand side of the PR page)
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
