### PR TITLE
Update Fortran 3D mesher to accommodate isotropic Cosserat

### DIFF
--- a/docs/sections/meshfem/meshfem3d/mesh_par_file.rst
+++ b/docs/sections/meshfem/meshfem3d/mesh_par_file.rst
@@ -485,7 +485,6 @@ For elastic isotropic Cosserat materials, use the following format:
 - ``domain_id``: must be 4 for elastic isotropic Cosserat
 
 :Type: ``string``
-1   2300.0   1500.0   2800.0   1e6 1e4 300.0 25.0 500.0 4
 :Format: ``material_id  rho  kappa  mu  nu  j  lambda_c  mu_c  nu_c  domain_id``
 
 .. code-block::

--- a/docs/sections/meshfem/meshfem3d/mesh_par_file.rst
+++ b/docs/sections/meshfem/meshfem3d/mesh_par_file.rst
@@ -468,6 +468,36 @@ For acoustic or elastic materials, use the following format:
 
     2   1020.0   1500.0   0.0   0   0   0   1
 
+Elastic Isotropic Cosserat Materials
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For elastic isotropic Cosserat materials, use the following format:
+
+- ``material_id``: integer number to reference the material
+- ``rho``: density (kg/m³)
+- ``kappa``: bulk modulus (Pa)
+- ``mu``: shear modulus (Pa)
+- ``nu``: Cosserat coupling parameter (Pa)
+- ``j``: Isotropic moment of inertia (kg/m)
+- ``lambda_c``: Cosserat Lamé parameter (N)
+- ``mu_c``: Cosserat shear modulus (N)
+- ``nu_c``: Second Cosserat coupling parameter (N)
+- ``domain_id``: must be 4 for elastic isotropic Cosserat
+
+:Type: ``string``
+1   2300.0   1500.0   2800.0   1e6 1e4 300.0 25.0 500.0 4
+:Format: ``material_id  rho  kappa  mu  nu  j  lambda_c  mu_c  nu_c  domain_id``
+
+.. code-block::
+    :caption: Example (Elastic)
+
+    1   2300.0   2800.0   1500.0   0   0   0   2
+
+.. code-block::
+    :caption: Example (Acoustic, vs = 0)
+
+    2   1020.0   1500.0   0.0   0   0   0   1
+
 
 Poroelastic Materials
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/sections/meshfem/meshfem3d/mesh_par_file.rst
+++ b/docs/sections/meshfem/meshfem3d/mesh_par_file.rst
@@ -488,14 +488,9 @@ For elastic isotropic Cosserat materials, use the following format:
 :Format: ``material_id  rho  kappa  mu  nu  j  lambda_c  mu_c  nu_c  domain_id``
 
 .. code-block::
-    :caption: Example (Elastic)
+    :caption: Example
 
-    1   2300.0   2800.0   1500.0   0   0   0   2
-
-.. code-block::
-    :caption: Example (Acoustic, vs = 0)
-
-    2   1020.0   1500.0   0.0   0   0   0   1
+    1   2300.0   1500.0   2800.0   1e6 1e4 300.0 25.0 500.0 4
 
 
 Poroelastic Materials

--- a/fortran/meshfem3d/meshfem3D/read_value_mesh_parameters.f90
+++ b/fortran/meshfem3d/meshfem3D/read_value_mesh_parameters.f90
@@ -252,7 +252,8 @@
 
   subroutine read_material_parameters(iunit,material_properties,material_properties_undef,imat,NMATERIALS,ier)
 
-  use constants, only: MAX_STRING_LEN,DONT_IGNORE_JUNK,IDOMAIN_ACOUSTIC,IDOMAIN_ELASTIC,IDOMAIN_POROELASTIC
+  use constants, only: MAX_STRING_LEN,DONT_IGNORE_JUNK,IDOMAIN_ACOUSTIC,IDOMAIN_ELASTIC,IDOMAIN_POROELASTIC, &
+    IDOMAIN_COSSERAT
   use constants_meshfem, only: NUMBER_OF_MATERIAL_PROPERTIES
   implicit none
 
