### PR TITLE
1123 Part II - Kernel writer for 3D

### DIFF
--- a/core/specfem/io/impl/medium_writer.hpp
+++ b/core/specfem/io/impl/medium_writer.hpp
@@ -33,6 +33,22 @@ int write_medium_group(
     const specfem::assembly::mesh<specfem::element::dimension_tag::dim2> &mesh,
     const ElementIndicesType &element_indices,
     const DataContainerType &data_container);
+
+template <typename OutputLibrary, typename ContainerType>
+void write_container(
+    const std::string &output_folder, const std::string &output_namespace,
+    const specfem::assembly::mesh<specfem::element::dimension_tag::dim3> &mesh,
+    const specfem::assembly::element_types<
+        specfem::element::dimension_tag::dim3> &element_types,
+    ContainerType &container);
+
+template <typename GroupType, typename ElementIndicesType,
+          typename DataContainerType>
+int write_medium_group(
+    GroupType &group,
+    const specfem::assembly::mesh<specfem::element::dimension_tag::dim3> &mesh,
+    const ElementIndicesType &element_indices,
+    const DataContainerType &data_container);
 } // namespace impl
 } // namespace io
 } // namespace specfem

--- a/core/specfem/io/impl/medium_writer.tpp
+++ b/core/specfem/io/impl/medium_writer.tpp
@@ -2,6 +2,7 @@
 
 #include "specfem/assembly/element_types.hpp"
 #include "specfem/assembly/mesh.hpp"
+#include "specfem/data_access/container.hpp"
 #include "specfem/datatype.hpp"
 #include "specfem/element.hpp"
 #include "specfem/io/impl/medium_writer.hpp"
