### PR TITLE
Fix: Clang Memory Limit by splitting updated wavefields and instantiation

### DIFF
--- a/core/specfem/CMakeLists.txt
+++ b/core/specfem/CMakeLists.txt
@@ -10,6 +10,7 @@ set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES
 # Add existing subdirectories
 add_subdirectory(algorithms)
 add_subdirectory(assembly)
+add_subdirectory(compute)
 add_subdirectory(attenuation)
 add_subdirectory(element)
 add_subdirectory(element_connections)
@@ -44,6 +45,7 @@ target_link_libraries(specfem_core_interface
     INTERFACE
         specfem::algorithms
         specfem::attenuation
+        specfem::compute
         specfem::assembly
         specfem::jacobian
         specfem::element

--- a/core/specfem/assembly/CMakeLists.txt
+++ b/core/specfem/assembly/CMakeLists.txt
@@ -1,6 +1,6 @@
-file(GLOB_RECURSE COMPUTE_SOURCE_FILES "*.cpp")
+file(GLOB_RECURSE ASSEMBLY_SOURCE_FILES "*.cpp")
 
-add_library(assembly ${COMPUTE_SOURCE_FILES})
+add_library(assembly ${ASSEMBLY_SOURCE_FILES})
 add_library(specfem::assembly ALIAS assembly)
 
 target_link_libraries(

--- a/core/specfem/compute.tpp
+++ b/core/specfem/compute.tpp
@@ -3,4 +3,4 @@
 #include "compute/compute_derivatives.tpp"
 #include "compute/compute_seismograms.tpp"
 #include "compute/initialize_mass_matrix.tpp"
-#include "compute/update_wavefields.tpp"
+#include "compute/update_wavefields.hpp"

--- a/core/specfem/compute/CMakeLists.txt
+++ b/core/specfem/compute/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(specfem_compute
 )
 add_library(specfem::compute ALIAS specfem_compute)
 
-set_target_properties(specfem_compute PROPERTIES UNITY_BUILD OFF)
+set_target_properties(specfem_compute PROPERTIES UNITY_BUILD ON)
 
 target_link_libraries(specfem_compute
     Kokkos::kokkos

--- a/core/specfem/compute/CMakeLists.txt
+++ b/core/specfem/compute/CMakeLists.txt
@@ -1,0 +1,14 @@
+
+file(GLOB_RECURSE COMPUTE_SOURCE_FILES "*.cpp")
+
+add_library(specfem_compute
+    ${COMPUTE_SOURCE_FILES}
+)
+add_library(specfem::compute ALIAS specfem_compute)
+
+set_target_properties(specfem_compute PROPERTIES UNITY_BUILD OFF)
+
+target_link_libraries(specfem_compute
+    Kokkos::kokkos
+    specfem::assembly
+)

--- a/core/specfem/compute/impl/compute_coupling.cpp
+++ b/core/specfem/compute/impl/compute_coupling.cpp
@@ -1,0 +1,14 @@
+#include "compute_coupling.tpp"
+#include "specfem/element.hpp"
+#include "specfem/macros/compute_instantiation_macros.hpp"
+#include "specfem/simulation.hpp"
+#include "specfem/tags.hpp"
+
+using specfem::element::dimension_tag;
+using specfem::element::medium_tag;
+using specfem::simulation::field_type;
+
+#define INST_COMPUTE_COUPLING(NGLL, DIM, WF, MED)                              \
+  INSTANTIATE_COMPUTE_FUNCTION(compute_coupling, NGLL, DIM, WF, MED)
+SPECFEM_COMPUTE_COMBINATIONS(INST_COMPUTE_COUPLING)
+#undef INST_COMPUTE_COUPLING

--- a/core/specfem/compute/impl/compute_coupling.cpp
+++ b/core/specfem/compute/impl/compute_coupling.cpp
@@ -8,7 +8,9 @@ using specfem::element::dimension_tag;
 using specfem::element::medium_tag;
 using specfem::simulation::field_type;
 
-#define INST_COMPUTE_COUPLING(NGLL, DIM, WF, MED)                              \
-  INSTANTIATE_COMPUTE_FUNCTION(compute_coupling, NGLL, DIM, WF, MED)
-SPECFEM_COMPUTE_COMBINATIONS(INST_COMPUTE_COUPLING)
-#undef INST_COMPUTE_COUPLING
+#define SIGNATURE(NGLL, DIM, WF, MED)                                          \
+  template void specfem::compute::impl::compute_coupling<                      \
+      NGLL, specfem::tags::Tags<DIM, WF, MED> >(                               \
+      const specfem::assembly::assembly<DIM> &);
+SPECFEM_COMPUTE_COMBINATIONS(SIGNATURE)
+#undef SIGNATURE

--- a/core/specfem/compute/impl/compute_coupling.hpp
+++ b/core/specfem/compute/impl/compute_coupling.hpp
@@ -7,11 +7,11 @@
 namespace specfem::compute::impl {
 
 template <int NGLL, int NQuad_intersection, typename Tags>
-void compute_coupling_weakly_conforming(
+void coupling_core_weakly_conforming(
     const specfem::assembly::assembly<Tags::dimension_tag> &assembly);
 
 template <int NGLL, int NQuad_intersection, typename Tags>
-void compute_coupling_nonconforming(
+void coupling_core_nonconforming(
     const specfem::assembly::assembly<Tags::dimension_tag> &assembly);
 
 /**
@@ -31,16 +31,7 @@ void compute_coupling_nonconforming(
  *
  * @param assembly SPECFEM++ assembly object.
  */
-template <int NGLL, int NQuad_intersection, typename Tags>
+template <int NGLL, typename Tags>
 void compute_coupling(
-    const specfem::assembly::assembly<Tags::dimension_tag> &assembly) {
-  constexpr auto connection_tag = Tags::connection_tag;
-  if constexpr (connection_tag ==
-                specfem::element_connections::type::nonconforming) {
-    compute_coupling_nonconforming<NGLL, NQuad_intersection, Tags>(assembly);
-  } else {
-    compute_coupling_weakly_conforming<NGLL, NQuad_intersection, Tags>(
-        assembly);
-  }
-}
+    const specfem::assembly::assembly<Tags::dimension_tag> &assembly);
 } // namespace specfem::compute::impl

--- a/core/specfem/compute/impl/compute_coupling.tpp
+++ b/core/specfem/compute/impl/compute_coupling.tpp
@@ -2,6 +2,7 @@
 
 #include "compute_coupling.hpp"
 #include "specfem/algorithms.hpp"
+#include "specfem/tags.hpp"
 #include "specfem/assembly/assembly.hpp"
 #include "specfem/boundary_conditions.hpp"
 #include "specfem/chunk_edge.hpp"
@@ -16,8 +17,10 @@
 #include <Kokkos_Core.hpp>
 #include <type_traits>
 
+namespace specfem::compute::impl {
+
 template <int NGLL, int NQuad_intersection, typename Tags>
-void specfem::compute::impl::compute_coupling_weakly_conforming(
+void compute_coupling_core_weakly_conforming(
     const specfem::assembly::assembly<Tags::dimension_tag> &assembly) {
 
   constexpr static auto dimension_tag = Tags::dimension_tag;
@@ -107,7 +110,7 @@ void specfem::compute::impl::compute_coupling_weakly_conforming(
 }
 
 template <int NGLL, int NQuad_intersection, typename Tags>
-void specfem::compute::impl::compute_coupling_nonconforming(
+void compute_coupling_core_nonconforming(
     const specfem::assembly::assembly<Tags::dimension_tag> &assembly) {
 
   constexpr bool using_simd = false;
@@ -233,3 +236,46 @@ void specfem::compute::impl::compute_coupling_nonconforming(
 
   return;
 }
+
+template <int NGLL, int NQuad_intersection, typename Tags>
+void compute_coupling_core(
+    const specfem::assembly::assembly<Tags::dimension_tag> &assembly) {
+  constexpr auto connection_tag = Tags::connection_tag;
+  if constexpr (connection_tag ==
+                specfem::element_connections::type::nonconforming) {
+    compute_coupling_core_nonconforming<NGLL, NQuad_intersection, Tags>(assembly);
+  } else {
+    compute_coupling_core_weakly_conforming<NGLL, NQuad_intersection, Tags>(assembly);
+  }
+}
+
+template <int NGLL, typename Tags>
+void compute_coupling(
+    const specfem::assembly::assembly<Tags::dimension_tag> &assembly) {
+
+  constexpr auto WavefieldType = Tags::wavefield_tag;
+  constexpr auto DimensionTag = Tags::dimension_tag;
+  constexpr auto MediumTag = Tags::medium_tag;
+
+  FOR_EACH_IN_PRODUCT(
+      (DIMENSION_TAG(DIM2), CONNECTION_TAG(WEAKLY_CONFORMING, NONCONFORMING),
+       INTERFACE_TAG(ELASTIC_ACOUSTIC, ACOUSTIC_ELASTIC),
+       BOUNDARY_TAG(NONE, ACOUSTIC_FREE_SURFACE, STACEY,
+                    COMPOSITE_STACEY_DIRICHLET),
+       FLUX_SCHEME_TAG(NATURAL)),
+      {
+        constexpr auto self_medium = specfem::element_coupling::attributes<
+            _dimension_tag_, _interface_tag_>::self_medium();
+        if constexpr (DimensionTag == _dimension_tag_ &&
+                      self_medium == MediumTag) {
+          compute_coupling_core<NGLL, NGLL,
+                        specfem::tags::Tags<_dimension_tag_, _connection_tag_,
+                                            WavefieldType, _interface_tag_,
+                                            _boundary_tag_,
+                                            _flux_scheme_tag_> >(assembly);
+          // second ngll is the number of quadrature points on the mortar.
+        }
+      })
+}
+
+} // namespace specfem::compute::impl

--- a/core/specfem/compute/impl/compute_source_interaction.cpp
+++ b/core/specfem/compute/impl/compute_source_interaction.cpp
@@ -8,8 +8,9 @@ using specfem::element::dimension_tag;
 using specfem::element::medium_tag;
 using specfem::simulation::field_type;
 
-#define INST_COMPUTE_SOURCE_INTERACTION(NGLL, DIM, WF, MED)                    \
-  INSTANTIATE_COMPUTE_FUNCTION_VOID_NONCONST_INT(compute_source_interaction,   \
-                                                 NGLL, DIM, WF, MED)
-SPECFEM_COMPUTE_COMBINATIONS(INST_COMPUTE_SOURCE_INTERACTION)
-#undef INST_COMPUTE_SOURCE_INTERACTION
+#define SIGNATURE(NGLL, DIM, WF, MED)                                          \
+  template void specfem::compute::impl::compute_source_interaction<            \
+      NGLL, specfem::tags::Tags<DIM, WF, MED> >(                               \
+      specfem::assembly::assembly<DIM> &, const int);
+SPECFEM_COMPUTE_COMBINATIONS(SIGNATURE)
+#undef SIGNATURE

--- a/core/specfem/compute/impl/compute_source_interaction.cpp
+++ b/core/specfem/compute/impl/compute_source_interaction.cpp
@@ -1,0 +1,15 @@
+#include "compute_source_interaction.tpp"
+#include "specfem/element.hpp"
+#include "specfem/macros/compute_instantiation_macros.hpp"
+#include "specfem/simulation.hpp"
+#include "specfem/tags.hpp"
+
+using specfem::element::dimension_tag;
+using specfem::element::medium_tag;
+using specfem::simulation::field_type;
+
+#define INST_COMPUTE_SOURCE_INTERACTION(NGLL, DIM, WF, MED)                    \
+  INSTANTIATE_COMPUTE_FUNCTION_VOID_NONCONST_INT(compute_source_interaction,   \
+                                                 NGLL, DIM, WF, MED)
+SPECFEM_COMPUTE_COMBINATIONS(INST_COMPUTE_SOURCE_INTERACTION)
+#undef INST_COMPUTE_SOURCE_INTERACTION

--- a/core/specfem/compute/impl/compute_source_interaction.hpp
+++ b/core/specfem/compute/impl/compute_source_interaction.hpp
@@ -28,7 +28,7 @@ namespace impl {
 template <int NGLL, typename Tags>
 void compute_source_interaction(
     specfem::assembly::assembly<Tags::dimension_tag> &assembly,
-    const int &timestep);
+    const int istep);
 } // namespace impl
 } // namespace compute
 } // namespace specfem

--- a/core/specfem/compute/impl/compute_source_interaction.tpp
+++ b/core/specfem/compute/impl/compute_source_interaction.tpp
@@ -11,10 +11,14 @@
 #include "specfem/execution.hpp"
 #include "specfem/point.hpp"
 #include "compute_source_interaction.hpp"
+#include "specfem/macros.hpp"
+#include "specfem/tags.hpp"
 #include <Kokkos_Core.hpp>
 
+namespace specfem::compute::impl {
+
 template <int NGLL, typename Tags>
-void specfem::compute::impl::compute_source_interaction(
+void compute_source_interaction_core(
     specfem::assembly::assembly<Tags::dimension_tag> &assembly, const int &timestep) {
 
   constexpr auto medium_tag = Tags::medium_tag;
@@ -97,3 +101,33 @@ void specfem::compute::impl::compute_source_interaction(
 
   Kokkos::Profiling::popRegion();
 }
+
+
+template <int NGLL, typename Tags>
+void compute_source_interaction(
+    specfem::assembly::assembly<Tags::dimension_tag> &assembly,
+    const int istep) {
+
+  constexpr auto WavefieldType = Tags::wavefield_tag;
+  constexpr auto DimensionTag = Tags::dimension_tag;
+  constexpr auto MediumTag = Tags::medium_tag;
+
+  FOR_EACH_IN_PRODUCT(
+      (DIMENSION_TAG(DIM2, DIM3),
+       MEDIUM_TAG(ELASTIC, ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
+                  ELASTIC_PSV_T),
+       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+       BOUNDARY_TAG(NONE, ACOUSTIC_FREE_SURFACE, STACEY,
+                    COMPOSITE_STACEY_DIRICHLET)),
+      {
+        if constexpr (DimensionTag == _dimension_tag_ &&
+                      MediumTag == _medium_tag_) {
+          compute_source_interaction_core<
+              NGLL,
+              specfem::tags::Tags<DimensionTag, WavefieldType, _medium_tag_,
+                                  _property_tag_, _boundary_tag_> >(assembly,
+                                                                    istep);
+        }
+      })
+}
+} // namespace specfem::compute::impl

--- a/core/specfem/compute/impl/compute_stiffness_interaction.cpp
+++ b/core/specfem/compute/impl/compute_stiffness_interaction.cpp
@@ -1,0 +1,15 @@
+#include "compute_stiffness_interaction.tpp"
+#include "specfem/element.hpp"
+#include "specfem/macros/compute_instantiation_macros.hpp"
+#include "specfem/simulation.hpp"
+#include "specfem/tags.hpp"
+
+using specfem::element::dimension_tag;
+using specfem::element::medium_tag;
+using specfem::simulation::field_type;
+
+#define INST_COMPUTE_STIFFNESS_INTERACTION(NGLL, DIM, WF, MED)                 \
+  INSTANTIATE_COMPUTE_FUNCTION_INT_CONST_INT(compute_stiffness_interaction,    \
+                                             NGLL, DIM, WF, MED)
+SPECFEM_COMPUTE_COMBINATIONS(INST_COMPUTE_STIFFNESS_INTERACTION)
+#undef INST_COMPUTE_STIFFNESS_INTERACTION

--- a/core/specfem/compute/impl/compute_stiffness_interaction.cpp
+++ b/core/specfem/compute/impl/compute_stiffness_interaction.cpp
@@ -8,8 +8,9 @@ using specfem::element::dimension_tag;
 using specfem::element::medium_tag;
 using specfem::simulation::field_type;
 
-#define INST_COMPUTE_STIFFNESS_INTERACTION(NGLL, DIM, WF, MED)                 \
-  INSTANTIATE_COMPUTE_FUNCTION_INT_CONST_INT(compute_stiffness_interaction,    \
-                                             NGLL, DIM, WF, MED)
-SPECFEM_COMPUTE_COMBINATIONS(INST_COMPUTE_STIFFNESS_INTERACTION)
-#undef INST_COMPUTE_STIFFNESS_INTERACTION
+#define SIGNATURE(NGLL, DIM, WF, MED)                                          \
+  template int specfem::compute::impl::compute_stiffness_interaction<          \
+      NGLL, specfem::tags::Tags<DIM, WF, MED> >(                               \
+      const specfem::assembly::assembly<DIM> &, const int);
+SPECFEM_COMPUTE_COMBINATIONS(SIGNATURE)
+#undef SIGNATURE

--- a/core/specfem/compute/impl/compute_stiffness_interaction.hpp
+++ b/core/specfem/compute/impl/compute_stiffness_interaction.hpp
@@ -34,7 +34,7 @@ namespace impl {
 template <int NGLL, typename Tags>
 int compute_stiffness_interaction(
     const specfem::assembly::assembly<Tags::dimension_tag> &assembly,
-    const int &istep);
+    const int istep);
 } // namespace impl
 } // namespace compute
 } // namespace specfem

--- a/core/specfem/compute/impl/compute_stiffness_interaction.tpp
+++ b/core/specfem/compute/impl/compute_stiffness_interaction.tpp
@@ -14,11 +14,15 @@
 #include "specfem/chunk_element.hpp"
 #include "specfem/point.hpp"
 #include "compute_stiffness_interaction.hpp"
+#include "specfem/macros.hpp"
+#include "specfem/tags.hpp"
 #include <Kokkos_Core.hpp>
 #include <type_traits>
 
+namespace specfem::compute::impl {
+
 template <int NGLL, typename Tags>
-int specfem::compute::impl::compute_stiffness_interaction(
+int compute_stiffness_interaction_core(
     const specfem::assembly::assembly<Tags::dimension_tag> &assembly,
     const int &istep) {
 
@@ -241,3 +245,36 @@ int specfem::compute::impl::compute_stiffness_interaction(
 
   return nelements;
 }
+
+template <int NGLL, typename Tags>
+int compute_stiffness_interaction(
+    const specfem::assembly::assembly<Tags::dimension_tag> &assembly,
+    const int istep) {
+
+  constexpr auto WavefieldType = Tags::wavefield_tag;
+  constexpr auto DimensionTag = Tags::dimension_tag;
+  constexpr auto MediumTag = Tags::medium_tag;
+
+  int elements_updated = 0;
+
+  FOR_EACH_IN_PRODUCT(
+      (DIMENSION_TAG(DIM2, DIM3),
+       MEDIUM_TAG(ELASTIC, ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
+                  ELASTIC_PSV_T),
+       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
+       BOUNDARY_TAG(NONE, ACOUSTIC_FREE_SURFACE, STACEY,
+                    COMPOSITE_STACEY_DIRICHLET)),
+      {
+        if constexpr (DimensionTag == _dimension_tag_ &&
+                      MediumTag == _medium_tag_) {
+          elements_updated += compute_stiffness_interaction_core<
+              NGLL,
+              specfem::tags::Tags<DimensionTag, WavefieldType, _medium_tag_,
+                                  _property_tag_, _boundary_tag_> >(assembly,
+                                                                    istep);
+        }
+      })
+
+  return elements_updated;
+}
+} // namespace specfem::compute::impl

--- a/core/specfem/compute/impl/divide_mass_matrix.cpp
+++ b/core/specfem/compute/impl/divide_mass_matrix.cpp
@@ -1,0 +1,14 @@
+#include "divide_mass_matrix.tpp"
+#include "specfem/element.hpp"
+#include "specfem/macros/compute_instantiation_macros.hpp"
+#include "specfem/simulation.hpp"
+#include "specfem/tags.hpp"
+
+using specfem::element::dimension_tag;
+using specfem::element::medium_tag;
+using specfem::simulation::field_type;
+
+#define INST_DIVIDE_MASS_MATRIX(NGLL, DIM, WF, MED)                            \
+  INSTANTIATE_COMPUTE_FUNCTION(divide_mass_matrix, NGLL, DIM, WF, MED)
+SPECFEM_COMPUTE_COMBINATIONS(INST_DIVIDE_MASS_MATRIX)
+#undef INST_DIVIDE_MASS_MATRIX

--- a/core/specfem/compute/impl/divide_mass_matrix.cpp
+++ b/core/specfem/compute/impl/divide_mass_matrix.cpp
@@ -8,7 +8,9 @@ using specfem::element::dimension_tag;
 using specfem::element::medium_tag;
 using specfem::simulation::field_type;
 
-#define INST_DIVIDE_MASS_MATRIX(NGLL, DIM, WF, MED)                            \
-  INSTANTIATE_COMPUTE_FUNCTION(divide_mass_matrix, NGLL, DIM, WF, MED)
-SPECFEM_COMPUTE_COMBINATIONS(INST_DIVIDE_MASS_MATRIX)
-#undef INST_DIVIDE_MASS_MATRIX
+#define SIGNATURE(NGLL, DIM, WF, MED)                                          \
+  template void specfem::compute::impl::divide_mass_matrix<                    \
+      NGLL, specfem::tags::Tags<DIM, WF, MED> >(                               \
+      const specfem::assembly::assembly<DIM> &);
+SPECFEM_COMPUTE_COMBINATIONS(SIGNATURE)
+#undef SIGNATURE

--- a/core/specfem/compute/impl/divide_mass_matrix.hpp
+++ b/core/specfem/compute/impl/divide_mass_matrix.hpp
@@ -22,7 +22,7 @@ namespace impl {
  * @tparam BoundaryTag Boundary tag (e.g., none, stacey)
  *
  */
-template <typename Tags>
+template <int NGLL, typename Tags>
 void divide_mass_matrix(
     const specfem::assembly::assembly<Tags::dimension_tag> &assembly);
 } // namespace impl

--- a/core/specfem/compute/impl/divide_mass_matrix.tpp
+++ b/core/specfem/compute/impl/divide_mass_matrix.tpp
@@ -5,10 +5,14 @@
 #include "specfem/assembly/assembly.hpp"
 #include "specfem/point.hpp"
 #include "divide_mass_matrix.hpp"
+#include "specfem/macros.hpp"
+#include "specfem/tags.hpp"
 #include <Kokkos_Core.hpp>
 
+namespace specfem::compute::impl {
+
 template <typename Tags>
-void specfem::compute::impl::divide_mass_matrix(
+void divide_mass_matrix_core(
     const specfem::assembly::assembly<Tags::dimension_tag> &assembly) {
 
   constexpr auto medium_tag = Tags::medium_tag;
@@ -65,3 +69,26 @@ void specfem::compute::impl::divide_mass_matrix(
 
   return;
 }
+
+template <int NGLL, typename Tags>
+void divide_mass_matrix(
+    const specfem::assembly::assembly<Tags::dimension_tag> &assembly) {
+
+  constexpr auto WavefieldType = Tags::wavefield_tag;
+  constexpr auto DimensionTag = Tags::dimension_tag;
+  constexpr auto MediumTag = Tags::medium_tag;
+
+  FOR_EACH_IN_PRODUCT(
+      (DIMENSION_TAG(DIM2, DIM3),
+       MEDIUM_TAG(ELASTIC, ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
+                  ELASTIC_PSV_T)),
+      {
+        if constexpr (DimensionTag == _dimension_tag_ &&
+                      MediumTag == _medium_tag_) {
+          divide_mass_matrix_core<
+              specfem::tags::Tags<DimensionTag, WavefieldType, _medium_tag_> >(
+              assembly);
+        }
+      })
+}
+} // namespace specfem::compute::impl

--- a/core/specfem/compute/update_wavefields.cpp
+++ b/core/specfem/compute/update_wavefields.cpp
@@ -8,8 +8,9 @@ using specfem::element::dimension_tag;
 using specfem::element::medium_tag;
 using specfem::simulation::field_type;
 
-#define INST_UPDATE_WAVEFIELDS(NGLL, DIM, WF, MED)                             \
-  INSTANTIATE_COMPUTE_FUNCTION_INT_NONCONST_INT(update_wavefields, NGLL, DIM,  \
-                                                WF, MED)
-SPECFEM_COMPUTE_COMBINATIONS(INST_UPDATE_WAVEFIELDS)
-#undef INST_UPDATE_WAVEFIELDS
+#define SIGNATURE(NGLL, DIM, WF, MED)                                          \
+  template int specfem::compute::update_wavefields<                            \
+      NGLL, specfem::tags::Tags<DIM, WF, MED> >(                               \
+      specfem::assembly::assembly<DIM> &, const int);
+SPECFEM_COMPUTE_COMBINATIONS(SIGNATURE)
+#undef SIGNATURE

--- a/core/specfem/compute/update_wavefields.cpp
+++ b/core/specfem/compute/update_wavefields.cpp
@@ -1,0 +1,15 @@
+#include "update_wavefields.tpp"
+#include "specfem/element.hpp"
+#include "specfem/macros/compute_instantiation_macros.hpp"
+#include "specfem/simulation.hpp"
+#include "specfem/tags.hpp"
+
+using specfem::element::dimension_tag;
+using specfem::element::medium_tag;
+using specfem::simulation::field_type;
+
+#define INST_UPDATE_WAVEFIELDS(NGLL, DIM, WF, MED)                             \
+  INSTANTIATE_COMPUTE_FUNCTION_INT_NONCONST_INT(update_wavefields, NGLL, DIM,  \
+                                                WF, MED)
+SPECFEM_COMPUTE_COMBINATIONS(INST_UPDATE_WAVEFIELDS)
+#undef INST_UPDATE_WAVEFIELDS

--- a/core/specfem/compute/update_wavefields.hpp
+++ b/core/specfem/compute/update_wavefields.hpp
@@ -24,4 +24,5 @@ template <int NGLL, typename Tags>
 int update_wavefields(
     specfem::assembly::assembly<Tags::dimension_tag> &assembly,
     const int istep);
+
 } // namespace specfem::compute

--- a/core/specfem/compute/update_wavefields.tpp
+++ b/core/specfem/compute/update_wavefields.tpp
@@ -1,14 +1,14 @@
 #include "update_wavefields.hpp"
-#include "impl/compute_coupling.tpp"
-#include "impl/compute_source_interaction.tpp"
-#include "impl/compute_stiffness_interaction.tpp"
-#include "impl/divide_mass_matrix.tpp"
+#include "impl/compute_coupling.hpp"
+#include "impl/compute_source_interaction.hpp"
+#include "impl/compute_stiffness_interaction.hpp"
+#include "impl/divide_mass_matrix.hpp"
 #include "specfem/assembly/assembly.hpp"
 #include "specfem/enums.hpp"
-#include "specfem/macros.hpp"
 #include "specfem/tags.hpp"
 
 namespace specfem::compute {
+
 /**
  * @brief Updates the wavefield for a given medium
  *
@@ -28,83 +28,11 @@ namespace specfem::compute {
 template <int NGLL, typename Tags>
 int update_wavefields(specfem::assembly::assembly<Tags::dimension_tag> &assembly,
                       const int istep) {
-
-  constexpr auto WavefieldType = Tags::wavefield_tag;
-  constexpr auto DimensionTag = Tags::dimension_tag;
-  constexpr auto MediumTag = Tags::medium_tag;
-
-  int elements_updated = 0;
-
-  FOR_EACH_IN_PRODUCT(
-      (DIMENSION_TAG(DIM2), CONNECTION_TAG(WEAKLY_CONFORMING, NONCONFORMING),
-       INTERFACE_TAG(ELASTIC_ACOUSTIC, ACOUSTIC_ELASTIC),
-       BOUNDARY_TAG(NONE, ACOUSTIC_FREE_SURFACE, STACEY,
-                    COMPOSITE_STACEY_DIRICHLET),
-       FLUX_SCHEME_TAG(NATURAL)),
-      {
-        constexpr auto self_medium = specfem::element_coupling::attributes<
-            _dimension_tag_, _interface_tag_>::self_medium();
-        if constexpr (DimensionTag == _dimension_tag_ &&
-                      self_medium == MediumTag) {
-          impl::compute_coupling<
-              NGLL, NGLL,
-              specfem::tags::Tags<_dimension_tag_, _connection_tag_,
-                                  WavefieldType, _interface_tag_,
-                                  _boundary_tag_, _flux_scheme_tag_> >(
-              assembly);
-          // second ngll is the number of quadrature points on the mortar.
-        }
-      })
-
-  FOR_EACH_IN_PRODUCT(
-      (DIMENSION_TAG(DIM2, DIM3),
-       MEDIUM_TAG(ELASTIC, ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
-                  ELASTIC_PSV_T),
-       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
-       BOUNDARY_TAG(NONE, ACOUSTIC_FREE_SURFACE, STACEY,
-                    COMPOSITE_STACEY_DIRICHLET)),
-      {
-        if constexpr (DimensionTag == _dimension_tag_ &&
-                      MediumTag == _medium_tag_) {
-          impl::compute_source_interaction<
-              NGLL,
-              specfem::tags::Tags<DimensionTag, WavefieldType, _medium_tag_,
-                                  _property_tag_, _boundary_tag_> >(assembly,
-                                                                    istep);
-        }
-      })
-
-  FOR_EACH_IN_PRODUCT(
-      (DIMENSION_TAG(DIM2, DIM3),
-       MEDIUM_TAG(ELASTIC, ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
-                  ELASTIC_PSV_T),
-       PROPERTY_TAG(ISOTROPIC, ANISOTROPIC, ISOTROPIC_COSSERAT),
-       BOUNDARY_TAG(NONE, ACOUSTIC_FREE_SURFACE, STACEY,
-                    COMPOSITE_STACEY_DIRICHLET)),
-      {
-        if constexpr (DimensionTag == _dimension_tag_ &&
-                      MediumTag == _medium_tag_) {
-          elements_updated += impl::compute_stiffness_interaction<
-              NGLL,
-              specfem::tags::Tags<DimensionTag, WavefieldType, _medium_tag_,
-                                  _property_tag_, _boundary_tag_> >(assembly,
-                                                                    istep);
-        }
-      })
-
-  FOR_EACH_IN_PRODUCT(
-      (DIMENSION_TAG(DIM2, DIM3),
-       MEDIUM_TAG(ELASTIC, ELASTIC_PSV, ELASTIC_SH, ACOUSTIC, POROELASTIC,
-                  ELASTIC_PSV_T)),
-      {
-        if constexpr (DimensionTag == _dimension_tag_ &&
-                      MediumTag == _medium_tag_) {
-          impl::divide_mass_matrix<
-              specfem::tags::Tags<DimensionTag, WavefieldType, _medium_tag_> >(
-              assembly);
-        }
-      })
-
-  return elements_updated;
+  impl::compute_coupling<NGLL, Tags>(assembly);
+  impl::compute_source_interaction<NGLL, Tags>(assembly, istep);
+  const int n = impl::compute_stiffness_interaction<NGLL, Tags>(assembly, istep);
+  impl::divide_mass_matrix<NGLL, Tags>(assembly);
+  return n;
 }
+
 } // namespace specfem::compute

--- a/core/specfem/macros/compute_instantiation_macros.hpp
+++ b/core/specfem/macros/compute_instantiation_macros.hpp
@@ -1,0 +1,89 @@
+#pragma once
+// !! Do NOT include this from specfem/macros.hpp !!
+// Include only in explicit-instantiation .cpp files.
+
+// ── Signature helpers
+// ───────────────────────────────────────────────────────── Callers must have
+// the following using-declarations in scope:
+//   using specfem::element::dimension_tag;
+//   using specfem::element::medium_tag;
+//   using specfem::simulation::field_type;
+
+// void(const assembly &)                  — compute_coupling,
+// divide_mass_matrix
+#define INSTANTIATE_COMPUTE_FUNCTION(FN, NGLL, DIM, WF, MED)                   \
+  template void                                                                \
+  specfem::compute::impl::FN<NGLL, specfem::tags::Tags<DIM, WF, MED> >(        \
+      const specfem::assembly::assembly<DIM> &);
+
+// void(assembly &, const int)             — compute_source_interaction
+#define INSTANTIATE_COMPUTE_FUNCTION_VOID_NONCONST_INT(FN, NGLL, DIM, WF, MED) \
+  template void                                                                \
+  specfem::compute::impl::FN<NGLL, specfem::tags::Tags<DIM, WF, MED> >(        \
+      specfem::assembly::assembly<DIM> &, const int);
+
+// int(const assembly &, const int)        — compute_stiffness_interaction
+#define INSTANTIATE_COMPUTE_FUNCTION_INT_CONST_INT(FN, NGLL, DIM, WF, MED)     \
+  template int                                                                 \
+  specfem::compute::impl::FN<NGLL, specfem::tags::Tags<DIM, WF, MED> >(        \
+      const specfem::assembly::assembly<DIM> &, const int);
+
+// int(assembly &, const int)              — update_wavefields
+#define INSTANTIATE_COMPUTE_FUNCTION_INT_NONCONST_INT(FN, NGLL, DIM, WF, MED)  \
+  template int specfem::compute::FN<NGLL, specfem::tags::Tags<DIM, WF, MED> >( \
+      specfem::assembly::assembly<DIM> &,                                      \
+      const int); // update_wavefields stays in compute::
+
+// ── Combination list (X-macro)
+// ──────────────────────────────────────────────── All (NGLL, DIM, WF, MED)
+// tuples used by time_marching instantiations. Requires dimension_tag /
+// field_type / medium_tag to be in scope (see above).
+#define SPECFEM_COMPUTE_COMBINATIONS(MACRO)                                    \
+  /* dim2, NGLL=5, forward */                                                  \
+  MACRO(5, dimension_tag::dim2, field_type::forward, medium_tag::acoustic)     \
+  MACRO(5, dimension_tag::dim2, field_type::forward, medium_tag::elastic)      \
+  MACRO(5, dimension_tag::dim2, field_type::forward, medium_tag::elastic_psv)  \
+  MACRO(5, dimension_tag::dim2, field_type::forward, medium_tag::elastic_sh)   \
+  MACRO(5, dimension_tag::dim2, field_type::forward,                           \
+        medium_tag::elastic_psv_t)                                             \
+  MACRO(5, dimension_tag::dim2, field_type::forward, medium_tag::poroelastic)  \
+  /* dim2, NGLL=8, forward */                                                  \
+  MACRO(8, dimension_tag::dim2, field_type::forward, medium_tag::acoustic)     \
+  MACRO(8, dimension_tag::dim2, field_type::forward, medium_tag::elastic)      \
+  MACRO(8, dimension_tag::dim2, field_type::forward, medium_tag::elastic_psv)  \
+  MACRO(8, dimension_tag::dim2, field_type::forward, medium_tag::elastic_sh)   \
+  MACRO(8, dimension_tag::dim2, field_type::forward,                           \
+        medium_tag::elastic_psv_t)                                             \
+  MACRO(8, dimension_tag::dim2, field_type::forward, medium_tag::poroelastic)  \
+  /* dim2, NGLL=5, adjoint */                                                  \
+  MACRO(5, dimension_tag::dim2, field_type::adjoint, medium_tag::acoustic)     \
+  MACRO(5, dimension_tag::dim2, field_type::adjoint, medium_tag::elastic)      \
+  MACRO(5, dimension_tag::dim2, field_type::adjoint, medium_tag::elastic_psv)  \
+  MACRO(5, dimension_tag::dim2, field_type::adjoint, medium_tag::elastic_sh)   \
+  MACRO(5, dimension_tag::dim2, field_type::adjoint, medium_tag::poroelastic)  \
+  /* dim2, NGLL=5, backward */                                                 \
+  MACRO(5, dimension_tag::dim2, field_type::backward, medium_tag::acoustic)    \
+  MACRO(5, dimension_tag::dim2, field_type::backward, medium_tag::elastic)     \
+  MACRO(5, dimension_tag::dim2, field_type::backward, medium_tag::elastic_psv) \
+  MACRO(5, dimension_tag::dim2, field_type::backward, medium_tag::elastic_sh)  \
+  MACRO(5, dimension_tag::dim2, field_type::backward, medium_tag::poroelastic) \
+  /* dim2, NGLL=8, adjoint */                                                  \
+  MACRO(8, dimension_tag::dim2, field_type::adjoint, medium_tag::acoustic)     \
+  MACRO(8, dimension_tag::dim2, field_type::adjoint, medium_tag::elastic)      \
+  MACRO(8, dimension_tag::dim2, field_type::adjoint, medium_tag::elastic_psv)  \
+  MACRO(8, dimension_tag::dim2, field_type::adjoint, medium_tag::elastic_sh)   \
+  MACRO(8, dimension_tag::dim2, field_type::adjoint, medium_tag::poroelastic)  \
+  /* dim2, NGLL=8, backward */                                                 \
+  MACRO(8, dimension_tag::dim2, field_type::backward, medium_tag::acoustic)    \
+  MACRO(8, dimension_tag::dim2, field_type::backward, medium_tag::elastic)     \
+  MACRO(8, dimension_tag::dim2, field_type::backward, medium_tag::elastic_psv) \
+  MACRO(8, dimension_tag::dim2, field_type::backward, medium_tag::elastic_sh)  \
+  MACRO(8, dimension_tag::dim2, field_type::backward, medium_tag::poroelastic) \
+  /* dim3, NGLL=5, forward */                                                  \
+  MACRO(5, dimension_tag::dim3, field_type::forward, medium_tag::acoustic)     \
+  MACRO(5, dimension_tag::dim3, field_type::forward, medium_tag::elastic)      \
+  MACRO(5, dimension_tag::dim3, field_type::forward, medium_tag::elastic_psv)  \
+  MACRO(5, dimension_tag::dim3, field_type::forward, medium_tag::elastic_sh)   \
+  MACRO(5, dimension_tag::dim3, field_type::forward,                           \
+        medium_tag::elastic_psv_t)                                             \
+  MACRO(5, dimension_tag::dim3, field_type::forward, medium_tag::poroelastic)

--- a/core/specfem/macros/compute_instantiation_macros.hpp
+++ b/core/specfem/macros/compute_instantiation_macros.hpp
@@ -1,38 +1,16 @@
 #pragma once
 // !! Do NOT include this from specfem/macros.hpp !!
 // Include only in explicit-instantiation .cpp files.
-
-// ── Signature helpers
-// ───────────────────────────────────────────────────────── Callers must have
-// the following using-declarations in scope:
+//
+// Each .cpp file defines its own SIGNATURE(NGLL, DIM, WF, MED) macro with
+// the full explicit-instantiation declaration, then invokes:
+//   SPECFEM_COMPUTE_COMBINATIONS(SIGNATURE)
+// and undefines SIGNATURE afterwards.
+//
+// Requires the following using-declarations in scope:
 //   using specfem::element::dimension_tag;
 //   using specfem::element::medium_tag;
 //   using specfem::simulation::field_type;
-
-// void(const assembly &)                  — compute_coupling,
-// divide_mass_matrix
-#define INSTANTIATE_COMPUTE_FUNCTION(FN, NGLL, DIM, WF, MED)                   \
-  template void                                                                \
-  specfem::compute::impl::FN<NGLL, specfem::tags::Tags<DIM, WF, MED> >(        \
-      const specfem::assembly::assembly<DIM> &);
-
-// void(assembly &, const int)             — compute_source_interaction
-#define INSTANTIATE_COMPUTE_FUNCTION_VOID_NONCONST_INT(FN, NGLL, DIM, WF, MED) \
-  template void                                                                \
-  specfem::compute::impl::FN<NGLL, specfem::tags::Tags<DIM, WF, MED> >(        \
-      specfem::assembly::assembly<DIM> &, const int);
-
-// int(const assembly &, const int)        — compute_stiffness_interaction
-#define INSTANTIATE_COMPUTE_FUNCTION_INT_CONST_INT(FN, NGLL, DIM, WF, MED)     \
-  template int                                                                 \
-  specfem::compute::impl::FN<NGLL, specfem::tags::Tags<DIM, WF, MED> >(        \
-      const specfem::assembly::assembly<DIM> &, const int);
-
-// int(assembly &, const int)              — update_wavefields
-#define INSTANTIATE_COMPUTE_FUNCTION_INT_NONCONST_INT(FN, NGLL, DIM, WF, MED)  \
-  template int specfem::compute::FN<NGLL, specfem::tags::Tags<DIM, WF, MED> >( \
-      specfem::assembly::assembly<DIM> &,                                      \
-      const int); // update_wavefields stays in compute::
 
 // ── Combination list (X-macro)
 // ──────────────────────────────────────────────── All (NGLL, DIM, WF, MED)

--- a/core/specfem/solver/CMakeLists.txt
+++ b/core/specfem/solver/CMakeLists.txt
@@ -17,4 +17,5 @@ target_link_libraries(
         specfem::logger
         specfem::io
         specfem::assembly
+        specfem::compute
 )

--- a/tests/unit-tests/point/properties/dim2/elastic_isotropic_cosserat.cpp
+++ b/tests/unit-tests/point/properties/dim2/elastic_isotropic_cosserat.cpp
@@ -149,8 +149,8 @@ TYPED_TEST(PointPropertiesTest, ElasticIsotropicCosserat2D) {
         kappa_val - static_cast<type_real>(2.0) / static_cast<type_real>(3.0) *
                         mu_val; // Lamé's first parameter
     constexpr type_real lambdaplus2mu_scalar = kappa_val + (4.0 / 3.0) * mu_val;
-    constexpr type_real vp = std::sqrt(lambdaplus2mu_scalar / rho_val);
-    constexpr type_real vs = std::sqrt(mu_val / rho_val);
+    const type_real vp = std::sqrt(lambdaplus2mu_scalar / rho_val);
+    const type_real vs = std::sqrt(mu_val / rho_val);
 
     // Assign to our variables
     rho = rho_val;

--- a/tests/unit-tests/point/properties/dim3/elastic_isotropic_cosserat.cpp
+++ b/tests/unit-tests/point/properties/dim3/elastic_isotropic_cosserat.cpp
@@ -149,8 +149,8 @@ TYPED_TEST(PointPropertiesTest, ElasticIsotropicCosserat3D) {
         kappa_val - static_cast<type_real>(2.0) / static_cast<type_real>(3.0) *
                         mu_val; // Lamé's first parameter
     constexpr type_real lambdaplus2mu_scalar = kappa_val + (4.0 / 3.0) * mu_val;
-    constexpr type_real vp = std::sqrt(lambdaplus2mu_scalar / rho_val);
-    constexpr type_real vs = std::sqrt(mu_val / rho_val);
+    const type_real vp = std::sqrt(lambdaplus2mu_scalar / rho_val);
+    const type_real vs = std::sqrt(mu_val / rho_val);
 
     // Assign to our variables
     rho = rho_val;


### PR DESCRIPTION
## Description

`time_marching.cpp` became way to large resulting in a massive > 1,000,000 line translation unit largely a result of update wavefield macro expansion.  

Splits `update_wavefields` into function defined in the `compute/impl/<func>.tpp` and instantiated in `compute/impl/<func>.cpp` using a simple instantiation macro for compute functions from a list of compute combinations (NGLL, field_type, medium). `update_wavefields` also being instantiated the same way.


## Issue Number

`Intel Devel` CI was failing this should fix it.

## Checklist

Please make sure to check developer documentation on specfem docs.

- [x] I ran the code through pre-commit to check style
- [x] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [x] I have added labels to the PR (see right hand side of the PR page)
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
