### PR TITLE
Add compile-time grid extents and tail-skip to chunked iterators

### DIFF
--- a/core/specfem/algorithms/scatter.hpp
+++ b/core/specfem/algorithms/scatter.hpp
@@ -41,14 +41,13 @@ namespace impl {
  * @param acc          Shared scratch acceleration view (non-const, atomic
  * writes)
  */
-template <typename TensorPointViewType, typename WeightsType,
-          typename QuadratureType, typename ChunkAccType>
+template <typename TensorPointViewType, typename T, typename QuadratureType,
+          typename ChunkAccType>
 KOKKOS_FORCEINLINE_FUNCTION void scattered_divergence(
     const TensorPointViewType &F,
     const specfem::point::index<specfem::element::dimension_tag::dim2,
                                 TensorPointViewType::using_simd> &local_index,
-    const WeightsType &weights, const QuadratureType &hprime,
-    ChunkAccType &acc) {
+    const T &w_product, const QuadratureType &hprime, ChunkAccType &acc) {
 
   constexpr int ngll = ChunkAccType::ngll;
   constexpr int components = TensorPointViewType::components;
@@ -60,15 +59,13 @@ KOKKOS_FORCEINLINE_FUNCTION void scattered_divergence(
   for (int ix = 0; ix < ngll; ++ix)
     for (int icomp = 0; icomp < components; ++icomp)
       Kokkos::atomic_add(&acc(ielement, iz0, ix, icomp),
-                         weights(iz0) * F(icomp, 0) * hprime.xi(ix0, ix) *
-                             weights(ix0));
+                         F(icomp, 0) * hprime.xi(ix0, ix) * w_product);
 
   // z-direction: F[c][1] at (iz0,ix0) scatters to acc[iz][ix0] for all iz
   for (int iz = 0; iz < ngll; ++iz)
     for (int icomp = 0; icomp < components; ++icomp)
       Kokkos::atomic_add(&acc(ielement, iz, ix0, icomp),
-                         weights(ix0) * F(icomp, 1) * hprime.gamma(iz0, iz) *
-                             weights(iz0));
+                         w_product * F(icomp, 1) * hprime.gamma(iz0, iz));
 }
 
 /**
@@ -88,14 +85,13 @@ KOKKOS_FORCEINLINE_FUNCTION void scattered_divergence(
  * @tparam QuadratureType       Lagrange derivative accessor (.xi, .eta, .gamma)
  * @tparam ChunkAccType         Chunk acceleration scratch type
  */
-template <typename TensorPointViewType, typename WeightsType,
-          typename QuadratureType, typename ChunkAccType>
+template <typename TensorPointViewType, typename T, typename QuadratureType,
+          typename ChunkAccType>
 KOKKOS_FORCEINLINE_FUNCTION void scattered_divergence(
     const TensorPointViewType &F,
     const specfem::point::index<specfem::element::dimension_tag::dim3,
                                 TensorPointViewType::using_simd> &local_index,
-    const WeightsType &weights, const QuadratureType &hprime,
-    ChunkAccType &acc) {
+    const T &w_product, const QuadratureType &hprime, ChunkAccType &acc) {
 
   constexpr int ngll = ChunkAccType::ngll;
   constexpr int components = TensorPointViewType::components;
@@ -108,22 +104,19 @@ KOKKOS_FORCEINLINE_FUNCTION void scattered_divergence(
   for (int ix = 0; ix < ngll; ++ix)
     for (int icomp = 0; icomp < components; ++icomp)
       Kokkos::atomic_add(&acc(ielement, iz0, iy0, ix, icomp),
-                         weights(iz0) * weights(iy0) * F(icomp, 0) *
-                             hprime.xi(ix0, ix) * weights(ix0));
+                         w_product * F(icomp, 0) * hprime.xi(ix0, ix));
 
   // y-direction: scatters to acc[iz0][iy][ix0] for all iy
   for (int iy = 0; iy < ngll; ++iy)
     for (int icomp = 0; icomp < components; ++icomp)
       Kokkos::atomic_add(&acc(ielement, iz0, iy, ix0, icomp),
-                         weights(iz0) * weights(ix0) * F(icomp, 1) *
-                             hprime.eta(iy0, iy) * weights(iy0));
+                         w_product * F(icomp, 1) * hprime.eta(iy0, iy));
 
   // z-direction: scatters to acc[iz][iy0][ix0] for all iz
   for (int iz = 0; iz < ngll; ++iz)
     for (int icomp = 0; icomp < components; ++icomp)
       Kokkos::atomic_add(&acc(ielement, iz, iy0, ix0, icomp),
-                         weights(iy0) * weights(ix0) * F(icomp, 2) *
-                             hprime.gamma(iz0, iz) * weights(iz0));
+                         w_product * F(icomp, 2) * hprime.gamma(iz0, iz));
 }
 
 } // namespace impl

