### PR TITLE
Issue 1600 unit conversion

### DIFF
--- a/core/specfem.cpp
+++ b/core/specfem.cpp
@@ -93,7 +93,7 @@ int run_simulation(const std::string &dimension, int argc, char **argv,
     const auto success = specfem::program::execute(dimension, parameter_dict);
 
     if (!success) {
-      std::cerr << "Execution failed" << std::endl;
+      std::cerr << "Execution failed. See log file for details." << std::endl;
       result = 1;
     }
 

--- a/core/specfem/io/mesh/impl/fortran/dim3/read_materials.cpp
+++ b/core/specfem/io/mesh/impl/fortran/dim3/read_materials.cpp
@@ -61,8 +61,7 @@ specfem::io::mesh::impl::fortran::dim3::read_materials(
             throw std::runtime_error(error_message.str());
           }
 
-          if (!attenuation_enabled && ((std::abs(Qkappa - 9999.0) < 1e-6) ||
-                                       (std::abs(Qkappa) < 1e-6))) {
+          if (!attenuation_enabled && (std::abs(Qkappa - 9999.0) < 1e-6)) {
 
             specfem::medium_container::material<
                 specfem::element::dimension_tag::dim3,
@@ -97,10 +96,8 @@ specfem::io::mesh::impl::fortran::dim3::read_materials(
                 "materials.");
           }
 
-          if (!attenuation_enabled &&
-              ((std::abs(Qmu - 9999.0) < 1e-6 &&
-                std::abs(Qkappa - 9999.0) < 1e-6) ||
-               (std::abs(Qmu) < 1e-6 && std::abs(Qkappa) < 1e-6))) {
+          if (!attenuation_enabled || (std::abs(Qkappa - 9999.0) < 1e-6 &&
+                                       std::abs(Qmu - 9999.0) < 1e-6)) {
             specfem::medium_container::material<
                 specfem::element::dimension_tag::dim3,
                 specfem::element::medium_tag::elastic,

--- a/core/specfem/io/mesh/impl/fortran/dim3/read_materials.cpp
+++ b/core/specfem/io/mesh/impl/fortran/dim3/read_materials.cpp
@@ -61,7 +61,7 @@ specfem::io::mesh::impl::fortran::dim3::read_materials(
             throw std::runtime_error(error_message.str());
           }
 
-          if (!attenuation_enabled && (std::abs(Qkappa - 9999.0) < 1e-6)) {
+          if (!attenuation_enabled || (std::abs(Qkappa - 9999.0) < 1e-6)) {
 
             specfem::medium_container::material<
                 specfem::element::dimension_tag::dim3,

--- a/core/specfem/runtime_configuration/attenuation.cpp
+++ b/core/specfem/runtime_configuration/attenuation.cpp
@@ -35,6 +35,12 @@ specfem::runtime_configuration::Attenuation::Attenuation(
         specfem::units::quantity_cast<specfem::units::Hertz>(
             band[1].as<std::string>());
 
+    if (minimum_frequency >= maximum_frequency) {
+      throw std::runtime_error(
+          "attenuation-frequency-band: first frequency must be less than the "
+          "second frequency.");
+    }
+
     this->attenuation_frequency_band =
         specfem::utilities::Band<specfem::units::Hertz>(minimum_frequency,
                                                         maximum_frequency);

--- a/core/specfem/runtime_configuration/attenuation.cpp
+++ b/core/specfem/runtime_configuration/attenuation.cpp
@@ -1,10 +1,15 @@
 #include "attenuation.hpp"
-
+#include "specfem/units.hpp"
 #include "yaml-cpp/yaml.h"
 #include <ostream>
 
 specfem::runtime_configuration::Attenuation::Attenuation(
-    const YAML::Node &attenuation_node) {
+    const YAML::Node &attenuation_node)
+    : attenuation_enabled(false),
+      reference_frequency(specfem::units::Hertz(-1.0)),
+      attenuation_frequency_band(specfem::units::Hertz(-1.0),
+                                 specfem::units::Hertz(-1.0)) {
+
   try {
     this->attenuation_enabled = attenuation_node["enabled"].as<bool>();
 
@@ -17,7 +22,8 @@ specfem::runtime_configuration::Attenuation::Attenuation(
 
   try {
     this->reference_frequency =
-        attenuation_node["reference-frequency"].as<type_real>();
+        specfem::units::quantity_cast<specfem::units::Hertz>(
+            attenuation_node["reference-frequency"].as<std::string>());
 
   } catch (YAML::ParserException &e) {
     std::ostringstream message;
@@ -28,29 +34,30 @@ specfem::runtime_configuration::Attenuation::Attenuation(
   }
 
   try {
-    this->maximum_attenuation_frequency =
-        attenuation_node["maximum-attenuation-frequency"].as<type_real>();
+    const YAML::Node band = attenuation_node["attenuation-frequency-band"];
+
+    if (!band.IsSequence() || band.size() != 2) {
+      throw std::runtime_error(
+          "attenuation-frequency-band must be a sequence of exactly 2 "
+          "values, e.g.:\n  attenuation-frequency-band:\n    - 0.1 Hz\n    - "
+          "10.0 Hz");
+    }
+    specfem::units::Hertz minimum_frequency =
+        specfem::units::quantity_cast<specfem::units::Hertz>(
+            band[0].as<std::string>());
+    specfem::units::Hertz maximum_frequency =
+        specfem::units::quantity_cast<specfem::units::Hertz>(
+            band[1].as<std::string>());
+
+    this->attenuation_frequency_band =
+        specfem::utilities::Band<specfem::units::Hertz>(minimum_frequency,
+                                                        maximum_frequency);
 
   } catch (YAML::ParserException &e) {
 
     std::ostringstream message;
-
     message << "Error reading attenuation configuration value: "
-               "maximum-attenuation-frequency. \n"
-            << e.what();
-    throw std::runtime_error(message.str());
-  }
-
-  try {
-    this->minimum_attenuation_frequency =
-        attenuation_node["minimum-attenuation-frequency"].as<type_real>();
-
-  } catch (YAML::ParserException &e) {
-
-    std::ostringstream message;
-
-    message << "Error reading attenuation configuration value: "
-               "minimum-attenuation-frequency. \n"
+               "attenuation-frequency-band. \n"
             << e.what();
     throw std::runtime_error(message.str());
   }

--- a/core/specfem/runtime_configuration/attenuation.cpp
+++ b/core/specfem/runtime_configuration/attenuation.cpp
@@ -4,21 +4,7 @@
 #include <ostream>
 
 specfem::runtime_configuration::Attenuation::Attenuation(
-    const YAML::Node &attenuation_node)
-    : attenuation_enabled(false),
-      reference_frequency(specfem::units::Hertz(-1.0)),
-      attenuation_frequency_band(specfem::units::Hertz(-1.0),
-                                 specfem::units::Hertz(-1.0)) {
-
-  try {
-    this->attenuation_enabled = attenuation_node["enabled"].as<bool>();
-
-  } catch (YAML::ParserException &e) {
-    std::ostringstream message;
-    message << "Error reading attenuation configuration value: enabled. \n"
-            << e.what();
-    throw std::runtime_error(message.str());
-  }
+    const YAML::Node &attenuation_node) {
 
   try {
     this->reference_frequency =

--- a/core/specfem/runtime_configuration/attenuation.hpp
+++ b/core/specfem/runtime_configuration/attenuation.hpp
@@ -2,6 +2,8 @@
 
 #include "specfem/mpi.hpp"
 #include "specfem/setup.hpp"
+#include "specfem/units.hpp"
+#include "specfem/utilities/band.hpp"
 #include "yaml-cpp/yaml.h"
 
 namespace specfem::runtime_configuration {
@@ -20,8 +22,8 @@ public:
    */
   Attenuation()
       : attenuation_enabled(false), reference_frequency(-1.0),
-        maximum_attenuation_frequency(-1.0),
-        minimum_attenuation_frequency(-1.0) {};
+        attenuation_frequency_band(specfem::units::Hertz(-10.0),
+                                   specfem::units::Hertz(-1.0)) {};
 
   /**
    * @brief Construct a new attenuation configuration object
@@ -37,8 +39,9 @@ public:
               const type_real minimum_attenuation_frequency)
       : attenuation_enabled(attenuation_enabled),
         reference_frequency(reference_frequency),
-        maximum_attenuation_frequency(maximum_attenuation_frequency),
-        minimum_attenuation_frequency(minimum_attenuation_frequency) {};
+        attenuation_frequency_band(
+            specfem::units::Hertz(minimum_attenuation_frequency),
+            specfem::units::Hertz(maximum_attenuation_frequency)) {};
 
   /**
    * @brief Construct a new attenuation configuration object
@@ -48,27 +51,22 @@ public:
   Attenuation(const YAML::Node &Node);
 
   bool is_attenuation_enabled() const { return this->attenuation_enabled; }
-  type_real get_reference_frequency() const {
-    return this->reference_frequency;
+  specfem::units::Hertz get_reference_frequency() const {
+    return specfem::units::Hertz(this->reference_frequency);
   }
-  type_real get_maximum_attenuation_frequency() const {
-    return this->maximum_attenuation_frequency;
-  }
-  type_real get_minimum_attenuation_frequency() const {
-    return this->minimum_attenuation_frequency;
+  specfem::utilities::Band<specfem::units::Hertz>
+  get_attenuation_frequency_band() const {
+    return this->attenuation_frequency_band;
   }
 
 private:
-  bool attenuation_enabled;      ///< whether to include attenuation in the
-                                 ///< simulation
-  type_real reference_frequency; ///< whether to include reference frequency in
-                                 ///< the simulation
-  type_real maximum_attenuation_frequency; ///< whether to include maximum
-                                           ///< attenuation frequency in the
-                                           ///< simulation
-  type_real minimum_attenuation_frequency; ///< whether to include minimum
-                                           ///< attenuation frequency in the
-                                           ///< simulation
+  bool attenuation_enabled; ///< whether to include attenuation in the
+                            ///< simulation
+  specfem::units::Hertz reference_frequency; ///< whether to include reference
+                                             ///< frequency in the simulation
+  specfem::utilities::Band<specfem::units::Hertz>
+      attenuation_frequency_band; ///< frequency band for attenuation in the
+                                  ///< simulation
 };
 
 } // namespace specfem::runtime_configuration

--- a/core/specfem/runtime_configuration/attenuation.hpp
+++ b/core/specfem/runtime_configuration/attenuation.hpp
@@ -20,10 +20,7 @@ public:
    * @brief Construct a new attenuation configuration object with default values
    *
    */
-  Attenuation()
-      : attenuation_enabled(false), reference_frequency(-1.0),
-        attenuation_frequency_band(specfem::units::Hertz(-10.0),
-                                   specfem::units::Hertz(-1.0)) {};
+  Attenuation();
 
   /**
    * @brief Construct a new attenuation configuration object
@@ -37,8 +34,7 @@ public:
               const type_real reference_frequency,
               const type_real maximum_attenuation_frequency,
               const type_real minimum_attenuation_frequency)
-      : attenuation_enabled(attenuation_enabled),
-        reference_frequency(reference_frequency),
+      : reference_frequency(reference_frequency),
         attenuation_frequency_band(
             specfem::units::Hertz(minimum_attenuation_frequency),
             specfem::units::Hertz(maximum_attenuation_frequency)) {};
@@ -50,18 +46,20 @@ public:
    */
   Attenuation(const YAML::Node &Node);
 
-  bool is_attenuation_enabled() const { return this->attenuation_enabled; }
+  /**
+   * @brief return reference frequency for attenuation
+   * @return type_real reference frequency for attenuation
+   */
   specfem::units::Hertz get_reference_frequency() const {
-    return specfem::units::Hertz(this->reference_frequency);
+    return this->reference_frequency;
   }
+
   specfem::utilities::Band<specfem::units::Hertz>
   get_attenuation_frequency_band() const {
     return this->attenuation_frequency_band;
   }
 
 private:
-  bool attenuation_enabled; ///< whether to include attenuation in the
-                            ///< simulation
   specfem::units::Hertz reference_frequency; ///< whether to include reference
                                              ///< frequency in the simulation
   specfem::utilities::Band<specfem::units::Hertz>

--- a/core/specfem/runtime_configuration/setup.cpp
+++ b/core/specfem/runtime_configuration/setup.cpp
@@ -320,8 +320,7 @@ specfem::runtime_configuration::setup::setup(const YAML::Node &parameter_dict) {
             attenuation_node);
   } else {
     // Default is attenuation disabled
-    this->attenuation =
-        std::make_unique<specfem::runtime_configuration::Attenuation>();
+    this->attenuation = nullptr;
   }
 };
 

--- a/core/specfem/runtime_configuration/setup.hpp
+++ b/core/specfem/runtime_configuration/setup.hpp
@@ -215,8 +215,43 @@ public:
    * @brief Whether attenuation is enabled in the simulation
    */
   bool is_attenuation_enabled() const {
-    return this->attenuation && this->attenuation->is_attenuation_enabled();
+    if (this->attenuation) {
+      return true;
+    } else {
+      return false;
+    }
   }
+
+  /**
+   * @brief Get the reference frequency for attenuation
+   *
+   * @return type_real reference frequency for attenuation
+   */
+  std::shared_ptr<specfem::units::Hertz>
+  get_attenuation_reference_frequency() const {
+    if (this->attenuation) {
+      return std::make_shared<specfem::units::Hertz>(
+          this->attenuation->get_reference_frequency());
+    } else {
+      return nullptr;
+    }
+  };
+
+  /**
+   * @brief Get the attenuation frequency band
+   *
+   * @return specfem::utilities::Band<specfem::units::Hertz> Attenuation
+   * frequency band
+   */
+  std::shared_ptr<specfem::utilities::Band<specfem::units::Hertz> >
+  get_attenuation_band() const {
+    if (this->attenuation) {
+      return std::make_shared<specfem::utilities::Band<specfem::units::Hertz> >(
+          this->attenuation->get_attenuation_frequency_band());
+    } else {
+      return nullptr; // Return null if attenuation is disabled
+    }
+  };
 
   /**
    * @brief Create wavefield writer for periodic output.

--- a/core/specfem/units.hpp
+++ b/core/specfem/units.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "units/conversions.hpp"
+#include "units/parse.hpp"
 #include "units/quantity.hpp"
 
 #include <Kokkos_Core.hpp>

--- a/core/specfem/units/conversions.hpp
+++ b/core/specfem/units/conversions.hpp
@@ -20,13 +20,20 @@ constexpr type_real two_pi =
 /**
  * @brief Implementation dispatcher for unit conversions.
  *
- * Primary template is undefined; specializations handle specific conversions.
- * Unsupported conversions produce compile-time errors.
+ * The primary template has no @c call member; specializations add @c call for
+ * supported conversions.  Attempting @c unit_cast for an unsupported pair
+ * produces a compile-time error (no member @c call).  The empty primary body
+ * also allows @c has_unit_cast<To,From> (in parse.hpp) to detect unsupported
+ * pairs via SFINAE without triggering an incomplete-type hard error.
  *
  * @tparam To Target quantity type
  * @tparam From Source quantity type
  */
-template <typename To, typename From, typename = void> struct unit_cast_impl;
+template <typename To, typename From, typename = void> struct unit_cast_impl {
+  // Intentionally empty: no call() member.
+  // Unsupported conversions are caught at compile time by unit_cast(), or at
+  // runtime by quantity_cast() via has_unit_cast<> detection in parse.hpp.
+};
 
 /// Identity conversion (no-op)
 template <typename T> struct unit_cast_impl<T, T, void> {

--- a/core/specfem/units/parse.hpp
+++ b/core/specfem/units/parse.hpp
@@ -3,6 +3,7 @@
 #include "quantity.hpp"
 
 #include <functional>
+#include <regex>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -146,7 +147,12 @@ inline bool strip_si_prefix(std::string_view unit, type_real &factor,
  *   parse("20.0Hz")     // Hertz(20.0)  — no whitespace is fine
  * @endcode
  *
- * Supported unit symbols (case-sensitive):
+ * Supported scaling symbols are SI prefixes: k (×1e3), M (×1e6), m (×1e-3),
+ * u/mu/µ (×1e-6). The table below shows a non-exhaustive list of supported
+ * unit symbols; any symbol not in the table may still be parsed if the SI
+ * prefix and base unit are both supported.
+ *
+ * (Some) supported unit symbols (case-sensitive):
  * | Category      | Symbols                                  |
  * |---------------|------------------------------------------|
  * | Dimensionless | 1                                        |
@@ -169,52 +175,18 @@ inline bool strip_si_prefix(std::string_view unit, type_real &factor,
  *
  */
 inline AnyQuantity parse(std::string_view s) {
+
   // ── Tokenise: numeric prefix + unit suffix ────────────────────────────────
-  std::size_t pos = 0;
-
-  // Skip leading whitespace
-  while (pos < s.size() && (s[pos] == ' ' || s[pos] == '\t'))
-    ++pos;
-
-  const std::size_t num_start = pos;
-
-  // Optional leading sign
-  if (pos < s.size() && (s[pos] == '+' || s[pos] == '-'))
-    ++pos;
-
-  // Integer digits
-  while (pos < s.size() && s[pos] >= '0' && s[pos] <= '9')
-    ++pos;
-
-  // Optional decimal part
-  if (pos < s.size() && s[pos] == '.') {
-    ++pos;
-    while (pos < s.size() && s[pos] >= '0' && s[pos] <= '9')
-      ++pos;
-  }
-
-  // Optional exponent
-  if (pos < s.size() && (s[pos] == 'e' || s[pos] == 'E')) {
-    ++pos;
-    if (pos < s.size() && (s[pos] == '+' || s[pos] == '-'))
-      ++pos;
-    while (pos < s.size() && s[pos] >= '0' && s[pos] <= '9')
-      ++pos;
-  }
-
-  if (pos == num_start) {
+  const std::string str(s);
+  static const std::regex num_unit_re(
+      R"(^\s*([+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)\s*(.*?)\s*$)");
+  std::smatch m;
+  if (!std::regex_match(str, m, num_unit_re) || m[1].length() == 0) {
     throw std::invalid_argument(
-        "specfem::units::parse: no numeric value found in \"" + std::string(s) +
-        "\"");
+        "specfem::units::parse: no numeric value found in \"" + str + "\"");
   }
-
-  const std::string num_str(s.substr(num_start, pos - num_start));
-
-  // Skip whitespace between number and unit
-  while (pos < s.size() && (s[pos] == ' ' || s[pos] == '\t'))
-    ++pos;
-
-  const std::string unit(s.substr(pos));
+  const std::string num_str = m[1].str();
+  const std::string unit = m[2].str();
 
   // ── Parse number ─────────────────────────────────────────────────────────
   type_real value;

--- a/core/specfem/units/parse.hpp
+++ b/core/specfem/units/parse.hpp
@@ -38,6 +38,10 @@ using AnyQuantity =
 
 namespace impl {
 
+// TODO (Lucas : CPP20) update units - fix replace void_t detection with a
+// requires clause:
+//   requires { unit_cast_impl<To, From>::call(std::declval<From>()); }
+
 /**
  * @brief Detects whether unit_cast_impl<To, From>::call is well-formed.
  *
@@ -46,9 +50,8 @@ namespace impl {
  * unsupported conversion pair without triggering an incomplete-type hard
  * error.
  *
- * // TODO (Lucas : CPP20) update units - fix replace void_t detection with a
- * requires clause:
- *   requires { unit_cast_impl<To, From>::call(std::declval<From>()); }
+ * @tparam To Target quantity type
+ * @tparam From Source quantity type
  */
 template <typename To, typename From, typename = void>
 struct has_unit_cast : std::false_type {};
@@ -58,17 +61,17 @@ struct has_unit_cast<To, From,
                      std::void_t<decltype(unit_cast_impl<To, From>::call(
                          std::declval<From>()))> > : std::true_type {};
 
+// TODO (Lucas : CPP20) update units - fix replace this struct with a
+// generic auto-lambda passed directly to std::visit once C++20 templated
+// lambdas are available:
+//   std::visit([](auto q) -> To { ... }, v)
+
 /**
  * @brief std::visit visitor that converts an AnyQuantity to type @p To.
  *
  * For each alternative From in AnyQuantity:
  *   - if unit_cast_impl<To, From>::call is defined  → convert
  *   - otherwise                                     → throw at runtime
- *
- * // TODO (Lucas : CPP20) update units - fix replace this struct with a
- * generic auto-lambda passed directly to std::visit once C++20 templated
- * lambdas are available:
- *   std::visit([](auto q) -> To { ... }, v)
  */
 template <typename To> struct quantity_cast_visitor {
   template <typename From> To operator()(From q) const {
@@ -82,6 +85,9 @@ template <typename To> struct quantity_cast_visitor {
   }
 };
 
+// TODO (Lucas : CPP20) update units - fix prefix scan with
+// std::string_view::starts_with instead of std::string::compare.
+
 /**
  * @brief Strip a leading SI prefix from @p unit and return whether one was
  * found.
@@ -92,9 +98,6 @@ template <typename To> struct quantity_cast_visitor {
  * "mu" are accepted as alternatives to "µ" (UTF-8 U+00B5 = 0xC2 0xB5).
  *
  * Supported prefixes: k (×1e3), M (×1e6), m (×1e-3), u/mu/µ (×1e-6).
- *
- * // TODO (Lucas : CPP20) update units - fix prefix scan with
- * std::string_view::starts_with instead of std::string::compare.
  */
 inline bool strip_si_prefix(std::string_view unit, type_real &factor,
                             std::string &base_unit) {
@@ -124,6 +127,10 @@ inline bool strip_si_prefix(std::string_view unit, type_real &factor,
 // ---------------------------------------------------------------------------
 // parse
 // ---------------------------------------------------------------------------
+
+// TODO (Lucas : CPP20) update units - fix use a std::string_view-keyed
+// unordered_map (heterogeneous lookup, P0919R3) to avoid constructing a
+// std::string from the unit string_view on each lookup call.
 
 /**
  * @brief Parse a string representation of a physical quantity.
@@ -160,9 +167,6 @@ inline bool strip_si_prefix(std::string_view unit, type_real &factor,
  * @return   AnyQuantity variant holding the parsed quantity.
  * @throws   std::invalid_argument on malformed number or unknown unit.
  *
- * // TODO (Lucas : CPP20) update units - fix use a std::string_view-keyed
- * unordered_map (heterogeneous lookup, P0919R3) to avoid constructing a
- * std::string from the unit string_view on each lookup call.
  */
 inline AnyQuantity parse(std::string_view s) {
   // ── Tokenise: numeric prefix + unit suffix ────────────────────────────────
@@ -313,6 +317,11 @@ inline AnyQuantity parse(std::string_view s) {
 // quantity_cast
 // ---------------------------------------------------------------------------
 
+// TODO (Lucas : CPP20) update units - fix replace
+// impl::quantity_cast_visitor struct with a generic auto-lambda once C++20
+// templated lambdas are fully supported by all targeted compilers: return
+// std::visit([](auto q) -> To { ... }, v);
+
 /**
  * @brief Convert an AnyQuantity to a specific statically-typed Quantity.
  *
@@ -331,10 +340,6 @@ inline AnyQuantity parse(std::string_view s) {
  * auto omega = specfem::units::quantity_cast<Omega>(any); // 2π·20 rad/s
  * @endcode
  *
- * // TODO (Lucas : CPP20) update units - fix replace
- * impl::quantity_cast_visitor struct with a generic auto-lambda once C++20
- * templated lambdas are fully supported by all targeted compilers: return
- * std::visit([](auto q) -> To { ... }, v);
  */
 template <typename To> To quantity_cast(const AnyQuantity &v) {
   return std::visit(impl::quantity_cast_visitor<To>{}, v);

--- a/core/specfem/units/parse.hpp
+++ b/core/specfem/units/parse.hpp
@@ -340,4 +340,23 @@ template <typename To> To quantity_cast(const AnyQuantity &v) {
   return std::visit(impl::quantity_cast_visitor<To>{}, v);
 }
 
+/**
+ * @brief Parse a string and convert directly to a specific quantity type.
+ *
+ * Convenience overload combining parse() and quantity_cast().
+ *
+ * @code
+ * auto f = specfem::units::quantity_cast<Hertz>("20.0 Hz");
+ * auto w = specfem::units::quantity_cast<Omega>("20.0 Hz"); // 2π·20 rad/s
+ * @endcode
+ *
+ * @tparam To  Target Quantity type.
+ * @param  s   Input string (number + unit symbol).
+ * @return     Converted quantity in the target unit.
+ * @throws std::invalid_argument on malformed input or unsupported conversion.
+ */
+template <typename To> To quantity_cast(std::string_view s) {
+  return quantity_cast<To>(parse(s));
+}
+
 } // namespace specfem::units

--- a/core/specfem/units/parse.hpp
+++ b/core/specfem/units/parse.hpp
@@ -1,0 +1,343 @@
+#pragma once
+#include "conversions.hpp"
+#include "quantity.hpp"
+
+#include <functional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <unordered_map>
+#include <variant>
+
+namespace specfem::units {
+
+// ---------------------------------------------------------------------------
+// AnyQuantity — runtime-erased physical quantity
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Runtime variant of all supported physical quantity types.
+ *
+ * Holds exactly one of the known Quantity specializations, allowing quantities
+ * parsed from strings to be stored without knowing the concrete type at compile
+ * time.  Use quantity_cast<To>() to recover a statically-typed value.
+ *
+ * @see parse()
+ * @see quantity_cast()
+ */
+using AnyQuantity =
+    std::variant<Dimensionless, Seconds, Hertz, Omega, Meters, Kilometers,
+                 MetersPerSecond, KilometersPerSecond, Radians, Grams,
+                 Kilograms, GramPerCubicMeter, KilogramPerCubicMeter, Pascal,
+                 Megapascal>;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+namespace impl {
+
+/**
+ * @brief Detects whether unit_cast_impl<To, From>::call is well-formed.
+ *
+ * The primary template of unit_cast_impl<> has an empty body (no call
+ * member), so the SFINAE check below correctly returns false_type for any
+ * unsupported conversion pair without triggering an incomplete-type hard
+ * error.
+ *
+ * // TODO (Lucas : CPP20) update units - fix replace void_t detection with a
+ * requires clause:
+ *   requires { unit_cast_impl<To, From>::call(std::declval<From>()); }
+ */
+template <typename To, typename From, typename = void>
+struct has_unit_cast : std::false_type {};
+
+template <typename To, typename From>
+struct has_unit_cast<To, From,
+                     std::void_t<decltype(unit_cast_impl<To, From>::call(
+                         std::declval<From>()))> > : std::true_type {};
+
+/**
+ * @brief std::visit visitor that converts an AnyQuantity to type @p To.
+ *
+ * For each alternative From in AnyQuantity:
+ *   - if unit_cast_impl<To, From>::call is defined  → convert
+ *   - otherwise                                     → throw at runtime
+ *
+ * // TODO (Lucas : CPP20) update units - fix replace this struct with a
+ * generic auto-lambda passed directly to std::visit once C++20 templated
+ * lambdas are available:
+ *   std::visit([](auto q) -> To { ... }, v)
+ */
+template <typename To> struct quantity_cast_visitor {
+  template <typename From> To operator()(From q) const {
+    if constexpr (has_unit_cast<To, From>::value) {
+      return unit_cast_impl<To, From>::call(q);
+    } else {
+      throw std::invalid_argument(
+          "specfem::units::quantity_cast: no conversion defined from the "
+          "parsed unit type to the requested target type");
+    }
+  }
+};
+
+/**
+ * @brief Strip a leading SI prefix from @p unit and return whether one was
+ * found.
+ *
+ * On success, @p factor is set to the prefix multiplier and @p base_unit to
+ * the remaining unit string.  Prefixes are tried longest-first to avoid
+ * ambiguity (e.g. "mu" is matched before "m").  The ASCII spellings "u" and
+ * "mu" are accepted as alternatives to "µ" (UTF-8 U+00B5 = 0xC2 0xB5).
+ *
+ * Supported prefixes: k (×1e3), M (×1e6), m (×1e-3), u/mu/µ (×1e-6).
+ *
+ * // TODO (Lucas : CPP20) update units - fix prefix scan with
+ * std::string_view::starts_with instead of std::string::compare.
+ */
+inline bool strip_si_prefix(std::string_view unit, type_real &factor,
+                            std::string &base_unit) {
+  // Ordered longest-first so "mu" is matched before "m".
+  // UTF-8 encoding of µ (U+00B5): 0xC2 0xB5 (2 bytes).
+  static const std::pair<std::string, type_real> prefixes[] = {
+    { "mu", type_real(1e-6) },
+    { "\xc2\xb5", type_real(1e-6) }, // µ (U+00B5, UTF-8)
+    { "u", type_real(1e-6) },
+    { "M", type_real(1e6) },
+    { "k", type_real(1e3) },
+    { "m", type_real(1e-3) },
+  };
+  const std::string u(unit);
+  for (const auto &[pfx, fac] : prefixes) {
+    if (u.size() > pfx.size() && u.compare(0, pfx.size(), pfx) == 0) {
+      factor = fac;
+      base_unit = u.substr(pfx.size());
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace impl
+
+// ---------------------------------------------------------------------------
+// parse
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Parse a string representation of a physical quantity.
+ *
+ * The string must contain a decimal number (including optional sign and
+ * scientific notation) optionally separated from a unit symbol by whitespace,
+ * e.g.:
+ * @code
+ *   parse("20.0 Hz")    // Hertz(20.0)
+ *   parse("1.5 km/s")   // KilometersPerSecond(1.5)
+ *   parse("10.0 ms")    // Seconds(0.01)
+ *   parse("2.0 kHz")    // Hertz(2000.0)
+ *   parse("20.0Hz")     // Hertz(20.0)  — no whitespace is fine
+ * @endcode
+ *
+ * Supported unit symbols (case-sensitive):
+ * | Category      | Symbols                                  |
+ * |---------------|------------------------------------------|
+ * | Dimensionless | 1                                        |
+ * | Time          | s, ms, us, µs                            |
+ * | Frequency     | Hz, kHz, MHz, mHz                        |
+ * | Angular freq  | rad/s                                    |
+ * | Angle         | rad                                      |
+ * | Length        | m, km                                    |
+ * | Velocity      | m/s, km/s                                |
+ * | Mass          | g, kg                                    |
+ * | Density       | g/m3, kg/m3                              |
+ * | Pressure      | Pa, kPa, MPa, GPa                        |
+ *
+ * For unit strings not in the table above, an SI prefix (k, M, m, µ/u/mu) is
+ * stripped and the remainder is looked up in the same table.
+ *
+ * @param s  Input string.
+ * @return   AnyQuantity variant holding the parsed quantity.
+ * @throws   std::invalid_argument on malformed number or unknown unit.
+ *
+ * // TODO (Lucas : CPP20) update units - fix use a std::string_view-keyed
+ * unordered_map (heterogeneous lookup, P0919R3) to avoid constructing a
+ * std::string from the unit string_view on each lookup call.
+ */
+inline AnyQuantity parse(std::string_view s) {
+  // ── Tokenise: numeric prefix + unit suffix ────────────────────────────────
+  std::size_t pos = 0;
+
+  // Skip leading whitespace
+  while (pos < s.size() && (s[pos] == ' ' || s[pos] == '\t'))
+    ++pos;
+
+  const std::size_t num_start = pos;
+
+  // Optional leading sign
+  if (pos < s.size() && (s[pos] == '+' || s[pos] == '-'))
+    ++pos;
+
+  // Integer digits
+  while (pos < s.size() && s[pos] >= '0' && s[pos] <= '9')
+    ++pos;
+
+  // Optional decimal part
+  if (pos < s.size() && s[pos] == '.') {
+    ++pos;
+    while (pos < s.size() && s[pos] >= '0' && s[pos] <= '9')
+      ++pos;
+  }
+
+  // Optional exponent
+  if (pos < s.size() && (s[pos] == 'e' || s[pos] == 'E')) {
+    ++pos;
+    if (pos < s.size() && (s[pos] == '+' || s[pos] == '-'))
+      ++pos;
+    while (pos < s.size() && s[pos] >= '0' && s[pos] <= '9')
+      ++pos;
+  }
+
+  if (pos == num_start) {
+    throw std::invalid_argument(
+        "specfem::units::parse: no numeric value found in \"" + std::string(s) +
+        "\"");
+  }
+
+  const std::string num_str(s.substr(num_start, pos - num_start));
+
+  // Skip whitespace between number and unit
+  while (pos < s.size() && (s[pos] == ' ' || s[pos] == '\t'))
+    ++pos;
+
+  const std::string unit(s.substr(pos));
+
+  // ── Parse number ─────────────────────────────────────────────────────────
+  type_real value;
+  try {
+    std::size_t consumed;
+    // type_real may be float or double; parse as double then cast.
+    value = static_cast<type_real>(std::stod(num_str, &consumed));
+    if (consumed != num_str.size())
+      throw std::invalid_argument("trailing characters");
+  } catch (...) {
+    throw std::invalid_argument("specfem::units::parse: invalid number \"" +
+                                num_str + "\" in \"" + std::string(s) + "\"");
+  }
+
+  // ── Unit lookup table ─────────────────────────────────────────────────────
+  // µs key uses the UTF-8 encoding of µ (U+00B5): bytes 0xC2 0xB5.
+  using Factory = std::function<AnyQuantity(type_real)>;
+  // TODO (Lucas : CPP20) update units - fix use std::string_view keys with
+  // transparent hash (P0919R3) to avoid constructing a std::string for each
+  // table lookup.
+  static const std::unordered_map<std::string, Factory> table = {
+    // ── Dimensionless ────────────────────────────────────────────────────
+    { "1", [](type_real v) -> AnyQuantity { return Dimensionless(v); } },
+
+    // ── Time ─────────────────────────────────────────────────────────────
+    { "s", [](type_real v) -> AnyQuantity { return Seconds(v); } },
+    { "ms",
+      [](type_real v) -> AnyQuantity { return Seconds(v * type_real(1e-3)); } },
+    { "us",
+      [](type_real v) -> AnyQuantity { return Seconds(v * type_real(1e-6)); } },
+    { "\xc2\xb5s",
+      [](type_real v) -> AnyQuantity { // µs (U+00B5, UTF-8)
+        return Seconds(v * type_real(1e-6));
+      } },
+
+    // ── Frequency ────────────────────────────────────────────────────────
+    { "Hz", [](type_real v) -> AnyQuantity { return Hertz(v); } },
+    { "kHz",
+      [](type_real v) -> AnyQuantity { return Hertz(v * type_real(1e3)); } },
+    { "MHz",
+      [](type_real v) -> AnyQuantity { return Hertz(v * type_real(1e6)); } },
+    { "mHz",
+      [](type_real v) -> AnyQuantity { return Hertz(v * type_real(1e-3)); } },
+
+    // ── Angular frequency ─────────────────────────────────────────────────
+    { "rad/s", [](type_real v) -> AnyQuantity { return Omega(v); } },
+
+    // ── Angle ─────────────────────────────────────────────────────────────
+    { "rad", [](type_real v) -> AnyQuantity { return Radians(v); } },
+
+    // ── Length ────────────────────────────────────────────────────────────
+    { "m", [](type_real v) -> AnyQuantity { return Meters(v); } },
+    { "km", [](type_real v) -> AnyQuantity { return Kilometers(v); } },
+
+    // ── Velocity ──────────────────────────────────────────────────────────
+    { "m/s", [](type_real v) -> AnyQuantity { return MetersPerSecond(v); } },
+    { "km/s",
+      [](type_real v) -> AnyQuantity { return KilometersPerSecond(v); } },
+
+    // ── Mass ──────────────────────────────────────────────────────────────
+    { "g", [](type_real v) -> AnyQuantity { return Grams(v); } },
+    { "kg", [](type_real v) -> AnyQuantity { return Kilograms(v); } },
+
+    // ── Density ───────────────────────────────────────────────────────────
+    { "g/m3", [](type_real v) -> AnyQuantity { return GramPerCubicMeter(v); } },
+    { "kg/m3",
+      [](type_real v) -> AnyQuantity { return KilogramPerCubicMeter(v); } },
+
+    // ── Pressure ─────────────────────────────────────────────────────────
+    { "Pa", [](type_real v) -> AnyQuantity { return Pascal(v); } },
+    { "kPa",
+      [](type_real v) -> AnyQuantity { return Pascal(v * type_real(1e3)); } },
+    { "MPa", [](type_real v) -> AnyQuantity { return Megapascal(v); } },
+    // GPa stored as Megapascal (raw × 1000 = MPa-equivalent raw value)
+    { "GPa",
+      [](type_real v) -> AnyQuantity {
+        return Megapascal(v * type_real(1e3));
+      } },
+  };
+
+  // Exact match
+  auto it = table.find(unit);
+  if (it != table.end())
+    return it->second(value);
+
+  // SI prefix fallback: strip prefix, look up base unit
+  type_real prefix_factor;
+  std::string base_unit;
+  if (impl::strip_si_prefix(unit, prefix_factor, base_unit)) {
+    auto base_it = table.find(base_unit);
+    if (base_it != table.end())
+      return base_it->second(value * prefix_factor);
+  }
+
+  throw std::invalid_argument("specfem::units::parse: unknown unit \"" + unit +
+                              "\" in \"" + std::string(s) + "\"");
+}
+
+// ---------------------------------------------------------------------------
+// quantity_cast
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Convert an AnyQuantity to a specific statically-typed Quantity.
+ *
+ * Internally calls unit_cast_impl, so all conversions supported by unit_cast
+ * are available — same-dimension scale changes (e.g. Km → m) and cross-
+ * dimension spectral conversions (e.g. Hz ↔ Omega ↔ Seconds).  Unsupported
+ * pairs throw at runtime.
+ *
+ * @tparam To  Target Quantity type (e.g. Hertz, Omega, Seconds, Meters, …).
+ * @param  v   Runtime-typed AnyQuantity obtained from parse().
+ * @return     Converted quantity in the target unit.
+ * @throws std::invalid_argument if the held unit cannot be converted to To.
+ *
+ * @code
+ * auto any   = specfem::units::parse("20.0 Hz");
+ * auto omega = specfem::units::quantity_cast<Omega>(any); // 2π·20 rad/s
+ * @endcode
+ *
+ * // TODO (Lucas : CPP20) update units - fix replace
+ * impl::quantity_cast_visitor struct with a generic auto-lambda once C++20
+ * templated lambdas are fully supported by all targeted compilers: return
+ * std::visit([](auto q) -> To { ... }, v);
+ */
+template <typename To> To quantity_cast(const AnyQuantity &v) {
+  return std::visit(impl::quantity_cast_visitor<To>{}, v);
+}
+
+} // namespace specfem::units

--- a/core/specfem/utilities/band.hpp
+++ b/core/specfem/utilities/band.hpp
@@ -19,6 +19,8 @@ namespace specfem::utilities {
 template <typename T> struct Band {
   T min, max;
 
+  Band() = default;
+
   /// Same-unit construction (identity).
   constexpr Band(T lo, T hi) noexcept : min(lo), max(hi) {}
 

--- a/docs/sections/api/specfem/units/index.rst
+++ b/docs/sections/api/specfem/units/index.rst
@@ -12,3 +12,4 @@
     quantity
     conversions
     unit_symbols
+    parse

--- a/docs/sections/api/specfem/units/parse.rst
+++ b/docs/sections/api/specfem/units/parse.rst
@@ -1,0 +1,21 @@
+.. _specfem_units_parse:
+
+``specfem::units`` Parsing
+===========================
+
+``AnyQuantity``
+---------------
+
+.. doxygentypedef:: specfem::units::AnyQuantity
+
+``parse``
+---------
+
+.. doxygenfunction:: specfem::units::parse
+
+``quantity_cast``
+-----------------
+
+.. doxygenfunction:: specfem::units::quantity_cast(const AnyQuantity &v)
+
+.. doxygenfunction:: specfem::units::quantity_cast(std::string_view s)

--- a/docs/sections/parameter_documentation/index.rst
+++ b/docs/sections/parameter_documentation/index.rst
@@ -985,9 +985,11 @@ Parameter definitions
             :caption: Example attenuation section
 
             attenuation:
-              enabled: true
-              min_attenuation_frequency: 0.1
-              max_attenuation_frequency: 20.0
+                enabled: false
+                reference-frequency: 1.0 Hz
+                attenuation-frequency-band:
+                    - 0.1 Hz
+                    - 10.0 Hz
 
         .. note::
 
@@ -1020,32 +1022,20 @@ Parameter definitions
             .. code-block:: yaml
                 :caption: Example
 
-                reference_frequency: 1.0
+                reference_frequency: 1.0 Hz
 
-        .. dropdown:: ``min_attenuation_frequency``
+        .. dropdown:: ``attenuation-frequency-band``
 
-            Minimum frequency for attenuation in Hz. This parameter is used to
-            calculate the absorption band for the simulation.
+            Frequency band for attenuation in Hz. This parameter is used to
+            calculate the unrelaxed moduli for the simulation.
 
             :default value: None
 
-            :possible values: [float, double]
+            :possible values: [YAML list]
 
             .. code-block:: yaml
                 :caption: Example
 
-                min_attenuation_frequency: 0.1
-
-        .. dropdown:: ``max_attenuation_frequency``
-
-            Maximum frequency for attenuation in Hz. This parameter is used to
-            calculate the absorption band for the simulation.
-
-            :default value: None
-
-            :possible values: [float, double]
-
-            .. code-block:: yaml
-                :caption: Example
-
-                max_attenuation_frequency: 20.0
+                attenuation-frequency-band:
+                    - 0.1 Hz
+                    - 10.0 Hz

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -130,6 +130,7 @@ add_executable(
   units_tests
   units/quantity_tests.cpp
   units/unit_cast_tests.cpp
+  units/parse_tests.cpp
 )
 
 target_link_libraries(

--- a/tests/unit-tests/units/parse_tests.cpp
+++ b/tests/unit-tests/units/parse_tests.cpp
@@ -314,3 +314,21 @@ TEST(Units_QuantityCast, ThrowsHertzToMeters) {
 TEST(Units_QuantityCast, ThrowsMetersToSeconds) {
   EXPECT_THROW(quantity_cast<Seconds>(parse("100.0 m")), std::invalid_argument);
 }
+
+// ---------------------------------------------------------------------------
+// quantity_cast string overload
+// ---------------------------------------------------------------------------
+
+TEST(Units_QuantityCast, StringOverloadHertz) {
+  auto f = quantity_cast<Hertz>("20.0 Hz");
+  EXPECT_TRUE(is_close(f.raw(), type_real(20.0)));
+}
+
+TEST(Units_QuantityCast, StringOverloadCrossDimension) {
+  auto w = quantity_cast<Omega>("20.0 Hz");
+  EXPECT_TRUE(is_close(w.raw(), type_real(20.0) * parse_two_pi));
+}
+
+TEST(Units_QuantityCast, StringOverloadThrowsUnknownUnit) {
+  EXPECT_THROW((quantity_cast<Hertz>("1.0 lightyear")), std::invalid_argument);
+}

--- a/tests/unit-tests/units/parse_tests.cpp
+++ b/tests/unit-tests/units/parse_tests.cpp
@@ -1,0 +1,316 @@
+#include "specfem/units.hpp"
+#include "specfem/utilities/is_close.hpp"
+#include <gtest/gtest.h>
+#include <stdexcept>
+#include <variant>
+
+using specfem::units::AnyQuantity;
+using specfem::units::Dimensionless;
+using specfem::units::GramPerCubicMeter;
+using specfem::units::Grams;
+using specfem::units::Hertz;
+using specfem::units::KilogramPerCubicMeter;
+using specfem::units::Kilograms;
+using specfem::units::Kilometers;
+using specfem::units::KilometersPerSecond;
+using specfem::units::Megapascal;
+using specfem::units::Meters;
+using specfem::units::MetersPerSecond;
+using specfem::units::Omega;
+using specfem::units::parse;
+using specfem::units::Pascal;
+using specfem::units::quantity_cast;
+using specfem::units::Radians;
+using specfem::units::Seconds;
+using specfem::utilities::is_close;
+
+namespace {
+constexpr type_real parse_two_pi = type_real(6.28318530717958647692);
+}
+
+// ---------------------------------------------------------------------------
+// parse — basic unit recognition
+// ---------------------------------------------------------------------------
+
+TEST(Units_Parse, Dimensionless) {
+  auto v = parse("1.0 1");
+  ASSERT_TRUE(std::holds_alternative<Dimensionless>(v));
+  EXPECT_TRUE(is_close(std::get<Dimensionless>(v).raw(), type_real(1.0)));
+}
+
+TEST(Units_Parse, Seconds) {
+  auto v = parse("0.5 s");
+  ASSERT_TRUE(std::holds_alternative<Seconds>(v));
+  EXPECT_TRUE(is_close(std::get<Seconds>(v).raw(), type_real(0.5)));
+}
+
+TEST(Units_Parse, Hertz) {
+  auto v = parse("20.0 Hz");
+  ASSERT_TRUE(std::holds_alternative<Hertz>(v));
+  EXPECT_TRUE(is_close(std::get<Hertz>(v).raw(), type_real(20.0)));
+}
+
+TEST(Units_Parse, Omega) {
+  auto v = parse("6.28 rad/s");
+  ASSERT_TRUE(std::holds_alternative<Omega>(v));
+  EXPECT_TRUE(is_close(std::get<Omega>(v).raw(), type_real(6.28)));
+}
+
+TEST(Units_Parse, Radians) {
+  auto v = parse("3.14 rad");
+  ASSERT_TRUE(std::holds_alternative<Radians>(v));
+  EXPECT_TRUE(is_close(std::get<Radians>(v).raw(), type_real(3.14)));
+}
+
+TEST(Units_Parse, Meters) {
+  auto v = parse("100.0 m");
+  ASSERT_TRUE(std::holds_alternative<Meters>(v));
+  EXPECT_TRUE(is_close(std::get<Meters>(v).raw(), type_real(100.0)));
+}
+
+TEST(Units_Parse, Kilometers) {
+  auto v = parse("1.5 km");
+  ASSERT_TRUE(std::holds_alternative<Kilometers>(v));
+  EXPECT_TRUE(is_close(std::get<Kilometers>(v).raw(), type_real(1.5)));
+}
+
+TEST(Units_Parse, MetersPerSecond) {
+  auto v = parse("3000.0 m/s");
+  ASSERT_TRUE(std::holds_alternative<MetersPerSecond>(v));
+  EXPECT_TRUE(is_close(std::get<MetersPerSecond>(v).raw(), type_real(3000.0)));
+}
+
+TEST(Units_Parse, KilometersPerSecond) {
+  auto v = parse("3.0 km/s");
+  ASSERT_TRUE(std::holds_alternative<KilometersPerSecond>(v));
+  EXPECT_TRUE(is_close(std::get<KilometersPerSecond>(v).raw(), type_real(3.0)));
+}
+
+TEST(Units_Parse, Grams) {
+  auto v = parse("5.0 g");
+  ASSERT_TRUE(std::holds_alternative<Grams>(v));
+  EXPECT_TRUE(is_close(std::get<Grams>(v).raw(), type_real(5.0)));
+}
+
+TEST(Units_Parse, Kilograms) {
+  auto v = parse("2.5 kg");
+  ASSERT_TRUE(std::holds_alternative<Kilograms>(v));
+  EXPECT_TRUE(is_close(std::get<Kilograms>(v).raw(), type_real(2.5)));
+}
+
+TEST(Units_Parse, GramPerCubicMeter) {
+  auto v = parse("2700.0 g/m3");
+  ASSERT_TRUE(std::holds_alternative<GramPerCubicMeter>(v));
+  EXPECT_TRUE(
+      is_close(std::get<GramPerCubicMeter>(v).raw(), type_real(2700.0)));
+}
+
+TEST(Units_Parse, KilogramPerCubicMeter) {
+  auto v = parse("2.7 kg/m3");
+  ASSERT_TRUE(std::holds_alternative<KilogramPerCubicMeter>(v));
+  EXPECT_TRUE(
+      is_close(std::get<KilogramPerCubicMeter>(v).raw(), type_real(2.7)));
+}
+
+TEST(Units_Parse, Pascal) {
+  auto v = parse("101325.0 Pa");
+  ASSERT_TRUE(std::holds_alternative<Pascal>(v));
+  EXPECT_TRUE(is_close(std::get<Pascal>(v).raw(), type_real(101325.0)));
+}
+
+TEST(Units_Parse, Megapascal) {
+  auto v = parse("1.0 MPa");
+  ASSERT_TRUE(std::holds_alternative<Megapascal>(v));
+  EXPECT_TRUE(is_close(std::get<Megapascal>(v).raw(), type_real(1.0)));
+}
+
+// ---------------------------------------------------------------------------
+// parse — explicit prefixed aliases in table
+// ---------------------------------------------------------------------------
+
+TEST(Units_Parse, Milliseconds_ExactEntry) {
+  // "ms" is an exact table entry → Seconds(v * 1e-3)
+  auto v = parse("10.0 ms");
+  ASSERT_TRUE(std::holds_alternative<Seconds>(v));
+  EXPECT_TRUE(is_close(std::get<Seconds>(v).raw(), type_real(10.0e-3)));
+}
+
+TEST(Units_Parse, Microseconds_us) {
+  auto v = parse("500.0 us");
+  ASSERT_TRUE(std::holds_alternative<Seconds>(v));
+  EXPECT_TRUE(is_close(std::get<Seconds>(v).raw(), type_real(500.0e-6)));
+}
+
+TEST(Units_Parse, KiloHertz_ExactEntry) {
+  // "kHz" is an exact table entry → Hertz(v * 1e3)
+  auto v = parse("2.0 kHz");
+  ASSERT_TRUE(std::holds_alternative<Hertz>(v));
+  EXPECT_TRUE(is_close(std::get<Hertz>(v).raw(), type_real(2000.0)));
+}
+
+TEST(Units_Parse, MegaHertz) {
+  auto v = parse("1.0 MHz");
+  ASSERT_TRUE(std::holds_alternative<Hertz>(v));
+  EXPECT_TRUE(is_close(std::get<Hertz>(v).raw(), type_real(1.0e6)));
+}
+
+TEST(Units_Parse, MilliHertz) {
+  auto v = parse("1.0 mHz");
+  ASSERT_TRUE(std::holds_alternative<Hertz>(v));
+  EXPECT_TRUE(is_close(std::get<Hertz>(v).raw(), type_real(1.0e-3)));
+}
+
+TEST(Units_Parse, KiloPascal) {
+  auto v = parse("100.0 kPa");
+  ASSERT_TRUE(std::holds_alternative<Pascal>(v));
+  EXPECT_TRUE(is_close(std::get<Pascal>(v).raw(), type_real(100.0e3)));
+}
+
+TEST(Units_Parse, GigaPascal) {
+  // GPa → stored as Megapascal(v * 1e3); raw = 1000 for 1 GPa
+  auto v = parse("1.0 GPa");
+  ASSERT_TRUE(std::holds_alternative<Megapascal>(v));
+  EXPECT_TRUE(is_close(std::get<Megapascal>(v).raw(), type_real(1000.0)));
+}
+
+// ---------------------------------------------------------------------------
+// parse — SI prefix fallback (not in exact table)
+// ---------------------------------------------------------------------------
+
+TEST(Units_Parse, PrefixFallback_kPa_via_prefix) {
+  // "kPa" is in the exact table; try a unit that exercises the fallback path:
+  // "km/s" is exact, but "Mm/s" is not — strip "M" prefix, look up "m/s"
+  auto v = parse("1.0 Mm/s"); // 1 mega-m/s = 1e6 m/s stored as MetersPerSecond
+  ASSERT_TRUE(std::holds_alternative<MetersPerSecond>(v));
+  EXPECT_TRUE(is_close(std::get<MetersPerSecond>(v).raw(), type_real(1.0e6)));
+}
+
+// ---------------------------------------------------------------------------
+// parse — whitespace and notation variants
+// ---------------------------------------------------------------------------
+
+TEST(Units_Parse, NoWhitespaceBetweenNumberAndUnit) {
+  auto v = parse("20.0Hz");
+  ASSERT_TRUE(std::holds_alternative<Hertz>(v));
+  EXPECT_TRUE(is_close(std::get<Hertz>(v).raw(), type_real(20.0)));
+}
+
+TEST(Units_Parse, LeadingWhitespace) {
+  auto v = parse("  20.0 Hz");
+  ASSERT_TRUE(std::holds_alternative<Hertz>(v));
+  EXPECT_TRUE(is_close(std::get<Hertz>(v).raw(), type_real(20.0)));
+}
+
+TEST(Units_Parse, ScientificNotation) {
+  auto v = parse("2.0e1 Hz");
+  ASSERT_TRUE(std::holds_alternative<Hertz>(v));
+  EXPECT_TRUE(is_close(std::get<Hertz>(v).raw(), type_real(20.0)));
+}
+
+TEST(Units_Parse, NegativeExponent) {
+  auto v = parse("1.0e-3 s");
+  ASSERT_TRUE(std::holds_alternative<Seconds>(v));
+  EXPECT_TRUE(is_close(std::get<Seconds>(v).raw(), type_real(1.0e-3)));
+}
+
+// ---------------------------------------------------------------------------
+// parse — error handling
+// ---------------------------------------------------------------------------
+
+TEST(Units_Parse, ThrowsOnBadNumber) {
+  EXPECT_THROW(parse("abc Hz"), std::invalid_argument);
+}
+
+TEST(Units_Parse, ThrowsOnUnknownUnit) {
+  EXPECT_THROW(parse("1.0 lightyear"), std::invalid_argument);
+}
+
+TEST(Units_Parse, ThrowsOnEmptyString) {
+  EXPECT_THROW(parse(""), std::invalid_argument);
+}
+
+TEST(Units_Parse, ThrowsOnNumberOnly) {
+  // No unit → unit string is empty → not in table → throws
+  EXPECT_THROW(parse("1.0 "), std::invalid_argument);
+}
+
+// ---------------------------------------------------------------------------
+// quantity_cast — identity (same type)
+// ---------------------------------------------------------------------------
+
+TEST(Units_QuantityCast, IdentityHertz) {
+  auto f = quantity_cast<Hertz>(parse("20.0 Hz"));
+  EXPECT_TRUE(is_close(f.raw(), type_real(20.0)));
+}
+
+TEST(Units_QuantityCast, IdentitySeconds) {
+  auto t = quantity_cast<Seconds>(parse("0.5 s"));
+  EXPECT_TRUE(is_close(t.raw(), type_real(0.5)));
+}
+
+TEST(Units_QuantityCast, IdentityOmega) {
+  auto w = quantity_cast<Omega>(parse("6.28 rad/s"));
+  EXPECT_TRUE(is_close(w.raw(), type_real(6.28)));
+}
+
+// ---------------------------------------------------------------------------
+// quantity_cast — cross-dimension spectral conversions
+// ---------------------------------------------------------------------------
+
+TEST(Units_QuantityCast, HertzToOmega) {
+  auto w = quantity_cast<Omega>(parse("20.0 Hz"));
+  EXPECT_TRUE(is_close(w.raw(), type_real(20.0) * parse_two_pi));
+}
+
+TEST(Units_QuantityCast, SecondsToHertz) {
+  auto f = quantity_cast<Hertz>(parse("0.5 s"));
+  EXPECT_TRUE(is_close(f.raw(), type_real(2.0)));
+}
+
+TEST(Units_QuantityCast, SecondsToOmega) {
+  auto w = quantity_cast<Omega>(parse("1.0 s"));
+  EXPECT_TRUE(is_close(w.raw(), parse_two_pi));
+}
+
+TEST(Units_QuantityCast, KiloHertzToOmega) {
+  // parse("2.0 kHz") → Hertz(2000), then cast through unit_cast<Omega,Hertz>
+  auto w = quantity_cast<Omega>(parse("2.0 kHz"));
+  EXPECT_TRUE(is_close(w.raw(), type_real(2000.0) * parse_two_pi));
+}
+
+TEST(Units_QuantityCast, MillisecondsToHertz) {
+  // 1 ms period → 1000 Hz
+  auto f = quantity_cast<Hertz>(parse("1.0 ms"));
+  EXPECT_TRUE(is_close(f.raw(), type_real(1000.0)));
+}
+
+// ---------------------------------------------------------------------------
+// quantity_cast — same-dimension scale conversions
+// ---------------------------------------------------------------------------
+
+TEST(Units_QuantityCast, KilometersToMeters) {
+  auto m = quantity_cast<Meters>(parse("1.5 km"));
+  EXPECT_TRUE(is_close(m.raw(), type_real(1500.0)));
+}
+
+TEST(Units_QuantityCast, MetersToKilometers) {
+  auto km = quantity_cast<Kilometers>(parse("3000.0 m"));
+  EXPECT_TRUE(is_close(km.raw(), type_real(3.0)));
+}
+
+TEST(Units_QuantityCast, KilometersPerSecondToMetersPerSecond) {
+  auto v = quantity_cast<MetersPerSecond>(parse("3.0 km/s"));
+  EXPECT_TRUE(is_close(v.raw(), type_real(3000.0)));
+}
+
+// ---------------------------------------------------------------------------
+// quantity_cast — unsupported conversion throws
+// ---------------------------------------------------------------------------
+
+TEST(Units_QuantityCast, ThrowsHertzToMeters) {
+  EXPECT_THROW(quantity_cast<Meters>(parse("20.0 Hz")), std::invalid_argument);
+}
+
+TEST(Units_QuantityCast, ThrowsMetersToSeconds) {
+  EXPECT_THROW(quantity_cast<Seconds>(parse("100.0 m")), std::invalid_argument);
+}


### PR DESCRIPTION
## Description

Implements 
```cpp
AnyQuantity = unit::parse(string)
```
and convenience functions
```cpp
your_desired_quantity = unit::quantity_cast<your_quantity>(AnyQuantity)`
your_desired_quantity = unit::quantity_cast<your_quantity>(string)`
```
Will through error if cannot be converted.

## Issue Number

Updates #1600 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [x] I ran the code through pre-commit to check style
- [x] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [x] I have added labels to the PR (see right hand side of the PR page)
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
