### PR TITLE
Remove GCC8 from jenkins.

### DIFF
--- a/.jenkins/gnu_compiler_checks.gvy
+++ b/.jenkins/gnu_compiler_checks.gvy
@@ -10,7 +10,7 @@ pipeline{
                 axes {
                     axis{
                         name 'GNUCompiler'
-                        values 'GCC8;gcc/11', 'GCC14;gcc-toolset/14'
+                        values 'GCC14;gcc-toolset/14'
                     }
                     axis{
                         name 'SIMD'

--- a/.jenkins/mpi_compiler_checks.gvy
+++ b/.jenkins/mpi_compiler_checks.gvy
@@ -10,7 +10,7 @@ pipeline {
                 axes {
                     axis{
                         name 'GNUCompiler'
-                        values 'GCC8;gcc/11', 'GCC14;gcc-toolset/14'
+                        values 'gcc/11', 'GCC14;gcc-toolset/14'
                     }
                     axis{
                         name 'SIMD'


### PR DESCRIPTION
GCC8 is deprecated and does not support some of the C++20 libraries.