--- a/core/specfem/chunk_element/index.hpp
+++ b/core/specfem/chunk_element/index.hpp
@@ -51,19 +51,18 @@ namespace chunk_element {
  */
 // clang-format on
 template <specfem::element::dimension_tag DimensionTag, typename SIMD,
-          typename ViewType, typename TeamMemberType>
-class Index
-    : public specfem::execution::ChunkElementIndex<DimensionTag, SIMD, ViewType,
-                                                   TeamMemberType>,
-      public specfem::data_access::Accessor<
-          specfem::datatype::AccessorType::chunk_element,
-          specfem::data_access::DataClassType::index, DimensionTag,
-          SIMD::using_simd> {
+          typename ViewType, typename TeamMemberType, typename G, int ChunkSize>
+class Index : public specfem::execution::ChunkElementIndex<
+                  DimensionTag, SIMD, ViewType, TeamMemberType, G, ChunkSize>,
+              public specfem::data_access::Accessor<
+                  specfem::datatype::AccessorType::chunk_element,
+                  specfem::data_access::DataClassType::index, DimensionTag,
+                  SIMD::using_simd> {
 private:
   /// @brief Base type providing chunk element iteration functionality
   using base_type =
       specfem::execution::ChunkElementIndex<DimensionTag, SIMD, ViewType,
-                                            TeamMemberType>;
+                                            TeamMemberType, G, ChunkSize>;
 
 public:
   /// @brief Iterator type for traversing elements in the chunk

--- a/core/specfem/chunk_element/mapped_index.hpp
+++ b/core/specfem/chunk_element/mapped_index.hpp
@@ -20,18 +20,19 @@ namespace chunk_element {
  * @tparam TeamMemberType Kokkos team execution context
  */
 template <specfem::element::dimension_tag DimensionTag, typename SIMD,
-          typename ViewType, typename TeamMemberType>
-class MappedIndex : public specfem::execution::MappedChunkElementIndex<
-                        DimensionTag, SIMD, ViewType, TeamMemberType>,
-                    public specfem::data_access::Accessor<
-                        specfem::datatype::AccessorType::chunk_element,
-                        specfem::data_access::DataClassType::mapped_index,
-                        DimensionTag, SIMD::using_simd> {
+          typename ViewType, typename TeamMemberType, typename G, int ChunkSize>
+class MappedIndex
+    : public specfem::execution::MappedChunkElementIndex<
+          DimensionTag, SIMD, ViewType, TeamMemberType, G, ChunkSize>,
+      public specfem::data_access::Accessor<
+          specfem::datatype::AccessorType::chunk_element,
+          specfem::data_access::DataClassType::mapped_index, DimensionTag,
+          SIMD::using_simd> {
 private:
   /// @brief Base execution index type for chunk element mapping
   using base_type =
       specfem::execution::MappedChunkElementIndex<DimensionTag, SIMD, ViewType,
-                                                  TeamMemberType>;
+                                                  TeamMemberType, G, ChunkSize>;
 
 public:
   /// @brief Iterator type from base class

--- a/core/specfem/compute/impl/compute_stiffness_interaction.hpp
+++ b/core/specfem/compute/impl/compute_stiffness_interaction.hpp
@@ -39,19 +39,20 @@ int compute_stiffness_interaction(
   // Get the number of elements that match the specified tags
   const int nelements = elements.extent(0);
 
-  // Get the element grid information (ngll, ngllx, ngllz, order)
-  const auto &element_grid = assembly.mesh.element_grid;
-
   // Return if there are no elements matching the tag combination
   if (nelements == 0)
     return 0;
 
   // Check if the number of GLL points in the mesh elements matches the template
-  if (element_grid != NGLL) {
+  if (assembly.mesh.element_grid != NGLL) {
     throw std::runtime_error(
         "The number of GLL points in the mesh elements must match "
         "the template parameter NGLL.");
   }
+
+  specfem::mesh_entity::element_grid<dimension_tag,
+                                     specfem::mesh_entity::Grid<NGLL>>
+      element_grid{};
 
   // Alias some assembly members for easier acces
   const auto &mesh = assembly.mesh;
@@ -182,6 +183,10 @@ int compute_stiffness_interaction(
                 specfem::assembly::load_on_device(index, properties,
                                                   point_property);
 
+                PointWeightsType point_weights;
+                specfem::assembly::load_on_device(index, mesh.weights,
+                                                  point_weights);
+
                 const auto field_derivatives =
                     grad_pack.template get_du<PointTags>();
 
@@ -209,8 +214,8 @@ int compute_stiffness_interaction(
 
                 // Scatter F contributions into shared acceleration scratch
                 specfem::algorithms::impl::scattered_divergence(
-                    F, local_index, mesh.weights, lagrange_derivative,
-                    scratch_acc);
+                    F, local_index, point_weights.product(),
+                    lagrange_derivative, scratch_acc);
 
                 // Cosserat couple stress: local-point scatter to spin
                 // component. Guarded by has_cosserat_couple_stress — zero
@@ -220,9 +225,6 @@ int compute_stiffness_interaction(
                         dimension_tag, medium_tag>::has_cosserat_couple_stress;
 
                 if constexpr (has_cosserat_couple_stress) {
-                  PointWeightsType point_weights;
-                  specfem::assembly::load_on_device(index, mesh.weights,
-                                                    point_weights);
 
                   PointAccelerationType cosserat_delta;
                   for (int icomp = 0; icomp < ncomp; ++icomp)

--- a/core/specfem/execution/chunked_domain_iterator.hpp
+++ b/core/specfem/execution/chunked_domain_iterator.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "policy.hpp"
+#include "specfem/mesh_entity.hpp"
 #include "specfem/point.hpp"
 #include "void_iterator.hpp"
 #include <Kokkos_Core.hpp>
@@ -11,7 +12,8 @@ namespace chunk_element {
 
 // Forward declaration for PointIndex
 template <specfem::element::dimension_tag DimensionTag, typename SIMD,
-          typename ViewType, typename TeamMemberType>
+          typename ViewType, typename TeamMemberType,
+          typename G = specfem::mesh_entity::Grid<>, int ChunkSize = 1>
 class Index;
 } // namespace chunk_element
 } // namespace specfem
@@ -170,10 +172,21 @@ public:
       : index(ispec, iz, iy, ix), local_index(ielement, iz, iy, ix),
         kokkos_index(kokkos_index) {}
 
+  /// @brief Construct an "end" sentinel index. Used by the chunked iterator
+  /// to signal that the policy index falls in the unused tail of the last
+  /// chunk and the closure must be skipped.
   KOKKOS_INLINE_FUNCTION
-  constexpr bool is_end() const {
-    return false; ///< Returns false as this is not an end iterator
+  static PointIndex end() {
+    PointIndex index;
+    index.is_end_flag = true;
+    return index;
   }
+
+  KOKKOS_INLINE_FUNCTION
+  PointIndex() = default;
+
+  KOKKOS_INLINE_FUNCTION
+  bool is_end() const { return is_end_flag; }
 
 private:
   point_index_type index;       ///< Index of the GLL
@@ -183,6 +196,8 @@ private:
                                 ///< relative to
                                 ///< current chunk
   KokkosIndexType kokkos_index; ///< The Kokkos index
+  bool is_end_flag = false;     ///< True if this index is the tail-skip
+                                ///< sentinel.
 };
 
 /**
@@ -196,7 +211,8 @@ private:
  *
  */
 template <specfem::element::dimension_tag DimensionTag, typename SIMD,
-          typename ViewType, typename TeamMemberType>
+          typename ViewType, typename TeamMemberType,
+          typename G = specfem::mesh_entity::Grid<>, int ChunkSize = 1>
 class ChunkElementIterator
     : public TeamThreadRangePolicy<TeamMemberType,
                                    typename ViewType::value_type> {
@@ -231,19 +247,32 @@ public:
    * @param i The policy index to convert to an index.
    * @return const index_type The index corresponding to the policy index.
    */
+  KOKKOS_INLINE_FUNCTION
+  const index_type operator()(const policy_index_type &i) const {
+    return dispatch(i, G{});
+  }
+
+private:
+  // ---------------------------------------------------------------
+  // Dynamic-grid dispatch overloads (G = Grid<>): divisors are runtime
+  // members of `element_grid`. Bodies are the existing implementation,
+  // selected by SFINAE on (dimension, using_simd).
+  // ---------------------------------------------------------------
   template <bool U = using_simd,
             specfem::element::dimension_tag D = dimension_tag>
   KOKKOS_INLINE_FUNCTION
       typename std::enable_if<U && D == specfem::element::dimension_tag::dim2,
                               const index_type>::type
-      operator()(const policy_index_type &i) const {
+      dispatch(const policy_index_type &i, specfem::mesh_entity::Grid<>) const {
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
-    int ielement = i % num_elements;
+    int ielement = i % ChunkSize;
+    if (ielement >= num_elements)
+      return index_type::end();
     int simd_elements = (simd_size + ielement > indices.extent(0))
                             ? indices.extent(0) - ielement
                             : simd_size;
     int ispec = indices(ielement);
-    int xz = i / num_elements;
+    int xz = i / ChunkSize;
     const int iz = xz / element_grid.ngllx;
     const int ix = xz % element_grid.ngllx;
 #else
@@ -251,6 +280,8 @@ public:
     const int ix = i % element_grid.ngllx;
     const int iz = (i / element_grid.ngllx) % element_grid.ngllz;
     const int ielement = i / ngll_total;
+    if (ielement >= num_elements)
+      return index_type::end();
     int simd_elements = (simd_size + ielement > indices.extent(0))
                             ? indices.extent(0) - ielement
                             : simd_size;
@@ -264,41 +295,41 @@ public:
   KOKKOS_INLINE_FUNCTION
       typename std::enable_if<!U && D == specfem::element::dimension_tag::dim2,
                               const index_type>::type
-      operator()(const policy_index_type &i) const {
+      dispatch(const policy_index_type &i, specfem::mesh_entity::Grid<>) const {
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
-    int ielement = i % num_elements;
+    int ielement = i % ChunkSize;
+    if (ielement >= num_elements)
+      return index_type::end();
     int ispec = indices(ielement);
-    int xz = i / num_elements;
+    int xz = i / ChunkSize;
     const int iz = xz / element_grid.ngllx;
     const int ix = xz % element_grid.ngllx;
 #else
     const int ix = i % element_grid.ngllx;
     const int iz = (i / element_grid.ngllx) % element_grid.ngllz;
     const int ielement = i / (element_grid.ngllz * element_grid.ngllx);
+    if (ielement >= num_elements)
+      return index_type::end();
     int ispec = indices(ielement);
 #endif
     return index_type(ispec, iz, ix, ielement, i);
   }
 
-  /**
-   * @brief Operator to get the index for a given policy index.
-   *
-   * @param i The policy index to convert to an index.
-   * @return const index_type The index corresponding to the policy index.
-   */
   template <bool U = using_simd,
             specfem::element::dimension_tag D = dimension_tag>
   KOKKOS_INLINE_FUNCTION
       typename std::enable_if<U && D == specfem::element::dimension_tag::dim3,
                               const index_type>::type
-      operator()(const policy_index_type &i) const {
+      dispatch(const policy_index_type &i, specfem::mesh_entity::Grid<>) const {
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
-    int ielement = i % num_elements;
+    int ielement = i % ChunkSize;
+    if (ielement >= num_elements)
+      return index_type::end();
     int simd_elements = (simd_size + ielement > indices.extent(0))
                             ? indices.extent(0) - ielement
                             : simd_size;
     int ispec = indices(ielement);
-    int zyx = i / num_elements;
+    int zyx = i / ChunkSize;
     const int iz = zyx / (element_grid.nglly * element_grid.ngllx);
     const int iy = (zyx / element_grid.ngllx) % element_grid.nglly;
     const int ix = zyx % element_grid.ngllx;
@@ -310,6 +341,8 @@ public:
     const int iz =
         (i / (element_grid.ngllx * element_grid.nglly)) % element_grid.ngllz;
     const int ielement = i / ngll_total;
+    if (ielement >= num_elements)
+      return index_type::end();
     int simd_elements = (simd_size + ielement > indices.extent(0))
                             ? indices.extent(0) - ielement
                             : simd_size;
@@ -323,11 +356,13 @@ public:
   KOKKOS_INLINE_FUNCTION
       typename std::enable_if<!U && D == specfem::element::dimension_tag::dim3,
                               const index_type>::type
-      operator()(const policy_index_type &i) const {
+      dispatch(const policy_index_type &i, specfem::mesh_entity::Grid<>) const {
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
-    int ielement = i % num_elements;
+    int ielement = i % ChunkSize;
+    if (ielement >= num_elements)
+      return index_type::end();
     int ispec = indices(ielement);
-    int zyx = i / num_elements;
+    int zyx = i / ChunkSize;
     const int iz = zyx / (element_grid.nglly * element_grid.ngllx);
     const int iy = (zyx / element_grid.ngllx) % element_grid.nglly;
     const int ix = zyx % element_grid.ngllx;
@@ -338,11 +373,93 @@ public:
         (i / (element_grid.ngllx * element_grid.nglly)) % element_grid.ngllz;
     const int ielement =
         i / (element_grid.ngllz * element_grid.nglly * element_grid.ngllx);
+    if (ielement >= num_elements)
+      return index_type::end();
     int ispec = indices(ielement);
 #endif
     return index_type(ispec, iz, iy, ix, ielement, i);
   }
 
+  // ---------------------------------------------------------------
+  // Compile-time-grid dispatch overloads: divisors are non-type template
+  // parameters Nz/Ny/Nx so the compiler is *guaranteed* to substitute the
+  // literal extent into the div/mod expressions.
+  // ---------------------------------------------------------------
+  template <int Nz, int Nx>
+  KOKKOS_INLINE_FUNCTION const index_type dispatch(
+      const policy_index_type &i, specfem::mesh_entity::Grid<Nz, Nx>) const {
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+    int ielement = i % ChunkSize;
+    if (ielement >= num_elements)
+      return index_type::end();
+    int ispec = indices(ielement);
+    int xz = i / ChunkSize;
+    const int iz = xz / Nx;
+    const int ix = xz % Nx;
+#else
+    const int ix = i % Nx;
+    const int iz = (i / Nx) % Nz;
+    const int ielement = i / (Nz * Nx);
+    if (ielement >= num_elements)
+      return index_type::end();
+    int ispec = indices(ielement);
+#endif
+    if constexpr (using_simd) {
+      int simd_elements = (simd_size + ielement > indices.extent(0))
+                              ? indices.extent(0) - ielement
+                              : simd_size;
+      return index_type(ispec, simd_elements, iz, ix, ielement, i);
+    } else {
+      return index_type(ispec, iz, ix, ielement, i);
+    }
+  }
+
+  // Isotropic shortcut: Grid<N> forwards to the canonical multi-arg
+  // overload based on dimension_tag. N stays a non-type template parameter
+  // so the literal substitution propagates through the forward.
+  template <int N>
+  KOKKOS_INLINE_FUNCTION const index_type
+  dispatch(const policy_index_type &i, specfem::mesh_entity::Grid<N>) const {
+    if constexpr (dimension_tag == specfem::element::dimension_tag::dim2) {
+      return dispatch(i, specfem::mesh_entity::Grid<N, N>{});
+    } else {
+      return dispatch(i, specfem::mesh_entity::Grid<N, N, N>{});
+    }
+  }
+
+  template <int Nz, int Ny, int Nx>
+  KOKKOS_INLINE_FUNCTION const index_type
+  dispatch(const policy_index_type &i,
+           specfem::mesh_entity::Grid<Nz, Ny, Nx>) const {
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+    int ielement = i % ChunkSize;
+    if (ielement >= num_elements)
+      return index_type::end();
+    int ispec = indices(ielement);
+    int zyx = i / ChunkSize;
+    const int iz = zyx / (Ny * Nx);
+    const int iy = (zyx / Nx) % Ny;
+    const int ix = zyx % Nx;
+#else
+    const int ix = i % Nx;
+    const int iy = (i / Nx) % Ny;
+    const int iz = (i / (Nx * Ny)) % Nz;
+    const int ielement = i / (Nz * Ny * Nx);
+    if (ielement >= num_elements)
+      return index_type::end();
+    int ispec = indices(ielement);
+#endif
+    if constexpr (using_simd) {
+      int simd_elements = (simd_size + ielement > indices.extent(0))
+                              ? indices.extent(0) - ielement
+                              : simd_size;
+      return index_type(ispec, simd_elements, iz, iy, ix, ielement, i);
+    } else {
+      return index_type(ispec, iz, iy, ix, ielement, i);
+    }
+  }
+
+public:
   /**
    * @brief Constructor for ChunkElementIterator.
    *
@@ -353,18 +470,16 @@ public:
    */
   KOKKOS_INLINE_FUNCTION ChunkElementIterator(
       const TeamMemberType &team, const ViewType indices,
-      const specfem::mesh_entity::element_grid<dimension_tag> &element_grid)
+      const specfem::mesh_entity::element_grid<dimension_tag, G> &element_grid)
       : indices(indices), element_grid(element_grid),
         num_elements((indices.extent(0) / simd_size) +
                      ((indices.extent(0) % simd_size) != 0)),
-        base_type(team, (((indices.extent(0) / simd_size) +
-                          (indices.extent(0) % simd_size != 0)) *
-                         element_grid.size)) {}
+        base_type(team, ChunkSize * element_grid.size) {}
 
 private:
   ViewType indices; ///< View of indices of elements within this chunk
   int num_elements; ///< Number of elements in the chunk, adjusted for SIMD
-  specfem::mesh_entity::element_grid<dimension_tag>
+  specfem::mesh_entity::element_grid<dimension_tag, G>
       element_grid; ///< Element grid
                     ///< information
 };
@@ -383,21 +498,24 @@ private:
  * @tparam TeamMemberType The type of the Kokkos team member.
  */
 template <specfem::element::dimension_tag DimensionTag, typename SIMD,
-          typename ViewType, typename TeamMemberType>
+          typename ViewType, typename TeamMemberType,
+          typename G = specfem::mesh_entity::Grid<>, int ChunkSize = 1>
 class ChunkElementIndex {
 private:
   using index_type =
       specfem::chunk_element::Index<DimensionTag, SIMD, ViewType,
-                                    TeamMemberType>; ///< Underlying index type
-                                                     ///< used to store the
-                                                     ///< indices within the
-                                                     ///< chunk.
+                                    TeamMemberType, G,
+                                    ChunkSize>; ///< Underlying
+                                                ///< index
+                                                ///< type for
+                                                ///< the
+                                                ///< chunk element index.
 
 public:
   using iterator_type =
-      ChunkElementIterator<DimensionTag, SIMD, ViewType,
-                           TeamMemberType>; ///< Iterator type for iterating
-                                            ///< over the elements in the chunk.
+      ChunkElementIterator<DimensionTag, SIMD, ViewType, TeamMemberType, G,
+                           ChunkSize>; ///< Iterator type for iterating
+                                       ///< over the elements in the chunk.
 
   /**
    * @brief Get the policy index that defined this chunk element index.
@@ -438,7 +556,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   ChunkElementIndex(
       const ViewType indices,
-      const specfem::mesh_entity::element_grid<DimensionTag> &element_grid,
+      const specfem::mesh_entity::element_grid<DimensionTag, G> &element_grid,
       const TeamMemberType &kokkos_index)
       : indices(indices), element_grid(element_grid),
         kokkos_index(kokkos_index),
@@ -461,7 +579,7 @@ public:
 
 private:
   ViewType indices; ///< View of indices
-  specfem::mesh_entity::element_grid<DimensionTag>
+  specfem::mesh_entity::element_grid<DimensionTag, G>
       element_grid;            ///< Element grid
                                ///< information
   TeamMemberType kokkos_index; ///< Kokkos index type
@@ -481,7 +599,7 @@ private:
  * @tparam ViewType Type of the view containing indices of elements.
  */
 template <specfem::element::dimension_tag DimensionTag, typename ParallelConfig,
-          typename ViewType>
+          typename ViewType, typename G = specfem::mesh_entity::Grid<>>
 class ChunkedDomainIterator : public TeamPolicy<ParallelConfig> {
 private:
   using base_type = TeamPolicy<ParallelConfig>;       ///< Base policy type
@@ -499,11 +617,12 @@ public:
   using index_type = ChunkElementIndex<
       DimensionTag, typename ParallelConfig::simd,
       decltype(Kokkos::subview(std::declval<ViewType>(),
-                               std::declval<Kokkos::pair<int, int> >())),
-      policy_index_type>; ///< Underlying index type. This index
-                          ///< will be passed to the closure when
-                          ///< calling @ref
-                          ///< specfem::execution::for_each_level
+                               std::declval<Kokkos::pair<int, int>>())),
+      policy_index_type, G,
+      ParallelConfig::chunk_size>; ///< Underlying index type. This index
+                                   ///< will be passed to the closure when
+                                   ///< calling @ref
+                                   ///< specfem::execution::for_each_level
   using execution_space =
       typename base_type::execution_space; ///< Execution space type.
   using base_index_type = PointIndex<
@@ -524,7 +643,7 @@ public:
    */
   ChunkedDomainIterator(
       const ViewType indices,
-      const specfem::mesh_entity::element_grid<DimensionTag> &element_grid)
+      const specfem::mesh_entity::element_grid<DimensionTag, G> &element_grid)
       : indices(indices), element_grid(element_grid),
         base_type(((indices.extent(0) / (chunk_size * simd_size)) +
                    ((indices.extent(0) % (chunk_size * simd_size)) != 0)),
@@ -541,7 +660,7 @@ public:
    */
   ChunkedDomainIterator(
       const ParallelConfig, const ViewType indices,
-      const specfem::mesh_entity::element_grid<DimensionTag> &element_grid)
+      const specfem::mesh_entity::element_grid<DimensionTag, G> &element_grid)
       : ChunkedDomainIterator(indices, element_grid) {}
 
   /**
@@ -584,24 +703,27 @@ public:
 
 protected:
   ViewType indices; ///< View of indices of elements within this iterator
-  specfem::mesh_entity::element_grid<DimensionTag>
+  specfem::mesh_entity::element_grid<DimensionTag, G>
       element_grid; ///< Element grid
                     ///< information
 };
 
 // Template argument deduction guides
 template <typename ParallelConfig, typename ViewType,
-          specfem::element::dimension_tag DimensionTag>
-ChunkedDomainIterator(ParallelConfig, ViewType,
-                      const specfem::mesh_entity::element_grid<DimensionTag> &)
-    -> ChunkedDomainIterator<DimensionTag, ParallelConfig, ViewType>;
+          specfem::element::dimension_tag DimensionTag, typename G>
+ChunkedDomainIterator(
+    ParallelConfig, ViewType,
+    const specfem::mesh_entity::element_grid<DimensionTag, G> &)
+    -> ChunkedDomainIterator<DimensionTag, ParallelConfig, ViewType, G>;
 
-template <typename ViewType, specfem::element::dimension_tag DimensionTag>
-ChunkedDomainIterator(ViewType,
-                      const specfem::mesh_entity::element_grid<DimensionTag> &)
+template <typename ViewType, specfem::element::dimension_tag DimensionTag,
+          typename G>
+ChunkedDomainIterator(
+    ViewType, const specfem::mesh_entity::element_grid<DimensionTag, G> &)
     -> ChunkedDomainIterator<
         DimensionTag,
-        decltype(std::declval<typename ViewType::execution_space>()), ViewType>;
+        decltype(std::declval<typename ViewType::execution_space>()), ViewType,
+        G>;
 
 } // namespace execution
 } // namespace specfem

--- a/core/specfem/execution/chunked_edge_iterator.hpp
+++ b/core/specfem/execution/chunked_edge_iterator.hpp
@@ -153,6 +153,11 @@ public:
   KOKKOS_INLINE_FUNCTION
   constexpr const iterator_type get_iterator() const { return iterator_type{}; }
 
+  /// @brief Tail-skip flag required by the for_each_level dispatcher.
+  /// Edge points have no tail-skip semantics, so this is always false.
+  KOKKOS_INLINE_FUNCTION
+  constexpr bool is_end() const { return false; }
+
 private:
   index_type index;       ///< Local element coordinates of the edge point
   index_type local_index; ///< Local element coordinates relative to chunk

--- a/core/specfem/execution/chunked_face_iterator.hpp
+++ b/core/specfem/execution/chunked_face_iterator.hpp
@@ -102,6 +102,11 @@ public:
     return iterator_type{};
   }
 
+  /// @brief Tail-skip flag required by the for_each_level dispatcher.
+  /// Face points have no tail-skip semantics, so this is always false.
+  KOKKOS_INLINE_FUNCTION
+  constexpr bool is_end() const { return false; }
+
 private:
   index_type index;       ///< Local element coordinates of the face point
   index_type local_index; ///< Local element coordinates relative to chunk

--- a/core/specfem/execution/chunked_intersection_iterator.hpp
+++ b/core/specfem/execution/chunked_intersection_iterator.hpp
@@ -155,6 +155,11 @@ public:
   KOKKOS_INLINE_FUNCTION
   constexpr const iterator_type get_iterator() const { return iterator_type{}; }
 
+  /// @brief Tail-skip flag required by the for_each_level dispatcher.
+  /// Interface points have no tail-skip semantics, so this is always false.
+  KOKKOS_INLINE_FUNCTION
+  constexpr bool is_end() const { return false; }
+
 private:
   index_type index;             ///< Index of the GLL point on the interface
   KokkosIndexType kokkos_index; ///< Kokkos index type

--- a/core/specfem/execution/for_each_level.hpp
+++ b/core/specfem/execution/for_each_level.hpp
@@ -125,6 +125,8 @@ impl_for_each_level(const Iterator &iterator, const ClosureType &closure) {
       static_cast<const typename Iterator::base_policy_type &>(iterator),
       [&](const typename Iterator::policy_index_type &i) {
         const typename Iterator::index_type index = iterator(i);
+        if (index.is_end())
+          return; // skip tail-chunk positions with no backing element
         closure(index);
       });
 }
@@ -146,6 +148,8 @@ impl_for_each_level(const Iterator &iterator, const ClosureType &closure) {
       static_cast<const typename Iterator::base_policy_type &>(iterator),
       [&](const typename Iterator::policy_index_type &i) {
         const typename Iterator::index_type index = iterator(i);
+        if (index.is_end())
+          return; // skip tail-chunk positions with no backing element
         closure(index);
       });
 }

--- a/core/specfem/execution/mapped_chunked_domain_iterator.hpp
+++ b/core/specfem/execution/mapped_chunked_domain_iterator.hpp
@@ -12,7 +12,8 @@ namespace chunk_element {
 
 // Forward declaration for PointIndex
 template <specfem::element::dimension_tag DimensionTag, typename SIMD,
-          typename ViewType, typename TeamMemberType>
+          typename ViewType, typename TeamMemberType,
+          typename G = specfem::mesh_entity::Grid<>, int ChunkSize = 1>
 class MappedIndex;
 } // namespace chunk_element
 } // namespace specfem
@@ -61,24 +62,36 @@ public:
         kokkos_index(kokkos_index) {}
 
   KOKKOS_INLINE_FUNCTION
-  constexpr bool is_end() const {
-    return false; ///< Returns false as this is not an end iterator
+  MappedPointIndex() = default;
+
+  /// @brief Construct an "end" sentinel index — tail-skip marker for the
+  /// chunked iterator.
+  KOKKOS_INLINE_FUNCTION
+  static MappedPointIndex end() {
+    MappedPointIndex index;
+    index.is_end_flag = true;
+    return index;
   }
+
+  KOKKOS_INLINE_FUNCTION
+  bool is_end() const { return is_end_flag; }
 
 private:
   index_type index;             ///< Point
   point_index_type local_index; ///< Local point index
   KokkosIndexType kokkos_index; ///< Kokkos index type
+  bool is_end_flag = false;     ///< True if this is the tail-skip sentinel.
 };
 
 template <specfem::element::dimension_tag DimensionTag, typename SIMD,
-          typename ViewType, typename TeamMemberType>
+          typename ViewType, typename TeamMemberType,
+          typename G = specfem::mesh_entity::Grid<>, int ChunkSize = 1>
 class MappedChunkElementIterator
-    : public ChunkElementIterator<DimensionTag, SIMD, ViewType,
-                                  TeamMemberType> {
+    : public ChunkElementIterator<DimensionTag, SIMD, ViewType, TeamMemberType,
+                                  G, ChunkSize> {
 private:
-  using base_type =
-      ChunkElementIterator<DimensionTag, SIMD, ViewType, TeamMemberType>;
+  using base_type = ChunkElementIterator<DimensionTag, SIMD, ViewType,
+                                         TeamMemberType, G, ChunkSize>;
   constexpr static auto simd_size = SIMD::size();
   constexpr static auto using_simd = SIMD::using_simd;
 
@@ -93,6 +106,8 @@ public:
   KOKKOS_INLINE_FUNCTION const index_type
   operator()(const policy_index_type &i) const {
     const auto base_index = base_type::operator()(i);
+    if (base_index.is_end())
+      return index_type::end();
     // Calculate the mapped index
     const auto index = base_index.get_index();
     const auto local_index = base_index.get_local_index();
@@ -103,7 +118,7 @@ public:
   MappedChunkElementIterator(
       const TeamMemberType &team, const ViewType indices,
       const ViewType mapping,
-      const specfem::mesh_entity::element_grid<DimensionTag> &element_grid)
+      const specfem::mesh_entity::element_grid<DimensionTag, G> &element_grid)
       : base_type(team, indices, element_grid), mapping(mapping) {}
 
 private:
@@ -111,23 +126,27 @@ private:
 };
 
 template <specfem::element::dimension_tag DimensionTag, typename SIMD,
-          typename ViewType, typename TeamMemberType>
+          typename ViewType, typename TeamMemberType,
+          typename G = specfem::mesh_entity::Grid<>, int ChunkSize = 1>
 class MappedChunkElementIndex
-    : public ChunkElementIndex<DimensionTag, SIMD, ViewType, TeamMemberType> {
+    : public ChunkElementIndex<DimensionTag, SIMD, ViewType, TeamMemberType, G,
+                               ChunkSize> {
 private:
-  using base_type =
-      ChunkElementIndex<DimensionTag, SIMD, ViewType, TeamMemberType>;
+  using base_type = ChunkElementIndex<DimensionTag, SIMD, ViewType,
+                                      TeamMemberType, G, ChunkSize>;
   using index_type =
       specfem::chunk_element::MappedIndex<DimensionTag, SIMD, ViewType,
-                                          TeamMemberType>; ///< Underlying index
-                                                           ///< type used to
-                                                           ///< store the
-                                                           ///< indices within
-                                                           ///< the chunk.
+                                          TeamMemberType, G,
+                                          ChunkSize>; ///< Underlying index
+                                                      ///< type used to
+                                                      ///< store the
+                                                      ///< indices within
+                                                      ///< the chunk.
 
 public:
   using iterator_type =
-      MappedChunkElementIterator<DimensionTag, SIMD, ViewType, TeamMemberType>;
+      MappedChunkElementIterator<DimensionTag, SIMD, ViewType, TeamMemberType,
+                                 G, ChunkSize>;
 
   KOKKOS_INLINE_FUNCTION
   constexpr const index_type get_index() const { return { *this }; }
@@ -138,7 +157,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   MappedChunkElementIndex(
       const ViewType indices, const ViewType mapping,
-      const specfem::mesh_entity::element_grid<DimensionTag> &element_grid,
+      const specfem::mesh_entity::element_grid<DimensionTag, G> &element_grid,
       const TeamMemberType &kokkos_index)
       : base_type(indices, element_grid, kokkos_index), mapping(mapping),
         iterator(kokkos_index, indices, mapping, element_grid) {}
@@ -149,12 +168,12 @@ private:
 };
 
 template <specfem::element::dimension_tag DimensionTag, typename ParallelConfig,
-          typename ViewType>
+          typename ViewType, typename G = specfem::mesh_entity::Grid<>>
 class MappedChunkedDomainIterator
-    : public ChunkedDomainIterator<DimensionTag, ParallelConfig, ViewType> {
+    : public ChunkedDomainIterator<DimensionTag, ParallelConfig, ViewType, G> {
 private:
   using base_type =
-      ChunkedDomainIterator<DimensionTag, ParallelConfig, ViewType>;
+      ChunkedDomainIterator<DimensionTag, ParallelConfig, ViewType, G>;
   constexpr static auto simd_size = ParallelConfig::simd::size();
   constexpr static auto chunk_size = ParallelConfig::chunk_size;
 
@@ -164,8 +183,8 @@ public:
   using index_type = MappedChunkElementIndex<
       ParallelConfig::dimension, typename ParallelConfig::simd,
       decltype(Kokkos::subview(std::declval<ViewType>(),
-                               std::declval<Kokkos::pair<int, int> >())),
-      policy_index_type>;
+                               std::declval<Kokkos::pair<int, int>>())),
+      policy_index_type, G, ParallelConfig::chunk_size>;
   using execution_space =
       typename base_type::execution_space; ///< Execution space type
 
@@ -175,12 +194,12 @@ public:
 
   MappedChunkedDomainIterator(
       const ViewType indices, const ViewType mapping,
-      const specfem::mesh_entity::element_grid<DimensionTag> &element_grid)
+      const specfem::mesh_entity::element_grid<DimensionTag, G> &element_grid)
       : base_type(indices, element_grid), mapping(mapping) {}
 
   MappedChunkedDomainIterator(
       const ParallelConfig, const ViewType indices, const ViewType mapping,
-      const specfem::mesh_entity::element_grid<DimensionTag> &element_grid)
+      const specfem::mesh_entity::element_grid<DimensionTag, G> &element_grid)
       : MappedChunkedDomainIterator(indices, mapping, element_grid) {}
 
   KOKKOS_INLINE_FUNCTION
@@ -210,19 +229,21 @@ private:
 
 // Template argument deduction guides
 template <typename ParallelConfig, typename ViewType,
-          specfem::element::dimension_tag DimensionTag>
+          specfem::element::dimension_tag DimensionTag, typename G>
 MappedChunkedDomainIterator(
     ParallelConfig, ViewType, ViewType,
-    const specfem::mesh_entity::element_grid<DimensionTag> &)
-    -> MappedChunkedDomainIterator<DimensionTag, ParallelConfig, ViewType>;
+    const specfem::mesh_entity::element_grid<DimensionTag, G> &)
+    -> MappedChunkedDomainIterator<DimensionTag, ParallelConfig, ViewType, G>;
 
-template <typename ViewType, specfem::element::dimension_tag DimensionTag>
+template <typename ViewType, specfem::element::dimension_tag DimensionTag,
+          typename G>
 MappedChunkedDomainIterator(
     ViewType, ViewType,
-    const specfem::mesh_entity::element_grid<DimensionTag> &)
+    const specfem::mesh_entity::element_grid<DimensionTag, G> &)
     -> MappedChunkedDomainIterator<
         DimensionTag,
-        decltype(std::declval<typename ViewType::execution_space>()), ViewType>;
+        decltype(std::declval<typename ViewType::execution_space>()), ViewType,
+        G>;
 
 } // namespace execution
 } // namespace specfem

--- a/core/specfem/execution/team_thread_md_range_iterator.hpp
+++ b/core/specfem/execution/team_thread_md_range_iterator.hpp
@@ -8,6 +8,32 @@
 
 namespace specfem {
 namespace execution {
+
+/**
+ * @brief Integer coordinate index for a rank-`Rank` multi-dimensional range.
+ *
+ * Holds the `Rank` integer coordinates produced by a multi-dimensional
+ * iterator. Coordinates are accessed via `index(0)`, `index(1)`, ...,
+ * `index(Rank - 1)`. `is_end()` reports whether this index is a
+ * past-the-end sentinel.
+ *
+ * @tparam Rank Number of coordinate dimensions (2 or 3).
+ */
+template <int Rank>
+struct MDRangeIndex
+    : public specfem::datatype::RegisterArray<
+          int, Kokkos::extents<std::size_t, Rank>, Kokkos::layout_left> {
+  using base_type =
+      specfem::datatype::RegisterArray<int, Kokkos::extents<std::size_t, Rank>,
+                                       Kokkos::layout_left>;
+  using base_type::base_type;
+  using base_type::operator();
+
+  /// @brief True if this index is a past-the-end sentinel.
+  KOKKOS_INLINE_FUNCTION
+  constexpr bool is_end() const { return false; }
+};
+
 /**
  * @brief Multi-dimensional range iterator for team-based parallel execution
  *
@@ -32,18 +58,16 @@ public:
   using base_policy_type =
       typename base_type::base_policy_type; ///< Base policy type. Evaluates to
                                             ///< @c Kokkos::TeamThreadRange
-  using index_type = specfem::datatype::RegisterArray<
-      int, Kokkos::extents<std::size_t, rank>,
-      Kokkos::layout_left>; ///< Underlying
-                            ///< index type.
-                            ///< This index
-                            ///< will be passed
-                            ///< to the closure
-                            ///< when calling
-                            ///< @ref
-                            ///< kokkos::parallel_for
-                            ///< with this
-                            ///< iterator.
+  using index_type = MDRangeIndex<rank>;    ///< Underlying
+                                            ///< index type.
+                                            ///< This index
+                                            ///< will be passed
+                                            ///< to the closure
+                                            ///< when calling
+                                            ///< @ref
+                                            ///< kokkos::parallel_for
+                                            ///< with this
+                                            ///< iterator.
 
   using execution_space =
       typename base_type::execution_space; ///< Execution space type.
@@ -107,8 +131,8 @@ public:
 #endif
 
   template <typename... Indices>
-  KOKKOS_INLINE_FUNCTION constexpr
-  TeamThreadMDRangeIterator(const TeamMemberType &team, Indices... indices)
+  KOKKOS_INLINE_FUNCTION constexpr TeamThreadMDRangeIterator(
+      const TeamMemberType &team, Indices... indices)
       : base_type(team,
                   [&]() {
                     size_t product = 1;

--- a/core/specfem/mesh_entity.hpp
+++ b/core/specfem/mesh_entity.hpp
@@ -19,10 +19,21 @@ namespace specfem::mesh_entity {
 template <specfem::element::dimension_tag DimensionTag> struct edge;
 
 /**
+ * @brief Compile-time grid extent tag for @ref element_grid.
+ *
+ * Empty form `Grid<>` selects the runtime (dynamic) variant; a non-empty form
+ * encodes the GLL counts in the type (e.g. `Grid<5, 5>` for 2D, `Grid<5, 5, 5>`
+ * for 3D), selecting the compile-time variant.
+ */
+template <int... Extents> struct Grid {};
+
+/**
  * @brief Element grid structure with GLL point configuration.
  * @tparam DimensionTag Spatial dimension (2D or 3D)
+ * @tparam G Grid extent tag; defaults to `Grid<>` (runtime variant).
  */
-template <specfem::element::dimension_tag DimensionTag> struct element_grid;
+template <specfem::element::dimension_tag DimensionTag, typename G = Grid<>>
+struct element_grid;
 
 /**
  * @brief Element structure with coordinate mapping capabilities.

--- a/core/specfem/mesh_entity/dim2/mesh_entity.hpp
+++ b/core/specfem/mesh_entity/dim2/mesh_entity.hpp
@@ -107,12 +107,13 @@ template <> struct edge<specfem::element::dimension_tag::dim2> {
 };
 
 template <specfem::element::dimension_tag Dimension> struct element;
-template <specfem::element::dimension_tag Dimension> struct element_grid;
+template <specfem::element::dimension_tag Dimension, typename G>
+struct element_grid;
 
 /**
- * @brief 2D element grid with GLL point configuration.
+ * @brief 2D element grid with GLL point configuration (runtime variant).
  */
-template <> struct element_grid<specfem::element::dimension_tag::dim2> {
+template <> struct element_grid<specfem::element::dimension_tag::dim2, Grid<>> {
 
 public:
   int ngllz;  ///< Number of GLL points in z-direction
@@ -168,13 +169,56 @@ public:
 };
 
 /**
+ * @brief 2D element grid with GLL point configuration (compile-time variant).
+ *
+ * GLL counts are encoded as non-type template parameters so the compiler can
+ * treat dimensions, strides, and `size` as compile-time constants.
+ */
+template <int Nz, int Nx>
+struct element_grid<specfem::element::dimension_tag::dim2, Grid<Nz, Nx>> {
+  static_assert(
+      Nz == Nx,
+      "Different number of GLL points for Z and X are not supported.");
+
+  static constexpr int ngllz = Nz;      ///< Number of GLL points in z
+  static constexpr int ngllx = Nx;      ///< Number of GLL points in x
+  static constexpr int ngll = Nz;       ///< Number of GLL points (Nz == Nx)
+  static constexpr int orderz = Nz - 1; ///< Polynomial order in z
+  static constexpr int orderx = Nx - 1; ///< Polynomial order in x
+  static constexpr int size = Nz * Nx;  ///< Total number of GLL points
+
+  KOKKOS_INLINE_FUNCTION
+  element_grid() = default;
+
+  /// @brief Check if element matches specified GLL point count.
+  KOKKOS_INLINE_FUNCTION
+  constexpr bool operator==(const int ngll_in) const {
+    return ngll_in == ngllz && ngll_in == ngllx;
+  }
+  /// @brief Check if element does not match specified GLL point count.
+  KOKKOS_INLINE_FUNCTION
+  constexpr bool operator!=(const int ngll_in) const {
+    return !(*this == ngll_in);
+  }
+};
+
+/**
+ * @brief 2D element grid with isotropic compile-time GLL count.
+ *
+ * Convenience specialization: `Grid<N>` expands to `Grid<N, N>`.
+ */
+template <int N>
+struct element_grid<specfem::element::dimension_tag::dim2, Grid<N>>
+    : element_grid<specfem::element::dimension_tag::dim2, Grid<N, N>> {};
+
+/**
  * @brief 2D element with coordinate mapping capabilities.
  */
 template <>
 struct element<specfem::element::dimension_tag::dim2>
-    : public element_grid<specfem::element::dimension_tag::dim2> {
+    : public element_grid<specfem::element::dimension_tag::dim2, Grid<>> {
 private:
-  using base = element_grid<specfem::element::dimension_tag::dim2>;
+  using base = element_grid<specfem::element::dimension_tag::dim2, Grid<>>;
 
 public:
   /**

--- a/core/specfem/mesh_entity/dim3/mesh_entity.hpp
+++ b/core/specfem/mesh_entity/dim3/mesh_entity.hpp
@@ -211,12 +211,13 @@ template <> struct edge<specfem::element::dimension_tag::dim3> {
 };
 
 template <specfem::element::dimension_tag Dimension> struct element;
-template <specfem::element::dimension_tag Dimension> struct element_grid;
+template <specfem::element::dimension_tag Dimension, typename G>
+struct element_grid;
 
 /**
- * @brief 3D element grid with GLL point configuration.
+ * @brief 3D element grid with GLL point configuration (runtime variant).
  */
-template <> struct element_grid<specfem::element::dimension_tag::dim3> {
+template <> struct element_grid<specfem::element::dimension_tag::dim3, Grid<>> {
 
 public:
   int ngllz;  ///< Number of GLL points in z-direction
@@ -279,11 +280,55 @@ public:
 };
 
 /**
+ * @brief 3D element grid with GLL point configuration (compile-time variant).
+ *
+ * GLL counts are encoded as non-type template parameters so the compiler can
+ * treat dimensions, strides, and `size` as compile-time constants.
+ */
+template <int Nz, int Ny, int Nx>
+struct element_grid<specfem::element::dimension_tag::dim3, Grid<Nz, Ny, Nx>> {
+  static_assert(Nz >= 2 && Ny >= 2 && Nx >= 2,
+                "ngllz, nglly, and ngllx must be at least 2 to define a 3D "
+                "element");
+  static_assert(Nz == Ny && Nz == Nx,
+                "ngllz, nglly, and ngllx must be equal for a cubic 3D element");
+
+  static constexpr int ngllz = Nz;          ///< Number of GLL points in z
+  static constexpr int nglly = Ny;          ///< Number of GLL points in y
+  static constexpr int ngllx = Nx;          ///< Number of GLL points in x
+  static constexpr int orderz = Nz - 1;     ///< Polynomial order in z
+  static constexpr int ordery = Ny - 1;     ///< Polynomial order in y
+  static constexpr int orderx = Nx - 1;     ///< Polynomial order in x
+  static constexpr int size = Nz * Ny * Nx; ///< Total number of GLL points
+
+  KOKKOS_INLINE_FUNCTION
+  element_grid() = default;
+
+  /// @brief Check if element matches specified GLL point count.
+  KOKKOS_INLINE_FUNCTION
+  constexpr bool operator==(const int ngll) const {
+    return ngll == ngllz && ngll == nglly && ngll == ngllx;
+  }
+  /// @brief Check if element does not match specified GLL point count.
+  KOKKOS_INLINE_FUNCTION
+  constexpr bool operator!=(const int ngll) const { return !(*this == ngll); }
+};
+
+/**
+ * @brief 3D element grid with isotropic compile-time GLL count.
+ *
+ * Convenience specialization: `Grid<N>` expands to `Grid<N, N, N>`.
+ */
+template <int N>
+struct element_grid<specfem::element::dimension_tag::dim3, Grid<N>>
+    : element_grid<specfem::element::dimension_tag::dim3, Grid<N, N, N>> {};
+
+/**
  * @brief 3D element with coordinate mapping capabilities.
  */
 template <>
 struct element<specfem::element::dimension_tag::dim3>
-    : element_grid<specfem::element::dimension_tag::dim3> {
+    : element_grid<specfem::element::dimension_tag::dim3, Grid<>> {
 
 public:
   int ngll2d; ///< Points per 2D face

--- a/core/specfem/point/mapped_index.hpp
+++ b/core/specfem/point/mapped_index.hpp
@@ -52,6 +52,9 @@ public:
   KOKKOS_INLINE_FUNCTION
   mapped_index(const base_type &index, const int &imap)
       : base_type(index), imap(imap) {}
+
+  KOKKOS_INLINE_FUNCTION
+  mapped_index() = default;
 };
 
 } // namespace point


### PR DESCRIPTION
## Description

Please describe the changes/features in this pull request.

This reduces some register usage on GPU by using compile time div-mods

- Add a `Grid<...>` tag and specialize `element_grid` on it so GLL extents can be baked in at compile time. The runtime `Grid<>` form still works; `Grid<N>` / `Grid<Nz,Nx>` / `Grid<Nz,Ny,Nx>` turn `ngllx`, `size`, etc. into `static constexpr`.
- Plumb the grid tag and a `ChunkSize` template parameter through the chunked and mapped-chunked iterators so the div/mod math that maps a policy index to (ielement, ix, iy, iz) uses literal divisors when the extents are known at compile time.
- Allow a fixed compile-time chunk size by giving chunk indices an `is_end()` sentinel and having `for_each_level` skip those positions, so partial trailing chunks are handled correctly. Edge, face, and intersection indices get a trivial `is_end() == false` for uniformity.
- In `compute_stiffness_interaction`, build the `element_grid` locally with the compile-time `Grid<NGLL>` extent and load `PointWeights` once up front instead of reloading it inside the Cosserat branch.
- `scattered_divergence` now takes the precomputed weight product rather than the weights view, dropping redundant `weights(...)` reads from the inner atomic-add loops.

## Issue Number

If there is an issue created for these changes, link it here

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
