### PR TITLE
Added `flux_scheme_tag` template param to NCIs + deps

### DIFF
--- a/core/specfem/algorithms/coupling_integral.hpp
+++ b/core/specfem/algorithms/coupling_integral.hpp
@@ -65,7 +65,8 @@ KOKKOS_FUNCTION void coupling_integral(
                           IntersectionFieldViewType::simd::using_simd> >;
   using SelfTransferFunctionType = specfem::point::transfer_function_self<
       IntersectionFactor::n_quad_intersection, dimension_tag,
-      IntersectionFactor::interface_tag, IntersectionFactor::boundary_tag>;
+      IntersectionFactor::interface_tag, IntersectionFactor::boundary_tag,
+      IntersectionFactor::flux_scheme_tag>;
 
   constexpr int ncomp = PointFieldType::components;
   constexpr int nquad_intersection = IntersectionFactor::n_quad_intersection;

--- a/core/specfem/algorithms/shape_function_normal_derivative.hpp
+++ b/core/specfem/algorithms/shape_function_normal_derivative.hpp
@@ -29,9 +29,11 @@ namespace specfem::algorithms {
  * @param nonconforming_interfaces - assembly.nonconforming_interfaces struct
  */
 template <specfem::element_coupling::interface_tag interface_tag,
-          specfem::element::boundary_tag boundary_tag, int nquad_element_,
-          int nquad_intersection_, typename SelfEdgeListView,
-          typename HPrimeView, typename TransformedIntersectionNormalView>
+          specfem::element::boundary_tag boundary_tag,
+          specfem::element_coupling::flux_scheme_tag flux_scheme_tag,
+          int nquad_element_, int nquad_intersection_,
+          typename SelfEdgeListView, typename HPrimeView,
+          typename TransformedIntersectionNormalView>
 Kokkos::View<type_real ****, Kokkos::DefaultExecutionSpace>
 shape_function_self_normal_derivatives(
     const SelfEdgeListView &self_edges,
@@ -63,8 +65,8 @@ shape_function_self_normal_derivatives(
   specfem::execution::ChunkedEdgeIterator chunk(parallel_config(), self_edges);
 
   using TransferFunctionSelf = specfem::chunk_edge::transfer_function_self<
-      dimension_tag, interface_tag, boundary_tag, parallel_config::chunk_size,
-      nquad_intersection_, nquad_element_>;
+      dimension_tag, interface_tag, boundary_tag, flux_scheme_tag,
+      parallel_config::chunk_size, nquad_intersection_, nquad_element_>;
 
   specfem::execution::for_each_level(
       "specfem::compute::shape_function_normal_derivative",

--- a/core/specfem/assembly/nonconforming_interfaces.hpp
+++ b/core/specfem/assembly/nonconforming_interfaces.hpp
@@ -2,6 +2,7 @@
 
 #include "specfem/element_connections.hpp"
 #include "specfem/element_coupling.hpp"
+#include "specfem/element_coupling/tags.hpp"
 #include "specfem/enums.hpp"
 
 namespace specfem::assembly {
@@ -11,7 +12,8 @@ namespace nonconforming_interfaces_impl {
 template <specfem::element::dimension_tag DimensionTag,
           specfem::element_coupling::interface_tag InterfaceTag,
           specfem::element::boundary_tag BoundaryTag,
-          specfem::element_connections::type ConnectionTag>
+          specfem::element_connections::type ConnectionTag,
+          specfem::element_coupling::flux_scheme_tag FluxSchemeTag>
 struct interface_container;
 
 } // namespace nonconforming_interfaces_impl

--- a/core/specfem/assembly/nonconforming_interfaces/dim2/data_access/load.hpp
+++ b/core/specfem/assembly/nonconforming_interfaces/dim2/data_access/load.hpp
@@ -52,9 +52,9 @@ inline void load_on_host(const IndexType &index, const ContainerType &container,
                              IndexType::accessor_type>;
 
   container
-      .template get_interface_container<AccessorType::interface_tag,
-                                        AccessorType::boundary_tag,
-                                        AccessorType::connection_tag>()
+      .template get_interface_container<
+          AccessorType::interface_tag, AccessorType::boundary_tag,
+          AccessorType::connection_tag, AccessorType::flux_scheme_tag>()
       .template impl_load<false>(accessor_dispatch(), index, accessor);
 }
 
@@ -98,9 +98,9 @@ KOKKOS_FORCEINLINE_FUNCTION void load_on_device(const IndexType &index,
       std::integral_constant<specfem::datatype::AccessorType,
                              IndexType::accessor_type>;
   container
-      .template get_interface_container<AccessorType::interface_tag,
-                                        AccessorType::boundary_tag,
-                                        AccessorType::connection_tag>()
+      .template get_interface_container<
+          AccessorType::interface_tag, AccessorType::boundary_tag,
+          AccessorType::connection_tag, AccessorType::flux_scheme_tag>()
       .template impl_load<true>(accessor_dispatch(), index, accessor);
 
   return;

--- a/core/specfem/assembly/nonconforming_interfaces/dim2/impl/interface_container.hpp
+++ b/core/specfem/assembly/nonconforming_interfaces/dim2/impl/interface_container.hpp
@@ -4,6 +4,7 @@
 #include "specfem/assembly/element_intersections.hpp"
 #include "specfem/assembly/mesh.hpp"
 #include "specfem/data_access.hpp"
+#include "specfem/element_coupling/tags.hpp"
 #include "specfem/enums.hpp"
 #include "specfem/execution.hpp"
 
@@ -22,10 +23,11 @@ namespace specfem::assembly::nonconforming_interfaces_impl {
  * @tparam BoundaryTag Boundary condition type (NONE, STACEY, etc.)
  */
 template <specfem::element_coupling::interface_tag InterfaceTag,
-          specfem::element::boundary_tag BoundaryTag>
-struct interface_container<specfem::element::dimension_tag::dim2, InterfaceTag,
-                           BoundaryTag,
-                           specfem::element_connections::type::nonconforming>
+          specfem::element::boundary_tag BoundaryTag,
+          specfem::element_coupling::flux_scheme_tag FluxSchemeTag>
+struct interface_container<
+    specfem::element::dimension_tag::dim2, InterfaceTag, BoundaryTag,
+    specfem::element_connections::type::nonconforming, FluxSchemeTag>
     : public specfem::data_access::Container<
           specfem::data_access::ContainerType::edge,
           specfem::data_access::DataClassType::nonconforming_interface,
@@ -37,6 +39,8 @@ public:
   constexpr static auto interface_tag = InterfaceTag;
   /** @brief Boundary condition type */
   constexpr static auto boundary_tag = BoundaryTag;
+  /** @brief Flux scheme type */
+  constexpr static auto flux_scheme_tag = FluxSchemeTag;
   /** @brief Medium type on the self side of the interface */
   constexpr static auto self_medium =
       specfem::element_coupling::attributes<dimension_tag,

--- a/core/specfem/assembly/nonconforming_interfaces/dim2/impl/interface_container.tpp
+++ b/core/specfem/assembly/nonconforming_interfaces/dim2/impl/interface_container.tpp
@@ -6,15 +6,17 @@
 #include "specfem/assembly/mesh.hpp"
 #include "specfem/assembly/nonconforming_interfaces.hpp"
 #include "specfem/data_access.hpp"
+#include "specfem/element_coupling/tags.hpp"
 #include "specfem/enums.hpp"
 #include "specfem/jacobian.hpp"
 #include "specfem/macros.hpp"
 
 template <specfem::element_coupling::interface_tag InterfaceTag,
-          specfem::element::boundary_tag BoundaryTag>
+          specfem::element::boundary_tag BoundaryTag,
+          specfem::element_coupling::flux_scheme_tag FluxSchemeTag>
 specfem::assembly::nonconforming_interfaces_impl::interface_container<
     specfem::element::dimension_tag::dim2, InterfaceTag, BoundaryTag,
-    specfem::element_connections::type::nonconforming>::
+    specfem::element_connections::type::nonconforming, FluxSchemeTag>::
     interface_container(
         const int ngllz, const int ngllx,
         const specfem::assembly::element_intersections<
@@ -49,8 +51,6 @@ specfem::assembly::nonconforming_interfaces_impl::interface_container<
 
   const auto element = specfem::mesh_entity::element(ngllz, ngllx);
 
-  //TODO replace with struct template parameter later
-  specfem::element_coupling::flux_scheme_tag FluxSchemeTag = specfem::element_coupling::flux_scheme_tag::natural;
   const auto [self_edges, coupled_edges] =
       element_intersections.get_intersections_on_host(
           specfem::element_connections::type::nonconforming, InterfaceTag,

--- a/core/specfem/assembly/nonconforming_interfaces/dim2/nonconforming_interfaces.cpp
+++ b/core/specfem/assembly/nonconforming_interfaces/dim2/nonconforming_interfaces.cpp
@@ -14,15 +14,18 @@ specfem::assembly::nonconforming_interfaces<
             specfem::element::dimension_tag::dim2> &element_intersections,
         const specfem::assembly::mesh<dimension_tag> &mesh) {
 
-  FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM2), CONNECTION_TAG(NONCONFORMING),
-                       INTERFACE_TAG(ELASTIC_ACOUSTIC, ACOUSTIC_ELASTIC),
-                       BOUNDARY_TAG(NONE, STACEY, ACOUSTIC_FREE_SURFACE,
-                                    COMPOSITE_STACEY_DIRICHLET)),
-                      CAPTURE(interface_container) {
-                        _interface_container_ = InterfaceContainerType<
-                            _interface_tag_, _boundary_tag_, _connection_tag_>(
-                            ngllz, ngllx, element_intersections, mesh);
-                      })
+  FOR_EACH_IN_PRODUCT(
+      (DIMENSION_TAG(DIM2), CONNECTION_TAG(NONCONFORMING),
+       INTERFACE_TAG(ELASTIC_ACOUSTIC, ACOUSTIC_ELASTIC),
+       BOUNDARY_TAG(NONE, STACEY, ACOUSTIC_FREE_SURFACE,
+                    COMPOSITE_STACEY_DIRICHLET),
+       FLUX_SCHEME_TAG(NATURAL)),
+      CAPTURE(interface_container) {
+        _interface_container_ =
+            InterfaceContainerType<_interface_tag_, _boundary_tag_,
+                                   _connection_tag_, _flux_scheme_tag_>(
+                ngllz, ngllx, element_intersections, mesh);
+      })
 
   return;
 }

--- a/core/specfem/assembly/nonconforming_interfaces/dim2/nonconforming_interfaces.hpp
+++ b/core/specfem/assembly/nonconforming_interfaces/dim2/nonconforming_interfaces.hpp
@@ -4,8 +4,10 @@
 #include "specfem/assembly/element_intersections.hpp"
 #include "specfem/assembly/mesh.hpp"
 #include "specfem/data_access.hpp"
+#include "specfem/element_coupling/tags.hpp"
 #include "specfem/enums.hpp"
 #include "specfem/macros.hpp"
+#include "specfem/macros/interface_iterators.hpp"
 #include <Kokkos_Core.hpp>
 #include <type_traits>
 
@@ -23,18 +25,21 @@ public:
 protected:
   template <specfem::element_coupling::interface_tag InterfaceTag,
             specfem::element::boundary_tag BoundaryTag,
-            specfem::element_connections::type ConnectionTag>
+            specfem::element_connections::type ConnectionTag,
+            specfem::element_coupling::flux_scheme_tag FluxSchemeTag>
   using InterfaceContainerType =
       specfem::assembly::nonconforming_interfaces_impl::interface_container<
-          dimension_tag, InterfaceTag, BoundaryTag, ConnectionTag>;
+          dimension_tag, InterfaceTag, BoundaryTag, ConnectionTag,
+          FluxSchemeTag>;
 
   FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM2), CONNECTION_TAG(NONCONFORMING),
                        INTERFACE_TAG(ELASTIC_ACOUSTIC, ACOUSTIC_ELASTIC),
                        BOUNDARY_TAG(NONE, ACOUSTIC_FREE_SURFACE, STACEY,
-                                    COMPOSITE_STACEY_DIRICHLET)),
+                                    COMPOSITE_STACEY_DIRICHLET),
+                       FLUX_SCHEME_TAG(NATURAL)),
                       DECLARE(((InterfaceContainerType,
                                 (_INTERFACE_TAG_, _BOUNDARY_TAG_,
-                                 _CONNECTION_TAG_)),
+                                 _CONNECTION_TAG_, _FLUX_SCHEME_TAG_)),
                                interface_container)))
 
 public:
