### PR TITLE
NCI Config: Interface meshing type

### DIFF
--- a/core/specfem/assembly/assembly/dim2/assembly.cpp
+++ b/core/specfem/assembly/assembly/dim2/assembly.cpp
@@ -60,7 +60,8 @@ specfem::assembly::assembly<specfem::element::dimension_tag::dim2>::assembly(
                                   this->jacobian_matrix, this->mesh };
   this->nonconforming_interfaces = { this->mesh.element_grid.ngllz,
                                      this->mesh.element_grid.ngllx,
-                                     this->element_intersections, this->mesh };
+                                     this->element_intersections, this->mesh,
+                                     flux_scheme_config };
   this->fields = { this->mesh, this->element_types, simulation };
 
   this->info = { this->mesh, this->properties, this->element_types };

--- a/core/specfem/assembly/nonconforming_interfaces/dim2/impl/interface_container.hpp
+++ b/core/specfem/assembly/nonconforming_interfaces/dim2/impl/interface_container.hpp
@@ -4,6 +4,7 @@
 #include "specfem/assembly/element_intersections.hpp"
 #include "specfem/assembly/mesh.hpp"
 #include "specfem/data_access.hpp"
+#include "specfem/element_coupling/flux_scheme_configuration.hpp"
 #include "specfem/element_coupling/tags.hpp"
 #include "specfem/enums.hpp"
 #include "specfem/execution.hpp"
@@ -97,7 +98,9 @@ public:
       const int ngllz, const int ngllx,
       const specfem::assembly::element_intersections<
           specfem::element::dimension_tag::dim2> &element_intersections,
-      const specfem::assembly::mesh<dimension_tag> &mesh);
+      const specfem::assembly::mesh<dimension_tag> &mesh,
+      const specfem::element_coupling::flux_scheme_configuration
+          &flux_scheme_config = {});
 
   /** @brief Default constructor */
   interface_container() = default;
