### PR TITLE
`...ChunkFaceViewType` types created + `...ChunkElementViewType` refactor

### DIFF
--- a/core/specfem/data_access/accessor.hpp
+++ b/core/specfem/data_access/accessor.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "data_class.hpp"
-#include "specfem/datatype.hpp"
+#include "specfem/datatype/accessor_type.hpp"
 #include "specfem/enums.hpp"
 #include <type_traits>
 
@@ -35,7 +35,7 @@ template <typename T, typename = void> struct is_accessor : std::false_type {};
 template <typename T>
 struct is_accessor<
     T, std::enable_if_t<std::is_same_v<decltype(T::accessor_type),
-                                       specfem::datatype::AccessorType> > >
+                                       specfem::datatype::AccessorType>>>
     : std::true_type {};
 
 } // namespace specfem::data_access

--- a/core/specfem/data_access/accessor/chunk_edge.hpp
+++ b/core/specfem/data_access/accessor/chunk_edge.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "specfem/data_access/accessor.hpp"
-#include "specfem/datatype.hpp"
+#include "specfem/datatype/simd.hpp"
 #include "specfem/enums.hpp"
 #include <Kokkos_Core.hpp>
 
@@ -50,7 +50,7 @@ struct Accessor<specfem::datatype::AccessorType::chunk_edge, DataClass,
   using scalar_type =
       Kokkos::View<typename simd<T>::datatype[nelements][ngll],
                    Kokkos::DefaultExecutionSpace::scratch_memory_space,
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
   /**
    * @brief Vector field storage for chunked edge elements
@@ -64,7 +64,7 @@ struct Accessor<specfem::datatype::AccessorType::chunk_edge, DataClass,
   using vector_type =
       Kokkos::View<typename simd<T>::datatype[nelements][ngll][components],
                    Kokkos::DefaultExecutionSpace::scratch_memory_space,
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
   /**
    * @brief Tensor field storage for chunked edge elements
@@ -79,7 +79,7 @@ struct Accessor<specfem::datatype::AccessorType::chunk_edge, DataClass,
   using tensor_type = Kokkos::View<
       typename simd<T>::datatype[nelements][ngll][components][dimension],
       Kokkos::DefaultExecutionSpace::scratch_memory_space,
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 };
 
 /**
@@ -91,7 +91,7 @@ struct is_chunk_edge : std::false_type {};
 template <typename T>
 struct is_chunk_edge<
     T, std::enable_if_t<T::accessor_type ==
-                        specfem::datatype::AccessorType::chunk_edge> >
+                        specfem::datatype::AccessorType::chunk_edge>>
     : std::true_type {};
 
 } // namespace specfem::data_access

--- a/core/specfem/data_access/accessor/chunk_face.hpp
+++ b/core/specfem/data_access/accessor/chunk_face.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "specfem/data_access/accessor.hpp"
+#include "specfem/datatype/simd.hpp"
 #include "specfem/element.hpp"
-
-#include "specfem/datatype.hpp"
 #include <Kokkos_Core.hpp>
 
 namespace specfem::data_access {
@@ -51,7 +51,7 @@ struct Accessor<specfem::datatype::AccessorType::chunk_face, DataClass,
   using scalar_type =
       Kokkos::View<typename simd<T>::datatype[nfaces][ngll][ngll],
                    Kokkos::DefaultExecutionSpace::scratch_memory_space,
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
   /**
    * @brief Vector field storage for chunked face elements
@@ -65,7 +65,7 @@ struct Accessor<specfem::datatype::AccessorType::chunk_face, DataClass,
   using vector_type =
       Kokkos::View<typename simd<T>::datatype[nfaces][ngll][ngll][components],
                    Kokkos::DefaultExecutionSpace::scratch_memory_space,
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
   /**
    * @brief Tensor field storage for chunked face elements
@@ -80,7 +80,7 @@ struct Accessor<specfem::datatype::AccessorType::chunk_face, DataClass,
   using tensor_type = Kokkos::View<
       typename simd<T>::datatype[nfaces][ngll][ngll][components][dimension],
       Kokkos::DefaultExecutionSpace::scratch_memory_space,
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 };
 
 /**
@@ -92,7 +92,7 @@ struct is_chunk_face : std::false_type {};
 template <typename T>
 struct is_chunk_face<
     T, std::enable_if_t<T::accessor_type ==
-                        specfem::datatype::AccessorType::chunk_face> >
+                        specfem::datatype::AccessorType::chunk_face>>
     : std::true_type {};
 
 } // namespace specfem::data_access

--- a/core/specfem/data_access/accessor/element.hpp
+++ b/core/specfem/data_access/accessor/element.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "specfem/data_access/accessor.hpp"
-#include "specfem/datatype.hpp"
 #include "specfem/enums.hpp"
 #include <Kokkos_Core.hpp>
 
@@ -21,9 +20,8 @@ struct Accessor<specfem::datatype::AccessorType::element, DataClass,
 template <typename T, typename = void> struct is_element : std::false_type {};
 
 template <typename T>
-struct is_element<T,
-                  std::enable_if_t<T::accessor_type ==
-                                   specfem::datatype::AccessorType::element> >
+struct is_element<T, std::enable_if_t<T::accessor_type ==
+                                      specfem::datatype::AccessorType::element>>
     : std::true_type {};
 
 } // namespace specfem::data_access

--- a/core/specfem/data_access/accessor/point_accessor.hpp
+++ b/core/specfem/data_access/accessor/point_accessor.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "specfem/data_access/accessor.hpp"
-#include "specfem/datatype.hpp"
+#include "specfem/datatype/simd.hpp"
 #include "specfem/enums.hpp"
 
 namespace specfem::data_access {
@@ -97,7 +97,7 @@ template <typename T, typename = void> struct is_point : std::false_type {};
 
 template <typename T>
 struct is_point<T, std::enable_if_t<T::accessor_type ==
-                                    specfem::datatype::AccessorType::point> >
+                                    specfem::datatype::AccessorType::point>>
     : std::true_type {};
 
 } // namespace specfem::data_access

--- a/core/specfem/datatype/chunk_element_view.hpp
+++ b/core/specfem/datatype/chunk_element_view.hpp
@@ -100,6 +100,7 @@ struct VectorChunkElementViewType
   ///@}
 
   using chunk_ndim_view_type::operator();
+  using chunk_ndim_view_type::chunk_ndim_view_type;
 
   /**
    * @brief Get vector subview by a point index.
@@ -158,6 +159,7 @@ struct TensorChunkElementViewType
                                                         ///< component access
 
   using chunk_ndim_view_type::operator();
+  using chunk_ndim_view_type::chunk_ndim_view_type;
   /**
    * @brief Get tensor subview by a point index.
    *

--- a/core/specfem/datatype/chunk_element_view.hpp
+++ b/core/specfem/datatype/chunk_element_view.hpp
@@ -33,22 +33,21 @@ template <typename T, specfem::element::dimension_tag DimensionTag,
               Kokkos::DefaultExecutionSpace::scratch_memory_space,
           typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged>>
 struct ScalarChunkElementViewType
-    : public ChunkNDimViewType<
-          T, DimensionTag, NumberOfElements, NumberOfGLLPoints,
-          specfem::element::dimension<DimensionTag>::dim,
-          std::integer_sequence<int>, UseSIMD, MemorySpace, MemoryTraits> {
+    : public ChunkNDimViewType<T, DimensionTag, NumberOfElements,
+                               NumberOfGLLPoints,
+                               specfem::element::dimension<DimensionTag>::dim,
+                               std::integer_sequence<int>,
+                               specfem::datatype::AccessorType::chunk_element,
+                               UseSIMD, MemorySpace, MemoryTraits> {
   using chunk_ndim_view_type =
       ChunkNDimViewType<T, DimensionTag, NumberOfElements, NumberOfGLLPoints,
                         specfem::element::dimension<DimensionTag>::dim,
-                        std::integer_sequence<int>, UseSIMD, MemorySpace,
-                        MemoryTraits>;
+                        std::integer_sequence<int>,
+                        specfem::datatype::AccessorType::chunk_element, UseSIMD,
+                        MemorySpace, MemoryTraits>;
 
   constexpr static int nelements = NumberOfElements; ///< Number of elements in
                                                      ///< the chunk
-  constexpr static auto accessor_type =
-      specfem::datatype::AccessorType::chunk_element; ///< Accessor type for
-                                                      ///< identifying the
-                                                      ///< class
 };
 
 /**
@@ -75,12 +74,14 @@ struct VectorChunkElementViewType
     : public ChunkNDimViewType<T, DimensionTag, NumberOfElements,
                                NumberOfGLLPoints,
                                specfem::element::dimension<DimensionTag>::dim,
-                               std::integer_sequence<int, Components>, UseSIMD,
-                               MemorySpace, MemoryTraits> {
+                               std::integer_sequence<int, Components>,
+                               specfem::datatype::AccessorType::chunk_element,
+                               UseSIMD, MemorySpace, MemoryTraits> {
   using chunk_ndim_view_type =
       ChunkNDimViewType<T, DimensionTag, NumberOfElements, NumberOfGLLPoints,
                         specfem::element::dimension<DimensionTag>::dim,
-                        std::integer_sequence<int, Components>, UseSIMD,
+                        std::integer_sequence<int, Components>,
+                        specfem::datatype::AccessorType::chunk_element, UseSIMD,
                         MemorySpace, MemoryTraits>;
   using point_view_type =
       VectorPointViewType<T, Components, UseSIMD>; ///< Point view type for
@@ -92,12 +93,8 @@ struct VectorChunkElementViewType
    *
    */
   ///@{