@@ -48,19 +53,23 @@ public:
 
   template <specfem::element_coupling::interface_tag InterfaceTag,
             specfem::element::boundary_tag BoundaryTag,
-            specfem::element_connections::type ConnectionTag>
+            specfem::element_connections::type ConnectionTag,
+            specfem::element_coupling::flux_scheme_tag FluxSchemeTag>
   KOKKOS_INLINE_FUNCTION const
-      InterfaceContainerType<InterfaceTag, BoundaryTag, ConnectionTag> &
+      InterfaceContainerType<InterfaceTag, BoundaryTag, ConnectionTag,
+                             FluxSchemeTag> &
       get_interface_container() const {
     // Compile-time dispatch using FOR_EACH_IN_PRODUCT macro
     FOR_EACH_IN_PRODUCT((DIMENSION_TAG(DIM2), CONNECTION_TAG(NONCONFORMING),
                          INTERFACE_TAG(ELASTIC_ACOUSTIC, ACOUSTIC_ELASTIC),
                          BOUNDARY_TAG(NONE, ACOUSTIC_FREE_SURFACE, STACEY,
-                                      COMPOSITE_STACEY_DIRICHLET)),
+                                      COMPOSITE_STACEY_DIRICHLET),
+                         FLUX_SCHEME_TAG(NATURAL)),
                         CAPTURE((interface_container, interface_container)) {
                           if constexpr (InterfaceTag == _interface_tag_ &&
                                         BoundaryTag == _boundary_tag_ &&
-                                        ConnectionTag == _connection_tag_) {
+                                        ConnectionTag == _connection_tag_ &&
+                                        FluxSchemeTag == _flux_scheme_tag_) {
                             return _interface_container_;
                           }
                         })

