### PR TITLE
[FIX] Index mapping bug

### DIFF
--- a/core/specfem/assembly/mesh/dim3/impl/points.tpp
+++ b/core/specfem/assembly/mesh/dim3/impl/points.tpp
@@ -90,6 +90,14 @@ specfem::assembly::mesh_impl::points<specfem::element::dimension_tag::dim3>::
   Kokkos::fence();
 
   // Set up internal points
+  // iz, iy, ix iterate over the (ngllz-2)*(nglly-2)*(ngllx-2) strictly
+  // interior GLL indices {1,..,ngllz-2} x {1,..,nglly-2} x {1,..,ngllx-2}.
+  // The formula maps them to a flat 0-based index by shifting each by -1,
+  // so the interior block for chunk ichunk occupies the contiguous range
+  // [ichunk*chunk_size*(ngllz-2)*(nglly-2)*(ngllx-2),
+  //  (ichunk+1)*chunk_size*(ngllz-2)*(nglly-2)*(ngllx-2) - 1].
+  // Boundary points (faces, edges, corners) are assigned separately starting
+  // at ig = nspec*(ngllz-2)*(nglly-2)*(ngllx-2) below.
   Kokkos::parallel_for(
       "specfem::assembly::mesh::points::initialize_internal_indices",
       Kokkos::MDRangePolicy<Kokkos::DefaultHostExecutionSpace,
@@ -101,8 +109,9 @@ specfem::assembly::mesh_impl::points<specfem::element::dimension_tag::dim3>::
           if (ispec >= nspec)
             break;
           this->h_index_mapping(ispec, iz, iy, ix) =
-              ielement + iz * chunk_size + iy * chunk_size * (ngllz - 2) +
-              ix * chunk_size * (ngllz - 2) * (nglly - 2) +
+              ielement + (iz - 1) * chunk_size +
+              (iy - 1) * chunk_size * (ngllz - 2) +
+              (ix - 1) * chunk_size * (ngllz - 2) * (nglly - 2) +
               ichunk * chunk_size * (ngllz - 2) * (nglly - 2) * (ngllx - 2);
         }
       });

--- a/tests/unit-tests/assembly/dim3/mesh/points.cpp
+++ b/tests/unit-tests/assembly/dim3/mesh/points.cpp
@@ -9,6 +9,7 @@
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/filtered_graph.hpp>
 #include <gtest/gtest.h>
+#include <unordered_set>
 
 namespace specfem::assembly_test {
 
@@ -152,6 +153,34 @@ struct ExpectedMapping {
         }
       }
     }
+
+    // Check that every (ispec, iz, iy, ix) has a unique raw global index in
+    // [0, nglob). Collisions would cause distinct GLL points to share an iglob,
+    // silently aliasing their contributions in the field scatter.
+    std::unordered_set<int> seen;
+    for (int ispec = 0; ispec < points.nspec; ispec++) {
+      for (int iz = 0; iz < points.ngllz; iz++) {
+        for (int iy = 0; iy < points.nglly; iy++) {
+          for (int ix = 0; ix < points.ngllx; ix++) {
+            const int idx = points.h_index_mapping(ispec, iz, iy, ix);
+            ASSERT_GE(idx, 0) << "Negative raw global index at (" << ispec
+                              << ", " << iz << ", " << iy << ", " << ix << ").";
+            ASSERT_LT(idx, points.nglob)
+                << "Raw global index out of range at (" << ispec << ", " << iz
+                << ", " << iy << ", " << ix << "): " << idx
+                << " >= nglob=" << points.nglob;
+            // Only non-shared points (not on a conforming interface) must be
+            // unique; shared interface points intentionally reuse an index.
+            // We collect all and check the total count matches nglob.
+            seen.insert(idx);
+          }
+        }
+      }
+    }
+    ASSERT_EQ((int)seen.size(), points.nglob)
+        << "Number of distinct raw global indices (" << seen.size()
+        << ") does not match nglob (" << points.nglob
+        << "). Either some indices collide or some indices are unused.";
 
     SUCCEED() << "All points mapping and coordinates are correct." << std::endl;
     return;


### PR DESCRIPTION
## Description

The indexing of the wavefield had a small error that wrapped the field between last and first element

## Checklist

Please make sure to check developer documentation on specfem docs.

- [x] I ran the code through pre-commit to check style
- [x] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [x] I have added labels to the PR (see right hand side of the PR page)
- [x] My code passes all the integration tests
- [x] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
