### PR TITLE
1702 - Add SPECFEM_MPI_SAFE_CALL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,9 +176,11 @@ endif()
 if (SPECFEM_ENABLE_DOUBLE_PRECISION)
     message(STATUS "Enabling double precision")
     set(TYPE_REAL "double")
+    set(MPI_TYPE_REAL "MPI_DOUBLE")
 else(SPECFEM_ENABLE_DOUBLE_PRECISION)
     message(STATUS "Enabling single precision")
     set(TYPE_REAL "float")
+    set(MPI_TYPE_REAL "MPI_FLOAT")
 endif(SPECFEM_ENABLE_DOUBLE_PRECISION)
 
 # Add the include directories so that the generated files can be found

--- a/core/specfem/io/mesh/impl/fortran/dim2/mesh.cpp
+++ b/core/specfem/io/mesh/impl/fortran/dim2/mesh.cpp
@@ -1,5 +1,6 @@
 // Internal Includes
 #include "specfem/mesh.hpp"
+#include "specfem/mpi.hpp"
 
 #include "specfem/enums.hpp"
 #include "specfem/io.hpp"
@@ -74,11 +75,17 @@ specfem::io::read_2d_mesh(
                                           Kokkos::DefaultHostExecutionSpace>(
       "specfem::mesh::knods", mesh.parameters.ngnod, mesh.nspec);
 
-  int nspec_all = specfem::MPI::reduce(mesh.parameters.nspec, specfem::sum);
-  int nelem_acforcing_all =
-      specfem::MPI::reduce(mesh.parameters.nelem_acforcing, specfem::sum);
-  int nelem_acoustic_surface_all = specfem::MPI::reduce(
-      mesh.parameters.nelem_acoustic_surface, specfem::sum);
+  int nspec_all = mesh.parameters.nspec;
+  SPECFEM_MPI_SAFECALL(MPI_Reduce(&mesh.parameters.nspec, &nspec_all, 1,
+                                  MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD));
+  int nelem_acforcing_all = mesh.parameters.nelem_acforcing;
+  SPECFEM_MPI_SAFECALL(MPI_Reduce(&mesh.parameters.nelem_acforcing,
+                                  &nelem_acforcing_all, 1, MPI_INT, MPI_SUM, 0,
+                                  MPI_COMM_WORLD));
+  int nelem_acoustic_surface_all = mesh.parameters.nelem_acoustic_surface;
+  SPECFEM_MPI_SAFECALL(MPI_Reduce(&mesh.parameters.nelem_acoustic_surface,
+                                  &nelem_acoustic_surface_all, 1, MPI_INT,
+                                  MPI_SUM, 0, MPI_COMM_WORLD));
 
   try {
     auto [n_sls, attenuation_f0_reference, read_velocities_at_f0] =

--- a/core/specfem/mpi/mpi.hpp
+++ b/core/specfem/mpi/mpi.hpp
@@ -14,15 +14,6 @@
 
 namespace specfem {
 
-#ifdef SPECFEM_ENABLE_MPI
-using reduce_type = MPI_Op;
-const static reduce_type sum = MPI_SUM;
-const static reduce_type min = MPI_MIN;
-const static reduce_type max = MPI_MAX;
-#else
-enum reduce_type { sum, min, max };
-#endif
-
 // Forward declaration
 namespace program {
 class Context;
@@ -130,6 +121,14 @@ public:
    * @return std::string Formatted filename with processor number
    * @throws Exits with error code 1 if called outside Context scope
    */
+  static bool check_context() {
+    if (rank_ == -1 || size_ == -1) {
+      std::cerr << "ERROR: MPI used outside Context scope" << std::endl;
+      std::exit(1);
+    }
+    return true;
+  }
+
   static std::string format_proc_filename(const std::string &filename) {
     check_context();
 
@@ -157,58 +156,6 @@ public:
     return result.string();
   }
 
-  /**
-   * @brief MPI reduce operation
-   *
-   * @param lvalue Local value to reduce
-   * @param reduce_op Reduction operation (specfem::sum, specfem::min,
-   * specfem::max)
-   * @return Reduced value (only valid on root process)
-   * @throws Exits with error code 1 if called outside Context scope
-   */
-  static int reduce(int lvalue, specfem::reduce_type reduce_op) {
-    check_context();
-    int result = lvalue;
-#ifdef SPECFEM_ENABLE_MPI
-    MPI_Reduce(&lvalue, &result, 1, MPI_INT, reduce_op, 0, MPI_COMM_WORLD);
-#endif
-    return result;
-  }
-
-  /**
-   * @brief MPI reduce operation for float
-   *
-   * @param lvalue Local value to reduce
-   * @param reduce_op Reduction operation
-   * @return Reduced value (only valid on root process)
-   * @throws Exits with error code 1 if called outside Context scope
-   */
-  static float reduce(float lvalue, specfem::reduce_type reduce_op) {
-    check_context();
-    float result = lvalue;
-#ifdef SPECFEM_ENABLE_MPI
-    MPI_Reduce(&lvalue, &result, 1, MPI_FLOAT, reduce_op, 0, MPI_COMM_WORLD);
-#endif
-    return result;
-  }
-
-  /**
-   * @brief MPI reduce operation for double
-   *
-   * @param lvalue Local value to reduce
-   * @param reduce_op Reduction operation
-   * @return Reduced value (only valid on root process)
-   * @throws Exits with error code 1 if called outside Context scope
-   */
-  static double reduce(double lvalue, specfem::reduce_type reduce_op) {
-    check_context();
-    double result = lvalue;
-#ifdef SPECFEM_ENABLE_MPI
-    MPI_Reduce(&lvalue, &result, 1, MPI_DOUBLE, reduce_op, 0, MPI_COMM_WORLD);
-#endif
-    return result;
-  }
-
 private:
   MPI() = default;
   ~MPI() = default;
@@ -234,23 +181,26 @@ private:
    */
   static void finalize();
 
-  /**
-   * @brief Check if MPI is initialized (Context exists)
-   *
-   * Verifies that rank and size are valid (not -1).
-   * Exits with error code 1 if check fails.
-   */
-  static bool check_context() {
-    if (rank_ == -1 || size_ == -1) {
-      std::cerr << "ERROR: MPI used outside Context scope" << std::endl;
-      std::exit(1);
-    }
-    return true;
-  }
-
   friend class specfem::program::Context;
   friend void specfem::program::abort(const std::string &, int, const int,
                                       const char *);
 };
 
 } // namespace specfem
+
+#ifndef SPECFEM_ENABLE_MPI
+#define SPECFEM_MPI_SAFECALL(call) ((void)0)
+#else
+#define SPECFEM_MPI_SAFECALL(call)                                             \
+  do {                                                                         \
+    specfem::MPI::check_context();                                             \
+    int e = call;                                                              \
+    if (e != MPI_SUCCESS) {                                                    \
+      char err[MPI_MAX_ERROR_STRING];                                          \
+      int len;                                                                 \
+      MPI_Error_string(e, err, &len);                                          \
+      fprintf(stderr, "MPI error %s:%d: %s\n", __FILE__, __LINE__, err);       \
+      MPI_Abort(MPI_COMM_WORLD, e);                                            \
+    }                                                                          \
+  } while (0)
+#endif

--- a/core/specfem/setup.hpp.in
+++ b/core/specfem/setup.hpp.in
@@ -3,6 +3,9 @@
 #include <Kokkos_Core.hpp>
 
 using type_real = @TYPE_REAL@;
+#ifdef SPECFEM_ENABLE_MPI
+#define SPECFEM_MPI_TYPE_REAL @MPI_TYPE_REAL@
+#endif
 const static int ndim{ 2 };
 const static int fint{ 4 }, ffloat{ 4 }, fdouble{ 8 }, fbool{ 4 }, fchar{ 512 };
 constexpr static int freal = sizeof(type_real);


### PR DESCRIPTION
## Description

Add SPECFEM_SAFE_CALL wrapper for MPI functions.

## Issue Number

Adds to #1702

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