--- a/core/specfem/chunk_edge/nonconforming_interface.hpp
+++ b/core/specfem/chunk_edge/nonconforming_interface.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "specfem/element_coupling/tags.hpp"
 namespace specfem::chunk_edge {
 
 namespace impl {
@@ -26,6 +27,7 @@ template <specfem::element::dimension_tag DimensionTag, int NumberElements,
           specfem::data_access::DataClassType DataClass,
           specfem::element_coupling::interface_tag InterfaceTag,
           specfem::element::boundary_tag BoundaryTag,
+          specfem::element_coupling::flux_scheme_tag FluxSchemeTag,
           typename MemorySpace =
               Kokkos::DefaultExecutionSpace::scratch_memory_space,
           typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged> >
@@ -41,11 +43,13 @@ struct transfer_function;
 template <int NumberElements, int NQuadIntersection, int NQuadElement,
           specfem::data_access::DataClassType DataClass,
           specfem::element_coupling::interface_tag InterfaceTag,
-          specfem::element::boundary_tag BoundaryTag, typename MemorySpace,
-          typename MemoryTraits>
+          specfem::element::boundary_tag BoundaryTag,
+          specfem::element_coupling::flux_scheme_tag FluxSchemeTag,
+          typename MemorySpace, typename MemoryTraits>
 struct transfer_function<specfem::element::dimension_tag::dim2, NumberElements,
                          NQuadIntersection, NQuadElement, DataClass,
-                         InterfaceTag, BoundaryTag, MemorySpace, MemoryTraits>
+                         InterfaceTag, BoundaryTag, FluxSchemeTag, MemorySpace,
+                         MemoryTraits>
     : public specfem::data_access::Accessor<
           specfem::datatype::AccessorType::chunk_edge, DataClass,
           specfem::element::dimension_tag::dim2, false> {
@@ -63,6 +67,8 @@ public:
   static constexpr auto interface_tag = InterfaceTag;
   /// Boundary condition tag
   static constexpr auto boundary_tag = BoundaryTag;
+  /// Flux scheme tag
+  static constexpr auto flux_scheme_tag = FluxSchemeTag;
   /// Connection type for nonconforming interfaces
   static constexpr auto connection_tag =
       specfem::element_connections::type::nonconforming;
@@ -138,12 +144,13 @@ public:
  */
 template <specfem::element::dimension_tag DimensionTag,
           specfem::element_coupling::interface_tag InterfaceTag,
-          specfem::element::boundary_tag BoundaryTag, int NumberElements,
-          int NQuadIntersection, int NQuadElement>
+          specfem::element::boundary_tag BoundaryTag,
+          specfem::element_coupling::flux_scheme_tag FluxSchemeTag,
+          int NumberElements, int NQuadIntersection, int NQuadElement>
 using transfer_function_self = impl::transfer_function<
     DimensionTag, NumberElements, NQuadIntersection, NQuadElement,
     specfem::data_access::DataClassType::transfer_function_self, InterfaceTag,
-    BoundaryTag>;
+    BoundaryTag, FluxSchemeTag>;
 
 /**
  * @brief Type alias for coupled transfer function
@@ -160,12 +167,13 @@ using transfer_function_self = impl::transfer_function<
  */
 template <specfem::element::dimension_tag DimensionTag,
           specfem::element_coupling::interface_tag InterfaceTag,
-          specfem::element::boundary_tag BoundaryTag, int NumberElements,
-          int NQuadIntersection, int NQuadElement>
+          specfem::element::boundary_tag BoundaryTag,
+          specfem::element_coupling::flux_scheme_tag FluxSchemeTag,
+          int NumberElements, int NQuadIntersection, int NQuadElement>
 using transfer_function_coupled = impl::transfer_function<
     DimensionTag, NumberElements, NQuadIntersection, NQuadElement,
     specfem::data_access::DataClassType::transfer_function_coupled,
-    InterfaceTag, BoundaryTag>;
+    InterfaceTag, BoundaryTag, FluxSchemeTag>;
 
 /**
  * @brief Template accessor for intersection scaling factors
@@ -183,8 +191,9 @@ using transfer_function_coupled = impl::transfer_function<
  */
 template <specfem::element::dimension_tag DimensionTag,
           specfem::element_coupling::interface_tag InterfaceTag,
-          specfem::element::boundary_tag BoundaryTag, int NumberElements,
-          int NQuadIntersection,
+          specfem::element::boundary_tag BoundaryTag,
+          specfem::element_coupling::flux_scheme_tag FluxSchemeTag,
+          int NumberElements, int NQuadIntersection,
           typename MemorySpace =
               Kokkos::DefaultExecutionSpace::scratch_memory_space,
           typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged> >
@@ -196,11 +205,13 @@ struct intersection_factor;
  * Stores geometric scaling factors for intersection quadrature points.
  */
 template <specfem::element_coupling::interface_tag InterfaceTag,
-          specfem::element::boundary_tag BoundaryTag, int NumberElements,
-          int NQuadIntersection, typename MemorySpace, typename MemoryTraits>
+          specfem::element::boundary_tag BoundaryTag,
+          specfem::element_coupling::flux_scheme_tag FluxSchemeTag,
+          int NumberElements, int NQuadIntersection, typename MemorySpace,
+          typename MemoryTraits>
 struct intersection_factor<specfem::element::dimension_tag::dim2, InterfaceTag,
-                           BoundaryTag, NumberElements, NQuadIntersection,
-                           MemorySpace, MemoryTraits>
+                           BoundaryTag, FluxSchemeTag, NumberElements,
+                           NQuadIntersection, MemorySpace, MemoryTraits>
     : public specfem::data_access::Accessor<
           specfem::datatype::AccessorType::chunk_edge,
           specfem::data_access::DataClassType::intersection_factor,
@@ -213,6 +224,8 @@ public:
   static constexpr auto interface_tag = InterfaceTag;
   /// Boundary condition tag
   static constexpr auto boundary_tag = BoundaryTag;
+  /// Flux scheme tag
+  static constexpr auto flux_scheme_tag = FluxSchemeTag;
   /// Connection type for nonconforming interfaces
   static constexpr auto connection_tag =
       specfem::element_connections::type::nonconforming;
@@ -295,8 +308,9 @@ public:
  */
 template <specfem::element::dimension_tag DimensionTag,
           specfem::element_coupling::interface_tag InterfaceTag,
-          specfem::element::boundary_tag BoundaryTag, int NumberElements,
-          int NQuadIntersection,
+          specfem::element::boundary_tag BoundaryTag,
+          specfem::element_coupling::flux_scheme_tag FluxSchemeTag,
+          int NumberElements, int NQuadIntersection,
           typename MemorySpace =
               Kokkos::DefaultExecutionSpace::scratch_memory_space,
           typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged> >
@@ -308,11 +322,13 @@ struct intersection_normal;
  * Stores 2D unit normal vectors at intersection quadrature points.
  */
 template <specfem::element_coupling::interface_tag InterfaceTag,
-          specfem::element::boundary_tag BoundaryTag, int NumberElements,
-          int NQuadIntersection, typename MemorySpace, typename MemoryTraits>
+          specfem::element::boundary_tag BoundaryTag,
+          specfem::element_coupling::flux_scheme_tag FluxSchemeTag,
+          int NumberElements, int NQuadIntersection, typename MemorySpace,
+          typename MemoryTraits>
 struct intersection_normal<specfem::element::dimension_tag::dim2, InterfaceTag,
-                           BoundaryTag, NumberElements, NQuadIntersection,
-                           MemorySpace, MemoryTraits>
+                           BoundaryTag, FluxSchemeTag, NumberElements,
+                           NQuadIntersection, MemorySpace, MemoryTraits>
     : public specfem::data_access::Accessor<
           specfem::datatype::AccessorType::chunk_edge,
           specfem::data_access::DataClassType::intersection_normal,
@@ -325,6 +341,8 @@ public:
   static constexpr auto interface_tag = InterfaceTag;
   /// Boundary condition tag
   static constexpr auto boundary_tag = BoundaryTag;
+  /// Flux scheme tag
+  static constexpr auto flux_scheme_tag = FluxSchemeTag;
   /// Connection type for nonconforming interfaces
   static constexpr auto connection_tag =
       specfem::element_connections::type::nonconforming;
@@ -418,6 +436,9 @@ struct NonconformingAccessorPack
   /// Boundary condition tag inherited from first accessor
   constexpr static auto boundary_tag =
       std::tuple_element_t<0, std::tuple<Accessors...> >::boundary_tag;
+  /// Flux scheme tag inherited from first accessor
+  constexpr static auto flux_scheme_tag =
+      std::tuple_element_t<0, std::tuple<Accessors...> >::flux_scheme_tag;
   /// Number of packed accessor types
   constexpr static size_t n_accessors = sizeof...(Accessors);
   /// Tuple type containing all packed accessors
@@ -457,6 +478,16 @@ struct NonconformingAccessorPack
        ...),
       "All Accessors in NonconformingAccessorPack must have the same "
       "boundary_tag");
+
+  static_assert(
+      (std::is_same_v<
+           std::integral_constant<specfem::element_coupling::flux_scheme_tag,
+                                  Accessors::flux_scheme_tag>,
+           std::integral_constant<specfem::element_coupling::flux_scheme_tag,
+                                  flux_scheme_tag> > &&
+       ...),
+      "All Accessors in NonconformingAccessorPack must have the same "
+      "flux_scheme_tag");
 
   /**
    * @brief Default constructor
@@ -504,13 +535,15 @@ struct NonconformingAccessorPack
  */
 template <specfem::element::dimension_tag DimensionTag,
           specfem::element_coupling::interface_tag InterfaceTag,
-          specfem::element::boundary_tag BoundaryTag, int NumberElements,
-          int NQuadIntersection, int NQuadElement>
+          specfem::element::boundary_tag BoundaryTag,
+          specfem::element_coupling::flux_scheme_tag FluxSchemeTag,
+          int NumberElements, int NQuadIntersection, int NQuadElement>
 using coupling_terms_pack = NonconformingAccessorPack<
     transfer_function_coupled<DimensionTag, InterfaceTag, BoundaryTag,
-                              NumberElements, NQuadIntersection, NQuadElement>,
-    intersection_normal<DimensionTag, InterfaceTag, BoundaryTag, NumberElements,
-                        NQuadIntersection> >;
+                              FluxSchemeTag, NumberElements, NQuadIntersection,
+                              NQuadElement>,
+    intersection_normal<DimensionTag, InterfaceTag, BoundaryTag, FluxSchemeTag,
+                        NumberElements, NQuadIntersection> >;
 
 /**
  * @brief Type alias for integral data accessor pack
@@ -520,10 +553,11 @@ using coupling_terms_pack = NonconformingAccessorPack<
  */
 template <specfem::element::dimension_tag DimensionTag,
           specfem::element_coupling::interface_tag InterfaceTag,
-          specfem::element::boundary_tag BoundaryTag, int NumberElements,
-          int NQuadIntersection>
+          specfem::element::boundary_tag BoundaryTag,
+          specfem::element_coupling::flux_scheme_tag FluxSchemeTag,
+          int NumberElements, int NQuadIntersection>
 using integral_data_pack = NonconformingAccessorPack<
-    intersection_factor<DimensionTag, InterfaceTag, BoundaryTag, NumberElements,
-                        NQuadIntersection> >;
+    intersection_factor<DimensionTag, InterfaceTag, BoundaryTag, FluxSchemeTag,
+                        NumberElements, NQuadIntersection> >;
 
 } // namespace specfem::chunk_edge