@@ -405,8 +406,8 @@
     ! format: #material_id #rho #kappa #mu #nu #j #lambda_c #mu_c #nu_c #domain_id
     read(string_read,*,iostat=ier) mat_id,rho,kappa,mu,nu,j,lambda_c, &
                                    mu_c,nu_c,domain_id
-    if (domain_id /= IDOMAIN_ISOTROPIC_COSSERAT) &
-      stop 'Error material parameters for isotropic cosserat domains must have domain_id == 4'
+    if (domain_id /= IDOMAIN_COSSERAT) &
+      stop 'Error material parameters for cosserat domains must have domain_id == 4'
 
   case default
     print *,'Error: material parameter line format not recognized:'
@@ -442,8 +443,9 @@
 
   ! checks domain
   if (domain_id /= IDOMAIN_ACOUSTIC .and. domain_id /= IDOMAIN_ELASTIC .and. domain_id /= IDOMAIN_POROELASTIC &
-                                                              .and. domain_id /= IDOMAIN_ISOTROPIC_COSSERAT) then
-    print *,'Error: material has invalid domain_id, must be either 1 == acoustic,2 == elastic, 3 == poroelastic or 4 == isotropic cosserat'
+                                                              .and. domain_id /= IDOMAIN_COSSERAT) then
+    print *,'Error: material has invalid domain_id, must be either 1 == acoustic,2 == elastic, 3 == poroelastic &
+    or 4 == cosserat'
     print *,'  line : ',trim(string_read)
     stop 'Invalid domain_id in material parameters'
   endif
@@ -485,7 +487,7 @@
     material_properties(imat,16) = kappa_f
     material_properties(imat,17) = kappa_fr
     material_properties(imat,18) = mu_fr      ! anisotropy_flag - not implemented yet
-  case (IDOMAIN_ISOTROPIC_COSSERAT)
+  case (IDOMAIN_COSSERAT)
     ! isotropic cosserat
     ! input format: #material_id #rho #kappa #mu #nu #j #lambda_c #mu_c #nu_c #domain_id
     material_properties(imat,1) = rho

--- a/fortran/meshfem3d/meshfem3D/read_value_mesh_parameters.f90
+++ b/fortran/meshfem3d/meshfem3D/read_value_mesh_parameters.f90
@@ -266,6 +266,7 @@
   double precision :: rho,vp,vs,Q_Kappa,Q_mu,anisotropy_flag
   double precision :: kxx,kxy,kxz,kyy,kyz,kzz
   double precision :: phi,tort,rho_s,rho_f,kappa_s,kappa_f,mu_fr,kappa_fr,eta
+  double precision :: kappa,mu,nu,j,lambda_c,mu_c,nu_c
   integer :: domain_id
   integer :: i,counter,idummy
   character(len=MAX_STRING_LEN) :: string_read
@@ -301,6 +302,14 @@
   kyz = 0.d0
   kzz = 0.d0
 
+  kappa = 0.d0
+  mu = 0.d0
+  nu = 0.d0
+  j = 0.d0
+  lambda_c = 0.d0
+  mu_c = 0.d0
+  nu_c = 0.d0
+
   mat_id = 0
 
   call read_next_line(iunit,DONT_IGNORE_JUNK,string_read,ier)
@@ -316,6 +325,9 @@
   ! example: tomographic
   !   -1 tomography elastic tomography_model.xyz 0 2
   !   -> 3 numbers (note that tomography_model_1.xyz 0 2 would count 4)
+  ! example: isotropic cosserat
+  !   1 #rho #kappa #mu #nu #j #lambda_c #mu_c #nu_c #domain_id
+  !   -> 10 numbers
   counter = 0
   new_number = .true.
   do i = 1,len_trim(string_read)
@@ -388,6 +400,14 @@
       stop 'Error in tomography material domain definition'
     endif
 
+  case (10)
+    ! isotropic cosserat line
+    ! format: #material_id #rho #kappa #mu #nu #j #lambda_c #mu_c #nu_c #domain_id
+    read(string_read,*,iostat=ier) mat_id,rho,kappa,mu,nu,j,lambda_c, &
+                                   mu_c,nu_c,domain_id
+    if (domain_id /= IDOMAIN_ISOTROPIC_COSSERAT) &
+      stop 'Error material parameters for isotropic cosserat domains must have domain_id == 4'
+
   case default
     print *,'Error: material parameter line format not recognized:'
     print *,'  line: ',trim(string_read)