-  constexpr static auto accessor_type =
-      specfem::datatype::AccessorType::chunk_element; ///< Accessor type for
-                                                      ///< identifying the
-                                                      ///< class
-  constexpr static int nelements = NumberOfElements;  ///< Number of elements in
-                                                      ///< the chunk
+  constexpr static int nelements = NumberOfElements; ///< Number of elements in
+                                                     ///< the chunk
   constexpr static int components = Components; ///< Number of vector values at
                                                 ///< each GLL point
   ///@}
@@ -141,23 +138,21 @@ struct TensorChunkElementViewType
     : public ChunkNDimViewType<
           T, DimensionTag, NumberOfElements, NumberOfGLLPoints,
           specfem::element::dimension<DimensionTag>::dim,
-          std::integer_sequence<int, Components, NumberOfDimensions>, UseSIMD,
-          MemorySpace, MemoryTraits> {
+          std::integer_sequence<int, Components, NumberOfDimensions>,
+          specfem::datatype::AccessorType::chunk_element, UseSIMD, MemorySpace,
+          MemoryTraits> {
 
   using chunk_ndim_view_type = ChunkNDimViewType<
       T, DimensionTag, NumberOfElements, NumberOfGLLPoints,
       specfem::element::dimension<DimensionTag>::dim,
-      std::integer_sequence<int, Components, NumberOfDimensions>, UseSIMD,
-      MemorySpace, MemoryTraits>;
+      std::integer_sequence<int, Components, NumberOfDimensions>,
+      specfem::datatype::AccessorType::chunk_element, UseSIMD, MemorySpace,
+      MemoryTraits>;
 
   constexpr static int nelements = NumberOfElements; ///< Number of elements in
   ///< the chunk
   constexpr static int components = Components;
   constexpr static int dimensions = NumberOfDimensions;
-  constexpr static auto accessor_type =
-      specfem::datatype::AccessorType::chunk_element; ///< Accessor type for
-                                                      ///< identifying the
-                                                      ///< class
   using point_view_type = TensorPointViewType<T, Components, NumberOfDimensions,
                                               UseSIMD>; ///< Point view type for
                                                         ///< component access

--- a/core/specfem/datatype/chunk_element_view.hpp
+++ b/core/specfem/datatype/chunk_element_view.hpp
@@ -1,10 +1,8 @@
 #pragma once
 
 #include "accessor_type.hpp"
+#include "chunk_ndim_view.hpp"
 #include "impl/chunk_element_subview.hpp"
-#include "point_view.hpp"
-#include "simd.hpp"
-#include "specfem/enums.hpp"
 #include <Kokkos_Core.hpp>
 
 // Forward declarations
@@ -33,213 +31,24 @@ template <typename T, specfem::element::dimension_tag DimensionTag,
           int NumberOfElements, int NumberOfGLLPoints, bool UseSIMD = false,
           typename MemorySpace =
               Kokkos::DefaultExecutionSpace::scratch_memory_space,
-          typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged> >
-struct ScalarChunkElementViewType;
+          typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged>>
+struct ScalarChunkElementViewType
+    : public ChunkNDimViewType<
+          T, DimensionTag, NumberOfElements, NumberOfGLLPoints,
+          specfem::element::dimension<DimensionTag>::dim,
+          std::integer_sequence<int>, UseSIMD, MemorySpace, MemoryTraits> {
+  using chunk_ndim_view_type =
+      ChunkNDimViewType<T, DimensionTag, NumberOfElements, NumberOfGLLPoints,
+                        specfem::element::dimension<DimensionTag>::dim,
+                        std::integer_sequence<int>, UseSIMD, MemorySpace,
+                        MemoryTraits>;
 
-/**
- * @brief 2D specialization for ScalarChunkElementViewType
- *
- * @tparam T Data type of the scalar values
- * @tparam NumberOfElements Number of elements in the chunk
- * @tparam NumberOfGLLPoints Number of GLL points in each element
- * @tparam UseSIMD Use SIMD datatypes for the array. If true, value_type is a
- * SIMD type
- * @tparam MemorySpace Memory space of the view
- * @tparam MemoryTraits Memory traits of the view
- */
-template <typename T, int NumberOfElements, int NumberOfGLLPoints, bool UseSIMD,
-          typename MemorySpace, typename MemoryTraits>
-struct ScalarChunkElementViewType<T, specfem::element::dimension_tag::dim2,
-                                  NumberOfElements, NumberOfGLLPoints, UseSIMD,
-                                  MemorySpace, MemoryTraits>
-    : public Kokkos::View<
-          typename specfem::datatype::simd<T, UseSIMD>::datatype
-              [NumberOfElements][NumberOfGLLPoints][NumberOfGLLPoints],
-          MemorySpace, MemoryTraits> {
-  /**
-   * @name Typedefs
-   *
-   */
-  ///@{
-  using simd = specfem::datatype::simd<T, UseSIMD>; ///< SIMD data type
-  using type =
-      Kokkos::View<typename simd::datatype[NumberOfElements][NumberOfGLLPoints]
-                                          [NumberOfGLLPoints],
-                   MemorySpace, MemoryTraits>; ///< Underlying data type used to
-                                               ///< store values
-  using value_type = typename type::value_type; ///< Value type used to store
-                                                ///< the elements of the array
-  using base_type = T;                          ///< Base type of the array
-  constexpr static auto dimension_tag =
-      specfem::element::dimension_tag::dim2; ///< Dimension tag
-  using index_type =
-      typename specfem::point::index<dimension_tag,
-                                     UseSIMD>; ///< index type for accessing at
-                                               ///< GLL level
-  constexpr static bool using_simd = UseSIMD;  ///< Use SIMD datatypes for the
-                                               ///< array. If false,
-                                               ///< std::is_same<value_type,
-                                               ///< base_type>::value is true
-  ///@}
-
-  /**
-   * @name Compile time constants
-   *
-   */
-  ///@{
+  constexpr static int nelements = NumberOfElements; ///< Number of elements in
+                                                     ///< the chunk
   constexpr static auto accessor_type =
       specfem::datatype::AccessorType::chunk_element; ///< Accessor type for
                                                       ///< identifying the
                                                       ///< class
-
-  constexpr static int nelements = NumberOfElements; ///< Number of elements in
-                                                     ///< the chunk
-  constexpr static int ngll = NumberOfGLLPoints; ///< Number of GLL points in
-                                                 ///< each element
-  ///@}
-
-  /**
-   * @name Constructors and assignment operators
-   *
-   */
-  ///@{
-  /**
-   * @brief Default constructor
-   */
-  KOKKOS_FUNCTION
-  ScalarChunkElementViewType() = default;
-
-  /**
-   * @brief Construct a new ScalarChunkElementViewType object within
-   * ScratchMemorySpace.
-   * Allocates an unmanaged view within ScratchMemorySpace. Useful for
-   * generating scratch views.
-   *
-   * @tparam ScratchMemorySpace Memory space of the view
-   * @param scratch_memory_space Memory space of the view
-   */
-  template <typename ScratchMemorySpace>
-  KOKKOS_FUNCTION
-  ScalarChunkElementViewType(const ScratchMemorySpace &scratch_memory_space)
-      : Kokkos::View<
-            value_type[NumberOfElements][NumberOfGLLPoints][NumberOfGLLPoints],
-            MemorySpace, MemoryTraits>(scratch_memory_space) {}
-  ///@}
-
-  using type::operator();
-
-  /**
-   * @brief Get scalar value by a point index.
-   *
-   * @param index Point index
-   */
-  KOKKOS_INLINE_FUNCTION
-  constexpr value_type &operator()(index_type index) {
-    return (*this)(index.ispec, index.iz, index.ix);
-  }
-};
-
-/**
- * @brief 3D specialization for ScalarChunkElementViewType
- *
- * @tparam T Data type of the scalar values
- * @tparam NumberOfElements Number of elements in the chunk
- * @tparam NumberOfGLLPoints Number of GLL points in each element
- * @tparam UseSIMD Use SIMD datatypes for the array. If true, value_type is a
- * SIMD type
- * @tparam MemorySpace Memory space of the view
- * @tparam MemoryTraits Memory traits of the view
- */
-template <typename T, int NumberOfElements, int NumberOfGLLPoints, bool UseSIMD,
-          typename MemorySpace, typename MemoryTraits>
-struct ScalarChunkElementViewType<T, specfem::element::dimension_tag::dim3,
-                                  NumberOfElements, NumberOfGLLPoints, UseSIMD,
-                                  MemorySpace, MemoryTraits>
-    : public Kokkos::View<typename specfem::datatype::simd<T, UseSIMD>::datatype
-                              [NumberOfElements][NumberOfGLLPoints]
-                              [NumberOfGLLPoints][NumberOfGLLPoints],
-                          MemorySpace, MemoryTraits> {
-  /**
-   * @name Typedefs
-   *
-   */
-  ///@{
-  using simd = specfem::datatype::simd<T, UseSIMD>; ///< SIMD data type
-  using type = Kokkos::View<
-      typename simd::datatype[NumberOfElements][NumberOfGLLPoints]
-                             [NumberOfGLLPoints][NumberOfGLLPoints],
-      MemorySpace, MemoryTraits>; ///< Underlying data type used to
-                                  ///< store values
-  using value_type = typename type::value_type; ///< Value type used to store
-                                                ///< the elements of the array
-  using base_type = T;                          ///< Base type of the array
-  constexpr static auto dimension_tag =
-      specfem::element::dimension_tag::dim3; ///< Dimension tag
-  using index_type =
-      typename specfem::point::index<dimension_tag,
-                                     UseSIMD>; ///< index type for accessing at
-                                               ///< GLL level
-  constexpr static bool using_simd = UseSIMD;  ///< Use SIMD datatypes for the
-                                               ///< array. If false,
-                                               ///< std::is_same<value_type,
-                                               ///< base_type>::value is true
-  ///@}
-
-  /**
-   * @name Compile time constants
-   *
-   */
-  ///@{
-  constexpr static auto accessor_type =
-      specfem::datatype::AccessorType::chunk_element; ///< Accessor type for
-                                                      ///< identifying the
-                                                      ///< class
-
-  constexpr static int nelements = NumberOfElements; ///< Number of elements in
-                                                     ///< the chunk
-  constexpr static int ngll = NumberOfGLLPoints; ///< Number of GLL points in
-                                                 ///< each element
-  ///@}
-
-  /**
-   * @name Constructors and assignment operators
-   *
-   */
-  ///@{
-  /**
-   * @brief Default constructor
-   */
-  KOKKOS_FUNCTION
-  ScalarChunkElementViewType() = default;
-
-  /**
-   * @brief Construct a new ScalarChunkElementViewType object within
-   * ScratchMemorySpace.
-   * Allocates an unmanaged view within ScratchMemorySpace. Useful for
-   * generating scratch views.
-   *
-   * @tparam ScratchMemorySpace Memory space of the view
-   * @param scratch_memory_space Memory space of the view
-   */
-  template <typename ScratchMemorySpace>
-  KOKKOS_FUNCTION
-  ScalarChunkElementViewType(const ScratchMemorySpace &scratch_memory_space)
-      : Kokkos::View<value_type[NumberOfElements][NumberOfGLLPoints]
-                               [NumberOfGLLPoints][NumberOfGLLPoints],
-                     MemorySpace, MemoryTraits>(scratch_memory_space) {}
-  ///@}
-
-  using type::operator();
-
-  /**
-   * @brief Get scalar value by a point index.
-   *
-   * @param index Point index
-   */
-  KOKKOS_INLINE_FUNCTION
-  constexpr value_type &operator()(index_type index) {
-    return (*this)(index.ispec, index.iz, index.iy, index.ix);
-  }
 };
 
 /**
@@ -261,58 +70,21 @@ template <typename T, specfem::element::dimension_tag DimensionTag,
           bool UseSIMD = false,
           typename MemorySpace =
               Kokkos::DefaultExecutionSpace::scratch_memory_space,
-          typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged> >
-struct VectorChunkElementViewType;
-
-/**
- * @brief 2D specialization for VectorChunkElementViewType
- *
- * @tparam T Data type of the vector values
- * @tparam NumberOfElements Number of elements in the chunk
- * @tparam NumberOfGLLPoints Number of GLL points in each element
- * @tparam Components Number of vector values (components) at each GLL point
- * @tparam UseSIMD Use SIMD datatypes for the array. If true, value_type is a
- * SIMD type
- * @tparam MemorySpace Memory space of the view
- * @tparam MemoryTraits Memory traits of the view
- */
-template <typename T, int NumberOfElements, int NumberOfGLLPoints,
-          int Components, bool UseSIMD, typename MemorySpace,
-          typename MemoryTraits>
-struct VectorChunkElementViewType<
-    T, specfem::element::dimension_tag::dim2, NumberOfElements,
-    NumberOfGLLPoints, Components, UseSIMD, MemorySpace, MemoryTraits>
-    : public Kokkos::View<typename specfem::datatype::simd<T, UseSIMD>::datatype
-                              [NumberOfElements][NumberOfGLLPoints]
-                              [NumberOfGLLPoints][Components],
-                          MemorySpace, MemoryTraits> {
-  /**
-   * @name Typedefs
-   *
-   */
-  ///@{
-  using simd = specfem::datatype::simd<T, UseSIMD>; ///< SIMD data type
-  using type =
-      Kokkos::View<typename simd::datatype[NumberOfElements][NumberOfGLLPoints]
-                                          [NumberOfGLLPoints][Components],
-                   MemorySpace, MemoryTraits>; ///< Underlying data type used to
-                                               ///< store values
-  using value_type = typename type::value_type; ///< Value type used to store
-                                                ///< the elements of the array
-  using base_type = T;                          ///< Base type of the array
-  constexpr static auto dimension_tag =
-      specfem::element::dimension_tag::dim2; ///< Dimension tag
-  using index_type =
-      typename specfem::point::index<dimension_tag,
-                                     UseSIMD>; ///< index type for accessing at
-                                               ///< GLL level
+          typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged>>
+struct VectorChunkElementViewType
+    : public ChunkNDimViewType<T, DimensionTag, NumberOfElements,
+                               NumberOfGLLPoints,
+                               specfem::element::dimension<DimensionTag>::dim,
+                               std::integer_sequence<int, Components>, UseSIMD,
+                               MemorySpace, MemoryTraits> {
+  using chunk_ndim_view_type =
+      ChunkNDimViewType<T, DimensionTag, NumberOfElements, NumberOfGLLPoints,
+                        specfem::element::dimension<DimensionTag>::dim,
+                        std::integer_sequence<int, Components>, UseSIMD,
+                        MemorySpace, MemoryTraits>;
   using point_view_type =
       VectorPointViewType<T, Components, UseSIMD>; ///< Point view type for
                                                    ///< component access
-  constexpr static bool using_simd = UseSIMD; ///< Use SIMD datatypes for the
-                                              ///< array. If false,
-                                              ///< std::is_same<value_type,
-                                              ///< base_type>::value is true
   ///@}
 
   /**
@@ -326,52 +98,11 @@ struct VectorChunkElementViewType<
                                                       ///< class
   constexpr static int nelements = NumberOfElements;  ///< Number of elements in
                                                       ///< the chunk
-  constexpr static int ngll = NumberOfGLLPoints; ///< Number of GLL points in
-                                                 ///< each element
-  constexpr static int components = Components;  ///< Number of vector values at
-                                                 ///< each GLL point
+  constexpr static int components = Components; ///< Number of vector values at
+                                                ///< each GLL point
   ///@}
 
-  /**
-   * @name Constructors and assignment operators
-   *
-   */
-  ///@{
-  /**
-   * @brief Default constructor
-   */
-  KOKKOS_FUNCTION
-  VectorChunkElementViewType() = default;
-
-  /**
-   * @brief Construct a new VectorChunkElementViewType object within
-   * ScratchMemorySpace.
-   * Allocates an unmanaged view within ScratchMemorySpace. Useful for
-   * generating scratch views.
-   *
-   * @tparam ScratchMemorySpace Memory space of the view
-   * @param scratch_memory_space Memory space of the view
-   */
-  template <typename ScratchMemorySpace>
-  KOKKOS_FUNCTION
-  VectorChunkElementViewType(const ScratchMemorySpace &scratch_memory_space)
-      : Kokkos::View<value_type[NumberOfElements][NumberOfGLLPoints]
-                               [NumberOfGLLPoints][Components],
-                     MemorySpace, MemoryTraits>(scratch_memory_space) {}
-  ///@}
-
-  using type::operator();
-
-  /**
-   * @brief Get vector component by a point index and vector indices.
-   *
-   * @param index Point index
-   * @param icomp Component index
-   */
-  KOKKOS_INLINE_FUNCTION
-  constexpr value_type &operator()(const index_type &index, const int &icomp) {
-    return (*this)(index.ispec, index.iz, index.ix, icomp);
-  }
+  using chunk_ndim_view_type::operator();
 
   /**
    * @brief Get vector subview by a point index.
@@ -380,130 +111,7 @@ struct VectorChunkElementViewType<
    */
   KOKKOS_INLINE_FUNCTION
   impl::VectorChunkElementSubview<VectorChunkElementViewType>
-  operator()(const index_type &index) {
-    return { *this, index };
-  }
-};
-
-/**
- * @brief 3D specialization for VectorChunkElementViewType
- *
- * @tparam T Data type of the vector values
- * @tparam NumberOfElements Number of elements in the chunk
- * @tparam NumberOfGLLPoints Number of GLL points in each element
- * @tparam Components Number of vector values (components) at each GLL point
- * @tparam UseSIMD Use SIMD datatypes for the array. If true, value_type is a
- * SIMD type
- * @tparam MemorySpace Memory space of the view
- * @tparam MemoryTraits Memory traits of the view
- */
-template <typename T, int NumberOfElements, int NumberOfGLLPoints,
-          int Components, bool UseSIMD, typename MemorySpace,
-          typename MemoryTraits>
-struct VectorChunkElementViewType<
-    T, specfem::element::dimension_tag::dim3, NumberOfElements,
-    NumberOfGLLPoints, Components, UseSIMD, MemorySpace, MemoryTraits>
-    : public Kokkos::View<
-          typename specfem::datatype::simd<T, UseSIMD>::datatype
-              [NumberOfElements][NumberOfGLLPoints][NumberOfGLLPoints]
-              [NumberOfGLLPoints][Components],
-          MemorySpace, MemoryTraits> {
-  /**
-   * @name Typedefs
-   *
-   */
-  ///@{
-  using simd = specfem::datatype::simd<T, UseSIMD>; ///< SIMD data type
-  using type = Kokkos::View<
-      typename simd::datatype[NumberOfElements][NumberOfGLLPoints]
-                             [NumberOfGLLPoints][NumberOfGLLPoints][Components],
-      MemorySpace, MemoryTraits>; ///< Underlying data type used to
-                                  ///< store values
-  using value_type = typename type::value_type; ///< Value type used to store
-                                                ///< the elements of the array
-  using base_type = T;                          ///< Base type of the array
-  constexpr static auto dimension_tag =
-      specfem::element::dimension_tag::dim3; ///< Dimension tag
-  using index_type =
-      typename specfem::point::index<dimension_tag,
-                                     UseSIMD>; ///< index type for accessing at
-                                               ///< GLL level
-  using point_view_type =
-      VectorPointViewType<T, Components, UseSIMD>; ///< Point view type for
-                                                   ///< component access
-  constexpr static bool using_simd = UseSIMD; ///< Use SIMD datatypes for the
-                                              ///< array. If false,
-                                              ///< std::is_same<value_type,
-                                              ///< base_type>::value is true
-  ///@}
-
-  /**
-   * @name Compile time constants
-   *
-   */
-  ///@{
-  constexpr static auto accessor_type =
-      specfem::datatype::AccessorType::chunk_element; ///< Accessor type for
-                                                      ///< identifying the
-                                                      ///< class
-  constexpr static int nelements = NumberOfElements;  ///< Number of elements in
-                                                      ///< the chunk
-  constexpr static int ngll = NumberOfGLLPoints; ///< Number of GLL points in
-                                                 ///< each element
-  constexpr static int components = Components;  ///< Number of vector values at
-                                                 ///< each GLL point
-  ///@}
-
-  /**
-   * @name Constructors and assignment operators
-   *
-   */
-  ///@{
-  /**
-   * @brief Default constructor
-   */
-  KOKKOS_FUNCTION
-  VectorChunkElementViewType() = default;
-
-  /**
-   * @brief Construct a new VectorChunkElementViewType object within
-   * ScratchMemorySpace.
-   * Allocates an unmanaged view within ScratchMemorySpace. Useful for
-   * generating scratch views.
-   *
-   * @tparam ScratchMemorySpace Memory space of the view
-   * @param scratch_memory_space Memory space of the view
-   */
-  template <typename ScratchMemorySpace>
-  KOKKOS_FUNCTION
-  VectorChunkElementViewType(const ScratchMemorySpace &scratch_memory_space)
-      : Kokkos::View<
-            value_type[NumberOfElements][NumberOfGLLPoints][NumberOfGLLPoints]
-                      [NumberOfGLLPoints][Components],
-            MemorySpace, MemoryTraits>(scratch_memory_space) {}
-  ///@}
-
-  using type::operator();
-
-  /**
-   * @brief Get vector component by a point index and vector indices.
-   *
-   * @param index Point index
-   * @param icomp Component index
-   */
-  KOKKOS_INLINE_FUNCTION
-  constexpr value_type &operator()(const index_type &index, const int &icomp) {
-    return (*this)(index.ispec, index.iz, index.iy, index.ix, icomp);
-  }
-
-  /**
-   * @brief Get vector subview by a point index.
-   *
-   * @param index Point index
-   */
-  KOKKOS_INLINE_FUNCTION
-  impl::VectorChunkElementSubview<VectorChunkElementViewType>
-  operator()(const index_type &index) {
+  operator()(const chunk_ndim_view_type::index_type &index) {
     return { *this, index };
   }
 };
@@ -528,133 +136,33 @@ template <typename T, specfem::element::dimension_tag DimensionTag,
           int NumberOfDimensions, bool UseSIMD = false,
           typename MemorySpace =
               Kokkos::DefaultExecutionSpace::scratch_memory_space,
-          typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged> >
-struct TensorChunkElementViewType;
-
-/**
- * @brief 2D specialization for TensorChunkElementViewType
- *
- * @tparam T Data type of the tensor values
- * @tparam NumberOfElements Number of elements in the chunk
- * @tparam NumberOfGLLPoints Number of GLL points in each element
- * @tparam Components Number of vector values (components) at each GLL point
- * @tparam NumberOfDimensions Number of dimensions of the tensor
- * @tparam UseSIMD Use SIMD datatypes for the array. If true, value_type is a
- * SIMD type
- * @tparam MemorySpace Memory space of the view
- * @tparam MemoryTraits Memory traits of the view
- */
-template <typename T, int NumberOfElements, int NumberOfGLLPoints,
-          int Components, int NumberOfDimensions, bool UseSIMD,
-          typename MemorySpace, typename MemoryTraits>
-struct TensorChunkElementViewType<T, specfem::element::dimension_tag::dim2,
-                                  NumberOfElements, NumberOfGLLPoints,
-                                  Components, NumberOfDimensions, UseSIMD,
-                                  MemorySpace, MemoryTraits>
-    : public Kokkos::View<
-          typename specfem::datatype::simd<T, UseSIMD>::datatype
-              [NumberOfElements][NumberOfGLLPoints][NumberOfGLLPoints]
-              [Components][NumberOfDimensions],
+          typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged>>
+struct TensorChunkElementViewType
+    : public ChunkNDimViewType<
+          T, DimensionTag, NumberOfElements, NumberOfGLLPoints,
+          specfem::element::dimension<DimensionTag>::dim,
+          std::integer_sequence<int, Components, NumberOfDimensions>, UseSIMD,
           MemorySpace, MemoryTraits> {
-  /**
-   * @name Typedefs
-   *
-   */
-  ///@{
-  using simd = specfem::datatype::simd<T, UseSIMD>; ///< SIMD data type
-  using type = typename Kokkos::View<
-      typename simd::datatype[NumberOfElements][NumberOfGLLPoints]
-                             [NumberOfGLLPoints][Components]
-                             [NumberOfDimensions],
-      MemorySpace, MemoryTraits>; ///< Underlying data type used to store values
-  using value_type = typename type::value_type; ///< Value type used to store
-                                                ///< the elements of the array
-  using base_type = T;                          ///< Base type of the array
-  constexpr static auto dimension_tag =
-      specfem::element::dimension_tag::dim2; ///< Dimension tag
-  using index_type =
-      typename specfem::point::index<dimension_tag, UseSIMD>; ///< index type
-                                                              ///< for accessing
-                                                              ///< at GLL level
-  using point_view_type = TensorPointViewType<T, Components, NumberOfDimensions,
-                                              UseSIMD>; ///< Point view type for
-                                                        ///< component access
-  constexpr static bool using_simd = UseSIMD; ///< Use SIMD datatypes for the
-                                              ///< array. If false,
-                                              ///< std::is_same<value_type,
-                                              ///< base_type>::value is true
-  ///@}
 
-  /**
-   * @name Compile time constants
-   *
-   */
-  ///@{
+  using chunk_ndim_view_type = ChunkNDimViewType<
+      T, DimensionTag, NumberOfElements, NumberOfGLLPoints,
+      specfem::element::dimension<DimensionTag>::dim,
+      std::integer_sequence<int, Components, NumberOfDimensions>, UseSIMD,
+      MemorySpace, MemoryTraits>;
+
+  constexpr static int nelements = NumberOfElements; ///< Number of elements in
+  ///< the chunk
+  constexpr static int components = Components;
+  constexpr static int dimensions = NumberOfDimensions;
   constexpr static auto accessor_type =
       specfem::datatype::AccessorType::chunk_element; ///< Accessor type for
                                                       ///< identifying the
                                                       ///< class
+  using point_view_type = TensorPointViewType<T, Components, NumberOfDimensions,
+                                              UseSIMD>; ///< Point view type for
+                                                        ///< component access
 
-  constexpr static int nelements = NumberOfElements; ///< Number of elements in
-                                                     ///< the chunk
-  constexpr static int ngll = NumberOfGLLPoints; ///< Number of GLL points in
-                                                 ///< each element
-  constexpr static int components = Components;  ///< Number of tensor values at
-                                                 ///< each GLL point
-  constexpr static int dimensions =
-      NumberOfDimensions; ///< Number of dimensions
-                          ///< of the tensor values
-  ///@}
-
-  /**
-   * @name Constructors and assignment operators
-   *
-   */
-  ///@{
-
-  /**
-   * @brief Default constructor
-   *
-   */
-  KOKKOS_FUNCTION
-  TensorChunkElementViewType() = default;
-
-  /**
-   * @brief Construct a new TensorChunkElementViewType object within
-   * ScratchMemorySpace.
-   * Allocates an unmanaged view within ScratchMemorySpace. Useful for
-   * generating scratch views.
-   *
-   * @tparam ScratchMemorySpace Memory space of the view
-   * @param scratch_memory_space Memory space of the view
-   */
-  template <typename ScratchMemorySpace,
-            typename std::enable_if<
-                std::is_same<MemorySpace, ScratchMemorySpace>::value,
-                bool>::type = true>
-  KOKKOS_FUNCTION
-  TensorChunkElementViewType(const ScratchMemorySpace &scratch_memory_space)
-      : Kokkos::View<
-            value_type[NumberOfElements][NumberOfGLLPoints][NumberOfGLLPoints]
-                      [Components][NumberOfDimensions],
-            MemorySpace, MemoryTraits>(scratch_memory_space) {}
-  ///@}
-
-  using type::operator();
-
-  /**
-   * @brief Get tensor component by a point index and tensor indices.
-   *
-   * @param index Point index
-   * @param icomp Component index
-   * @param idim Dimension index
-   */
-  KOKKOS_INLINE_FUNCTION
-  constexpr value_type &operator()(const index_type &index, const int &icomp,
-                                   const int &idim) {
-    return (*this)(index.ispec, index.iz, index.ix, icomp, idim);
-  }
-
+  using chunk_ndim_view_type::operator();
   /**
    * @brief Get tensor subview by a point index.
    *
@@ -662,143 +170,7 @@ struct TensorChunkElementViewType<T, specfem::element::dimension_tag::dim2,
    */
   KOKKOS_INLINE_FUNCTION
   impl::TensorChunkElementSubview<TensorChunkElementViewType>
-  operator()(const index_type &index) {
-    return { *this, index };
-  }
-};
-
-/**
- * @brief 3D specialization for TensorChunkElementViewType
- *
- * @tparam T Data type of the tensor values
- * @tparam NumberOfElements Number of elements in the chunk
- * @tparam NumberOfGLLPoints Number of GLL points in each element
- * @tparam Components Number of vector values (components) at each GLL point
- * @tparam NumberOfDimensions Number of dimensions of the tensor
- * @tparam UseSIMD Use SIMD datatypes for the array. If true, value_type is a
- * SIMD type
- * @tparam MemorySpace Memory space of the view
- * @tparam MemoryTraits Memory traits of the view
- */
-template <typename T, int NumberOfElements, int NumberOfGLLPoints,
-          int Components, int NumberOfDimensions, bool UseSIMD,
-          typename MemorySpace, typename MemoryTraits>
-struct TensorChunkElementViewType<T, specfem::element::dimension_tag::dim3,
-                                  NumberOfElements, NumberOfGLLPoints,
-                                  Components, NumberOfDimensions, UseSIMD,
-                                  MemorySpace, MemoryTraits>
-    : public Kokkos::View<
-          typename specfem::datatype::simd<T, UseSIMD>::datatype
-              [NumberOfElements][NumberOfGLLPoints][NumberOfGLLPoints]
-              [NumberOfGLLPoints][Components][NumberOfDimensions],
-          MemorySpace, MemoryTraits> {
-  /**
-   * @name Typedefs
-   *
-   */
-  ///@{
-  using simd = specfem::datatype::simd<T, UseSIMD>; ///< SIMD data type
-  using type = typename Kokkos::View<
-      typename simd::datatype[NumberOfElements][NumberOfGLLPoints]
-                             [NumberOfGLLPoints][NumberOfGLLPoints][Components]
-                             [NumberOfDimensions],
-      MemorySpace, MemoryTraits>; ///< Underlying data type used to store values
-  using value_type = typename type::value_type; ///< Value type used to store
-                                                ///< the elements of the array
-  using base_type = T;                          ///< Base type of the array
-  constexpr static auto dimension_tag =
-      specfem::element::dimension_tag::dim3; ///< Dimension tag
-  using index_type =
-      typename specfem::point::index<dimension_tag, UseSIMD>; ///< index type
-                                                              ///< for accessing
-                                                              ///< at GLL level
-  using point_view_type = TensorPointViewType<T, Components, NumberOfDimensions,
-                                              UseSIMD>; ///< Point view type for
-                                                        ///< component access
-  constexpr static bool using_simd = UseSIMD; ///< Use SIMD datatypes for the
-                                              ///< array. If false,
-                                              ///< std::is_same<value_type,
-                                              ///< base_type>::value is true
-  ///@}
-
-  /**
-   * @name Compile time constants
-   *
-   */
-  ///@{
-  constexpr static auto accessor_type =
-      specfem::datatype::AccessorType::chunk_element; ///< Accessor type for
-                                                      ///< identifying the
-                                                      ///< class
-
-  constexpr static int nelements = NumberOfElements; ///< Number of elements in
-                                                     ///< the chunk
-  constexpr static int ngll = NumberOfGLLPoints; ///< Number of GLL points in
-                                                 ///< each element
-  constexpr static int components = Components;  ///< Number of tensor values at
-                                                 ///< each GLL point
-  constexpr static int dimensions =
-      NumberOfDimensions; ///< Number of dimensions
-                          ///< of the tensor values
-  ///@}
-
-  /**
-   * @name Constructors and assignment operators
-   *
-   */
-  ///@{
-
-  /**
-   * @brief Default constructor
-   *
-   */
-  KOKKOS_FUNCTION
-  TensorChunkElementViewType() = default;
-
-  /**
-   * @brief Construct a new TensorChunkElementViewType object within
-   * ScratchMemorySpace.
-   * Allocates an unmanaged view within ScratchMemorySpace. Useful for
-   * generating scratch views.
-   *
-   * @tparam ScratchMemorySpace Memory space of the view
-   * @param scratch_memory_space Memory space of the view
-   */
-  template <typename ScratchMemorySpace,
-            typename std::enable_if<
-                std::is_same<MemorySpace, ScratchMemorySpace>::value,
-                bool>::type = true>
-  KOKKOS_FUNCTION
-  TensorChunkElementViewType(const ScratchMemorySpace &scratch_memory_space)
-      : Kokkos::View<
-            value_type[NumberOfElements][NumberOfGLLPoints][NumberOfGLLPoints]
-                      [NumberOfGLLPoints][Components][NumberOfDimensions],
-            MemorySpace, MemoryTraits>(scratch_memory_space) {}
-  ///@}
-
-  using type::operator();
-
-  /**
-   * @brief Get tensor component by a point index and tensor indices.
-   *
-   * @param index Point index
-   * @param icomp Component index
-   * @param idim Dimension index
-   */
-  KOKKOS_INLINE_FUNCTION
-  constexpr value_type &operator()(const index_type &index, const int &icomp,
-                                   const int &idim) {
-    return (*this)(index.ispec, index.iz, index.iy, index.ix, icomp, idim);
-  }
-
-  /**
-   * @brief Get tensor subview by a point index.
-   *
-   * @param index Point index
-   */
-  KOKKOS_INLINE_FUNCTION
-  impl::TensorChunkElementSubview<TensorChunkElementViewType>
-  operator()(const index_type &index) {
+  operator()(const chunk_ndim_view_type::index_type &index) {
     return { *this, index };
   }
 };

--- a/core/specfem/datatype/chunk_face_view.hpp
+++ b/core/specfem/datatype/chunk_face_view.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "chunk_ndim_view.hpp"
+#include "specfem/datatype/accessor_type.hpp"
 #include <utility>
 
 namespace specfem {
@@ -13,6 +14,7 @@ template <typename T, specfem::element::dimension_tag DimensionTag,
 struct ScalarChunkFaceViewType
     : public ChunkNDimViewType<T, DimensionTag, NumberOfFaces,
                                NumberOfGLLPoints, 2, std::integer_sequence<int>,
+                               specfem::datatype::AccessorType::chunk_face,
                                UseSIMD, MemorySpace, MemoryTraits> {
   constexpr static auto accessor_type =
       specfem::datatype::AccessorType::chunk_face; ///< Accessor type for
@@ -28,8 +30,9 @@ template <
 struct VectorChunkFaceViewType
     : public ChunkNDimViewType<T, DimensionTag, NumberOfFaces,
                                NumberOfGLLPoints, 2,
-                               std::integer_sequence<int, Components>, UseSIMD,
-                               MemorySpace, MemoryTraits> {
+                               std::integer_sequence<int, Components>,
+                               specfem::datatype::AccessorType::chunk_face,
+                               UseSIMD, MemorySpace, MemoryTraits> {
   constexpr static auto accessor_type =
       specfem::datatype::AccessorType::chunk_face; ///< Accessor type for
                                                    ///< identifying the
@@ -46,8 +49,9 @@ template <typename T, specfem::element::dimension_tag DimensionTag,
 struct TensorChunkFaceViewType
     : public ChunkNDimViewType<
           T, DimensionTag, NumberOfFaces, NumberOfGLLPoints, 2,
-          std::integer_sequence<int, Components, NumberOfDimensions>, UseSIMD,
-          MemorySpace, MemoryTraits> {
+          std::integer_sequence<int, Components, NumberOfDimensions>,
+          specfem::datatype::AccessorType::chunk_face, UseSIMD, MemorySpace,
+          MemoryTraits> {
   constexpr static auto accessor_type =
       specfem::datatype::AccessorType::chunk_face; ///< Accessor type for
                                                    ///< identifying the

--- a/core/specfem/datatype/chunk_face_view.hpp
+++ b/core/specfem/datatype/chunk_face_view.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "chunk_ndim_view.hpp"
+#include <utility>
+
+namespace specfem {
+namespace datatype {
+template <typename T, specfem::element::dimension_tag DimensionTag,
+          int NumberOfFaces, int NumberOfGLLPoints, bool UseSIMD = false,
+          typename MemorySpace =
+              Kokkos::DefaultExecutionSpace::scratch_memory_space,
+          typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged>>
+struct ScalarChunkFaceViewType
+    : ChunkNDimViewType<T, DimensionTag, NumberOfFaces, NumberOfGLLPoints, 2,
+                        std::integer_sequence<int>> {};
+
+template <
+    typename T, specfem::element::dimension_tag DimensionTag, int NumberOfFaces,
+    int Components, int NumberOfGLLPoints, bool UseSIMD = false,
+    typename MemorySpace = Kokkos::DefaultExecutionSpace::scratch_memory_space,
+    typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged>>
+struct VectorChunkFaceViewType
+    : ChunkNDimViewType<T, DimensionTag, NumberOfFaces, NumberOfGLLPoints, 2,
+                        std::integer_sequence<int, Components>> {
+  constexpr static int components = Components;
+};
+
+template <typename T, specfem::element::dimension_tag DimensionTag,
+          int NumberOfFaces, int Components, int NumberOfDimensions,
+          int NumberOfGLLPoints, bool UseSIMD = false,
+          typename MemorySpace =
+              Kokkos::DefaultExecutionSpace::scratch_memory_space,
+          typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged>>
+struct TensorChunkFaceViewType
+    : ChunkNDimViewType<
+          T, DimensionTag, NumberOfFaces, NumberOfGLLPoints, 2,
+          std::integer_sequence<int, Components, NumberOfDimensions>> {
+  constexpr static int components = Components;
+  constexpr static int dimensions = NumberOfDimensions;
+};
+} // namespace datatype
+} // namespace specfem

--- a/core/specfem/datatype/chunk_face_view.hpp
+++ b/core/specfem/datatype/chunk_face_view.hpp
@@ -11,8 +11,14 @@ template <typename T, specfem::element::dimension_tag DimensionTag,
               Kokkos::DefaultExecutionSpace::scratch_memory_space,
           typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged>>
 struct ScalarChunkFaceViewType
-    : ChunkNDimViewType<T, DimensionTag, NumberOfFaces, NumberOfGLLPoints, 2,
-                        std::integer_sequence<int>> {};
+    : public ChunkNDimViewType<T, DimensionTag, NumberOfFaces,
+                               NumberOfGLLPoints, 2, std::integer_sequence<int>,
+                               UseSIMD, MemorySpace, MemoryTraits> {
+  constexpr static auto accessor_type =
+      specfem::datatype::AccessorType::chunk_face; ///< Accessor type for
+                                                   ///< identifying the
+                                                   ///< class
+};
 
 template <
     typename T, specfem::element::dimension_tag DimensionTag, int NumberOfFaces,
@@ -20,8 +26,14 @@ template <
     typename MemorySpace = Kokkos::DefaultExecutionSpace::scratch_memory_space,
     typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged>>
 struct VectorChunkFaceViewType
-    : ChunkNDimViewType<T, DimensionTag, NumberOfFaces, NumberOfGLLPoints, 2,
-                        std::integer_sequence<int, Components>> {
+    : public ChunkNDimViewType<T, DimensionTag, NumberOfFaces,
+                               NumberOfGLLPoints, 2,
+                               std::integer_sequence<int, Components>, UseSIMD,
+                               MemorySpace, MemoryTraits> {
+  constexpr static auto accessor_type =
+      specfem::datatype::AccessorType::chunk_face; ///< Accessor type for
+                                                   ///< identifying the
+                                                   ///< class
   constexpr static int components = Components;
 };
 
@@ -32,9 +44,14 @@ template <typename T, specfem::element::dimension_tag DimensionTag,
               Kokkos::DefaultExecutionSpace::scratch_memory_space,
           typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged>>
 struct TensorChunkFaceViewType
-    : ChunkNDimViewType<
+    : public ChunkNDimViewType<
           T, DimensionTag, NumberOfFaces, NumberOfGLLPoints, 2,
-          std::integer_sequence<int, Components, NumberOfDimensions>> {
+          std::integer_sequence<int, Components, NumberOfDimensions>, UseSIMD,
+          MemorySpace, MemoryTraits> {
+  constexpr static auto accessor_type =
+      specfem::datatype::AccessorType::chunk_face; ///< Accessor type for
+                                                   ///< identifying the
+                                                   ///< class
   constexpr static int components = Components;
   constexpr static int dimensions = NumberOfDimensions;
 };

--- a/core/specfem/datatype/chunk_ndim_view.hpp
+++ b/core/specfem/datatype/chunk_ndim_view.hpp
@@ -63,26 +63,19 @@ template <typename T> struct arrayify_datatype_expand<T> {
  * of size Dim. This is the sequence that should be passed in as
  * ElementSubspaceShapeIntegerSequence
  */
-template <int SubspaceDimension, int NGLL> struct subspace_shape {
-private:
-  template <int... Vals>
-  static std::integer_sequence<int, Vals..., NGLL>
-  type_expand(std::integer_sequence<int, Vals...> integer_sequence) {};
+template <int NGLL, int... repeats>
+std::integer_sequence<int, (NGLL + repeats * 0 /*hack to fold NGLL*/)...>
+_subspace_shape(std::integer_sequence<int, repeats...>) {}
 
-public:
-  using type = decltype(type_expand(
-      typename subspace_shape<SubspaceDimension - 1, NGLL>::type()));
-};
-template <int NGLL> struct subspace_shape<0, NGLL> {
-  using type = std::integer_sequence<int>;
-};
+template <int SubspaceDimension, int NGLL>
+using subspace_shape = decltype(_subspace_shape<NGLL>(
+    std::make_integer_sequence<int, SubspaceDimension>()));
 
 // mini-test: 8-7 tensor on NGLL=5 2D element (chunk size = 1)
 static_assert(
-    std::is_same<arrayify_datatype<type_real, 1,
-                                   typename impl::subspace_shape<2, 5>::type,
-                                   std::integer_sequence<int, 8, 7>>::type,
-                 type_real[1][5][5][8][7]>());
+    std::is_same_v<arrayify_datatype<type_real, 1, impl::subspace_shape<2, 5>,
+                                     std::integer_sequence<int, 8, 7>>::type,
+                   type_real[1][5][5][8][7]>);
 
 } // namespace impl
 
@@ -99,7 +92,7 @@ struct ChunkNDimViewType
     : public Kokkos::View<
           typename impl::arrayify_datatype<
               typename specfem::datatype::simd<T, UseSIMD>::datatype, ChunkSize,
-              typename impl::subspace_shape<ChunkSubspaceDimension, NGLL>::type,
+              typename impl::subspace_shape<ChunkSubspaceDimension, NGLL>,
               PointwiseShapeIntegerSequence>::type,
           MemorySpace, MemoryTraits> {
   /**
@@ -111,7 +104,7 @@ struct ChunkNDimViewType
   using type = Kokkos::View<
       typename impl::arrayify_datatype<
           typename specfem::datatype::simd<T, UseSIMD>::datatype, ChunkSize,
-          typename impl::subspace_shape<ChunkSubspaceDimension, NGLL>::type,
+          typename impl::subspace_shape<ChunkSubspaceDimension, NGLL>,
           PointwiseShapeIntegerSequence>::type,
       MemorySpace, MemoryTraits>; ///< Underlying data type used to
                                   ///< store values

--- a/core/specfem/datatype/chunk_ndim_view.hpp
+++ b/core/specfem/datatype/chunk_ndim_view.hpp
@@ -4,12 +4,15 @@
 #include "simd.hpp"
 #include "specfem/element/tags.hpp"
 #include <Kokkos_Core.hpp>
+#include <type_traits>
 #include <utility>
 
 // Forward declarations
 namespace specfem::point {
 template <specfem::element::dimension_tag DimensionTag, bool UseSIMD>
 struct index;
+template <specfem::element::dimension_tag DimensionTag> struct face_index;
+template <specfem::element::dimension_tag DimensionTag> struct edge_index;
 } // namespace specfem::point
 
 namespace specfem::datatype {
@@ -87,7 +90,8 @@ static_assert(
 
 template <typename T, specfem::element::dimension_tag DimensionTag,
           int ChunkSize, int NGLL, int ChunkSubspaceDimension,
-          typename PointwiseShapeIntegerSequence, bool UseSIMD = false,
+          typename PointwiseShapeIntegerSequence,
+          specfem::datatype::AccessorType AccessorType, bool UseSIMD = false,
           typename MemorySpace =
               Kokkos::DefaultExecutionSpace::scratch_memory_space,
           typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged>>
@@ -114,14 +118,19 @@ struct ChunkNDimViewType
   using value_type = typename type::value_type; ///< Value type used to store
                                                 ///< the elements of the array
   using base_type = T;                          ///< Base type of the array
-  constexpr static auto dimension_tag = DimensionTag; ///< Dimension tag
-  using index_type = specfem::point::index<dimension_tag,
-                                           UseSIMD>; ///< index type for
-                                                     ///< accessing at GLL level
-  constexpr static bool using_simd = UseSIMD; ///< Use SIMD datatypes for the
-                                              ///< array. If false,
-                                              ///< std::is_same<value_type,
-                                              ///< base_type>::value is true
+  using index_type = std::conditional_t<
+      AccessorType == specfem::datatype::AccessorType::chunk_element,
+      specfem::point::index<DimensionTag, UseSIMD>,
+      std::conditional_t<
+          AccessorType == specfem::datatype::AccessorType::chunk_face,
+          specfem::point::face_index<DimensionTag>,
+          std::conditional_t<
+              AccessorType == specfem::datatype::AccessorType::chunk_face,
+              specfem::point::edge_index<DimensionTag>, void>>>; ///< index type
+                                                                 ///< for
+                                                                 ///< accessing
+                                                                 ///< at GLL
+                                                                 ///< level
   ///@}
 
   /**
@@ -129,11 +138,19 @@ struct ChunkNDimViewType
    *
    */
   ///@{
+  constexpr static auto dimension_tag = DimensionTag; ///< Dimension tag
 
-  constexpr static int chunk_size = ChunkSize; ///< Number of elements in
-                                               ///< the chunk
-  constexpr static int ngll = NGLL;            ///< Number of GLL points in
-                                               ///< each element
+  constexpr static auto accessor_type = AccessorType; ///< Accessor type for
+                                                      ///< identifying the
+                                                      ///< class
+  constexpr static int chunk_size = ChunkSize;        ///< Number of elements in
+                                                      ///< the chunk
+  constexpr static int ngll = NGLL;           ///< Number of GLL points in
+                                              ///< each element
+  constexpr static bool using_simd = UseSIMD; ///< Use SIMD datatypes for the
+                                              ///< array. If false,
+                                              ///< std::is_same<value_type,
+                                              ///< base_type>::value is true
   ///@}
 
   /**
@@ -174,10 +191,20 @@ struct ChunkNDimViewType
   template <typename... ComponentTypes>
   KOKKOS_INLINE_FUNCTION constexpr value_type &
   operator()(index_type index, ComponentTypes... components) {
-    if constexpr (dimension_tag == element::dimension_tag::dim3) {
-      return (*this)(index.ispec, index.iz, index.iy, index.ix, components...);
-    } else {
-      return (*this)(index.ispec, index.iz, index.ix, components...);
+    if constexpr (accessor_type ==
+                  specfem::datatype::AccessorType::chunk_element) {
+      if constexpr (dimension_tag == element::dimension_tag::dim3) {
+        return (*this)(index.ispec, index.iz, index.iy, index.ix,
+                       components...);
+      } else {
+        return (*this)(index.ispec, index.iz, index.ix, components...);
+      }
+    } else if constexpr (accessor_type ==
+                         specfem::datatype::AccessorType::chunk_face) {
+      return (*this)(index.ispec, index.ipoint_i, index.ipoint_j);
+    } else if constexpr (accessor_type ==
+                         specfem::datatype::AccessorType::chunk_edge) {
+      return (*this)(index.ispec, index.ipoint);
     }
   }
 };

--- a/core/specfem/datatype/chunk_ndim_view.hpp
+++ b/core/specfem/datatype/chunk_ndim_view.hpp
@@ -1,0 +1,192 @@
+#pragma once
+
+#include "accessor_type.hpp"
+#include "simd.hpp"
+#include "specfem/element/tags.hpp"
+#include <Kokkos_Core.hpp>
+#include <utility>
+
+// Forward declarations
+namespace specfem::point {
+template <specfem::element::dimension_tag DimensionTag, bool UseSIMD>
+struct index;
+} // namespace specfem::point
+
+namespace specfem::datatype {
+
+namespace impl {
+/**
+ * @brief Converts <T, shape[0], ..., shape[n]> to type T[shape[0]]...[shape[n]]
+ */
+template <typename T, int... DataArrayShape> struct arrayify_datatype_expand;
+
+/**
+ * @brief Generates an array type T[...] from arguments for a Kokkos View.
+ *
+ * @tparam T base type (usually type_real)
+ * @tparam ElementSubspaceShapeIntegerSequence point index shape
+ * @tparam PointwiseShapeIntegerSequence tensor shape at each point
+ */
+template <typename T, typename ElementSubspaceShapeIntegerSequence,
+          typename PointwiseShapeIntegerSequence>
+struct arrayify_datatype {
+public:
+  using type = decltype(type_expand(ElementSubspaceShapeIntegerSequence(),
+                                    PointwiseShapeIntegerSequence()))::type;
+
+private:
+  template <int... DataArrayShape>
+  static arrayify_datatype_expand<T, DataArrayShape...>
+  type_expand(std::integer_sequence<int, DataArrayShape...> integer_sequence) {
+    return {};
+  }
+  template <int... SubspaceShape, int... PointwiseShape>
+  static arrayify_datatype_expand<T, SubspaceShape..., PointwiseShape...>
+  type_expand(std::integer_sequence<int, SubspaceShape...> integer_sequence1,
+              std::integer_sequence<int, PointwiseShape...> integer_sequence2) {
+    return {};
+  }
+};
+
+template <typename T, int NextInt, int... DataArrayShape>
+struct arrayify_datatype_expand<T, NextInt, DataArrayShape...> {
+  using type = arrayify_datatype_expand<T[NextInt], DataArrayShape...>::type;
+};
+template <typename T> struct arrayify_datatype_expand<T> {
+  using type = T;
+};
+
+// ==============================================
+
+/**
+ * @brief Converts the tuple <Dim,NGLL> to the integer sequence <NGLL,...,NGLL>
+ * of size Dim. This is the sequence that should be passed in as
+ * ElementSubspaceShapeIntegerSequence
+ */
+template <int SubspaceDimension, int NGLL> struct subspace_shape {
+  using type =
+      decltype(type_expand(subspace_shape<SubspaceDimension - 1, NGLL>()));
+
+private:
+  template <int... Vals>
+  std::integer_sequence<int, Vals..., NGLL>
+  type_expand(std::integer_sequence<int, Vals...> integer_sequence) {
+
+  };
+};
+template <int NGLL> struct subspace_shape<0, NGLL> {
+  using type = std::integer_sequence<int>;
+};
+
+} // namespace impl
+
+// ==============================================
+
+template <typename T, specfem::element::dimension_tag DimensionTag,
+          int ChunkSize, int NGLL, int ChunkSubspaceDimension,
+          typename PointwiseShapeIntegerSequence, bool UseSIMD = false,
+          typename MemorySpace =
+              Kokkos::DefaultExecutionSpace::scratch_memory_space,
+          typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged>>
+struct ChunkNDimViewType
+    : public Kokkos::View<
+          typename impl::arrayify_datatype<
+              typename specfem::datatype::simd<T, UseSIMD>::datatype,
+              impl::subspace_shape<ChunkSubspaceDimension, NGLL>,
+              PointwiseShapeIntegerSequence>::type,
+          MemorySpace, MemoryTraits> {
+  /**
+   * @name Typedefs
+   *
+   */
+  ///@{
+  using simd = specfem::datatype::simd<T, UseSIMD>; ///< SIMD data type
+  using type =
+      Kokkos::View<typename impl::arrayify_datatype<
+                       typename specfem::datatype::simd<T, UseSIMD>::datatype,
+                       impl::subspace_shape<ChunkSubspaceDimension, NGLL>,
+                       PointwiseShapeIntegerSequence>::type,
+                   MemorySpace, MemoryTraits>; ///< Underlying data type used to
+                                               ///< store values
+  using value_type = typename type::value_type; ///< Value type used to store
+                                                ///< the elements of the array
+  using base_type = T;                          ///< Base type of the array
+  constexpr static auto dimension_tag =
+      specfem::element::dimension_tag::dim3; ///< Dimension tag
+  using index_type =
+      typename specfem::point::index<dimension_tag,
+                                     UseSIMD>; ///< index type for accessing at
+                                               ///< GLL level
+  constexpr static bool using_simd = UseSIMD;  ///< Use SIMD datatypes for the
+                                               ///< array. If false,
+                                               ///< std::is_same<value_type,
+                                               ///< base_type>::value is true
+  ///@}
+
+  /**
+   * @name Compile time constants
+   *
+   */
+  ///@{
+  constexpr static auto accessor_type =
+      specfem::datatype::AccessorType::chunk_element; ///< Accessor type for
+                                                      ///< identifying the
+                                                      ///< class
+
+  constexpr static int chunk_size = ChunkSize; ///< Number of elements in
+                                               ///< the chunk
+  constexpr static int ngll = NGLL;            ///< Number of GLL points in
+                                               ///< each element
+  ///@}
+
+  /**
+   * @name Constructors and assignment operators
+   *
+   */
+  ///@{
+  /**
+   * @brief Default constructor
+   */
+  KOKKOS_FUNCTION
+  ChunkNDimViewType() = default;
+
+  /**
+   * @brief Construct a new ChunkNDimViewType object within
+   * ScratchMemorySpace.
+   * Allocates an unmanaged view within ScratchMemorySpace. Useful for
+   * generating scratch views.
+   *
+   * @tparam ScratchMemorySpace Memory space of the view
+   * @param scratch_memory_space Memory space of the view
+   */
+  template <typename ScratchMemorySpace>
+  KOKKOS_FUNCTION
+  ChunkNDimViewType(const ScratchMemorySpace &scratch_memory_space)
+      : Kokkos::View<typename impl::arrayify_datatype<
+                         typename specfem::datatype::simd<T, UseSIMD>::datatype,
+                         impl::subspace_shape<ChunkSubspaceDimension, NGLL>,
+                         PointwiseShapeIntegerSequence>::type,
+                     MemorySpace, MemoryTraits>(scratch_memory_space) {}
+  ///@}
+
+  using type::operator();
+
+  /**
+   * @brief Get scalar value by a point index.
+   *
+   * @param index Point index
+   * @param icomp...
+   */
+
+  template <typename... ComponentTypes>
+  KOKKOS_INLINE_FUNCTION constexpr value_type &
+  operator()(index_type index, ComponentTypes... components) {
+    if constexpr (dimension_tag == element::dimension_tag::dim3) {
+      return (*this)(index.ispec, index.iz, index.iy, index.ix, components...);
+    } else {
+      return (*this)(index.ispec, index.iz, index.ix, components...);
+    }
+  }
+};
+
+} // namespace specfem::datatype

--- a/core/specfem/datatype/chunk_ndim_view.hpp
+++ b/core/specfem/datatype/chunk_ndim_view.hpp
@@ -27,30 +27,27 @@ template <typename T, int... DataArrayShape> struct arrayify_datatype_expand;
  * @tparam ElementSubspaceShapeIntegerSequence point index shape
  * @tparam PointwiseShapeIntegerSequence tensor shape at each point
  */
-template <typename T, typename ElementSubspaceShapeIntegerSequence,
+template <typename T, int chunk_size,
+          typename ElementSubspaceShapeIntegerSequence,
           typename PointwiseShapeIntegerSequence>
 struct arrayify_datatype {
-public:
-  using type = decltype(type_expand(ElementSubspaceShapeIntegerSequence(),
-                                    PointwiseShapeIntegerSequence()))::type;
-
 private:
-  template <int... DataArrayShape>
-  static arrayify_datatype_expand<T, DataArrayShape...>
-  type_expand(std::integer_sequence<int, DataArrayShape...> integer_sequence) {
-    return {};
-  }
   template <int... SubspaceShape, int... PointwiseShape>
-  static arrayify_datatype_expand<T, SubspaceShape..., PointwiseShape...>
+  static arrayify_datatype_expand<T, chunk_size, SubspaceShape...,
+                                  PointwiseShape...>
   type_expand(std::integer_sequence<int, SubspaceShape...> integer_sequence1,
               std::integer_sequence<int, PointwiseShape...> integer_sequence2) {
     return {};
   }
+
+public:
+  using type = decltype(type_expand(ElementSubspaceShapeIntegerSequence(),
+                                    PointwiseShapeIntegerSequence()))::type;
 };
 
 template <typename T, int NextInt, int... DataArrayShape>
 struct arrayify_datatype_expand<T, NextInt, DataArrayShape...> {
-  using type = arrayify_datatype_expand<T[NextInt], DataArrayShape...>::type;
+  using type = arrayify_datatype_expand<T, DataArrayShape...>::type[NextInt];
 };
 template <typename T> struct arrayify_datatype_expand<T> {
   using type = T;
@@ -64,19 +61,25 @@ template <typename T> struct arrayify_datatype_expand<T> {
  * ElementSubspaceShapeIntegerSequence
  */
 template <int SubspaceDimension, int NGLL> struct subspace_shape {
-  using type =
-      decltype(type_expand(subspace_shape<SubspaceDimension - 1, NGLL>()));
-
 private:
   template <int... Vals>
-  std::integer_sequence<int, Vals..., NGLL>
-  type_expand(std::integer_sequence<int, Vals...> integer_sequence) {
+  static std::integer_sequence<int, Vals..., NGLL>
+  type_expand(std::integer_sequence<int, Vals...> integer_sequence) {};
 
-  };
+public:
+  using type = decltype(type_expand(
+      typename subspace_shape<SubspaceDimension - 1, NGLL>::type()));
 };
 template <int NGLL> struct subspace_shape<0, NGLL> {
   using type = std::integer_sequence<int>;
 };
+
+// mini-test: 8-7 tensor on NGLL=5 2D element (chunk size = 1)
+static_assert(
+    std::is_same<arrayify_datatype<type_real, 1,
+                                   typename impl::subspace_shape<2, 5>::type,
+                                   std::integer_sequence<int, 8, 7>>::type,
+                 type_real[1][5][5][8][7]>());
 
 } // namespace impl
 
@@ -91,8 +94,8 @@ template <typename T, specfem::element::dimension_tag DimensionTag,
 struct ChunkNDimViewType
     : public Kokkos::View<
           typename impl::arrayify_datatype<
-              typename specfem::datatype::simd<T, UseSIMD>::datatype,
-              impl::subspace_shape<ChunkSubspaceDimension, NGLL>,
+              typename specfem::datatype::simd<T, UseSIMD>::datatype, ChunkSize,
+              typename impl::subspace_shape<ChunkSubspaceDimension, NGLL>::type,
               PointwiseShapeIntegerSequence>::type,
           MemorySpace, MemoryTraits> {
   /**
@@ -101,26 +104,24 @@ struct ChunkNDimViewType
    */
   ///@{
   using simd = specfem::datatype::simd<T, UseSIMD>; ///< SIMD data type
-  using type =
-      Kokkos::View<typename impl::arrayify_datatype<
-                       typename specfem::datatype::simd<T, UseSIMD>::datatype,
-                       impl::subspace_shape<ChunkSubspaceDimension, NGLL>,
-                       PointwiseShapeIntegerSequence>::type,
-                   MemorySpace, MemoryTraits>; ///< Underlying data type used to
-                                               ///< store values
+  using type = Kokkos::View<
+      typename impl::arrayify_datatype<
+          typename specfem::datatype::simd<T, UseSIMD>::datatype, ChunkSize,
+          typename impl::subspace_shape<ChunkSubspaceDimension, NGLL>::type,
+          PointwiseShapeIntegerSequence>::type,
+      MemorySpace, MemoryTraits>; ///< Underlying data type used to
+                                  ///< store values
   using value_type = typename type::value_type; ///< Value type used to store
                                                 ///< the elements of the array
   using base_type = T;                          ///< Base type of the array
-  constexpr static auto dimension_tag =
-      specfem::element::dimension_tag::dim3; ///< Dimension tag
-  using index_type =
-      typename specfem::point::index<dimension_tag,
-                                     UseSIMD>; ///< index type for accessing at
-                                               ///< GLL level
-  constexpr static bool using_simd = UseSIMD;  ///< Use SIMD datatypes for the
-                                               ///< array. If false,
-                                               ///< std::is_same<value_type,
-                                               ///< base_type>::value is true
+  constexpr static auto dimension_tag = DimensionTag; ///< Dimension tag
+  using index_type = specfem::point::index<dimension_tag,
+                                           UseSIMD>; ///< index type for
+                                                     ///< accessing at GLL level
+  constexpr static bool using_simd = UseSIMD; ///< Use SIMD datatypes for the
+                                              ///< array. If false,
+                                              ///< std::is_same<value_type,
+                                              ///< base_type>::value is true
   ///@}
 
   /**
@@ -128,10 +129,6 @@ struct ChunkNDimViewType
    *
    */
   ///@{
-  constexpr static auto accessor_type =
-      specfem::datatype::AccessorType::chunk_element; ///< Accessor type for
-                                                      ///< identifying the
-                                                      ///< class
 
   constexpr static int chunk_size = ChunkSize; ///< Number of elements in
                                                ///< the chunk
@@ -162,11 +159,7 @@ struct ChunkNDimViewType
   template <typename ScratchMemorySpace>
   KOKKOS_FUNCTION
   ChunkNDimViewType(const ScratchMemorySpace &scratch_memory_space)
-      : Kokkos::View<typename impl::arrayify_datatype<
-                         typename specfem::datatype::simd<T, UseSIMD>::datatype,
-                         impl::subspace_shape<ChunkSubspaceDimension, NGLL>,
-                         PointwiseShapeIntegerSequence>::type,
-                     MemorySpace, MemoryTraits>(scratch_memory_space) {}
+      : type(scratch_memory_space) {}
   ///@}
 
   using type::operator();

--- a/core/specfem/point/edge_index.hpp
+++ b/core/specfem/point/edge_index.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "specfem/data_access/accessor.hpp"
 #include "specfem/enums.hpp"
 #include "specfem/mesh_entity.hpp"
 

--- a/core/specfem/point/face_index.hpp
+++ b/core/specfem/point/face_index.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "specfem/data_access/accessor.hpp"
 #include "specfem/element.hpp"
 #include "specfem/mesh_entity.hpp"
 


### PR DESCRIPTION
## Description

Please describe the changes/features in this pull request.
- Creates `ChunkNDimViewType` to unify code.
- Creates `<Scalar|Vector|Tensor>ChunkFaceViewType` types similar to `chunk_edge`, delegating to `ChunkNDimViewType`.
- Refactors `chunk_element_view.hpp` to use `ChunkNDimViewType` (807 -> 179 lines)

## Issue Number

If there is an issue created for these changes, link it here
- defines base type to be used in #1863

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
