### PR TITLE
1719 - tag_dispatch for element coupling.

### DIFF
--- a/core/specfem/algorithms/locate_point/locate_point_impl.hpp
+++ b/core/specfem/algorithms/locate_point/locate_point_impl.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "specfem/point.hpp"
 #include <Kokkos_Core.hpp>
 #include <tuple>

--- a/core/specfem/compute/impl/compute_coupling.tpp
+++ b/core/specfem/compute/impl/compute_coupling.tpp
@@ -8,11 +8,11 @@
 #include "specfem/element_connections.hpp"
 #include "specfem/enums.hpp"
 #include "specfem/execution.hpp"
-#include "specfem/macros.hpp"
 #include "specfem/medium_physics.hpp"
 #include "specfem/parallel_configuration.hpp"
 #include "specfem/point.hpp"
 #include "specfem/point/interface_index.hpp"
+#include "specfem/tag_dispatch.hpp"
 #include "specfem/tags.hpp"
 #include <Kokkos_Core.hpp>
 #include <type_traits>
@@ -257,30 +257,30 @@ void compute_coupling(
     const specfem::assembly::assembly<Tags::dimension_tag> &assembly) {
 
   constexpr auto WavefieldType = Tags::wavefield_tag;
-  constexpr auto DimensionTag = Tags::dimension_tag;
-  constexpr auto MediumTag = Tags::medium_tag;
 
-  FOR_EACH_IN_PRODUCT(
-      (DIMENSION_TAG(DIM2, DIM3),
-       CONNECTION_TAG(WEAKLY_CONFORMING, NONCONFORMING),
-       INTERFACE_TAG(ELASTIC_ACOUSTIC, ACOUSTIC_ELASTIC),
-       BOUNDARY_TAG(NONE, ACOUSTIC_FREE_SURFACE, STACEY,
-                    COMPOSITE_STACEY_DIRICHLET),
-       FLUX_SCHEME_TAG(NATURAL)),
-      {
+  specfem::tag_dispatch::for_each(
+      specfem::tag_dispatch::dimension_set<Tags::dimension_tag>{} *
+      CONNECTION_SET(weakly_conforming, nonconforming) *
+      INTERFACE_SET(elastic_acoustic, acoustic_elastic) *
+      BOUNDARY_SET(none, acoustic_free_surface, stacey,
+                   composite_stacey_dirichlet) *
+      FLUX_SCHEME_SET(natural),
+      [&]<typename ElementTags>() {
         constexpr auto self_medium = specfem::element_coupling::attributes<
-            _dimension_tag_, _interface_tag_>::self_medium();
-        if constexpr (DimensionTag == _dimension_tag_ &&
-                      self_medium == MediumTag) {
+            ElementTags::dimension_tag,
+            ElementTags::interface_tag>::self_medium();
+        if constexpr (self_medium == Tags::medium_tag) {
           compute_coupling_core<
               NGLL, NGLL,
-              specfem::tags::Tags<_dimension_tag_, _connection_tag_,
-                                  WavefieldType, _interface_tag_,
-                                  _boundary_tag_, _flux_scheme_tag_> >(
+              specfem::tags::Tags<ElementTags::dimension_tag,
+                                  ElementTags::connection_tag,
+                                  WavefieldType,
+                                  ElementTags::interface_tag,
+                                  ElementTags::boundary_tag,
+                                  ElementTags::flux_scheme_tag> >(
               assembly);
-          // second ngll is the number of quadrature points on the mortar.
         }
-      })
+      });
 }
 
 } // namespace specfem::compute::impl

--- a/core/specfem/element_connections.hpp
+++ b/core/specfem/element_connections.hpp
@@ -8,6 +8,7 @@
 
 #include "specfem/element.hpp"
 #include "specfem/element_connections/tags.hpp"
+#include "specfem/element_connections/to_string.hpp"
 #include <string>
 
 /**

--- a/core/specfem/element_connections/dim2/connections.cpp
+++ b/core/specfem/element_connections/dim2/connections.cpp
@@ -6,24 +6,6 @@
 #include <tuple>
 #include <unordered_map>
 
-const std::string specfem::element_connections::to_string(
-    const specfem::element_connections::type &conn) {
-  switch (conn) {
-  case specfem::element_connections::type::strongly_conforming:
-    return "strongly_conforming";
-  case specfem::element_connections::type::weakly_conforming:
-    return "weakly_conforming";
-  case specfem::element_connections::type::nonconforming:
-    return "nonconforming";
-  default:
-    throw std::runtime_error(
-        std::string(
-            "specfem::element_connections::to_string does not handle ") +
-        std::to_string(static_cast<int>(conn)));
-    return "!ERR";
-  }
-}
-
 template <typename ViewType>
 std::array<int, 2> get_edge_nodes(const specfem::mesh_entity::dim2::type &edge,
                                   const ViewType element) {

--- a/core/specfem/element_connections/to_string.cpp
+++ b/core/specfem/element_connections/to_string.cpp
@@ -1,4 +1,5 @@
 #include "to_string.hpp"
+#include <stdexcept>
 
 const std::string specfem::element_connections::to_string(
     const specfem::element_connections::type &conn) {

--- a/core/specfem/element_connections/to_string.cpp
+++ b/core/specfem/element_connections/to_string.cpp
@@ -1,0 +1,19 @@
+#include "to_string.hpp"
+
+const std::string specfem::element_connections::to_string(
+    const specfem::element_connections::type &conn) {
+  switch (conn) {
+  case specfem::element_connections::type::strongly_conforming:
+    return "strongly_conforming";
+  case specfem::element_connections::type::weakly_conforming:
+    return "weakly_conforming";
+  case specfem::element_connections::type::nonconforming:
+    return "nonconforming";
+  default:
+    throw std::runtime_error(
+        std::string(
+            "specfem::element_connections::to_string does not handle ") +
+        std::to_string(static_cast<int>(conn)));
+    return "!ERR";
+  }
+}

--- a/core/specfem/element_connections/to_string.hpp
+++ b/core/specfem/element_connections/to_string.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include "tags.hpp"
+#include <string>
+
+namespace specfem::element_connections {
+const std::string to_string(const specfem::element_connections::type &conn);
+} // namespace specfem::element_connections

--- a/core/specfem/element_coupling/to_string.hpp
+++ b/core/specfem/element_coupling/to_string.hpp
@@ -1,4 +1,6 @@
-#include "specfem/element_coupling.hpp"
+#pragma once
+#include "tags.hpp"
+#include <string>
 
 namespace specfem::element_coupling {
 

--- a/core/specfem/macros/tag_dispatch.hpp
+++ b/core/specfem/macros/tag_dispatch.hpp
@@ -54,3 +54,17 @@
 #define BOUNDARY_SET(...)                                                      \
   specfem::tag_dispatch::boundary_set<_SPECFEM_TAG_ENUM(_SPECFEM_BND_VAL,      \
                                                         __VA_ARGS__)> {}
+
+#define _SPECFEM_CONN_VAL(s, _, v) specfem::element_connections::type::v
+#define _SPECFEM_IFACE_VAL(s, _, v) specfem::element_coupling::interface_tag::v
+#define _SPECFEM_FLUX_VAL(s, _, v) specfem::element_coupling::flux_scheme_tag::v
+
+#define CONNECTION_SET(...)                                                    \
+  specfem::tag_dispatch::connection_set<_SPECFEM_TAG_ENUM(_SPECFEM_CONN_VAL,   \
+                                                          __VA_ARGS__)> {}
+#define INTERFACE_SET(...)                                                     \
+  specfem::tag_dispatch::interface_set<_SPECFEM_TAG_ENUM(_SPECFEM_IFACE_VAL,   \
+                                                         __VA_ARGS__)> {}
+#define FLUX_SCHEME_SET(...)                                                   \
+  specfem::tag_dispatch::flux_scheme_set<_SPECFEM_TAG_ENUM(_SPECFEM_FLUX_VAL,  \
+                                                           __VA_ARGS__)> {}

--- a/core/specfem/simulation.hpp
+++ b/core/specfem/simulation.hpp
@@ -100,6 +100,27 @@ inline std::string to_string(specfem::simulation::model mdl) {
 }
 
 /**
+ * @brief Convert field type to string.
+ *
+ * @param field Field type
+ * @return String representation
+ */
+inline std::string to_string(specfem::simulation::field_type field) {
+  switch (field) {
+  case specfem::simulation::field_type::forward:
+    return "forward";
+  case specfem::simulation::field_type::adjoint:
+    return "adjoint";
+  case specfem::simulation::field_type::backward:
+    return "backward";
+  case specfem::simulation::field_type::buffer:
+    return "buffer";
+  default:
+    return "unknown";
+  }
+}
+
+/**
  * @brief Simulation type traits template.
  * @tparam SimulationType Simulation type (forward or combined)
  */
@@ -111,12 +132,6 @@ template <specfem::simulation::type SimulationType> class simulation;
 template <> class simulation<specfem::simulation::type::forward> {
 public:
   static constexpr auto simulation_type = specfem::simulation::type::forward;
-
-  /**
-   * @brief Get simulation type name.
-   * @return String representation of simulation type
-   */
-  static std::string to_string() { return "Forward"; }
 };
 
 /**
@@ -125,12 +140,6 @@ public:
 template <> class simulation<specfem::simulation::type::combined> {
 public:
   static constexpr auto simulation_type = specfem::simulation::type::combined;
-
-  /**
-   * @brief Get simulation type name.
-   * @return String representation of simulation type
-   */
-  static std::string to_string() { return "Adjoint & Forward combined"; }
 };
 
 } // namespace simulation