@@ -251,6 +254,14 @@ private:
                         edge_t>::value ||
                     specfem::data_access::is_transfer_function_coupled<
                         edge_t>::value) {
+        // TODO(nquad_intersection::runtime_vs_template): I forsee a bug
+        // where the runtime-nquad_intersection value (set by runtime
+        // config) is set to something smaller than the kernel template
+        // parameter NQuadIntersection, and the values in the chunk_edge
+        // data container are not zero-padded. intersection/transfer View
+        // extents are set by the runtime value. Keep this in mind! (This TODO
+        // message is copy-pasted in other places -- remove all instances by
+        // TOOD(...) header when resolved)
         for (int iquad = 0; iquad < nquad_intersection; iquad++) {
           edge(local_index.iedge, local_index.ipoint, iquad) =
               this->get_value<on_device>(
@@ -263,6 +274,14 @@ private:
 
     specfem::execution::for_each_level(
         specfem::execution::TeamThreadMDRangeIterator(
+            // TODO(nquad_intersection::runtime_vs_template): I forsee a bug
+            // where the runtime-nquad_intersection value (set by runtime
+            // config) is set to something smaller than the kernel template
+            // parameter NQuadIntersection, and the values in the chunk_edge
+            // data container are not zero-padded. intersection/transfer View
+            // extents are set by the runtime value. Keep this in mind! (This
+            // TODO message is copy-pasted in other places -- remove all
+            // instances by TOOD(...) header when resolved)
             index.get_policy_index(), index.nedges(), nquad_intersection),
         [&](const auto index) {
           (factor_call(edges, index), ...);

--- a/core/specfem/assembly/nonconforming_interfaces/dim2/impl/interface_container.tpp
+++ b/core/specfem/assembly/nonconforming_interfaces/dim2/impl/interface_container.tpp
@@ -21,24 +21,22 @@ specfem::assembly::nonconforming_interfaces_impl::interface_container<
         const int ngllz, const int ngllx,
         const specfem::assembly::element_intersections<
             specfem::element::dimension_tag::dim2> &element_intersections,
-        const specfem::assembly::mesh<dimension_tag> &mesh) {
+        const specfem::assembly::mesh<dimension_tag> &mesh,
+        const specfem::element_coupling::flux_scheme_configuration
+            &flux_scheme_config) {
+  const auto &interfacial_quadrature_rule =
+      flux_scheme_config.get_interfacial_quadrature();
+  const auto &interface_knots = interfacial_quadrature_rule.get_hxi();
+  const auto &interface_weights = interfacial_quadrature_rule.get_hw();
+  const auto &interface_deriv = interfacial_quadrature_rule.get_hhprime();
 
-  // TODO: make this a parameter for now, use same gll quadrature
-  Kokkos::View<type_real *, Kokkos::HostSpace> interface_quadrature(
-      "interface_quadrature", ngllx);
-  Kokkos::View<type_real *, Kokkos::HostSpace> interface_weights(
-      "interface_weights", ngllx);
-  Kokkos::View<type_real **, Kokkos::HostSpace> interface_deriv(
-      "interface_deriv", ngllx, ngllx);
-  for (int i = 0; i < mesh.h_xi.extent(0); i++) {
-    interface_quadrature(i) = mesh.h_xi(i);
-    interface_weights(i) = mesh.h_weights(i);
-    for (int j = 0; j < mesh.h_xi.extent(0); j++) {
-      interface_deriv(i, j) = mesh.h_hprime(i, j);
-    }
-  }
-
-  const int nquad_intersection = interface_quadrature.extent(0);
+  // TODO(nquad_intersection::runtime_vs_template): I forsee a bug where this
+  // value, below, is set to something smaller than the kernel template
+  // parameter NQuadIntersection, and the values in the chunk_edge data
+  // container are not zero-padded. intersection/transfer View extents are set
+  // by the runtime value. Keep this in mind! (This TODO message is copy-pasted
+  // in other places -- remove all instances by TOOD(...) header when resolved)
+  const int nquad_intersection = interface_knots.extent(0);
 
   if (ngllz <= 0 || ngllx <= 0) {
     KOKKOS_ABORT_WITH_LOCATION("Invalid GLL grid size");
@@ -110,7 +108,7 @@ specfem::assembly::nonconforming_interfaces_impl::interface_container<
     auto transfer_subview_other =
         Kokkos::subview(h_transfer_function_other, i, Kokkos::ALL, Kokkos::ALL);
     specfem::assembly::nonconforming_interfaces_impl::set_transfer_functions(
-        icoorg, jcoorg, iedge_type, jedge_type, interface_quadrature, mesh.h_xi,
+        icoorg, jcoorg, iedge_type, jedge_type, interface_knots, mesh.h_xi,
         transfer_subview, transfer_subview_other);
     // compute normal on edge
     const int npoints = element.number_of_points_on_orientation(iedge_type);

--- a/core/specfem/assembly/nonconforming_interfaces/dim2/impl/interface_container.tpp
+++ b/core/specfem/assembly/nonconforming_interfaces/dim2/impl/interface_container.tpp
@@ -24,11 +24,34 @@ specfem::assembly::nonconforming_interfaces_impl::interface_container<
         const specfem::assembly::mesh<dimension_tag> &mesh,
         const specfem::element_coupling::flux_scheme_configuration
             &flux_scheme_config) {
-  const auto &interfacial_quadrature_rule =
-      flux_scheme_config.get_interfacial_quadrature();
-  const auto &interface_knots = interfacial_quadrature_rule.get_hxi();
-  const auto &interface_weights = interfacial_quadrature_rule.get_hw();
-  const auto &interface_deriv = interfacial_quadrature_rule.get_hhprime();
+
+  Kokkos::View<type_real *, Kokkos::HostSpace> interface_knots;
+  Kokkos::View<type_real *, Kokkos::HostSpace> interface_weights;
+  Kokkos::View<type_real **, Kokkos::HostSpace> interface_deriv;
+
+  if (flux_scheme_config.was_interfacial_quadrature_set()) {
+    const auto &interfacial_quadrature_rule =
+        flux_scheme_config.get_interfacial_quadrature();
+    interface_knots = interfacial_quadrature_rule.get_hxi();
+    interface_weights = interfacial_quadrature_rule.get_hw();
+    interface_deriv = interfacial_quadrature_rule.get_hhprime();
+  } else {
+    // if flux_scheme_config does not give a quadrature rule (e.g. default arg),
+    // copy mesh quadrature
+    interface_knots =
+        Kokkos::View<type_real *, Kokkos::HostSpace>("interface_knots", ngllx);
+    interface_weights = Kokkos::View<type_real *, Kokkos::HostSpace>(
+        "interface_weights", ngllx);
+    interface_deriv = Kokkos::View<type_real **, Kokkos::HostSpace>(
+        "interface_deriv", ngllx, ngllx);
+    for (int i = 0; i < mesh.h_xi.extent(0); i++) {
+      interface_knots(i) = mesh.h_xi(i);
+      interface_weights(i) = mesh.h_weights(i);
+      for (int j = 0; j < mesh.h_xi.extent(0); j++) {
+        interface_deriv(i, j) = mesh.h_hprime(i, j);
+      }
+    }
+  }
 
   // TODO(nquad_intersection::runtime_vs_template): I forsee a bug where this
   // value, below, is set to something smaller than the kernel template

--- a/core/specfem/assembly/nonconforming_interfaces/dim2/nonconforming_interfaces.cpp
+++ b/core/specfem/assembly/nonconforming_interfaces/dim2/nonconforming_interfaces.cpp
@@ -11,8 +11,10 @@ specfem::assembly::nonconforming_interfaces<
         const int ngllz, const int ngllx,
         const specfem::assembly::element_intersections<
             specfem::element::dimension_tag::dim2> &element_intersections,
-        const specfem::assembly::mesh<dimension_tag> &mesh)
+        const specfem::assembly::mesh<dimension_tag> &mesh,
+        const specfem::element_coupling::flux_scheme_configuration
+            &flux_scheme_config)
     : interface_container([&]<typename TagsType>() {
         return InterfaceContainerTemplateType<TagsType>(
-            ngllz, ngllx, element_intersections, mesh);
+            ngllz, ngllx, element_intersections, mesh, flux_scheme_config);
       }){};

--- a/core/specfem/assembly/nonconforming_interfaces/dim2/nonconforming_interfaces.hpp
+++ b/core/specfem/assembly/nonconforming_interfaces/dim2/nonconforming_interfaces.hpp
@@ -4,6 +4,7 @@
 #include "specfem/assembly/element_intersections.hpp"
 #include "specfem/assembly/mesh.hpp"
 #include "specfem/data_access.hpp"
+#include "specfem/element_coupling/flux_scheme_configuration.hpp"
 #include "specfem/element_coupling/tags.hpp"
 #include "specfem/enums.hpp"
 #include "specfem/macros/tag_dispatch.hpp"
@@ -54,7 +55,9 @@ public:
       const int ngllz, const int ngllx,
       const specfem::assembly::element_intersections<dimension_tag>
           &element_intersections,
-      const specfem::assembly::mesh<dimension_tag> &mesh);
+      const specfem::assembly::mesh<dimension_tag> &mesh,
+      const specfem::element_coupling::flux_scheme_configuration
+          &flux_scheme_config = {});
 
   nonconforming_interfaces() = default;
 

--- a/core/specfem/element_coupling/flux_scheme_configuration.hpp
+++ b/core/specfem/element_coupling/flux_scheme_configuration.hpp
@@ -4,14 +4,34 @@
 #include "specfem/element_coupling.hpp"
 #include "specfem/quadrature/quadrature.hpp"
 
+#include <vector>
+
 namespace specfem::element_coupling {
 
+/**
+ * @brief Defines the (codimension-1) mesh of the interface for integration.
+ *
+ * The interfacial integrals are computed through composite quadrature. The
+ * composite components are specified by a mesh, constructed according to one of
+ * these rules.
+ */
+enum class interfacial_meshing_type {
+  intersections, ///< integrals defined on intersections.
+  acoustic_host, ///< integrals defined by element faces on acoustic side.
+  elastic_host,  ///< integrals defined by element faces on elastic side.
+  self_host      ///< integrals defined by element faces on self side.
+};
 struct flux_scheme_configuration {
+private:
+  // ====== acoustic-elastic ======
   specfem::element_coupling::flux_scheme_tag flux_scheme_tag;
+  specfem::element_coupling::interfacial_meshing_type interfacial_meshing_type;
+  specfem::quadrature::quadrature interfacial_quadrature;
+  // ==== end acoustic-elastic ====
+
   std::vector<type_real> scheme_parameters;
 
-  specfem::quadrature::quadrature interfacial_quadrature;
-
+public:
   flux_scheme_configuration()
       : flux_scheme_tag(specfem::element_coupling::flux_scheme_tag::natural) {}
 
@@ -28,6 +48,14 @@ struct flux_scheme_configuration {
   }
 
   /**
+   * @brief Sets the flux scheme tag for the acoustic-elastic interface.
+   */
+  void set_flux_scheme_tag(
+      specfem::element_coupling::flux_scheme_tag flux_scheme_tag) {
+    this->flux_scheme_tag = flux_scheme_tag;
+  }
+
+  /**
    * @brief Get the quadrature object corresponding to interfacial integration.
    *
    * @return specfem::quadrature::quadrature the quadrature object for the
@@ -35,6 +63,35 @@ struct flux_scheme_configuration {
    */
   specfem::quadrature::quadrature get_interfacial_quadrature() const {
     return interfacial_quadrature;
+  }
+  /**
+   * @brief Sets the quadrature object corresponding to interfacial integration.
+   *
+   */
+  void set_interfacial_quadrature(
+      specfem::quadrature::quadrature interfacial_quadrature) {
+    this->interfacial_quadrature = interfacial_quadrature;
+  }
+
+  /**
+   * @brief Get the interfacial meshing type for the acoustic-elastic interface.
+   *
+   * @return specfem::element_coupling::interfacial_meshing_type the meshing
+   * type
+   */
+  specfem::element_coupling::interfacial_meshing_type
+  get_interfacial_meshing_type() const {
+    return interfacial_meshing_type;
+  }
+  /**
+   * @brief Set the interfacial meshing type for the acoustic-elastic interface
+   *
+   * @param interfacial_meshing_type the value to set to
+   */
+  void set_interfacial_meshing_type(
+      specfem::element_coupling::interfacial_meshing_type
+          interfacial_meshing_type) {
+    this->interfacial_meshing_type = interfacial_meshing_type;
   }
 };
 } // namespace specfem::element_coupling

--- a/core/specfem/element_coupling/flux_scheme_configuration.hpp
+++ b/core/specfem/element_coupling/flux_scheme_configuration.hpp
@@ -27,13 +27,20 @@ private:
   specfem::element_coupling::flux_scheme_tag flux_scheme_tag;
   specfem::element_coupling::interfacial_meshing_type interfacial_meshing_type;
   specfem::quadrature::quadrature interfacial_quadrature;
+  bool was_quadrature_set;
   // ==== end acoustic-elastic ====
 
   std::vector<type_real> scheme_parameters;
 
 public:
   flux_scheme_configuration()
-      : flux_scheme_tag(specfem::element_coupling::flux_scheme_tag::natural) {}
+      : flux_scheme_tag(specfem::element_coupling::flux_scheme_tag::natural),
+        was_quadrature_set(false),
+        interfacial_meshing_type(
+            specfem::
+                element_coupling:: // this may differ from defaults in
+                                   // core/specfem/runtime_configuration/flux_schemes.hpp
+            interfacial_meshing_type::intersections) {}
 
   /**
    * @brief Get the flux scheme tag for a given intersection. At the moment, the
@@ -64,6 +71,13 @@ public:
   specfem::quadrature::quadrature get_interfacial_quadrature() const {
     return interfacial_quadrature;
   }
+
+  /**
+   * @brief Returns whether or not the interfacial_quadrature object was set. If
+   * False, quadrature Views may not be initialized.
+   */
+  bool was_interfacial_quadrature_set() const { return was_quadrature_set; }
+
   /**
    * @brief Sets the quadrature object corresponding to interfacial integration.
    *
@@ -71,6 +85,7 @@ public:
   void set_interfacial_quadrature(
       specfem::quadrature::quadrature interfacial_quadrature) {
     this->interfacial_quadrature = interfacial_quadrature;
+    was_quadrature_set = true;
   }
 
   /**

--- a/core/specfem/runtime_configuration/flux_schemes.cpp
+++ b/core/specfem/runtime_configuration/flux_schemes.cpp
@@ -6,7 +6,9 @@
 
 specfem::runtime_configuration::flux_schemes::flux_schemes(
     const YAML::Node &Node)
-    : flux_schemes_node(Node) {
+    : flux_schemes() // inherit default values from default constructor
+{
+  flux_schemes_node = Node;
 
   // multi-rules in commit 4a27c96cde7e8548556da6caf628eda034fd35b3
 
@@ -37,6 +39,34 @@ specfem::runtime_configuration::flux_schemes::flux_schemes(
                                std::string(e.what()));
     }
   }
+
+  if (const YAML::Node interfacial_meshing_type_node =
+          Node["interfacial-mesh"]) {
+    try {
+      std::string meshing_type_str =
+          interfacial_meshing_type_node.as<std::string>();
+      // consider replacing with from_string() or add alias handling.
+      if (meshing_type_str == "intersections") {
+        interfacial_meshing_type =
+            specfem::element_coupling::interfacial_meshing_type::intersections;
+      } else if (meshing_type_str == "acoustic-host") {
+        interfacial_meshing_type =
+            specfem::element_coupling::interfacial_meshing_type::acoustic_host;
+      } else if (meshing_type_str == "elastic-host") {
+        interfacial_meshing_type =
+            specfem::element_coupling::interfacial_meshing_type::elastic_host;
+      } else if (meshing_type_str == "self-host") {
+        interfacial_meshing_type =
+            specfem::element_coupling::interfacial_meshing_type::self_host;
+      } else {
+        throw std::runtime_error("Unsupported interfacial meshing type: " +
+                                 meshing_type_str);
+      }
+    } catch (const YAML::Exception &e) {
+      throw std::runtime_error("Error parsing interfacial_meshing_type: " +
+                               std::string(e.what()));
+    }
+  }
 }
 
 specfem::element_coupling::flux_scheme_configuration
@@ -44,15 +74,18 @@ specfem::runtime_configuration::flux_schemes::get_flux_scheme(
     const int &ngll) const {
   specfem::element_coupling::flux_scheme_configuration config;
 
-  config.flux_scheme_tag = flux_scheme_tag;
+  config.set_flux_scheme_tag(flux_scheme_tag);
+  config.set_interfacial_meshing_type(interfacial_meshing_type);
 
   if (interfacial_quadrature != nullptr) {
-    config.interfacial_quadrature = interfacial_quadrature->instantiate().gll;
+    config.set_interfacial_quadrature(
+        interfacial_quadrature->instantiate().gll);
   } else {
     // default interfacial quadrature rule (GLL-N)
-    // TODO: replace with GL-(N-1)
-    config.interfacial_quadrature =
-        specfem::quadrature::gll::gll(0.0, 0.0, ngll);
+    // TODO: replace with GL-(N-1) for interfacial_meshing_type::intersections,
+    // (GLL-N) for host
+    config.set_interfacial_quadrature(
+        specfem::quadrature::gll::gll(0.0, 0.0, ngll));
   }
 
   return config;

--- a/core/specfem/runtime_configuration/flux_schemes.hpp
+++ b/core/specfem/runtime_configuration/flux_schemes.hpp
@@ -19,14 +19,24 @@ namespace runtime_configuration {
 class flux_schemes {
 public:
   flux_schemes(const YAML::Node &Node);
-  flux_schemes()
+  flux_schemes() // default values here; noded constructor delegates to this
+                 // one:
+                 //
+                 // (TODO: remember to re-examine interfacial_meshing_type
+                 // after self-host study)
       : flux_scheme_tag(specfem::element_coupling::flux_scheme_tag::natural),
-        interfacial_quadrature(nullptr) {};
+        interfacial_quadrature(nullptr),
+        interfacial_meshing_type(specfem::element_coupling::
+                                     interfacial_meshing_type::intersections) {
+        };
 
 private:
+  // ====== acoustic-elastic ======
   specfem::element_coupling::flux_scheme_tag flux_scheme_tag;
+  specfem::element_coupling::interfacial_meshing_type interfacial_meshing_type;
   std::unique_ptr<specfem::runtime_configuration::quadrature>
       interfacial_quadrature;
+  // ==== end acoustic-elastic ====
 
 public:
   /**

--- a/core/specfem/runtime_configuration/setup.cpp
+++ b/core/specfem/runtime_configuration/setup.cpp
@@ -55,7 +55,8 @@ specfem::runtime_configuration::setup::setup(const YAML::Node &parameter_dict) {
   }
 
   // Get flux scheme info (optional)
-  if (const YAML::Node &flux_schemes_node = simulation_setup["flux-scheme"]) {
+  if (const YAML::Node &flux_schemes_node =
+          simulation_setup["nonconforming-coupling"]) {
     this->flux_schemes =
         std::make_unique<specfem::runtime_configuration::flux_schemes>(
             flux_schemes_node);


### PR DESCRIPTION
## Description

Please describe the changes/features in this pull request.

- Introduces `specfem::element_coupling::interfacial_meshing_type` for intersections and self-host (+ acoustic/elastic host).
- Renames `flux-scheme` node to `nonconforming-coupling`
- adds YAML config for `interfacial_meshing_type`. New example YAML:
```yaml
nonconforming-coupling:
  # optional
  type: natural

  # optional
  quadrature:
    # same format as element quadrature; example here:
    quadrature-type: GLL4

  # optional
  interfacial-mesh: intersections
```
- `flux_scheme_configuration` now passed to NCI container constructors.
- `flux_scheme_configuration`'s quadrature rule is now used instead of mesh's GLL when populating NCI container views.

## Issue Number

If there is an issue created for these changes, link it here

#1825

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
