### PR TITLE
Fix suppress warnings bug on GCC

### DIFF
--- a/core/specfem/assembly/conforming_interfaces/dim2/conforming_interface.hpp
+++ b/core/specfem/assembly/conforming_interfaces/dim2/conforming_interface.hpp
@@ -152,7 +152,7 @@ public:
 
     // Unreachable code - satisfy compiler return requirements
 
-    SUPPRESS_TEMPORARY_REF(return {};)
+    SUPPRESS_UNREACHABLE(return {};)
   }
 };
 

--- a/core/specfem/assembly/conforming_interfaces/dim3/conforming_interface.hpp
+++ b/core/specfem/assembly/conforming_interfaces/dim3/conforming_interface.hpp
@@ -153,7 +153,7 @@ public:
 
     // Unreachable code - satisfy compiler return requirements
 
-    SUPPRESS_TEMPORARY_REF(return {};)
+    SUPPRESS_UNREACHABLE(return {};)
   }
 };
 

--- a/core/specfem/assembly/impl/value_containers/dim2/value_containers.hpp
+++ b/core/specfem/assembly/impl/value_containers/dim2/value_containers.hpp
@@ -85,7 +85,7 @@ struct value_containers<specfem::element::dimension_tag::dim2,
 
     /// code path should never be reached
 
-    SUPPRESS_TEMPORARY_REF(return {};)
+    SUPPRESS_UNREACHABLE(return {};)
   }
 
   /**

--- a/core/specfem/assembly/nonconforming_interfaces/dim2/nonconforming_interfaces.hpp
+++ b/core/specfem/assembly/nonconforming_interfaces/dim2/nonconforming_interfaces.hpp
@@ -74,7 +74,7 @@ public:
 
     // Unreachable code - satisfy compiler return requirements
 
-    SUPPRESS_TEMPORARY_REF(return {};)
+    SUPPRESS_UNREACHABLE(return {};)
   }
 };
 

--- a/core/specfem/macros/suppress_warnings.hpp
+++ b/core/specfem/macros/suppress_warnings.hpp
@@ -96,16 +96,25 @@
 #endif
 
 /**
- * @brief Suppress warnings about returning reference to temporary.
+ * @brief Mark unreachable code paths that exist only to satisfy compiler return
+ * requirements.
  *
- * This macro wraps a code block to suppress compiler warnings about returning
- * the address of a local variable or temporary. It handles compiler-specific
- * pragmas for MSVC, GCC, Clang, and Intel LLVM.
+ * Uses compiler intrinsics (__builtin_unreachable / __assume(false)) to inform
+ * the compiler that the code path is unreachable, eliminating warnings about
+ * returning references to temporaries. The pragma-based approach does not work
+ * reliably on GCC due to bug #53431 (_Pragma inside macros fails to suppress
+ * warnings during template instantiation).
  *
- * @param CODEBLOCK The code to be executed with the warning suppressed.
+ * @param CODEBLOCK Ignored; kept for backward compatibility with call sites.
  */
-#define SUPPRESS_TEMPORARY_REF(CODEBLOCK)                                      \
+#if defined(__GNUC__) || defined(__clang__) || defined(__INTEL_LLVM_COMPILER)
+#define SUPPRESS_UNREACHABLE(CODEBLOCK) __builtin_unreachable();
+#elif defined(_MSC_VER)
+#define SUPPRESS_UNREACHABLE(CODEBLOCK) __assume(false);
+#else
+#define SUPPRESS_UNREACHABLE(CODEBLOCK)                                        \
   _SUPPRESS_WARNING_START                                                      \
   _SUPPRESS_TEMPORARY_RETURN_CODE                                              \
   CODEBLOCK                                                                    \
   _SUPPRESS_WARNING_END
+#endif

--- a/docs/sections/api/specfem/macros/suppress_warnings.rst
+++ b/docs/sections/api/specfem/macros/suppress_warnings.rst
@@ -1,6 +1,6 @@
 .. _specfem_macros_suppress_warnings:
 
-SUPPRESS_TEMPORARY_REF
-======================
+SUPPRESS_UNREACHABLE
+====================
 
 .. doxygenfile:: suppress_warnings.hpp


### PR DESCRIPTION
## Description

Please describe the changes or features in this pull request.

Uses compiler intrinsics (__builtin_unreachable / __assume(false)) to inform the compiler that the code path is unreachable, eliminating warnings about returning references to temporaries. The pragma-based approach does not work reliably on GCC due to bug [#53431](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53431), as (_Pragma inside macros fails to suppress warnings during template instantiation).

The bug was fixed in GCC 13

## Issue Number

If there is an issue created for these changes, link it here

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