--- a/core/specfem/tag_dispatch.hpp
+++ b/core/specfem/tag_dispatch.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "specfem/macros.hpp"
 #include "tag_dispatch/element_combinations.hpp"
 #include "tag_dispatch/for_each.hpp"

--- a/core/specfem/tag_dispatch/element_combinations.hpp
+++ b/core/specfem/tag_dispatch/element_combinations.hpp
@@ -48,28 +48,68 @@ template <specfem::element::boundary_tag... Vs> struct boundary_set {
       values{ { Vs... } };
 };
 
+template <specfem::element_connections::type... Vs> struct connection_set {
+  using tag_enum = specfem::element_connections::type;
+  static constexpr std::array<specfem::element_connections::type, sizeof...(Vs)>
+      values{ { Vs... } };
+};
+
+template <specfem::element_coupling::interface_tag... Vs> struct interface_set {
+  using tag_enum = specfem::element_coupling::interface_tag;
+  static constexpr
+      std::array<specfem::element_coupling::interface_tag, sizeof...(Vs)>
+          values{ { Vs... } };
+};
+
+template <specfem::element_coupling::flux_scheme_tag... Vs>
+struct flux_scheme_set {
+  using tag_enum = specfem::element_coupling::flux_scheme_tag;
+  static constexpr
+      std::array<specfem::element_coupling::flux_scheme_tag, sizeof...(Vs)>
+          values{ { Vs... } };
+};
+
 // ── Helpers
 // ───────────────────────────────────────────────────────────────────
 
 namespace impl {
 
 // Map TagValueTuple arity → the right validity predicate.
+// Dispatch first on the type of the second tag (T1), then on arity.
+// This avoids calling is_valid_medium_combo on non-medium 2-element tuples
+// such as <dimension_tag, connection_type> that arise from intermediate
+// dimension_set * connection_set products.
 template <typename Tuple> constexpr bool is_valid(const Tuple &t) {
-  if constexpr (Tuple::arity == 2)
-    return is_valid_medium_combo(t);
-  else if constexpr (Tuple::arity == 3)
-    return is_valid_property_combo(t);
-  else if constexpr (Tuple::arity == 4) {
-    using T3 = decltype(t.template get<3>());
-    if constexpr (std::is_same_v<T3, specfem::element::boundary_tag>)
-      return is_valid_boundary_combo(t);
-    else if constexpr (std::is_same_v<T3, specfem::element::attenuation_tag>)
-      return is_valid_material_combo(t);
+  using T1 = decltype(t.template get<1>());
+  if constexpr (std::is_same_v<T1, specfem::element::medium_tag>) {
+    // Medium-based element combinations
+    if constexpr (Tuple::arity == 2)
+      return is_valid_medium_combo(t);
+    else if constexpr (Tuple::arity == 3)
+      return is_valid_property_combo(t);
+    else if constexpr (Tuple::arity == 4) {
+      using T3 = decltype(t.template get<3>());
+      if constexpr (std::is_same_v<T3, specfem::element::boundary_tag>)
+        return is_valid_boundary_combo(t);
+      else if constexpr (std::is_same_v<T3, specfem::element::attenuation_tag>)
+        return is_valid_material_combo(t);
+      else
+        return false;
+    } else if constexpr (Tuple::arity == 5)
+      return is_valid_full_combo(t);
     else
       return false;
-  } else if constexpr (Tuple::arity == 5)
-    return is_valid_full_combo(t);
-  else
+  } else if constexpr (std::is_same_v<T1, specfem::element_connections::type>) {
+    // Interface / coupling combinations
+    if constexpr (Tuple::arity == 3)
+      return is_valid_interface_system(t);
+    else if constexpr (Tuple::arity == 4)
+      return is_valid_edge(t);
+    else if constexpr (Tuple::arity == 5)
+      return is_valid_edge_and_flux_scheme(t);
+    else
+      return false;
+  } else
     return false;
 }
 

--- a/core/specfem/tag_dispatch/is_valid.hpp
+++ b/core/specfem/tag_dispatch/is_valid.hpp
@@ -174,4 +174,72 @@ constexpr bool is_valid_full_combo(ElementTagTuple t) {
          is_valid_boundary_combo({ d, m, p, b });
 }
 
+// ── Interface / coupling combinations ────────────────────────────────────────
+
+using InterfaceSystemTuple =
+    TagValueTuple<specfem::element::dimension_tag,
+                  specfem::element_connections::type,
+                  specfem::element_coupling::interface_tag>;
+
+using EdgeTuple = TagValueTuple<
+    specfem::element::dimension_tag, specfem::element_connections::type,
+    specfem::element_coupling::interface_tag, specfem::element::boundary_tag>;
+
+using EdgeFluxSchemeTuple = TagValueTuple<
+    specfem::element::dimension_tag, specfem::element_connections::type,
+    specfem::element_coupling::interface_tag, specfem::element::boundary_tag,
+    specfem::element_coupling::flux_scheme_tag>;
+
+/// Valid interface systems: weakly_conforming, elastic↔acoustic, dim2 or dim3.
+constexpr bool is_valid_interface_system(InterfaceSystemTuple t) {
+  using C = specfem::element_connections::type;
+  using I = specfem::element_coupling::interface_tag;
+  auto c = t.get<1>();
+  auto i = t.get<2>();
+  if (c != C::weakly_conforming)
+    return false;
+  return i == I::elastic_acoustic || i == I::acoustic_elastic;
+}
+
+/// Valid edge combinations (dim + connection + interface + boundary).
+constexpr bool is_valid_edge(EdgeTuple t) {
+  using D = specfem::element::dimension_tag;
+  using C = specfem::element_connections::type;
+  using I = specfem::element_coupling::interface_tag;
+  using B = specfem::element::boundary_tag;
+  auto d = t.get<0>();
+  auto c = t.get<1>();
+  auto i = t.get<2>();
+  auto b = t.get<3>();
+
+  if (c != C::weakly_conforming && c != C::nonconforming)
+    return false;
+  if (i != I::elastic_acoustic && i != I::acoustic_elastic)
+    return false;
+
+  // dim3: only weakly_conforming + none
+  if (d == D::dim3)
+    return c == C::weakly_conforming && b == B::none;
+
+  // dim2: boundary rules depend on interface direction
+  if (i == I::elastic_acoustic)
+    return b == B::none || b == B::stacey;
+  else // acoustic_elastic
+    return b == B::none || b == B::stacey || b == B::acoustic_free_surface ||
+           b == B::composite_stacey_dirichlet;
+}
+
+/// Valid edge + flux scheme combinations.
+constexpr bool is_valid_edge_and_flux_scheme(EdgeFluxSchemeTuple t) {
+  using F = specfem::element_coupling::flux_scheme_tag;
+  auto d = t.get<0>();
+  auto c = t.get<1>();
+  auto i = t.get<2>();
+  auto b = t.get<3>();
+  auto f = t.get<4>();
+  if (f != F::natural)
+    return false;
+  return is_valid_edge({ d, c, i, b });
+}
+
 } // namespace specfem::tag_dispatch::impl