--- a/core/specfem/compute/impl/compute_coupling.tpp
+++ b/core/specfem/compute/impl/compute_coupling.tpp
@@ -2,7 +2,6 @@
 
 #include "compute_coupling.hpp"
 #include "specfem/algorithms.hpp"
-#include "specfem/tags.hpp"
 #include "specfem/assembly/assembly.hpp"
 #include "specfem/boundary_conditions.hpp"
 #include "specfem/chunk_edge.hpp"
@@ -14,6 +13,7 @@
 #include "specfem/parallel_configuration.hpp"
 #include "specfem/point.hpp"
 #include "specfem/point/interface_index.hpp"
+#include "specfem/tags.hpp"
 #include <Kokkos_Core.hpp>
 #include <type_traits>
 
@@ -162,11 +162,11 @@ void compute_coupling_core_nonconforming(
                                         using_simd> >;
 
   using CouplingTermsPack = specfem::chunk_edge::coupling_terms_pack<
-      dimension_tag, interface_tag, boundary_tag, parallel_config::chunk_size,
-      NGLL, NQuad_intersection>;
+      dimension_tag, interface_tag, boundary_tag, flux_scheme_tag,
+      parallel_config::chunk_size, NGLL, NQuad_intersection>;
   using IntegrationFactor = specfem::chunk_edge::intersection_factor<
-      dimension_tag, interface_tag, boundary_tag, parallel_config::chunk_size,
-      NQuad_intersection>;
+      dimension_tag, interface_tag, boundary_tag, flux_scheme_tag,
+      parallel_config::chunk_size, NQuad_intersection>;
 
   using InterfaceFieldViewType = specfem::datatype::VectorChunkEdgeViewType<
       type_real, dimension_tag, parallel_config::chunk_size, NQuad_intersection,
@@ -217,7 +217,8 @@ void compute_coupling_core_nonconforming(
         team.team_barrier();
 
         specfem::algorithms::coupling_integral(
-            assembly.nonconforming_interfaces, self_chunk_index, interface_field, integration_factor,
+            assembly.nonconforming_interfaces, self_chunk_index,
+            interface_field, integration_factor,
             [&](const auto &self_index, auto &self_field) {
               specfem::point::boundary<boundary_tag, dimension_tag, false>
                   point_boundary;
@@ -243,9 +244,11 @@ void compute_coupling_core(
   constexpr auto connection_tag = Tags::connection_tag;
   if constexpr (connection_tag ==
                 specfem::element_connections::type::nonconforming) {
-    compute_coupling_core_nonconforming<NGLL, NQuad_intersection, Tags>(assembly);
+    compute_coupling_core_nonconforming<NGLL, NQuad_intersection, Tags>(
+        assembly);
   } else {
-    compute_coupling_core_weakly_conforming<NGLL, NQuad_intersection, Tags>(assembly);
+    compute_coupling_core_weakly_conforming<NGLL, NQuad_intersection, Tags>(
+        assembly);
   }
 }
 
@@ -268,11 +271,12 @@ void compute_coupling(
             _dimension_tag_, _interface_tag_>::self_medium();
         if constexpr (DimensionTag == _dimension_tag_ &&
                       self_medium == MediumTag) {
-          compute_coupling_core<NGLL, NGLL,
-                        specfem::tags::Tags<_dimension_tag_, _connection_tag_,
-                                            WavefieldType, _interface_tag_,
-                                            _boundary_tag_,
-                                            _flux_scheme_tag_> >(assembly);
+          compute_coupling_core<
+              NGLL, NGLL,
+              specfem::tags::Tags<_dimension_tag_, _connection_tag_,
+                                  WavefieldType, _interface_tag_,
+                                  _boundary_tag_, _flux_scheme_tag_> >(
+              assembly);
           // second ngll is the number of quadrature points on the mortar.
         }
       })

--- a/core/specfem/point/nonconforming_interface.hpp
+++ b/core/specfem/point/nonconforming_interface.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "specfem/data_access.hpp"
+#include "specfem/element_coupling/tags.hpp"
 
 namespace specfem::point {
 
@@ -19,7 +20,8 @@ namespace impl {
 template <int NQuadIntersection, specfem::element::dimension_tag DimensionTag,
           specfem::data_access::DataClassType DataClass,
           specfem::element_coupling::interface_tag InterfaceTag,
-          specfem::element::boundary_tag BoundaryTag>
+          specfem::element::boundary_tag BoundaryTag,
+          specfem::element_coupling::flux_scheme_tag FluxSchemeTag>
 struct nonconforming_transfer_function
     : public specfem::data_access::Accessor<
           specfem::datatype::AccessorType::point, DataClass, DimensionTag,
@@ -45,6 +47,11 @@ public:
    */
   static constexpr auto connection_tag =
       specfem::element_connections::type::nonconforming;
+
+  /**
+   * @brief Flux scheme tag.
+   */
+  static constexpr auto flux_scheme_tag = FluxSchemeTag;
 
   /**
    * @brief View type for the transfer function values.
@@ -105,22 +112,24 @@ public:
  */
 template <int NQuadIntersection, specfem::element::dimension_tag DimensionTag,
           specfem::element_coupling::interface_tag InterfaceTag,
-          specfem::element::boundary_tag BoundaryTag>
+          specfem::element::boundary_tag BoundaryTag,
+          specfem::element_coupling::flux_scheme_tag FluxSchemeTag>
 using transfer_function_self = impl::nonconforming_transfer_function<
     NQuadIntersection, DimensionTag,
     specfem::data_access::DataClassType::transfer_function_self, InterfaceTag,
-    BoundaryTag>;
+    BoundaryTag, FluxSchemeTag>;
 
 /**
  * @brief Type alias for coupled-side transfer function.
  */
 template <int NQuadIntersection, specfem::element::dimension_tag DimensionTag,
           specfem::element_coupling::interface_tag InterfaceTag,
-          specfem::element::boundary_tag BoundaryTag>
+          specfem::element::boundary_tag BoundaryTag,
+          specfem::element_coupling::flux_scheme_tag FluxSchemeTag>
 using transfer_function_coupled = impl::nonconforming_transfer_function<
     NQuadIntersection, DimensionTag,
     specfem::data_access::DataClassType::transfer_function_coupled,
-    InterfaceTag, BoundaryTag>;
+    InterfaceTag, BoundaryTag, FluxSchemeTag>;
 
 /**
  * @struct NonconformingAccessorPack
@@ -178,6 +187,12 @@ public:
       specfem::element_connections::type::nonconforming;
 
   /**
+   * @brief Flux scheme tag derived from the first accessor.
+   */
+  constexpr static auto flux_scheme_tag =
+      std::tuple_element_t<0, std::tuple<Accessors...> >::flux_scheme_tag;
+
+  /**
    * @brief Dimension tag.
    */
   constexpr static auto dimension_tag = accessor_base::dimension_tag;
@@ -225,6 +240,15 @@ public:
       "All Accessors in NonconformingAccessorPack must have the same "
       "boundary_tag");
 
+  static_assert(
+      (std::is_same_v<
+           std::integral_constant<specfem::element_coupling::flux_scheme_tag,
+                                  Accessors::flux_scheme_tag>,
+           std::integral_constant<specfem::element_coupling::flux_scheme_tag,
+                                  flux_scheme_tag> > &&
+       ...),
+      "All Accessors in NonconformingAccessorPack must have the same "
+      "flux_scheme_tag");
   /**
    * @brief Default constructor.
    */
@@ -253,9 +277,10 @@ public:
  */
 template <int NQuadIntersection, specfem::element::dimension_tag DimensionTag,
           specfem::element_coupling::interface_tag InterfaceTag,
-          specfem::element::boundary_tag BoundaryTag>
-using transfer_function_pack =
-    NonconformingAccessorPack<transfer_function_coupled<
-        NQuadIntersection, DimensionTag, InterfaceTag, BoundaryTag> >;
+          specfem::element::boundary_tag BoundaryTag,
+          specfem::element_coupling::flux_scheme_tag FluxSchemeTag>
+using transfer_function_pack = NonconformingAccessorPack<
+    transfer_function_coupled<NQuadIntersection, DimensionTag, InterfaceTag,
+                              BoundaryTag, FluxSchemeTag> >;
 
 } // namespace specfem::point

--- a/tests/unit-tests/algorithms/dim2/coupling_integral/dshape.cpp
+++ b/tests/unit-tests/algorithms/dim2/coupling_integral/dshape.cpp
@@ -19,6 +19,8 @@ void execute_simple_dshape_test() {
   constexpr auto interface_tag =
       specfem::element_coupling::interface_tag::acoustic_elastic;
   constexpr auto boundary_tag = specfem::element::boundary_tag::none;
+  constexpr auto flux_scheme_tag =
+      specfem::element_coupling::flux_scheme_tag::natural;
   using memory_space = Kokkos::DefaultExecutionSpace::memory_space;
 
   // ==========================================================
@@ -60,7 +62,8 @@ void execute_simple_dshape_test() {
   // we will probably fixturize this at some point to make it not so bloated
   using IntersectionFactor =
       specfem::test_fixture::impl::NonconformingIntersectionFactorPatch<
-          interface_tag, boundary_tag, num_edges, QuadIntersection::nquad>;
+          interface_tag, boundary_tag, flux_scheme_tag, num_edges,
+          QuadIntersection::nquad>;
   auto intersection_factor = IntersectionFactor("dshape::intersection_factor");
 
   {
@@ -121,12 +124,13 @@ void execute_simple_dshape_test() {
       nonconforming_interfaces(ngllz, ngllx, nquad_intersection);
   nonconforming_interfaces.template reinit_container<
       interface_tag, boundary_tag,
-      specfem::element_connections::type::nonconforming>(num_edges);
+      specfem::element_connections::type::nonconforming, flux_scheme_tag>(
+      num_edges);
 
   const auto &interface_container =
       nonconforming_interfaces.template get_interface_container<
           interface_tag, boundary_tag,
-          specfem::element_connections::type::nonconforming>();
+          specfem::element_connections::type::nonconforming, flux_scheme_tag>();
 
   // =================================================================
   // populate this nonconforming interface container and
@@ -263,9 +267,10 @@ void execute_simple_dshape_test() {
   }
   const auto shape_function_normal_derivatives =
       specfem::algorithms::shape_function_self_normal_derivatives<
-          interface_tag, boundary_tag, nquad_element_, nquad_intersection_>(
-          edgelist, nonconforming_interfaces, ngllz, ngllx,
-          lagrange_derivative.xi, intersection_contra_normal);
+          interface_tag, boundary_tag, flux_scheme_tag, nquad_element_,
+          nquad_intersection_>(edgelist, nonconforming_interfaces, ngllz, ngllx,
+                               lagrange_derivative.xi,
+                               intersection_contra_normal);
 
   using default_parallel_config =
       specfem::parallel_configuration::default_chunk_edge_config<

--- a/tests/unit-tests/algorithms/dim2/coupling_integral/timesshape.cpp
+++ b/tests/unit-tests/algorithms/dim2/coupling_integral/timesshape.cpp
@@ -19,6 +19,8 @@ void execute_simple_timesshape_test() {
   constexpr auto interface_tag =
       specfem::element_coupling::interface_tag::acoustic_elastic;
   constexpr auto boundary_tag = specfem::element::boundary_tag::none;
+  constexpr auto flux_scheme_tag =
+      specfem::element_coupling::flux_scheme_tag::natural;
   using memory_space = Kokkos::DefaultExecutionSpace::memory_space;
 
   // ==========================================================
@@ -60,7 +62,8 @@ void execute_simple_timesshape_test() {
   // we will probably fixturize this at some point to make it not so bloated
   using IntersectionFactor =
       specfem::test_fixture::impl::NonconformingIntersectionFactorPatch<
-          interface_tag, boundary_tag, num_edges, QuadIntersection::nquad>;
+          interface_tag, boundary_tag, flux_scheme_tag, num_edges,
+          QuadIntersection::nquad>;
   auto intersection_factor = IntersectionFactor("dshape::intersection_factor");
 
   {
@@ -109,12 +112,13 @@ void execute_simple_timesshape_test() {
       nonconforming_interfaces(ngllz, ngllx, nquad_intersection);
   nonconforming_interfaces.template reinit_container<
       interface_tag, boundary_tag,
-      specfem::element_connections::type::nonconforming>(num_edges);
+      specfem::element_connections::type::nonconforming, flux_scheme_tag>(
+      num_edges);
 
   const auto &interface_container =
       nonconforming_interfaces.template get_interface_container<
           interface_tag, boundary_tag,
-          specfem::element_connections::type::nonconforming>();
+          specfem::element_connections::type::nonconforming, flux_scheme_tag>();
 
   // =================================================================
   // populate this nonconforming interface container and

--- a/tests/unit-tests/algorithms/dim2/transfer.cpp
+++ b/tests/unit-tests/algorithms/dim2/transfer.cpp
@@ -64,6 +64,9 @@ constexpr static auto interface_tag =
     specfem::element_coupling::interface_tag::acoustic_elastic;
 /** Boundary type (dummy for testing) */
 constexpr static auto boundary_tag = specfem::element::boundary_tag::none;
+/** Flux scheme tag (dummy for testing) */
+constexpr static auto flux_scheme_tag =
+    specfem::element_coupling::flux_scheme_tag::natural;
 
 template <typename T, typename = void>
 struct is_analytical2d : std::false_type {};
@@ -193,8 +196,8 @@ void execute(const TransferFunction2D &transfer_function,
       dimension_tag, 1, TransferFunction2D::nquad_intersection,
       TransferFunction2D::nquad_edge,
       specfem::data_access::DataClassType::transfer_function_self,
-      interface_tag, boundary_tag, typename TransferFunction2D::memory_space,
-      Kokkos::MemoryTraits<> >;
+      interface_tag, boundary_tag, flux_scheme_tag,
+      typename TransferFunction2D::memory_space, Kokkos::MemoryTraits<> >;
   using FunctionType = specfem::datatype::VectorChunkEdgeViewType<
       type_real, dimension_tag, 1, TransferFunction2D::nquad_edge,
       EdgeFunction2D::num_components, false,

--- a/tests/unit-tests/assembly/nonconforming_interfaces/container_init_test.cpp
+++ b/tests/unit-tests/assembly/nonconforming_interfaces/container_init_test.cpp
@@ -170,13 +170,15 @@ void test_nonconforming_container_transfers(
       assembly.nonconforming_interfaces.get_interface_container<
           specfem::element_coupling::interface_tag::acoustic_elastic,
           specfem::element::boundary_tag::none,
-          specfem::element_connections::type::nonconforming>();
+          specfem::element_connections::type::nonconforming,
+          specfem::element_coupling::flux_scheme_tag::natural>();
 
   const auto &nc_interface_elastic_acoustic =
       assembly.nonconforming_interfaces.get_interface_container<
           specfem::element_coupling::interface_tag::elastic_acoustic,
           specfem::element::boundary_tag::none,
-          specfem::element_connections::type::nonconforming>();
+          specfem::element_connections::type::nonconforming,
+          specfem::element_coupling::flux_scheme_tag::natural>();
 
   const auto [acoustic_edges, elastic_edges] =
       assembly.element_intersections.get_intersections_on_host(

--- a/tests/unit-tests/compute_coupling/nonconforming/nonconforming.hpp
+++ b/tests/unit-tests/compute_coupling/nonconforming/nonconforming.hpp
@@ -80,6 +80,8 @@ execute_impl_compute_coupling(const TransferFunction2D &transfer_function,
   constexpr int num_edges = EdgeFunction2D::num_edges;
   constexpr auto dimension_tag = specfem::element::dimension_tag::dim2;
   constexpr auto boundary_tag = specfem::element::boundary_tag::none;
+  constexpr auto flux_scheme_tag =
+      specfem::element_coupling::flux_scheme_tag::natural;
 
   constexpr specfem::element::medium_tag self_medium =
       specfem::element_coupling::attributes<dimension_tag,
@@ -91,10 +93,10 @@ execute_impl_compute_coupling(const TransferFunction2D &transfer_function,
       dimension_tag, 1, TransferFunction2D::nquad_intersection,
       TransferFunction2D::nquad_edge,
       specfem::data_access::DataClassType::transfer_function_self,
-      interface_tag, boundary_tag, typename TransferFunction2D::memory_space,
-      Kokkos::MemoryTraits<> >;
+      interface_tag, boundary_tag, flux_scheme_tag,
+      typename TransferFunction2D::memory_space, Kokkos::MemoryTraits<> >;
   using IntersectionNormalType = specfem::chunk_edge::intersection_normal<
-      dimension_tag, interface_tag, boundary_tag, 1,
+      dimension_tag, interface_tag, boundary_tag, flux_scheme_tag, 1,
       TransferFunction2D::nquad_intersection,
       typename TransferFunction2D::memory_space, Kokkos::MemoryTraits<> >;
 

--- a/tests/unit-tests/utilities/include/builder/nonconforming_interfaces.hpp
+++ b/tests/unit-tests/utilities/include/builder/nonconforming_interfaces.hpp
@@ -31,21 +31,24 @@ public:
 
   template <specfem::element_coupling::interface_tag InterfaceTag,
             specfem::element::boundary_tag BoundaryTag,
-            specfem::element_connections::type ConnectionTag>
+            specfem::element_connections::type ConnectionTag,
+            specfem::element_coupling::flux_scheme_tag FluxSchemeTag>
   void reinit_container(const int &num_edges) {
 
     FOR_EACH_IN_PRODUCT(
         (DIMENSION_TAG(DIM2), CONNECTION_TAG(NONCONFORMING),
          INTERFACE_TAG(ELASTIC_ACOUSTIC, ACOUSTIC_ELASTIC),
          BOUNDARY_TAG(NONE, STACEY, ACOUSTIC_FREE_SURFACE,
-                      COMPOSITE_STACEY_DIRICHLET)),
+                      COMPOSITE_STACEY_DIRICHLET),
+         FLUX_SCHEME_TAG(NATURAL)),
         CAPTURE(interface_container) {
           if constexpr (_interface_tag_ == InterfaceTag &&
                         _boundary_tag_ == BoundaryTag &&
-                        _connection_tag_ == ConnectionTag) {
+                        _connection_tag_ == ConnectionTag &&
+                        _flux_scheme_tag_ == FluxSchemeTag) {
             _interface_container_ =
                 InterfaceContainerType<_interface_tag_, _boundary_tag_,
-                                       _connection_tag_>(
+                                       _connection_tag_, _flux_scheme_tag_>(
                     ngllz, ngllx, nquad_intersection, num_edges);
           }
         })

--- a/tests/unit-tests/utilities/include/fixture/impl/accessors.hpp
+++ b/tests/unit-tests/utilities/include/fixture/impl/accessors.hpp
@@ -11,11 +11,13 @@ namespace specfem::test_fixture::impl {
  *
  * @tparam InterfaceTag
  * @tparam BoundaryTag
+ * @tparam FluxSchemeTag
  * @tparam DataClassType
  * @tparam Axes The size of the view along each axis.
  */
 template <specfem::element_coupling::interface_tag InterfaceTag,
           specfem::element::boundary_tag BoundaryTag,
+          specfem::element_coupling::flux_scheme_tag FluxSchemeTag,
           specfem::data_access::DataClassType DataClassType, int... Axes>
 struct NonconformingAccessorPatch2D
     : specfem::data_access::Accessor<
@@ -27,6 +29,7 @@ public:
   static constexpr auto boundary_tag = BoundaryTag;
   static constexpr auto connection_tag =
       specfem::element_connections::type::nonconforming;
+  static constexpr auto flux_scheme_tag = FluxSchemeTag;
   /// View type for storing intersection scaling factors
 private:
   // ======================================================================================
@@ -90,15 +93,16 @@ public:
 };
 
 template <specfem::element_coupling::interface_tag InterfaceTag,
-          specfem::element::boundary_tag BoundaryTag, int NumberElements,
-          int NQuadElement, int NQuadIntersection>
+          specfem::element::boundary_tag BoundaryTag,
+          specfem::element_coupling::flux_scheme_tag FluxSchemeTag,
+          int NumberElements, int NQuadElement, int NQuadIntersection>
 struct NonconformingTransferFunctionSelfPatch
     : NonconformingAccessorPatch2D<
-          InterfaceTag, BoundaryTag,
+          InterfaceTag, BoundaryTag, FluxSchemeTag,
           specfem::data_access::DataClassType::transfer_function_self,
           NumberElements, NQuadElement, NQuadIntersection> {
   using NonconformingAccessorPatch2D<
-      InterfaceTag, BoundaryTag,
+      InterfaceTag, BoundaryTag, FluxSchemeTag,
       specfem::data_access::DataClassType::transfer_function_self,
       NumberElements, NQuadElement,
       NQuadIntersection>::NonconformingAccessorPatch2D;
@@ -107,15 +111,16 @@ struct NonconformingTransferFunctionSelfPatch
   static constexpr int n_quad_intersection = NQuadIntersection;
 };
 template <specfem::element_coupling::interface_tag InterfaceTag,
-          specfem::element::boundary_tag BoundaryTag, int NumberElements,
-          int NQuadElement, int NQuadIntersection>
+          specfem::element::boundary_tag BoundaryTag,
+          specfem::element_coupling::flux_scheme_tag FluxSchemeTag,
+          int NumberElements, int NQuadElement, int NQuadIntersection>
 struct NonconformingTransferFunctionCoupledPatch
     : NonconformingAccessorPatch2D<
-          InterfaceTag, BoundaryTag,
+          InterfaceTag, BoundaryTag, FluxSchemeTag,
           specfem::data_access::DataClassType::transfer_function_coupled,
           NumberElements, NQuadElement, NQuadIntersection> {
   using NonconformingAccessorPatch2D<
-      InterfaceTag, BoundaryTag,
+      InterfaceTag, BoundaryTag, FluxSchemeTag,
       specfem::data_access::DataClassType::transfer_function_coupled,
       NumberElements, NQuadElement,
       NQuadIntersection>::NonconformingAccessorPatch2D;
@@ -124,30 +129,32 @@ struct NonconformingTransferFunctionCoupledPatch
   static constexpr int n_quad_intersection = NQuadIntersection;
 };
 template <specfem::element_coupling::interface_tag InterfaceTag,
-          specfem::element::boundary_tag BoundaryTag, int NumberElements,
-          int NQuadIntersection>
+          specfem::element::boundary_tag BoundaryTag,
+          specfem::element_coupling::flux_scheme_tag FluxSchemeTag,
+          int NumberElements, int NQuadIntersection>
 struct NonconformingIntersectionNormalPatch
     : NonconformingAccessorPatch2D<
-          InterfaceTag, BoundaryTag,
+          InterfaceTag, BoundaryTag, FluxSchemeTag,
           specfem::data_access::DataClassType::intersection_normal,
           NumberElements, NQuadIntersection, 2> {
   using NonconformingAccessorPatch2D<
-      InterfaceTag, BoundaryTag,
+      InterfaceTag, BoundaryTag, FluxSchemeTag,
       specfem::data_access::DataClassType::intersection_normal, NumberElements,
       NQuadIntersection, 2>::NonconformingAccessorPatch2D;
   static constexpr int chunk_size = NumberElements;
   static constexpr int n_quad_intersection = NQuadIntersection;
 };
 template <specfem::element_coupling::interface_tag InterfaceTag,
-          specfem::element::boundary_tag BoundaryTag, int NumberElements,
-          int NQuadIntersection>
+          specfem::element::boundary_tag BoundaryTag,
+          specfem::element_coupling::flux_scheme_tag FluxSchemeTag,
+          int NumberElements, int NQuadIntersection>
 struct NonconformingIntersectionFactorPatch
     : NonconformingAccessorPatch2D<
-          InterfaceTag, BoundaryTag,
+          InterfaceTag, BoundaryTag, FluxSchemeTag,
           specfem::data_access::DataClassType::intersection_factor,
           NumberElements, NQuadIntersection> {
   using NonconformingAccessorPatch2D<
-      InterfaceTag, BoundaryTag,
+      InterfaceTag, BoundaryTag, FluxSchemeTag,
       specfem::data_access::DataClassType::intersection_factor, NumberElements,
       NQuadIntersection>::NonconformingAccessorPatch2D;
   static constexpr int chunk_size = NumberElements;


### PR DESCRIPTION
## Description

Please describe the changes/features in this pull request.
- `flux_scheme_tag` template parameter added to `nonconforming_interfaces_impl::interface_container`
- `nonconforming_interfaces` now stores containers by `flux_scheme_tag`
- `flux_scheme_tag` added to accessor types for `load_on_<host/device> calls`

## Issue Number

If there is an issue created for these changes, link it here

#1659

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