@@ -410,6 +430,9 @@
     print *,'For poroelastic materials, we use the input format:'
     print *,'  mat_id,rho_s,rho_f,phi,tort,kxx,kxy,kxz,kyy,kyz,kzz,kappa_s,kappa_f,kappa_fr,eta,mu_fr,domain_id'
     print *
+    print *,'For isotropic cosserat materials, we use the input format:'
+    print *,'  mat_id,rho,kappa,mu,nu,j,lambda_c,mu_c,nu_c,domain_id'
+    print *
     print *,'It is likely that your input file still uses the old convention and needs to be updated.'
     print *,'If you do not know what value to add for Q_Kappa, add 9999., i.e negligible Q_Kappa attenuation'
     print *,'and then your results will be unchanged compared to older versions of the code.'
@@ -418,8 +441,9 @@
   endif
 
   ! checks domain
-  if (domain_id /= IDOMAIN_ACOUSTIC .and. domain_id /= IDOMAIN_ELASTIC .and. domain_id /= IDOMAIN_POROELASTIC) then
-    print *,'Error: material has invalid domain_id, must be either 1 == acoustic,2 == elastic or 3 == poroelastic'
+  if (domain_id /= IDOMAIN_ACOUSTIC .and. domain_id /= IDOMAIN_ELASTIC .and. domain_id /= IDOMAIN_POROELASTIC &
+                                                              .and. domain_id /= IDOMAIN_ISOTROPIC_COSSERAT) then
+    print *,'Error: material has invalid domain_id, must be either 1 == acoustic,2 == elastic, 3 == poroelastic or 4 == isotropic cosserat'
     print *,'  line : ',trim(string_read)
     stop 'Invalid domain_id in material parameters'
   endif
@@ -461,6 +485,20 @@
     material_properties(imat,16) = kappa_f
     material_properties(imat,17) = kappa_fr
     material_properties(imat,18) = mu_fr      ! anisotropy_flag - not implemented yet
+  case (IDOMAIN_ISOTROPIC_COSSERAT)
+    ! isotropic cosserat
+    ! input format: #material_id #rho #kappa #mu #nu #j #lambda_c #mu_c #nu_c #domain_id
+    material_properties(imat,1) = rho
+    material_properties(imat,2) = kappa
+    material_properties(imat,3) = mu
+    material_properties(imat,4) = nu
+    material_properties(imat,5) = j
+    material_properties(imat,6) = lambda_c
+    material_properties(imat,7) = domain_id   ! must be position 7
+    material_properties(imat,8) = mat_id      ! must be position 8
+    material_properties(imat,9) = mu_c
+    material_properties(imat,10) = nu_c
+
   end select
 
   ! undefined/tomography materials

--- a/fortran/meshfem3d/meshfem3D/save_databases.F90
+++ b/fortran/meshfem3d/meshfem3D/save_databases.F90
@@ -202,6 +202,15 @@
         matpropl(1:7) = material_properties(i,1:7)
         ! skipping mat_id, not needed
         matpropl(8:17) = material_properties(i,9:18)
+      case (IDOMAIN_ISOTROPIC_COSSERAT)
+        ! material properties format:
+        !#(1)rho #(2)kappa #(3)mu #(4)nu #(5)j #(6)lambda_c #(7)domain_id #(8)mat_id #(9)mu_c #(10)nu_c
+        !
+        ! output format for xgenerate_database:
+        !   rho,kappa,mu,nu,j,lambda_c,material_domain_id,mu_c,nu_c
+        matpropl(1:7) = material_properties(i,1:7)
+        ! skipping mat_id, not needed
+        matpropl(8:9) = material_properties(i,9:10)
       end select
       ! writes to database
       write(IIN_database) matpropl(:)
