### PR TITLE
1719 - Introduce `specfem::tags::expand` to simplify creation

### DIFF
--- a/core/specfem/compute/compute_seismograms.hpp
+++ b/core/specfem/compute/compute_seismograms.hpp
@@ -23,9 +23,6 @@ template <int NGLL, typename Tags>
 void compute_seismograms(
     specfem::assembly::assembly<Tags::dimension_tag> &assembly,
     const int &isig_step) {
-  constexpr auto DimensionTag = Tags::dimension_tag;
-  constexpr auto WavefieldType = Tags::wavefield_tag;
-
   specfem::tag_dispatch::for_each(
       specfem::tag_dispatch::dimension_set<Tags::dimension_tag>{} *
           MEDIUM_SET(elastic, elastic_psv, elastic_sh, acoustic, poroelastic,
@@ -34,10 +31,8 @@ void compute_seismograms(
           ATTENUATION_SET(none),
       [&]<typename ElementTags>() {
         impl::compute_seismograms<
-            NGLL, specfem::tags::Tags<Tags::dimension_tag, WavefieldType,
-                                      ElementTags::medium_tag,
-                                      ElementTags::property_tag> >(assembly,
-                                                                   isig_step);
+            NGLL, specfem::tags::expand<ElementTags, Tags::wavefield_tag> >(
+            assembly, isig_step);
       });
 }
 } // namespace specfem::compute

--- a/core/specfem/compute/impl/compute_source_interaction.tpp
+++ b/core/specfem/compute/impl/compute_source_interaction.tpp
@@ -107,8 +107,6 @@ void compute_source_interaction(
     specfem::assembly::assembly<Tags::dimension_tag> &assembly,
     const int istep) {
 
-  constexpr auto WavefieldType = Tags::wavefield_tag;
-
   specfem::tag_dispatch::for_each(
       specfem::tag_dispatch::dimension_set<Tags::dimension_tag>{} *
       specfem::tag_dispatch::medium_set<Tags::medium_tag>{} *
@@ -118,11 +116,8 @@ void compute_source_interaction(
       [&]<typename ElementTags>() {
         compute_source_interaction_core<
             NGLL,
-            specfem::tags::Tags<Tags::dimension_tag, WavefieldType,
-                                ElementTags::medium_tag,
-                                ElementTags::property_tag,
-                                ElementTags::boundary_tag> >(assembly,
-                                                             istep);
+            specfem::tags::expand<ElementTags, Tags::wavefield_tag>>(
+            assembly, istep);
       });
 }
 } // namespace specfem::compute::impl

--- a/core/specfem/compute/impl/compute_stiffness_interaction.hpp
+++ b/core/specfem/compute/impl/compute_stiffness_interaction.hpp
@@ -21,7 +21,7 @@
 
 namespace specfem::compute::impl {
 
-template <int NGLL, specfem::simulation::field_type WaveType, typename Tags>
+template <int NGLL, typename Tags>
 int compute_stiffness_interaction(
     const specfem::assembly::assembly<Tags::dimension_tag> &assembly,
     const int &istep) {
@@ -60,7 +60,8 @@ int compute_stiffness_interaction(
   const auto &boundaries = assembly.boundaries;
 
   // Get the simulation field and boundary values
-  const auto field = assembly.fields.template get_simulation_field<WaveType>();
+  const auto field =
+      assembly.fields.template get_simulation_field<Tags::wavefield_tag>();
   const auto boundary_values =
       assembly.boundary_values.template get_container<boundary_tag>();
 
@@ -121,7 +122,8 @@ int compute_stiffness_interaction(
   Kokkos::Profiling::pushRegion("Compute Stiffness Interaction");
 
   if constexpr (Tags::boundary_tag == specfem::element::boundary_tag::stacey &&
-                WaveType == specfem::simulation::field_type::backward) {
+                Tags::wavefield_tag ==
+                    specfem::simulation::field_type::backward) {
 
     specfem::execution::for_all(
         "specfem::compute::compute_stiffness_interaction", chunk,
@@ -241,7 +243,8 @@ int compute_stiffness_interaction(
                 // Store forward boundary values for reconstruction during
                 // adjoint simulations. The function does nothing if the
                 // boundary tag is not stacey
-                if (WaveType == specfem::simulation::field_type::forward) {
+                if (Tags::wavefield_tag ==
+                    specfem::simulation::field_type::forward) {
                   specfem::assembly::store_on_device(istep, index, acceleration,
                                                      boundary_values);
                 }

--- a/core/specfem/compute/update_wavefields.tpp
+++ b/core/specfem/compute/update_wavefields.tpp
@@ -42,7 +42,7 @@ int update_wavefields(
       BOUNDARY_SET(none, stacey, acoustic_free_surface,
                    composite_stacey_dirichlet), [&]<typename ElementTags>() {
     elements_updated +=
-        impl::compute_stiffness_interaction<NGLL, Tags::wavefield_tag, ElementTags>(
+        impl::compute_stiffness_interaction<NGLL, specfem::tags::expand<ElementTags, Tags::wavefield_tag>>(
             assembly, istep);
   });
 

--- a/core/specfem/tags.hpp
+++ b/core/specfem/tags.hpp
@@ -154,6 +154,20 @@ private:
 
 public:
   /**
+   * @brief Compile-time tag expansion: appends a single tag value to this Tags
+   * type.
+   *
+   * @tparam NewTag The compile-time tag value to append.
+   *
+   * Example:
+   * @code
+   * using Combined = ElementTags::expand<wavefield_tag_value>;
+   * // Combined has all members of ElementTags plus wavefield_tag
+   * @endcode
+   */
+  template <auto NewTag> using expand = Tags<TagMembers..., NewTag>;
+
+  /**
    * @brief Runtime subset check for one or more tag values.
    *
    * Returns true if every provided runtime tag exists in this `Tags` type.
@@ -172,5 +186,24 @@ public:
     return s;
   }
 };
+
+/**
+ * @brief Free alias template for appending a tag to an existing Tags type.
+ *
+ * Avoids the `typename T::template expand<V>` dependent-name syntax at call
+ * sites; use `specfem::tags::expand<TagsType, NewTag>` instead.
+ *
+ * @tparam TagsType An existing Tags specialization.
+ * @tparam NewTag   Compile-time tag value to append.
+ */
+template <typename TagsType, auto NewTag> struct expand_impl;
+
+template <auto... TagMembers, auto NewTag>
+struct expand_impl<Tags<TagMembers...>, NewTag> {
+  using type = Tags<TagMembers..., NewTag>;
+};
+
+template <typename TagsType, auto NewTag>
+using expand = typename expand_impl<TagsType, NewTag>::type;
 
 } // namespace specfem::tags


### PR DESCRIPTION
## Description

`specfem::tags::expand` takes an `Tags` class and an additional tag enum, returns a new `Tags` class with the additional enum.

## Issue Number

Adds to #1719

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
