### PR TITLE
Issue 1714 Alt

### DIFF
--- a/core/specfem/algorithms/gradient.hpp
+++ b/core/specfem/algorithms/gradient.hpp
@@ -3,6 +3,7 @@
 #include "specfem/assembly/jacobian_matrix.hpp"
 #include "specfem/chunk_element/field_pack.hpp"
 #include "specfem/data_access.hpp"
+#include "specfem/element.hpp"
 #include "specfem/execution.hpp"
 #include "specfem/point.hpp"
 #include <Kokkos_Core.hpp>
@@ -181,19 +182,21 @@ KOKKOS_FORCEINLINE_FUNCTION auto element_gradient(
  *        (iterator_index, TensorPointViewType<components, dim>)
  */
 template <typename ChunkIndexType, typename VectorFieldType,
-          specfem::element::dimension_tag DimTag, typename QuadratureType,
+          typename JacobianMatrixType, typename QuadratureType,
           typename CallbackFunctor,
           std::enable_if_t<
               specfem::data_access::is_chunk_element<VectorFieldType>::value,
               int> = 0>
 KOKKOS_FORCEINLINE_FUNCTION void
 gradient(const ChunkIndexType &chunk_index,
-         const specfem::assembly::jacobian_matrix<DimTag> &jacobian_matrix,
+         const JacobianMatrixType &jacobian_matrix,
          const QuadratureType &quadrature, const VectorFieldType &f,
          const CallbackFunctor &callback) {
+
+  constexpr specfem::element::dimension_tag dimension_tag =
+      VectorFieldType::dimension_tag;
   constexpr int components = VectorFieldType::components;
-  constexpr int dimension =
-      DimTag == specfem::element::dimension_tag::dim2 ? 2 : 3;
+  constexpr int dimension = specfem::element::dimension<dimension_tag>::dim;
   constexpr bool using_simd = VectorFieldType::simd::using_simd;
 
   using TensorPointViewType =
@@ -216,11 +219,11 @@ gradient(const ChunkIndexType &chunk_index,
         const auto local_index = iterator_index.get_local_index();
         datatype df_dxi[components] = { 0.0 };
         datatype df_dgamma[components] = { 0.0 };
-        specfem::point::jacobian_matrix<DimTag, false, using_simd>
+        specfem::point::jacobian_matrix<dimension_tag, false, using_simd>
             point_jacobian_matrix;
         specfem::assembly::load_on_device(index, jacobian_matrix,
                                           point_jacobian_matrix);
-        if constexpr (DimTag == specfem::element::dimension_tag::dim3) {
+        if constexpr (dimension_tag == specfem::element::dimension_tag::dim3) {
           datatype df_deta[components] = { 0.0 };
           callback(iterator_index, impl::element_gradient(
                                        f, local_index, point_jacobian_matrix,
@@ -255,19 +258,21 @@ gradient(const ChunkIndexType &chunk_index,
  *         TensorPointViewType<components, dim>)
  */
 template <typename ChunkIndexType, typename VectorFieldType,
-          specfem::element::dimension_tag DimTag, typename QuadratureType,
+          typename JacobianMatrixType, typename QuadratureType,
           typename CallbackFunctor,
           std::enable_if_t<
               specfem::data_access::is_chunk_element<VectorFieldType>::value,
               int> = 0>
 KOKKOS_FORCEINLINE_FUNCTION void
 gradient(const ChunkIndexType &chunk_index,
-         const specfem::assembly::jacobian_matrix<DimTag> &jacobian_matrix,
+         const JacobianMatrixType &jacobian_matrix,
          const QuadratureType &quadrature, const VectorFieldType &f,
          const VectorFieldType &g, const CallbackFunctor &callback) {
+
+  constexpr specfem::element::dimension_tag dimension_tag =
+      VectorFieldType::dimension_tag;
   constexpr int components = VectorFieldType::components;
-  constexpr int dimension =
-      DimTag == specfem::element::dimension_tag::dim2 ? 2 : 3;
+  constexpr int dimension = specfem::element::dimension<dimension_tag>::dim;
   constexpr bool using_simd = VectorFieldType::simd::using_simd;
 
   using TensorPointViewType =
@@ -292,11 +297,11 @@ gradient(const ChunkIndexType &chunk_index,
         datatype df_dgamma[components] = { 0.0 };
         datatype dg_dxi[components] = { 0.0 };
         datatype dg_dgamma[components] = { 0.0 };
-        specfem::point::jacobian_matrix<DimTag, false, using_simd>
+        specfem::point::jacobian_matrix<dimension_tag, false, using_simd>
             point_jacobian_matrix;
         specfem::assembly::load_on_device(index, jacobian_matrix,
                                           point_jacobian_matrix);
-        if constexpr (DimTag == specfem::element::dimension_tag::dim3) {
+        if constexpr (dimension_tag == specfem::element::dimension_tag::dim3) {
           datatype df_deta[components] = { 0.0 };
           datatype dg_deta[components] = { 0.0 };
           callback(
@@ -322,31 +327,33 @@ gradient(const ChunkIndexType &chunk_index,
  * @ingroup AlgorithmsGradient
  *
  * @tparam ChunkIndexType  Chunk index type
- * @tparam DisplacementF   Chunk element field type held by holds_u
+ * @tparam VectorFieldType   Chunk element field type held by holds_u
  * @tparam DimTag          Dimension tag (dim2 or dim3), deduced from
  *                         the jacobian_matrix argument
  * @tparam QuadratureType  Quadrature view type
  * @tparam CallbackFunctor Callback functor receiving
  *         (iterator_index, GradientPack<holds_du<TU>>)
  */
-template <typename ChunkIndexType, typename DisplacementF,
-          specfem::element::dimension_tag DimTag, typename QuadratureType,
+template <typename ChunkIndexType, typename VectorFieldType,
+          typename JacobianMatrixType, typename QuadratureType,
           typename CallbackFunctor>
 KOKKOS_FORCEINLINE_FUNCTION void
 gradient(const ChunkIndexType &chunk_index,
-         const specfem::assembly::jacobian_matrix<DimTag> &jacobian_matrix,
+         const JacobianMatrixType &jacobian_matrix,
          const QuadratureType &quadrature,
          const specfem::chunk_element::FieldPack<
-             specfem::chunk_element::holds_u<DisplacementF> > &field_pack,
+             specfem::chunk_element::holds_u<VectorFieldType> > &field_pack,
          const CallbackFunctor &callback) {
-  constexpr int components = DisplacementF::components;
-  constexpr int dimension =
-      DimTag == specfem::element::dimension_tag::dim2 ? 2 : 3;
-  constexpr bool using_simd = DisplacementF::simd::using_simd;
+  constexpr specfem::element::dimension_tag dimension_tag =
+      VectorFieldType::dimension_tag;
+  constexpr bool using_simd = VectorFieldType::simd::using_simd;
+  constexpr int dimension = specfem::element::dimension<dimension_tag>::dim;
+  constexpr int components = VectorFieldType::components;
 
-  using TU = specfem::datatype::TensorPointViewType<type_real, components,
-                                                    dimension, using_simd>;
-  using datatype = typename DisplacementF::simd::datatype;
+  using TensorPointViewTypeF =
+      specfem::datatype::TensorPointViewType<type_real, components, dimension,
+                                             using_simd>;
+  using datatypeF = typename VectorFieldType::simd::datatype;
 
   specfem::execution::for_each_level(
       chunk_index.get_iterator(),
@@ -354,25 +361,29 @@ gradient(const ChunkIndexType &chunk_index,
               &iterator_index) {
         const auto index = iterator_index.get_index();
         const auto local_index = iterator_index.get_local_index();
-        datatype df_dxi[components] = { 0.0 };
-        datatype df_dgamma[components] = { 0.0 };
-        specfem::point::jacobian_matrix<DimTag, false, using_simd>
+        datatypeF df_dxi[components] = { 0.0 };
+        datatypeF df_dgamma[components] = { 0.0 };
+        specfem::point::jacobian_matrix<dimension_tag, false, using_simd>
             point_jacobian_matrix;
         specfem::assembly::load_on_device(index, jacobian_matrix,
                                           point_jacobian_matrix);
-        if constexpr (DimTag == specfem::element::dimension_tag::dim3) {
-          datatype df_deta[components] = { 0.0 };
+        if constexpr (dimension_tag == specfem::element::dimension_tag::dim3) {
+          datatypeF df_deta[components] = { 0.0 };
           callback(iterator_index,
-                   specfem::point::GradientPack<specfem::point::holds_du<TU> >{
-                       specfem::point::holds_du<TU>{ impl::element_gradient(
-                           field_pack.u, local_index, point_jacobian_matrix,
-                           quadrature, df_dxi, df_deta, df_dgamma) } });
+                   specfem::point::GradientPack<
+                       specfem::point::holds_du<TensorPointViewTypeF> >{
+                       specfem::point::holds_du<TensorPointViewTypeF>{
+                           impl::element_gradient(
+                               field_pack.u, local_index, point_jacobian_matrix,
+                               quadrature, df_dxi, df_deta, df_dgamma) } });
         } else {
           callback(iterator_index,
-                   specfem::point::GradientPack<specfem::point::holds_du<TU> >{
-                       specfem::point::holds_du<TU>{ impl::element_gradient(
-                           field_pack.u, local_index, point_jacobian_matrix,
-                           quadrature, df_dxi, df_dgamma) } });
+                   specfem::point::GradientPack<
+                       specfem::point::holds_du<TensorPointViewTypeF> >{
+                       specfem::point::holds_du<TensorPointViewTypeF>{
+                           impl::element_gradient(
+                               field_pack.u, local_index, point_jacobian_matrix,
+                               quadrature, df_dxi, df_dgamma) } });
         }
       });
 }
@@ -384,36 +395,46 @@ gradient(const ChunkIndexType &chunk_index,
  *
  * @ingroup AlgorithmsGradient
  *
- * @tparam ChunkIndexType  Chunk index type
- * @tparam DisplacementF   Chunk element field type held by holds_u
- * @tparam VelocityF       Chunk element field type held by holds_v
- * @tparam DimTag          Dimension tag (dim2 or dim3), deduced from
- *                         the jacobian_matrix argument
- * @tparam QuadratureType  Quadrature view type
- * @tparam CallbackFunctor Callback functor receiving
+ * @tparam ChunkIndexType   Chunk index type
+ * @tparam VectorFieldTypeF Chunk element field type held by holds_u
+ * @tparam VectorFieldTypeG Chunk element field type held by holds_v
+ * @tparam DimTag           Dimension tag (dim2 or dim3), deduced from
+ *                          the jacobian_matrix argument
+ * @tparam QuadratureType   Quadrature view type
+ * @tparam CallbackFunctor  Callback functor receiving
  *         (iterator_index, GradientPack<holds_du<TU>, holds_dv<TV>>)
  */
-template <typename ChunkIndexType, typename DisplacementF, typename VelocityF,
-          specfem::element::dimension_tag DimTag, typename QuadratureType,
-          typename CallbackFunctor>
+template <typename ChunkIndexType, typename VectorFieldTypeF,
+          typename VectorFieldTypeG, typename JacobianMatrixType,
+          typename QuadratureType, typename CallbackFunctor>
 KOKKOS_FORCEINLINE_FUNCTION void
 gradient(const ChunkIndexType &chunk_index,
-         const specfem::assembly::jacobian_matrix<DimTag> &jacobian_matrix,
+         const JacobianMatrixType &jacobian_matrix,
          const QuadratureType &quadrature,
          const specfem::chunk_element::FieldPack<
-             specfem::chunk_element::holds_u<DisplacementF>,
-             specfem::chunk_element::holds_v<VelocityF> > &field_pack,
+             specfem::chunk_element::holds_u<VectorFieldTypeF>,
+             specfem::chunk_element::holds_v<VectorFieldTypeG> > &field_pack,
          const CallbackFunctor &callback) {
-  constexpr int components = DisplacementF::components;
-  constexpr int dimension =
-      DimTag == specfem::element::dimension_tag::dim2 ? 2 : 3;
-  constexpr bool using_simd = DisplacementF::simd::using_simd;
 
-  using TU = specfem::datatype::TensorPointViewType<type_real, components,
-                                                    dimension, using_simd>;
-  using TV = specfem::datatype::TensorPointViewType<
-      type_real, VelocityF::components, dimension, VelocityF::simd::using_simd>;
-  using datatype = typename DisplacementF::simd::datatype;
+  static_assert(VectorFieldTypeF::dimension_tag ==
+                VectorFieldTypeG::dimension_tag);
+
+  constexpr specfem::element::dimension_tag dimension_tag =
+      VectorFieldTypeF::dimension_tag;
+  constexpr int dimension = specfem::element::dimension<dimension_tag>::dim;
+
+  constexpr int componentsF = VectorFieldTypeF::components;
+  constexpr int componentsG = VectorFieldTypeG::components;
+  constexpr bool using_simd = VectorFieldTypeF::simd::using_simd;
+
+  using TensorPointViewTypeF =
+      specfem::datatype::TensorPointViewType<type_real, componentsF, dimension,
+                                             using_simd>;
+  using TensorPointViewTypeG = specfem::datatype::TensorPointViewType<
+      type_real, componentsG, dimension, VectorFieldTypeG::simd::using_simd>;
+
+  using datatypeF = typename VectorFieldTypeF::simd::datatype;
+  using datatypeG = typename VectorFieldTypeG::simd::datatype;
 
   specfem::execution::for_each_level(
       chunk_index.get_iterator(),
@@ -421,36 +442,42 @@ gradient(const ChunkIndexType &chunk_index,
               &iterator_index) {
         const auto index = iterator_index.get_index();
         const auto local_index = iterator_index.get_local_index();
-        datatype df_dxi[components] = { 0.0 };
-        datatype df_dgamma[components] = { 0.0 };
-        datatype dg_dxi[VelocityF::components] = { 0.0 };
-        datatype dg_dgamma[VelocityF::components] = { 0.0 };
-        specfem::point::jacobian_matrix<DimTag, false, using_simd>
+        datatypeF df_dxi[componentsF] = { 0.0 };
+        datatypeF df_dgamma[componentsF] = { 0.0 };
+        datatypeG dg_dxi[componentsG] = { 0.0 };
+        datatypeG dg_dgamma[componentsG] = { 0.0 };
+        specfem::point::jacobian_matrix<dimension_tag, false, using_simd>
             point_jacobian_matrix;
         specfem::assembly::load_on_device(index, jacobian_matrix,
                                           point_jacobian_matrix);
-        if constexpr (DimTag == specfem::element::dimension_tag::dim3) {
-          datatype df_deta[components] = { 0.0 };
-          datatype dg_deta[VelocityF::components] = { 0.0 };
+        if constexpr (dimension_tag == specfem::element::dimension_tag::dim3) {
+          datatypeF df_deta[componentsF] = { 0.0 };
+          datatypeG dg_deta[componentsG] = { 0.0 };
           callback(iterator_index,
-                   specfem::point::GradientPack<specfem::point::holds_du<TU>,
-                                                specfem::point::holds_dv<TV> >{
-                       specfem::point::holds_du<TU>{ impl::element_gradient(
-                           field_pack.u, local_index, point_jacobian_matrix,
-                           quadrature, df_dxi, df_deta, df_dgamma) },
-                       specfem::point::holds_dv<TV>{ impl::element_gradient(
-                           field_pack.v, local_index, point_jacobian_matrix,
-                           quadrature, dg_dxi, dg_deta, dg_dgamma) } });
+                   specfem::point::GradientPack<
+                       specfem::point::holds_du<TensorPointViewTypeF>,
+                       specfem::point::holds_dv<TensorPointViewTypeG> >{
+                       specfem::point::holds_du<TensorPointViewTypeF>{
+                           impl::element_gradient(
+                               field_pack.u, local_index, point_jacobian_matrix,
+                               quadrature, df_dxi, df_deta, df_dgamma) },
+                       specfem::point::holds_dv<TensorPointViewTypeG>{
+                           impl::element_gradient(
+                               field_pack.v, local_index, point_jacobian_matrix,
+                               quadrature, dg_dxi, dg_deta, dg_dgamma) } });
         } else {
           callback(iterator_index,
-                   specfem::point::GradientPack<specfem::point::holds_du<TU>,
-                                                specfem::point::holds_dv<TV> >{
-                       specfem::point::holds_du<TU>{ impl::element_gradient(
-                           field_pack.u, local_index, point_jacobian_matrix,
-                           quadrature, df_dxi, df_dgamma) },
-                       specfem::point::holds_dv<TV>{ impl::element_gradient(
-                           field_pack.v, local_index, point_jacobian_matrix,
-                           quadrature, dg_dxi, dg_dgamma) } });
+                   specfem::point::GradientPack<
+                       specfem::point::holds_du<TensorPointViewTypeF>,
+                       specfem::point::holds_dv<TensorPointViewTypeG> >{
+                       specfem::point::holds_du<TensorPointViewTypeF>{
+                           impl::element_gradient(
+                               field_pack.u, local_index, point_jacobian_matrix,
+                               quadrature, df_dxi, df_dgamma) },
+                       specfem::point::holds_dv<TensorPointViewTypeG>{
+                           impl::element_gradient(
+                               field_pack.v, local_index, point_jacobian_matrix,
+                               quadrature, dg_dxi, dg_dgamma) } });
         }
       });
 }

--- a/core/specfem/algorithms/gradient.hpp
+++ b/core/specfem/algorithms/gradient.hpp
@@ -321,18 +321,18 @@ gradient(const ChunkIndexType &chunk_index,
 }
 
 /**
- * @brief Compute the gradient of a FieldPack<holds_u<F>> using the spectral
- * element formulation. The callback receives a GradientPack<holds_du<TU>>.
+ * @brief Compute the gradient of a FieldPack<F> using the spectral element
+ * formulation. The callback receives a GradientPack<TF>.
  *
  * @ingroup AlgorithmsGradient
  *
  * @tparam ChunkIndexType  Chunk index type
- * @tparam VectorFieldType   Chunk element field type held by holds_u
+ * @tparam VectorFieldType   Chunk element field type held as .f
  * @tparam DimTag          Dimension tag (dim2 or dim3), deduced from
  *                         the jacobian_matrix argument
  * @tparam QuadratureType  Quadrature view type
  * @tparam CallbackFunctor Callback functor receiving
- *         (iterator_index, GradientPack<holds_du<TU>>)
+ *         (iterator_index, GradientPack<TF>)
  */
 template <typename ChunkIndexType, typename VectorFieldType,
           typename JacobianMatrixType, typename QuadratureType,
@@ -341,8 +341,7 @@ KOKKOS_FORCEINLINE_FUNCTION void
 gradient(const ChunkIndexType &chunk_index,
          const JacobianMatrixType &jacobian_matrix,
          const QuadratureType &quadrature,
-         const specfem::chunk_element::FieldPack<
-             specfem::chunk_element::holds_u<VectorFieldType> > &field_pack,
+         const specfem::chunk_element::FieldPack<VectorFieldType> &field_pack,
          const CallbackFunctor &callback) {
   constexpr specfem::element::dimension_tag dimension_tag =
       VectorFieldType::dimension_tag;
@@ -370,51 +369,44 @@ gradient(const ChunkIndexType &chunk_index,
         if constexpr (dimension_tag == specfem::element::dimension_tag::dim3) {
           datatypeF df_deta[components] = { 0.0 };
           callback(iterator_index,
-                   specfem::point::GradientPack<
-                       specfem::point::holds_du<TensorPointViewTypeF> >{
-                       specfem::point::holds_du<TensorPointViewTypeF>{
-                           impl::element_gradient(
-                               field_pack.u, local_index, point_jacobian_matrix,
-                               quadrature, df_dxi, df_deta, df_dgamma) } });
+                   specfem::point::GradientPack<TensorPointViewTypeF>{
+                       impl::element_gradient(field_pack.f, local_index,
+                                              point_jacobian_matrix, quadrature,
+                                              df_dxi, df_deta, df_dgamma) });
         } else {
           callback(iterator_index,
-                   specfem::point::GradientPack<
-                       specfem::point::holds_du<TensorPointViewTypeF> >{
-                       specfem::point::holds_du<TensorPointViewTypeF>{
-                           impl::element_gradient(
-                               field_pack.u, local_index, point_jacobian_matrix,
-                               quadrature, df_dxi, df_dgamma) } });
+                   specfem::point::GradientPack<TensorPointViewTypeF>{
+                       impl::element_gradient(field_pack.f, local_index,
+                                              point_jacobian_matrix, quadrature,
+                                              df_dxi, df_dgamma) });
         }
       });
 }
 
 /**
- * @brief Compute the gradient of a FieldPack<holds_u<F1>, holds_v<F2>> using
- * the spectral element formulation. The callback receives a
- * GradientPack<holds_du<TU>, holds_dv<TV>>.
+ * @brief Compute the gradients of a FieldPack<F, G> using the spectral element
+ * formulation. The callback receives a GradientPack<TF, TG>.
  *
  * @ingroup AlgorithmsGradient
  *
  * @tparam ChunkIndexType   Chunk index type
- * @tparam VectorFieldTypeF Chunk element field type held by holds_u
- * @tparam VectorFieldTypeG Chunk element field type held by holds_v
+ * @tparam VectorFieldTypeF Chunk element field type held as .f
+ * @tparam VectorFieldTypeG Chunk element field type held as .g
  * @tparam DimTag           Dimension tag (dim2 or dim3), deduced from
  *                          the jacobian_matrix argument
  * @tparam QuadratureType   Quadrature view type
  * @tparam CallbackFunctor  Callback functor receiving
- *         (iterator_index, GradientPack<holds_du<TU>, holds_dv<TV>>)
+ *         (iterator_index, GradientPack<TF, TG>)
  */
 template <typename ChunkIndexType, typename VectorFieldTypeF,
           typename VectorFieldTypeG, typename JacobianMatrixType,
           typename QuadratureType, typename CallbackFunctor>
-KOKKOS_FORCEINLINE_FUNCTION void
-gradient(const ChunkIndexType &chunk_index,
-         const JacobianMatrixType &jacobian_matrix,
-         const QuadratureType &quadrature,
-         const specfem::chunk_element::FieldPack<
-             specfem::chunk_element::holds_u<VectorFieldTypeF>,
-             specfem::chunk_element::holds_v<VectorFieldTypeG> > &field_pack,
-         const CallbackFunctor &callback) {
+KOKKOS_FORCEINLINE_FUNCTION void gradient(
+    const ChunkIndexType &chunk_index,
+    const JacobianMatrixType &jacobian_matrix, const QuadratureType &quadrature,
+    const specfem::chunk_element::FieldPack<VectorFieldTypeF, VectorFieldTypeG>
+        &field_pack,
+    const CallbackFunctor &callback) {
 
   static_assert(VectorFieldTypeF::dimension_tag ==
                 VectorFieldTypeG::dimension_tag);
@@ -454,30 +446,24 @@ gradient(const ChunkIndexType &chunk_index,
           datatypeF df_deta[componentsF] = { 0.0 };
           datatypeG dg_deta[componentsG] = { 0.0 };
           callback(iterator_index,
-                   specfem::point::GradientPack<
-                       specfem::point::holds_du<TensorPointViewTypeF>,
-                       specfem::point::holds_dv<TensorPointViewTypeG> >{
-                       specfem::point::holds_du<TensorPointViewTypeF>{
-                           impl::element_gradient(
-                               field_pack.u, local_index, point_jacobian_matrix,
-                               quadrature, df_dxi, df_deta, df_dgamma) },
-                       specfem::point::holds_dv<TensorPointViewTypeG>{
-                           impl::element_gradient(
-                               field_pack.v, local_index, point_jacobian_matrix,
-                               quadrature, dg_dxi, dg_deta, dg_dgamma) } });
+                   specfem::point::GradientPack<TensorPointViewTypeF,
+                                                TensorPointViewTypeG>{
+                       impl::element_gradient(field_pack.f, local_index,
+                                              point_jacobian_matrix, quadrature,
+                                              df_dxi, df_deta, df_dgamma),
+                       impl::element_gradient(field_pack.g, local_index,
+                                              point_jacobian_matrix, quadrature,
+                                              dg_dxi, dg_deta, dg_dgamma) });
         } else {
           callback(iterator_index,
-                   specfem::point::GradientPack<
-                       specfem::point::holds_du<TensorPointViewTypeF>,
-                       specfem::point::holds_dv<TensorPointViewTypeG> >{
-                       specfem::point::holds_du<TensorPointViewTypeF>{
-                           impl::element_gradient(
-                               field_pack.u, local_index, point_jacobian_matrix,
-                               quadrature, df_dxi, df_dgamma) },
-                       specfem::point::holds_dv<TensorPointViewTypeG>{
-                           impl::element_gradient(
-                               field_pack.v, local_index, point_jacobian_matrix,
-                               quadrature, dg_dxi, dg_dgamma) } });
+                   specfem::point::GradientPack<TensorPointViewTypeF,
+                                                TensorPointViewTypeG>{
+                       impl::element_gradient(field_pack.f, local_index,
+                                              point_jacobian_matrix, quadrature,
+                                              df_dxi, df_dgamma),
+                       impl::element_gradient(field_pack.g, local_index,
+                                              point_jacobian_matrix, quadrature,
+                                              dg_dxi, dg_dgamma) });
         }
       });
 }

--- a/core/specfem/assembly/fields/data_access/load_on_device.hpp
+++ b/core/specfem/assembly/fields/data_access/load_on_device.hpp
@@ -4,6 +4,7 @@
 #include "specfem/assembly/fields.hpp"
 #include "specfem/assembly/fields/impl/check_accessor_compatibility.hpp"
 #include "specfem/assembly/fields/impl/load_access_functions.hpp"
+#include "specfem/chunk_element/field_pack.hpp"
 #include "specfem/data_access.hpp"
 #include <Kokkos_Core.hpp>
 #include <type_traits>
@@ -122,4 +123,22 @@ KOKKOS_FORCEINLINE_FUNCTION void load_on_device(const IndexType &index,
   fields_impl::load_on_device(index, field, accessors...);
   return;
 }
+
+/// @brief FieldPack<F>: load displacement into .f
+template <typename ChunkIndexType, typename FieldType, typename F>
+KOKKOS_FORCEINLINE_FUNCTION void
+load_on_device(const ChunkIndexType &chunk_index, const FieldType &field,
+               specfem::chunk_element::FieldPack<F> &field_pack) {
+  load_on_device(chunk_index, field, field_pack.f);
+}
+
+/// @brief FieldPack<F, G>: load displacement into .f, velocity into .g
+template <typename ChunkIndexType, typename FieldType, typename F, typename G>
+KOKKOS_FORCEINLINE_FUNCTION void
+load_on_device(const ChunkIndexType &chunk_index, const FieldType &field,
+               specfem::chunk_element::FieldPack<F, G> &field_pack) {
+  load_on_device(chunk_index, field, field_pack.f);
+  load_on_device(chunk_index, field, field_pack.g);
+}
+
 } // namespace specfem::assembly

--- a/core/specfem/chunk_element/field_pack.hpp
+++ b/core/specfem/chunk_element/field_pack.hpp
@@ -6,136 +6,109 @@
 
 namespace specfem::chunk_element {
 
+/// @brief Primary template — undefined; use 1-, 2-, or 3-field specializations.
+template <typename... Fs> struct FieldPack;
+
+// ---------------------------------------------------------------------------
+// 1-field specialization
+// ---------------------------------------------------------------------------
+
 /**
- * @brief Named holder for a displacement chunk field (accessed as .u)
- *
- * The constructor takes a Kokkos scratch memory space; the underlying field
- * allocates its storage from that space. When multiple holders are composed
- * via FieldPack, they are initialized in declaration order (C++ standard
- * guarantee), so each holder advances the shared scratch pointer sequentially
- * without overlap.
+ * @brief Single-field pack (accessed as .f).
  *
  * @tparam F Chunk element field type (e.g., chunk_element::displacement<...>)
  */
-template <typename F> struct holds_u {
-  F u;
-
-  KOKKOS_FUNCTION holds_u() = default;
-  KOKKOS_FUNCTION holds_u(const holds_u &) = default;
-  KOKKOS_FUNCTION holds_u &operator=(const holds_u &) = default;
-
-  /// @brief Construct directly from an existing field value (e.g., in tests)
-  KOKKOS_FUNCTION explicit holds_u(const F &f) : u(f) {}
-
-  /// @brief Construct from a Kokkos scratch memory space.
-  /// SFINAE guard prevents this overload from being selected when ScratchSpace
-  /// is F itself (which would cause ambiguity with the value constructor).
-  template <
-      typename ScratchSpace,
-      std::enable_if_t<!std::is_same_v<std::decay_t<ScratchSpace>, F>, int> = 0>
-  KOKKOS_FUNCTION holds_u(const ScratchSpace &scratch) : u(scratch) {}
-
-  /// @brief Shared memory size required for the field
-  static std::size_t shmem_size() { return F::shmem_size(); }
-};
-
-/**
- * @brief Named holder for a velocity chunk field (accessed as .v)
- *
- * @tparam F Chunk element field type (e.g., chunk_element::velocity<...>)
- */
-template <typename F> struct holds_v {
-  F v;
-
-  KOKKOS_FUNCTION holds_v() = default;
-  KOKKOS_FUNCTION holds_v(const holds_v &) = default;
-  KOKKOS_FUNCTION holds_v &operator=(const holds_v &) = default;
-
-  KOKKOS_FUNCTION explicit holds_v(const F &f) : v(f) {}
-
-  template <
-      typename ScratchSpace,
-      std::enable_if_t<!std::is_same_v<std::decay_t<ScratchSpace>, F>, int> = 0>
-  KOKKOS_FUNCTION holds_v(const ScratchSpace &scratch) : v(scratch) {}
-
-  static std::size_t shmem_size() { return F::shmem_size(); }
-};
-
-/**
- * @brief Named holder for an acceleration chunk field (accessed as .a)
- *
- * @tparam F Chunk element field type (e.g., chunk_element::acceleration<...>)
- */
-template <typename F> struct holds_a {
-  F a;
-
-  KOKKOS_FUNCTION holds_a() = default;
-  KOKKOS_FUNCTION holds_a(const holds_a &) = default;
-  KOKKOS_FUNCTION holds_a &operator=(const holds_a &) = default;
-
-  KOKKOS_FUNCTION explicit holds_a(const F &f) : a(f) {}
-
-  template <
-      typename ScratchSpace,
-      std::enable_if_t<!std::is_same_v<std::decay_t<ScratchSpace>, F>, int> = 0>
-  KOKKOS_FUNCTION holds_a(const ScratchSpace &scratch) : a(scratch) {}
-
-  static std::size_t shmem_size() { return F::shmem_size(); }
-};
-
-/**
- * @brief Variadic named-holder pack for chunk element fields.
- *
- * Bundles multiple named field holders (holds_u, holds_v, holds_a) via
- * multiple inheritance. Base classes are initialized in declaration/parameter
- * order (C++ standard guarantee), so scratch memory is allocated sequentially
- * without overlap even when multiple fields share the same
- * `team.team_scratch(0)`.
- *
- * Example:
- * @code
- * using Pack =
- *     FieldPack<holds_u<DisplacementType>, holds_v<VelocityType>>;
- * Pack pack(team.team_scratch(0));
- * pack.u  // displacement field
- * pack.v  // velocity field
- * @endcode
- *
- * Usage in compute_stiffness_interaction:
- * @code
- * // scratch_size uses FieldPack::shmem_size()
- * int scratch_size = ChunkFieldPackType::shmem_size() + ...;
- * ChunkFieldPackType field_pack(team.team_scratch(0));
- * specfem::assembly::load_on_device(chunk_index, field, field_pack.u);
- * if constexpr (needs_velocity) {
- *   specfem::assembly::load_on_device(chunk_index, field, field_pack.v);
- * }
- * @endcode
- *
- * @tparam Holders Variadic list of named holder types
- */
-template <typename... Holders> struct FieldPack : Holders... {
-  static constexpr std::size_t size = sizeof...(Holders);
+template <typename F> struct FieldPack<F> {
+  static constexpr std::size_t size = 1;
+  F f;
 
   KOKKOS_FUNCTION FieldPack() = default;
   KOKKOS_FUNCTION FieldPack(const FieldPack &) = default;
   KOKKOS_FUNCTION FieldPack &operator=(const FieldPack &) = default;
 
-  /// @brief Construct from existing holder instances (e.g., in tests)
-  KOKKOS_FUNCTION FieldPack(const Holders &...holders) : Holders(holders)... {}
+  /// @brief Construct directly from an existing field value (e.g., in tests).
+  KOKKOS_FUNCTION explicit FieldPack(const F &f_) : f(f_) {}
 
-  /// @brief Construct all holders from a Kokkos scratch memory space.
+  /// @brief Construct from a Kokkos scratch memory space.
   /// SFINAE guard prevents this overload from being selected when ScratchSpace
-  /// is one of the Holders types (which would ambiguate with value
-  /// constructor).
-  template <typename ScratchSpace,
-            std::enable_if_t<!std::disjunction_v<std::is_same<
-                                 std::decay_t<ScratchSpace>, Holders>...>,
-                             int> = 0>
-  KOKKOS_FUNCTION FieldPack(const ScratchSpace &scratch)
-      : Holders(scratch)... {}
+  /// is F itself (which would cause ambiguity with the value constructor).
+  template <typename S,
+            std::enable_if_t<!std::is_same_v<std::decay_t<S>, F>, int> = 0>
+  KOKKOS_FUNCTION FieldPack(const S &scratch) : f(scratch) {}
 
-  static std::size_t shmem_size() { return (Holders::shmem_size() + ...); }
+  /// @brief Shared memory size required for the field.
+  static std::size_t shmem_size() { return F::shmem_size(); }
+};
+
+// ---------------------------------------------------------------------------
+// 2-field specialization
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Two-field pack (accessed as .f and .g).
+ *
+ * Member initialization order (f then g) follows declaration order —
+ * a C++ standard guarantee — so each field advances the shared Kokkos scratch
+ * pointer sequentially without overlap.
+ *
+ * @tparam F First chunk element field type
+ * @tparam G Second chunk element field type
+ */
+template <typename F, typename G> struct FieldPack<F, G> {
+  static constexpr std::size_t size = 2;
+  F f;
+  G g;
+
+  KOKKOS_FUNCTION FieldPack() = default;
+  KOKKOS_FUNCTION FieldPack(const FieldPack &) = default;
+  KOKKOS_FUNCTION FieldPack &operator=(const FieldPack &) = default;
+
+  KOKKOS_FUNCTION FieldPack(const F &f_, const G &g_) : f(f_), g(g_) {}
+
+  template <typename S,
+            std::enable_if_t<!std::is_same_v<std::decay_t<S>, F> &&
+                                 !std::is_same_v<std::decay_t<S>, G>,
+                             int> = 0>
+  KOKKOS_FUNCTION FieldPack(const S &scratch) : f(scratch), g(scratch) {}
+
+  static std::size_t shmem_size() { return F::shmem_size() + G::shmem_size(); }
+};
+
+// ---------------------------------------------------------------------------
+// 3-field specialization
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Three-field pack (accessed as .f, .g, and .h).
+ *
+ * @tparam F First chunk element field type
+ * @tparam G Second chunk element field type
+ * @tparam H Third chunk element field type
+ */
+template <typename F, typename G, typename H> struct FieldPack<F, G, H> {
+  static constexpr std::size_t size = 3;
+  F f;
+  G g;
+  H h;
+
+  KOKKOS_FUNCTION FieldPack() = default;
+  KOKKOS_FUNCTION FieldPack(const FieldPack &) = default;
+  KOKKOS_FUNCTION FieldPack &operator=(const FieldPack &) = default;
+
+  KOKKOS_FUNCTION FieldPack(const F &f_, const G &g_, const H &h_)
+      : f(f_), g(g_), h(h_) {}
+
+  template <typename S,
+            std::enable_if_t<!std::is_same_v<std::decay_t<S>, F> &&
+                                 !std::is_same_v<std::decay_t<S>, G> &&
+                                 !std::is_same_v<std::decay_t<S>, H>,
+                             int> = 0>
+  KOKKOS_FUNCTION FieldPack(const S &scratch)
+      : f(scratch), g(scratch), h(scratch) {}
+
+  static std::size_t shmem_size() {
+    return F::shmem_size() + G::shmem_size() + H::shmem_size();
+  }
 };
 
 } // namespace specfem::chunk_element

--- a/core/specfem/compute/impl/compute_stiffness_interaction.tpp
+++ b/core/specfem/compute/impl/compute_stiffness_interaction.tpp
@@ -158,10 +158,7 @@ int specfem::compute::impl::compute_stiffness_interaction(
           ElementQuadratureType lagrange_derivative(team);
           ChunkStressIntegrandType stress_integrand(team);
           specfem::assembly::load_on_device(team, mesh, lagrange_derivative);
-          specfem::assembly::load_on_device(chunk_index, field, field_pack.f);
-          if constexpr (needs_velocity_gradient) {
-             specfem::assembly::load_on_device(chunk_index, field, field_pack.g);
-          }
+          specfem::assembly::load_on_device(chunk_index, field, field_pack);
 
           team.team_barrier();
 
@@ -179,13 +176,9 @@ int specfem::compute::impl::compute_stiffness_interaction(
                 specfem::assembly::load_on_device(index, properties,
                                                   point_property);
 
-                PointFieldDerivativesType field_derivatives(grad_pack.df);
-
-                if constexpr (needs_velocity_gradient) {
-                  // grad_pack.dg (∂v/∂x) is available for future attenuation
-                  // physics (SLS/Taylor-expanded strain). Currently unused.
-                  (void)grad_pack.dg;
-                }
+                PointFieldDerivativesType field_derivatives(grad_pack.get_df());
+                // TODO(attenuation): grad_pack.get_dg() = ∂v/∂x for SLS memory variable update
+                grad_pack.get_dg();
 
                 PointDisplacementType point_displacement;
                 specfem::assembly::load_on_device(index, field,

--- a/core/specfem/compute/impl/compute_stiffness_interaction.tpp
+++ b/core/specfem/compute/impl/compute_stiffness_interaction.tpp
@@ -84,11 +84,9 @@ int specfem::compute::impl::compute_stiffness_interaction(
 
   using ChunkFieldPackType = std::conditional_t<
       needs_velocity_gradient,
-      specfem::chunk_element::FieldPack<
-          specfem::chunk_element::holds_u<ChunkDisplacementFieldType>,
-          specfem::chunk_element::holds_v<ChunkVelocityFieldType>>,
-      specfem::chunk_element::FieldPack<
-          specfem::chunk_element::holds_u<ChunkDisplacementFieldType>>>;
+      specfem::chunk_element::FieldPack<ChunkDisplacementFieldType,
+                                        ChunkVelocityFieldType>,
+      specfem::chunk_element::FieldPack<ChunkDisplacementFieldType>>;
 
   using ChunkStressIntegrandType = specfem::chunk_element::stress_integrand<
       ParallelConfig::chunk_size, ngll, Tags::dimension_tag, Tags::medium_tag,
@@ -117,9 +115,8 @@ int specfem::compute::impl::compute_stiffness_interaction(
   using TensorType = typename PointFieldDerivativesType::value_type;
   using GradientFieldPackType = std::conditional_t<
       needs_velocity_gradient,
-      specfem::point::GradientPack<specfem::point::holds_du<TensorType>,
-                                   specfem::point::holds_dv<TensorType>>,
-      specfem::point::GradientPack<specfem::point::holds_du<TensorType>>>;
+      specfem::point::GradientPack<TensorType, TensorType>,
+      specfem::point::GradientPack<TensorType>>;
 
   using PointWeightsType = specfem::point::weights<Tags::dimension_tag>;
 
@@ -161,9 +158,9 @@ int specfem::compute::impl::compute_stiffness_interaction(
           ElementQuadratureType lagrange_derivative(team);
           ChunkStressIntegrandType stress_integrand(team);
           specfem::assembly::load_on_device(team, mesh, lagrange_derivative);
-          specfem::assembly::load_on_device(chunk_index, field, field_pack.u);
+          specfem::assembly::load_on_device(chunk_index, field, field_pack.f);
           if constexpr (needs_velocity_gradient) {
-             specfem::assembly::load_on_device(chunk_index, field, field_pack.v);
+             specfem::assembly::load_on_device(chunk_index, field, field_pack.g);
           }
 
           team.team_barrier();
@@ -182,12 +179,12 @@ int specfem::compute::impl::compute_stiffness_interaction(
                 specfem::assembly::load_on_device(index, properties,
                                                   point_property);
 
-                PointFieldDerivativesType field_derivatives(grad_pack.du);
+                PointFieldDerivativesType field_derivatives(grad_pack.df);
 
                 if constexpr (needs_velocity_gradient) {
-                  // grad_pack.dv (∂v/∂x) is available for future attenuation
+                  // grad_pack.dg (∂v/∂x) is available for future attenuation
                   // physics (SLS/Taylor-expanded strain). Currently unused.
-                  (void)grad_pack.dv;
+                  (void)grad_pack.dg;
                 }
 
                 PointDisplacementType point_displacement;

--- a/core/specfem/point/gradient_field_pack.hpp
+++ b/core/specfem/point/gradient_field_pack.hpp
@@ -5,75 +5,73 @@
 
 namespace specfem::point {
 
+/// @brief Primary template — undefined; use 1-, 2-, or 3-type specializations.
+template <typename... Ts> struct GradientPack;
+
+// ---------------------------------------------------------------------------
+// 1-type specialization
+// ---------------------------------------------------------------------------
+
 /**
- * @brief Named gradient holder for displacement gradient (accessed as .du)
+ * @brief Single gradient tensor pack (accessed as .df).
  *
- * @tparam V Point-level gradient tensor type
+ * @tparam T Point-level gradient tensor type
  *           (e.g., specfem::datatype::TensorPointViewType<...>)
  */
-template <typename V> struct holds_du {
-  V du;
-
-  KOKKOS_FUNCTION holds_du() = default;
-  KOKKOS_FUNCTION holds_du(const holds_du &) = default;
-  KOKKOS_FUNCTION holds_du &operator=(const holds_du &) = default;
-  KOKKOS_FUNCTION explicit holds_du(const V &v) : du(v) {}
-};
-
-/**
- * @brief Named gradient holder for velocity gradient (accessed as .dv)
- *
- * @tparam V Point-level gradient tensor type
- */
-template <typename V> struct holds_dv {
-  V dv;
-
-  KOKKOS_FUNCTION holds_dv() = default;
-  KOKKOS_FUNCTION holds_dv(const holds_dv &) = default;
-  KOKKOS_FUNCTION holds_dv &operator=(const holds_dv &) = default;
-  KOKKOS_FUNCTION explicit holds_dv(const V &v) : dv(v) {}
-};
-
-/**
- * @brief Named gradient holder for acceleration gradient (accessed as .da)
- *
- * @tparam V Point-level gradient tensor type
- */
-template <typename V> struct holds_da {
-  V da;
-
-  KOKKOS_FUNCTION holds_da() = default;
-  KOKKOS_FUNCTION holds_da(const holds_da &) = default;
-  KOKKOS_FUNCTION holds_da &operator=(const holds_da &) = default;
-  KOKKOS_FUNCTION explicit holds_da(const V &v) : da(v) {}
-};
-
-/**
- * @brief Variadic named-holder pack for point-level gradient tensors.
- *
- * Bundles multiple named gradient holders (holds_du, holds_dv, holds_da) via
- * multiple inheritance. Plain value types — no scratch memory involved.
- *
- * Example:
- * @code
- * // Displacement + velocity gradient pack
- * using GradPack = GradientPack<holds_du<TensorType>, holds_dv<TensorType>>;
- * GradPack gp(holds_du<TensorType>(g_u), holds_dv<TensorType>(g_v));
- * gp.du  // ∂u/∂x
- * gp.dv  // ∂v/∂x
- * @endcode
- *
- * @tparam Holders Variadic list of named gradient holder types
- */
-template <typename... Holders> struct GradientPack : Holders... {
-  static constexpr std::size_t size = sizeof...(Holders);
+template <typename T> struct GradientPack<T> {
+  static constexpr std::size_t size = 1;
+  T df;
 
   KOKKOS_FUNCTION GradientPack() = default;
   KOKKOS_FUNCTION GradientPack(const GradientPack &) = default;
   KOKKOS_FUNCTION GradientPack &operator=(const GradientPack &) = default;
+  KOKKOS_FUNCTION explicit GradientPack(const T &t) : df(t) {}
+};
 
-  KOKKOS_FUNCTION GradientPack(const Holders &...holders)
-      : Holders(holders)... {}
+// ---------------------------------------------------------------------------
+// 2-type specialization
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Two gradient tensor pack (accessed as .df and .dg).
+ *
+ * @tparam T1 First point-level gradient tensor type
+ * @tparam T2 Second point-level gradient tensor type
+ */
+template <typename T1, typename T2> struct GradientPack<T1, T2> {
+  static constexpr std::size_t size = 2;
+  T1 df;
+  T2 dg;
+
+  KOKKOS_FUNCTION GradientPack() = default;
+  KOKKOS_FUNCTION GradientPack(const GradientPack &) = default;
+  KOKKOS_FUNCTION GradientPack &operator=(const GradientPack &) = default;
+  KOKKOS_FUNCTION GradientPack(const T1 &t1, const T2 &t2) : df(t1), dg(t2) {}
+};
+
+// ---------------------------------------------------------------------------
+// 3-type specialization
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Three gradient tensor pack (accessed as .df, .dg, and .dh).
+ *
+ * @tparam T1 First point-level gradient tensor type
+ * @tparam T2 Second point-level gradient tensor type
+ * @tparam T3 Third point-level gradient tensor type
+ */
+template <typename T1, typename T2, typename T3>
+struct GradientPack<T1, T2, T3> {
+  static constexpr std::size_t size = 3;
+  T1 df;
+  T2 dg;
+  T3 dh;
+
+  KOKKOS_FUNCTION GradientPack() = default;
+  KOKKOS_FUNCTION GradientPack(const GradientPack &) = default;
+  KOKKOS_FUNCTION GradientPack &operator=(const GradientPack &) = default;
+  KOKKOS_FUNCTION GradientPack(const T1 &t1, const T2 &t2, const T3 &t3)
+      : df(t1), dg(t2), dh(t3) {}
 };
 
 } // namespace specfem::point

--- a/core/specfem/point/gradient_field_pack.hpp
+++ b/core/specfem/point/gradient_field_pack.hpp
@@ -26,6 +26,9 @@ template <typename T> struct GradientPack<T> {
   KOKKOS_FUNCTION GradientPack(const GradientPack &) = default;
   KOKKOS_FUNCTION GradientPack &operator=(const GradientPack &) = default;
   KOKKOS_FUNCTION explicit GradientPack(const T &t) : df(t) {}
+
+  KOKKOS_FUNCTION const T &get_df() const { return df; }
+  KOKKOS_FUNCTION void get_dg() const {}
 };
 
 // ---------------------------------------------------------------------------
@@ -47,6 +50,9 @@ template <typename T1, typename T2> struct GradientPack<T1, T2> {
   KOKKOS_FUNCTION GradientPack(const GradientPack &) = default;
   KOKKOS_FUNCTION GradientPack &operator=(const GradientPack &) = default;
   KOKKOS_FUNCTION GradientPack(const T1 &t1, const T2 &t2) : df(t1), dg(t2) {}
+
+  KOKKOS_FUNCTION const T1 &get_df() const { return df; }
+  KOKKOS_FUNCTION const T2 &get_dg() const { return dg; }
 };
 
 // ---------------------------------------------------------------------------
@@ -72,6 +78,9 @@ struct GradientPack<T1, T2, T3> {
   KOKKOS_FUNCTION GradientPack &operator=(const GradientPack &) = default;
   KOKKOS_FUNCTION GradientPack(const T1 &t1, const T2 &t2, const T3 &t3)
       : df(t1), dg(t2), dh(t3) {}
+
+  KOKKOS_FUNCTION const T1 &get_df() const { return df; }
+  KOKKOS_FUNCTION const T2 &get_dg() const { return dg; }
 };
 
 } // namespace specfem::point

--- a/core/specfem/source/CMakeLists.txt
+++ b/core/specfem/source/CMakeLists.txt
@@ -14,6 +14,5 @@ target_link_libraries(
         yaml-cpp
         specfem::element
         specfem::enums
-        specfem::algorithms
         ${BOOST_LIBS}
 )

--- a/core/specfem/source/dim2/vector_source/adjoint_source.cpp
+++ b/core/specfem/source/dim2/vector_source/adjoint_source.cpp
@@ -1,5 +1,3 @@
-
-#include "specfem/algorithms.hpp"
 #include "specfem/enums.hpp"
 #include "specfem/source.hpp"
 

--- a/tests/unit-tests/algorithms/dim2/gradient.cpp
+++ b/tests/unit-tests/algorithms/dim2/gradient.cpp
@@ -692,8 +692,7 @@ execute_fieldpack(const Jacobian &jacobian_matrix,
       type_real, specfem::element::dimension_tag::dim2, 1, ngll, 1, false,
       Kokkos::DefaultExecutionSpace::memory_space, Kokkos::MemoryTraits<> >;
 
-  using FieldPackType = specfem::chunk_element::FieldPack<
-      specfem::chunk_element::holds_u<Function2DView> >;
+  using FieldPackType = specfem::chunk_element::FieldPack<Function2DView>;
 
   Kokkos::View<type_real ****, Kokkos::LayoutLeft,
                Kokkos::DefaultExecutionSpace>
@@ -705,9 +704,7 @@ execute_fieldpack(const Jacobian &jacobian_matrix,
                                                Kokkos::ALL(), Kokkos::ALL(),
                                                Kokkos::ALL()));
 
-        const FieldPackType field_pack{
-          specfem::chunk_element::holds_u<Function2DView>{ f }
-        };
+        const FieldPackType field_pack{ f };
 
         specfem::algorithms::gradient(
             index, jacobian, quadrature_view, field_pack,
@@ -716,8 +713,8 @@ execute_fieldpack(const Jacobian &jacobian_matrix,
               const int ispec = local_index.ispec;
               const int iz = local_index.iz;
               const int ix = local_index.ix;
-              gradient_view(ispec, iz, ix, 0) = grad_pack.du(0, 0);
-              gradient_view(ispec, iz, ix, 1) = grad_pack.du(0, 1);
+              gradient_view(ispec, iz, ix, 0) = grad_pack.df(0, 0);
+              gradient_view(ispec, iz, ix, 1) = grad_pack.df(0, 1);
             });
       });
 

--- a/tests/unit-tests/algorithms/dim3/gradient.cpp
+++ b/tests/unit-tests/algorithms/dim3/gradient.cpp
@@ -779,8 +779,7 @@ execute_fieldpack(const Jacobian &jacobian_matrix,
       type_real, specfem::element::dimension_tag::dim3, 1, ngll, 1, false,
       Kokkos::DefaultExecutionSpace::memory_space, Kokkos::MemoryTraits<> >;
 
-  using FieldPackType = specfem::chunk_element::FieldPack<
-      specfem::chunk_element::holds_u<Function3DView> >;
+  using FieldPackType = specfem::chunk_element::FieldPack<Function3DView>;
 
   Kokkos::View<type_real *****, Kokkos::DefaultExecutionSpace> gradient_view(
       "gradient_view", function.n_elements(), ngll, ngll, ngll, 3);
@@ -791,9 +790,7 @@ execute_fieldpack(const Jacobian &jacobian_matrix,
                                                Kokkos::ALL(), Kokkos::ALL(),
                                                Kokkos::ALL(), Kokkos::ALL()));
 
-        const FieldPackType field_pack{
-          specfem::chunk_element::holds_u<Function3DView>{ f }
-        };
+        const FieldPackType field_pack{ f };
 
         specfem::algorithms::gradient(
             index, jacobian, quadrature_view, field_pack,
@@ -803,9 +800,9 @@ execute_fieldpack(const Jacobian &jacobian_matrix,
               const int iz = local_index.iz;
               const int iy = local_index.iy;
               const int ix = local_index.ix;
-              gradient_view(ispec, iz, iy, ix, 0) = grad_pack.du(0, 0);
-              gradient_view(ispec, iz, iy, ix, 1) = grad_pack.du(0, 1);
-              gradient_view(ispec, iz, iy, ix, 2) = grad_pack.du(0, 2);
+              gradient_view(ispec, iz, iy, ix, 0) = grad_pack.df(0, 0);
+              gradient_view(ispec, iz, iy, ix, 1) = grad_pack.df(0, 1);
+              gradient_view(ispec, iz, iy, ix, 2) = grad_pack.df(0, 2);
             });
       });
 


### PR DESCRIPTION

## Description

This is just an alternative. Cuda is not compiling because of the grad_pack.dg not being available on the non velocity gradient constexpr part.

```
if constexpr (needs_velocity_gradient) {
   // grad_pack.dg (∂v/∂x) is available for future attenuation
   // physics (SLS/Taylor-expanded strain). Currently unused.
   (void)grad_pack.dg;
}
```



### Commits

- Much cleaner apporach and better if we want to match algorithm implementation (cfb3cf976)
- Updated the function signatures to be of the old format again (64deb06b2)

## Issue Number

If there is an issue created for these changes, link it here

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