@@ -231,6 +240,8 @@
         if (trim(undef_mat_prop(3,1)) /= 'elastic')  stop 'Error in undef_mat_prop elastic domain'
       case (IDOMAIN_POROELASTIC)
         if (trim(undef_mat_prop(3,1)) /= 'poroelastic')  stop 'Error in undef_mat_prop poroelastic domain'
+      case (IDOMAIN_ISOTROPIC_COSSERAT)
+        if (trim(undef_mat_prop(3,1)) /= 'isotropic_cosserat')  stop 'Error in undef_mat_prop isotropic_cosserat domain'
       end select
       ! default name if none given
       if (trim(undef_mat_prop(4,1)) == "") undef_mat_prop(4,1) = 'tomography_model.xyz'

--- a/fortran/meshfem3d/meshfem3D/save_databases.F90
+++ b/fortran/meshfem3d/meshfem3D/save_databases.F90
@@ -31,8 +31,8 @@
                             nspec2D_xmin,nspec2D_xmax,nspec2D_ymin,nspec2D_ymax, &
                             ibelm_xmin,ibelm_xmax,ibelm_ymin,ibelm_ymax,ibelm_bottom,ibelm_top)
 
-  use constants, only: MAX_STRING_LEN,IDOMAIN_ACOUSTIC,IDOMAIN_ELASTIC,IDOMAIN_POROELASTIC, &
-    NDIM,IMAIN,IIN_DB,myrank,NGLLZ,NGLLY,NGLLX
+  use constants, only: MAX_STRING_LEN,IDOMAIN_ACOUSTIC,IDOMAIN_ELASTIC,IDOMAIN_COSSERAT, &
+    IDOMAIN_POROELASTIC, NDIM,IMAIN,IIN_DB,myrank,NGLLZ,NGLLY,NGLLX
 
   use constants_meshfem, only: NGLLX_M,NGLLY_M,NGLLZ_M,MAX_NEIGHBORS
 
@@ -202,7 +202,7 @@
         matpropl(1:7) = material_properties(i,1:7)
         ! skipping mat_id, not needed
         matpropl(8:17) = material_properties(i,9:18)
-      case (IDOMAIN_ISOTROPIC_COSSERAT)
+      case (IDOMAIN_COSSERAT)
         ! material properties format:
         !#(1)rho #(2)kappa #(3)mu #(4)nu #(5)j #(6)lambda_c #(7)domain_id #(8)mat_id #(9)mu_c #(10)nu_c
         !
@@ -240,8 +240,8 @@
         if (trim(undef_mat_prop(3,1)) /= 'elastic')  stop 'Error in undef_mat_prop elastic domain'
       case (IDOMAIN_POROELASTIC)
         if (trim(undef_mat_prop(3,1)) /= 'poroelastic')  stop 'Error in undef_mat_prop poroelastic domain'
-      case (IDOMAIN_ISOTROPIC_COSSERAT)
-        if (trim(undef_mat_prop(3,1)) /= 'isotropic_cosserat')  stop 'Error in undef_mat_prop isotropic_cosserat domain'
+      case (IDOMAIN_COSSERAT)
+        if (trim(undef_mat_prop(3,1)) /= 'cosserat')  stop 'Error in undef_mat_prop isotropic cosserat domain'
       end select
       ! default name if none given
       if (trim(undef_mat_prop(4,1)) == "") undef_mat_prop(4,1) = 'tomography_model.xyz'

--- a/fortran/meshfem3d/setup/constants.h.in
+++ b/fortran/meshfem3d/setup/constants.h.in
@@ -797,6 +797,7 @@
   integer, parameter :: IDOMAIN_ACOUSTIC    = 1
   integer, parameter :: IDOMAIN_ELASTIC     = 2
   integer, parameter :: IDOMAIN_POROELASTIC = 3
+  integer, parameter :: IDOMAIN_COSSERAT    = 4
 
 ! model ids
   integer, parameter :: IMODEL_DEFAULT          = 1


### PR DESCRIPTION
## Description

Adds a new material type for elastic Cosserat in the meshfem3d reader and material parsing branch to read in Cosserat materials.

## Issue Number

#1673 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [x] I ran the code through pre-commit to check style
- [x] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [x] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