--- a/core/specfem/tags.hpp
+++ b/core/specfem/tags.hpp
@@ -2,8 +2,8 @@
 
 #include "specfem/element/tags.hpp"
 #include "specfem/element/to_string.hpp"
-#include "specfem/element_connections.hpp"
 #include "specfem/element_connections/tags.hpp"
+#include "specfem/element_connections/to_string.hpp"
 #include "specfem/element_coupling/tags.hpp"
 #include "specfem/element_coupling/to_string.hpp"
 #include "specfem/simulation.hpp"

--- a/core/specfem/tags.hpp
+++ b/core/specfem/tags.hpp
@@ -2,13 +2,17 @@
 
 #include "specfem/element/tags.hpp"
 #include "specfem/element/to_string.hpp"
+#include "specfem/element_connections.hpp"
 #include "specfem/element_connections/tags.hpp"
 #include "specfem/element_coupling/tags.hpp"
+#include "specfem/element_coupling/to_string.hpp"
 #include "specfem/simulation.hpp"
 
+#include <string>
 #include <type_traits>
 
 namespace specfem::tags {
+
 /**
  * @brief Template specialization for storing compile-time tag values.
  *
@@ -163,7 +167,7 @@ public:
     std::string s;
     bool first = true;
     ((s += (first ? (first = false, std::string{}) : std::string{ "_" }) +
-           specfem::element::to_string(TagMembers)),
+           to_string(TagMembers)),
      ...);
     return s;
   }


### PR DESCRIPTION
## Description

- Add element coupling tags to `tag_dispatch`
- Update `Tags.name()` to call correct `to_string()` method for non-element tags (with Argument-Dependent Lookup)

## Issue Number

Adds to #1719

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