@@ -77,12 +78,113 @@ void specfem::io::impl::write_container(
         constexpr auto medium_tag = TagsType::medium_tag;
         constexpr auto property_tag = TagsType::property_tag;
 
+        const auto element_indices =
+            element_types.get_elements_on_host(medium_tag, property_tag);
+        if (element_indices.size() == 0)
+          return;
         const std::string name =
             std::string("/") + specfem::element::to_string(medium_tag,
                                                            property_tag);
         typename OutputLibrary::Group group = file.createGroup(name);
+        auto data_container =
+            container.template get_container<medium_tag, property_tag>();
+        n_written +=
+            write_medium_group(group, mesh, element_indices, data_container);
+      });
+
+  if (n_written != nspec) {
+    std::ostringstream message;
+    message << "Error while writing output container at" << __FILE__ << ":"
+            << __LINE__ << "\n"
+            << "Error writing output: expected to write " << nspec
+            << " elements, but wrote " << n_written << " elements.";
+    throw std::runtime_error(message.str());
+  }
+
+  specfem::Logger::info(output_namespace + " written to " + output_folder +
+                        "/" + output_namespace);
+}
+
+// ---------------------------------------------------------------------------
+// dim3 overloads
+// ---------------------------------------------------------------------------
+
+template <typename GroupType, typename ElementIndicesType,
+          typename DataContainerType>
+int specfem::io::impl::write_medium_group(
+    GroupType &group,
+    const specfem::assembly::mesh<specfem::element::dimension_tag::dim3> &mesh,
+    const ElementIndicesType &element_indices,
+    const DataContainerType &data_container) {
+
+  const int ngllz = mesh.element_grid.ngllz;
+  const int nglly = mesh.element_grid.nglly;
+  const int ngllx = mesh.element_grid.ngllx;
+
+  const int n_elements = element_indices.size();
+
+  using DomainView3d =
+      specfem::datatype::DomainView<specfem::element::dimension_tag::dim3,
+                                    type_real, 4, Kokkos::HostSpace>;
+  DomainView3d x("xcoordinates", n_elements, ngllz, nglly, ngllx);
+  DomainView3d y("ycoordinates", n_elements, ngllz, nglly, ngllx);
+  DomainView3d z("zcoordinates", n_elements, ngllz, nglly, ngllx);
+
+  for (int i = 0; i < n_elements; i++) {
+    const int ispec = element_indices(i);
+    for (int iz = 0; iz < ngllz; iz++) {
+      for (int iy = 0; iy < nglly; iy++) {
+        for (int ix = 0; ix < ngllx; ix++) {
+          x(i, iz, iy, ix) = mesh.h_coord(ispec, iz, iy, ix, 0);
+          y(i, iz, iy, ix) = mesh.h_coord(ispec, iz, iy, ix, 1);
+          z(i, iz, iy, ix) = mesh.h_coord(ispec, iz, iy, ix, 2);
+        }
+      }
+    }
+  }
+  group.createDataset("X", x).write();
+  group.createDataset("Y", y).write();
+  group.createDataset("Z", z).write();
+
+  data_container.for_each_host_view(
+      [&](const auto view, const std::string name) mutable {
+        group.createDataset(name, view).write();
+      });
+
+  return n_elements;
+}
+
+template <typename OutputLibrary, typename ContainerType>
+void specfem::io::impl::write_container(
+    const std::string &output_folder, const std::string &output_namespace,
+    const specfem::assembly::mesh<specfem::element::dimension_tag::dim3> &mesh,
+    const specfem::assembly::element_types<
+        specfem::element::dimension_tag::dim3> &element_types,
+    ContainerType &container) {
+
+  container.copy_to_host();
+
+  typename OutputLibrary::File file(output_folder + "/" + output_namespace);
+
+  const int nspec = mesh.nspec;
+
+  int n_written = 0;
+
+  specfem::tag_dispatch::for_each(
+      DIMENSION_SET(dim3) * MEDIUM_SET(elastic, acoustic) *
+          PROPERTY_SET(isotropic),
+      [&]<typename TagsType>() {
+        constexpr auto medium_tag = TagsType::medium_tag;
+        constexpr auto property_tag = TagsType::property_tag;
+
         const auto element_indices =
             element_types.get_elements_on_host(medium_tag, property_tag);
+        if (element_indices.size() == 0)
+          return;
+        const std::string name =
+            std::string("/") + specfem::element::to_string(medium_tag,
+                                                           property_tag);
+        typename OutputLibrary::Group group = file.createGroup(name);
         auto data_container =
             container.template get_container<medium_tag, property_tag>();
         n_written +=

--- a/core/specfem/io/kernel/writer.hpp
+++ b/core/specfem/io/kernel/writer.hpp
@@ -44,9 +44,7 @@ public:
    * @param assembly 3D Assembly object
    */
   void write(specfem::assembly::assembly<specfem::element::dimension_tag::dim3>
-                 &assembly) override {
-    throw std::runtime_error("3D kernel output not implemented yet");
-  }
+                 &assembly) override;
 
 private:
   std::string output_folder; ///< Path to output folder

--- a/core/specfem/io/kernel/writer.tpp
+++ b/core/specfem/io/kernel/writer.tpp
@@ -34,5 +34,21 @@ void kernel_writer<OutputLibrary>::write(
                                        assembly.kernels);
 }
 
+template <typename OutputLibrary>
+void kernel_writer<OutputLibrary>::write(
+    specfem::assembly::assembly<specfem::element::dimension_tag::dim3> &assembly) {
+  const std::string formatted =
+      specfem::MPI::format_proc_filename(output_folder + "/Kernels");
+  const boost::filesystem::path formatted_path(formatted);
+  const std::string base_folder = formatted_path.parent_path().string();
+  const std::string ns = formatted_path.stem().string();
+
+  boost::filesystem::create_directories(base_folder);
+
+  impl::write_container<OutputLibrary>(base_folder, ns, assembly.mesh,
+                                       assembly.element_types,
+                                       assembly.kernels);
+}
+
 } // namespace io
 } // namespace specfem


### PR DESCRIPTION
## Description

Adds kernel writer. @Rohit-Kakodkar I did not change the datatype to `scalar_type` for now because kernel containers are also defined as `DomainView` (`core/specfem/macros/data_container.hpp`).

## Issue Number

Adds to #1123 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
