### PR TITLE
Flux Scheme Configuration: Interfacial Quadrature

### DIFF
--- a/core/specfem/element_coupling/flux_scheme_configuration.hpp
+++ b/core/specfem/element_coupling/flux_scheme_configuration.hpp
@@ -2,11 +2,15 @@
 
 #include "specfem/constants.hpp"
 #include "specfem/element_coupling.hpp"
+#include "specfem/quadrature/quadrature.hpp"
+
 namespace specfem::element_coupling {
 
 struct flux_scheme_configuration {
   specfem::element_coupling::flux_scheme_tag flux_scheme_tag;
   std::vector<type_real> scheme_parameters;
+
+  specfem::quadrature::quadrature interfacial_quadrature;
 
   flux_scheme_configuration()
       : flux_scheme_tag(specfem::element_coupling::flux_scheme_tag::natural) {}
@@ -21,6 +25,16 @@ struct flux_scheme_configuration {
    */
   specfem::element_coupling::flux_scheme_tag get_flux_scheme_tag() const {
     return flux_scheme_tag;
+  }
+
+  /**
+   * @brief Get the quadrature object corresponding to interfacial integration.
+   *
+   * @return specfem::quadrature::quadrature the quadrature object for the
+   * interface.
+   */
+  specfem::quadrature::quadrature get_interfacial_quadrature() const {
+    return interfacial_quadrature;
   }
 };
 } // namespace specfem::element_coupling

--- a/core/specfem/runtime_configuration/flux_schemes.cpp
+++ b/core/specfem/runtime_configuration/flux_schemes.cpp
@@ -10,16 +10,50 @@ specfem::runtime_configuration::flux_schemes::flux_schemes(
 
   // multi-rules in commit 4a27c96cde7e8548556da6caf628eda034fd35b3
 
-  try {
-    std::string flux_scheme_str = Node["type"].as<std::string>();
-    if (flux_scheme_str == "natural") {
-      flux_scheme_tag = specfem::element_coupling::flux_scheme_tag::natural;
-    } else {
-      throw std::runtime_error("Unsupported flux scheme type: " +
-                               Node["type"].as<std::string>());
+  if (const YAML::Node flux_scheme_node = Node["type"]) {
+    try {
+      std::string flux_scheme_str = flux_scheme_node.as<std::string>();
+      if (flux_scheme_str == "natural") {
+        flux_scheme_tag = specfem::element_coupling::flux_scheme_tag::natural;
+      } else {
+        throw std::runtime_error("Unsupported flux scheme type: " +
+                                 flux_scheme_str);
+      }
+    } catch (const YAML::Exception &e) {
+      throw std::runtime_error("Error parsing flux scheme configuration: " +
+                               std::string(e.what()));
     }
-  } catch (const YAML::Exception &e) {
-    throw std::runtime_error("Error parsing flux scheme configuration: " +
-                             std::string(e.what()));
   }
+
+  if (const YAML::Node quadrature_node = Node["quadrature"]) {
+
+    try { // generate interfacial_quadrature by
+          // runtime_configuration::quadrature
+      interfacial_quadrature =
+          std::make_unique<specfem::runtime_configuration::quadrature>(
+              quadrature_node);
+    } catch (const YAML::Exception &e) {
+      throw std::runtime_error("Error parsing coupling quadrature rule: " +
+                               std::string(e.what()));
+    }
+  }
+}
+
+specfem::element_coupling::flux_scheme_configuration
+specfem::runtime_configuration::flux_schemes::get_flux_scheme(
+    const int &ngll) const {
+  specfem::element_coupling::flux_scheme_configuration config;
+
+  config.flux_scheme_tag = flux_scheme_tag;
+
+  if (interfacial_quadrature != nullptr) {
+    config.interfacial_quadrature = interfacial_quadrature->instantiate().gll;
+  } else {
+    // default interfacial quadrature rule (GLL-N)
+    // TODO: replace with GL-(N-1)
+    config.interfacial_quadrature =
+        specfem::quadrature::gll::gll(0.0, 0.0, ngll);
+  }
+
+  return config;
 }

--- a/core/specfem/runtime_configuration/flux_schemes.hpp
+++ b/core/specfem/runtime_configuration/flux_schemes.hpp
@@ -4,10 +4,10 @@
 #include "specfem/element_coupling.hpp"
 #include "specfem/element_coupling/flux_scheme_configuration.hpp"
 
+#include "specfem/runtime_configuration/quadrature.hpp"
 #include "yaml-cpp/yaml.h"
-#include <map>
-#include <string>
-#include <utility>
+
+#include <memory>
 
 namespace specfem {
 namespace runtime_configuration {
@@ -20,19 +20,26 @@ class flux_schemes {
 public:
   flux_schemes(const YAML::Node &Node);
   flux_schemes()
-      : flux_scheme_tag(specfem::element_coupling::flux_scheme_tag::natural) {};
+      : flux_scheme_tag(specfem::element_coupling::flux_scheme_tag::natural),
+        interfacial_quadrature(nullptr) {};
 
 private:
   specfem::element_coupling::flux_scheme_tag flux_scheme_tag;
+  std::unique_ptr<specfem::runtime_configuration::quadrature>
+      interfacial_quadrature;
 
 public:
-  specfem::element_coupling::flux_scheme_configuration get_flux_scheme() const {
-    specfem::element_coupling::flux_scheme_configuration config;
-
-    config.flux_scheme_tag = flux_scheme_tag;
-
-    return config;
-  }
+  /**
+   * @brief Generates a flux_scheme_configuration object from the given runtime
+   * configuration.
+   *
+   * @param ngll number of element quadrature points of the simulation. This is
+   * used for setting the default value of the interfacial quadrature rule.
+   * @return specfem::element_coupling::flux_scheme_configuration the generated
+   * configuration to be given to assembly.
+   */
+  specfem::element_coupling::flux_scheme_configuration
+  get_flux_scheme(const int &ngll) const;
 
   YAML::Node flux_schemes_node;
 };

--- a/core/specfem/runtime_configuration/quadrature.hpp
+++ b/core/specfem/runtime_configuration/quadrature.hpp
@@ -46,6 +46,13 @@ public:
    */
   specfem::quadrature::quadratures instantiate();
 
+  /**
+   * @brief Returns the number of quadrature points.
+   *
+   * @return int number of quadrature points.
+   */
+  int get_ngll() const { return ngll; }
+
 private:
   type_real alpha; ///< alpha value used to instantiate a
                    ///< specfem::quadrature::quadrature class

--- a/core/specfem/runtime_configuration/setup.hpp
+++ b/core/specfem/runtime_configuration/setup.hpp
@@ -402,7 +402,9 @@ public:
   }
 
   auto get_flux_scheme_configuration() const {
-    return this->flux_schemes->get_flux_scheme();
+    // provide element ngll to help decide interfacial order (if latter not
+    // given)
+    return this->flux_schemes->get_flux_scheme(this->quadrature->get_ngll());
   }
 
   /**


### PR DESCRIPTION
## Description

Please describe the changes/features in this pull request.
- adds `quadrature` optional parameter to `flux-schemes` (defaults to a `nullptr`)
  - right now, delegates to `specfem::runtime_configuration::quadrature` to gen a GLL quadrature, so the same arguments are used as for elemental quadrature rule.
  - future: GL quadrature could be given instead.
- `element_coupling::flux_scheme_configuration` now holds onto a `specfem::quadrature::quadrature`, generated from the above. The default scheme is set to `GLL${NGLL}`. This will likely change to `GL${NGLL-1}` in the future.

## Issue Number

If there is an issue created for these changes, link it here

#1750

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
