### PR TITLE
Add a memory prefetcher to specfem

### DIFF
--- a/core/specfem/algorithms/gradient.hpp
+++ b/core/specfem/algorithms/gradient.hpp
@@ -19,109 +19,122 @@ namespace specfem {
 namespace algorithms {
 /// @brief Implementation details
 namespace impl {
+
 /**
- * @brief Compute the gradient of a vector field at a specific point in a 2D
- * spectral element
+ * @brief Accumulate partial derivatives of a 2D vector field in reference
+ * coordinates.
  *
- * @tparam VectorFieldType Type of the vector field (must be 2D)
- * @tparam QuadratureType Type of the Lagrange derivative polynomial
- * @param f Vector field to compute gradient of
- * @param local_index Local indices within the spectral element
- * @param point_jacobian_matrix Jacobian matrix for coordinate transformation
- * @param lagrange_derivative Lagrange derivative polynomials for
- * differentiation
- * @param df_dxi Output array for derivatives with respect to xi
- * @param df_dgamma Output array for derivatives with respect to gamma
- * @return Auto-deduced return type containing the gradient values
+ * Computes partial derivatives with respect to reference coordinates (ξ, γ)
+ * by accumulating contributions from Lagrange polynomial derivatives.
+ * Reads field data and quadrature information from scratch memory.
+ *
+ * @tparam VectorFieldType Field type with dimension_tag=dim2
+ * @tparam QuadratureType Quadrature type providing lagrange derivatives
+ * @param f Input vector field
+ * @param local_index Element and point indices (ispec, iz, ix)
+ * @param lagrange_derivative Quadrature derivative values
+ * @param df_dq Output: accumulated partial derivatives (components × 2 tensor)
  */
 template <typename VectorFieldType, typename QuadratureType,
           typename std::enable_if_t<VectorFieldType::dimension_tag ==
                                         specfem::element::dimension_tag::dim2,
                                     int> = 0>
-KOKKOS_FORCEINLINE_FUNCTION auto element_gradient(
+KOKKOS_FORCEINLINE_FUNCTION void element_accumulate(
     const VectorFieldType &f,
     const specfem::point::index<specfem::element::dimension_tag::dim2,
                                 VectorFieldType::using_simd> &local_index,
-    const specfem::point::jacobian_matrix<specfem::element::dimension_tag::dim2,
-                                          false, VectorFieldType::using_simd>
-        &point_jacobian_matrix,
     const QuadratureType &lagrange_derivative,
-    typename VectorFieldType::simd::datatype (
-        &df_dxi)[VectorFieldType::components],
-    typename VectorFieldType::simd::datatype (
-        &df_dgamma)[VectorFieldType::components]) {
+    specfem::datatype::TensorPointViewType<
+        type_real, VectorFieldType::components, 2,
+        VectorFieldType::simd::using_simd> &df_dq) {
 
-  constexpr int dimension = 2;
   constexpr int components = VectorFieldType::components;
   constexpr int ngll = VectorFieldType::ngll;
-  using TensorPointViewType = specfem::datatype::TensorPointViewType<
-      type_real, VectorFieldType::components, dimension,
-      VectorFieldType::simd::using_simd>;
   const int ielement = local_index.ispec;
   const int iz = local_index.iz;
   const int ix = local_index.ix;
 
   for (int l = 0; l < ngll; ++l) {
     for (int icomponent = 0; icomponent < components; ++icomponent) {
-      df_dxi[icomponent] +=
+      df_dq(icomponent, 0) +=
           lagrange_derivative.xi(ix, l) * f(ielement, iz, l, icomponent);
-      df_dgamma[icomponent] +=
+      df_dq(icomponent, 1) +=
           lagrange_derivative.gamma(iz, l) * f(ielement, l, ix, icomponent);
     }
   }
+}
+
+/**
+ * @brief Transform 2D reference-frame derivatives to physical coordinates.
+ *
+ * Applies Jacobian matrix transformation to convert partial derivatives
+ * from reference coordinates to physical coordinates using the chain rule.
+ *
+ * @tparam VectorFieldType Field type with dimension_tag=dim2
+ * @param point_jacobian_matrix Jacobian transformation matrix
+ * @param df_dq Partial derivatives in reference frame (components × 2)
+ * @return Partial derivatives in physical coordinates
+ */
+template <typename VectorFieldType,
+          typename std::enable_if_t<VectorFieldType::dimension_tag ==
+                                        specfem::element::dimension_tag::dim2,
+                                    int> = 0>
+KOKKOS_FORCEINLINE_FUNCTION auto element_transform(
+    const specfem::point::jacobian_matrix<specfem::element::dimension_tag::dim2,
+                                          false, VectorFieldType::using_simd>
+        &point_jacobian_matrix,
+    const specfem::datatype::TensorPointViewType<
+        type_real, VectorFieldType::components, 2,
+        VectorFieldType::simd::using_simd> &df_dq) {
+
+  constexpr int dimension = 2;
+  constexpr int components = VectorFieldType::components;
+  using TensorPointViewType =
+      specfem::datatype::TensorPointViewType<type_real, components, dimension,
+                                             VectorFieldType::simd::using_simd>;
 
   TensorPointViewType df;
 
   for (int icomponent = 0; icomponent < components; ++icomponent) {
-    df(icomponent, 0) = point_jacobian_matrix.xix * df_dxi[icomponent] +
-                        point_jacobian_matrix.gammax * df_dgamma[icomponent];
+    df(icomponent, 0) = point_jacobian_matrix.xix * df_dq(icomponent, 0) +
+                        point_jacobian_matrix.gammax * df_dq(icomponent, 1);
 
-    df(icomponent, 1) = point_jacobian_matrix.xiz * df_dxi[icomponent] +
-                        point_jacobian_matrix.gammaz * df_dgamma[icomponent];
+    df(icomponent, 1) = point_jacobian_matrix.xiz * df_dq(icomponent, 0) +
+                        point_jacobian_matrix.gammaz * df_dq(icomponent, 1);
   }
   return df;
 }
+
 /**
- * @brief Compute the gradient of a vector field at a specific point in a 3D
- * spectral element
+ * @brief Accumulate partial derivatives of a 3D vector field in reference
+ * coordinates.
  *
- * @tparam VectorFieldType Type of the vector field (must be 3D)
- * @tparam QuadratureType Type of the Lagrange derivative polynomial
- * @param f Vector field to compute gradient of
- * @param local_index Local indices within the spectral element
- * @param point_jacobian_matrix Jacobian matrix for coordinate transformation
- * @param lagrange_derivative Lagrange derivative polynomials for
- * differentiation
- * @param df_dxi Output array for derivatives with respect to xi
- * @param df_deta Output array for derivatives with respect to eta
- * @param df_dgamma Output array for derivatives with respect to gamma
- * @return Auto-deduced return type containing the gradient values
+ * Computes partial derivatives with respect to reference coordinates (ξ, η, γ)
+ * by accumulating contributions from Lagrange polynomial derivatives.
+ * Reads field data and quadrature information from scratch memory.
+ *
+ * @tparam VectorFieldType Field type with dimension_tag=dim3
+ * @tparam QuadratureType Quadrature type providing lagrange derivatives
+ * @param f Input vector field
+ * @param local_index Element and point indices (ispec, iz, iy, ix)
+ * @param lagrange_derivative Quadrature derivative values
+ * @param df_dq Output: accumulated partial derivatives (components × 3 tensor)
  */
 template <typename VectorFieldType, typename QuadratureType,
           typename std::enable_if_t<VectorFieldType::dimension_tag ==
                                         specfem::element::dimension_tag::dim3,
                                     int> = 0>
-KOKKOS_FORCEINLINE_FUNCTION auto element_gradient(
+KOKKOS_FORCEINLINE_FUNCTION void element_accumulate(
     const VectorFieldType &f,
     const specfem::point::index<specfem::element::dimension_tag::dim3,
                                 VectorFieldType::using_simd> &local_index,
-    const specfem::point::jacobian_matrix<specfem::element::dimension_tag::dim3,
-                                          false, VectorFieldType::using_simd>
-        &point_jacobian_matrix,
     const QuadratureType &lagrange_derivative,
-    typename VectorFieldType::simd::datatype (
-        &df_dxi)[VectorFieldType::components],
-    typename VectorFieldType::simd::datatype (
-        &df_deta)[VectorFieldType::components],
-    typename VectorFieldType::simd::datatype (
-        &df_dgamma)[VectorFieldType::components]) {
+    specfem::datatype::TensorPointViewType<
+        type_real, VectorFieldType::components, 3,
+        VectorFieldType::simd::using_simd> &df_dq) {
 
-  constexpr int dimension = 3;
   constexpr int components = VectorFieldType::components;
   constexpr int ngll = VectorFieldType::ngll;
-  using TensorPointViewType = specfem::datatype::TensorPointViewType<
-      type_real, VectorFieldType::components, dimension,
-      VectorFieldType::simd::using_simd>;
   const int ielement = local_index.ispec;
   const int iz = local_index.iz;
   const int iy = local_index.iy;
@@ -129,67 +142,101 @@ KOKKOS_FORCEINLINE_FUNCTION auto element_gradient(
 
   for (int l = 0; l < ngll; ++l) {
     for (int icomponent = 0; icomponent < components; ++icomponent) {
-      df_dxi[icomponent] +=
+      df_dq(icomponent, 0) +=
           lagrange_derivative.xi(ix, l) * f(ielement, iz, iy, l, icomponent);
-      df_deta[icomponent] +=
+      df_dq(icomponent, 1) +=
           lagrange_derivative.eta(iy, l) * f(ielement, iz, l, ix, icomponent);
-      df_dgamma[icomponent] +=
+      df_dq(icomponent, 2) +=
           lagrange_derivative.gamma(iz, l) * f(ielement, l, iy, ix, icomponent);
     }
   }
+}
+
+/**
+ * @brief Transform 3D reference-frame derivatives to physical coordinates.
+ *
+ * Applies Jacobian matrix transformation to convert partial derivatives
+ * from reference coordinates (ξ, η, γ) to physical coordinates (x, y, z)
+ * using the chain rule.
+ *
+ * @tparam VectorFieldType Field type with dimension_tag=dim3
+ * @param point_jacobian_matrix Jacobian transformation matrix (9 components)
+ * @param df_dq Partial derivatives in reference frame (components × 3)
+ * @return Partial derivatives in physical coordinates
+ */
+template <typename VectorFieldType,
+          typename std::enable_if_t<VectorFieldType::dimension_tag ==
+                                        specfem::element::dimension_tag::dim3,
+                                    int> = 0>
+KOKKOS_FORCEINLINE_FUNCTION auto element_transform(
+    const specfem::point::jacobian_matrix<specfem::element::dimension_tag::dim3,
+                                          false, VectorFieldType::using_simd>
+        &point_jacobian_matrix,
+    const specfem::datatype::TensorPointViewType<
+        type_real, VectorFieldType::components, 3,
+        VectorFieldType::simd::using_simd> &df_dq) {
+
+  constexpr int dimension = 3;
+  constexpr int components = VectorFieldType::components;
+  using TensorPointViewType =
+      specfem::datatype::TensorPointViewType<type_real, components, dimension,
+                                             VectorFieldType::simd::using_simd>;
 
   TensorPointViewType df;
 
   for (int icomponent = 0; icomponent < components; ++icomponent) {
-    df(icomponent, 0) = point_jacobian_matrix.xix * df_dxi[icomponent] +
-                        point_jacobian_matrix.etax * df_deta[icomponent] +
-                        point_jacobian_matrix.gammax * df_dgamma[icomponent];
+    df(icomponent, 0) = point_jacobian_matrix.xix * df_dq(icomponent, 0) +
+                        point_jacobian_matrix.etax * df_dq(icomponent, 1) +
+                        point_jacobian_matrix.gammax * df_dq(icomponent, 2);
 
-    df(icomponent, 1) = point_jacobian_matrix.xiy * df_dxi[icomponent] +
-                        point_jacobian_matrix.etay * df_deta[icomponent] +
-                        point_jacobian_matrix.gammay * df_dgamma[icomponent];
+    df(icomponent, 1) = point_jacobian_matrix.xiy * df_dq(icomponent, 0) +
+                        point_jacobian_matrix.etay * df_dq(icomponent, 1) +
+                        point_jacobian_matrix.gammay * df_dq(icomponent, 2);
 
-    df(icomponent, 2) = point_jacobian_matrix.xiz * df_dxi[icomponent] +
-                        point_jacobian_matrix.etaz * df_deta[icomponent] +
-                        point_jacobian_matrix.gammaz * df_dgamma[icomponent];
+    df(icomponent, 2) = point_jacobian_matrix.xiz * df_dq(icomponent, 0) +
+                        point_jacobian_matrix.etaz * df_dq(icomponent, 1) +
+                        point_jacobian_matrix.gammaz * df_dq(icomponent, 2);
   }
   return df;
 }
+
 } // namespace impl
 
 /**
- * @defgroup AlgorithmsGradient
+ * @brief Compute gradients of a vector field in spectral elements.
  *
- */
-
-/**
- * @brief Compute the gradient of a vector field f using the spectral element
- * formulation (eqn: 29 in Komatitsch and Tromp, 1999)
+ * Computes field gradients at quadrature points using the spectral element
+ * method (Komatitsch & Tromp, 1999). Transforms from reference to physical
+ * coordinates via Jacobian matrices. Invokes callback for each quadrature point.
  *
- * @ingroup AlgorithmsGradient
+ * @tparam ChunkIndexType Chunk element index
+ * @tparam VectorFieldType Field container
+ * @tparam JacobianMatrixType Jacobian matrix container
+ * @tparam QuadratureType Lagrange derivative quadrature
+ * @tparam CallbackFunctor Callback taking (iterator_index, gradient_tensor)
  *
- * @tparam ChunkIndexType  Chunk index type
- * @tparam VectorFieldType Field view type (Chunk view)
- * @tparam QuadratureType  Quadrature view type
- * @tparam CallbackFunctor Callback functor type
- * @param chunk_index      Chunk index specifying the elements within this chunk
- * @param jacobian_matrix  Jacobian matrix of basis functions
- * @param quadrature       Integration quadrature
- * @param f                Field to compute the gradient of
- * @param callback         Callback functor receiving
- *        (iterator_index, TensorPointViewType<components, dim>)
- */
-template <typename ChunkIndexType, typename VectorFieldType,
-          typename JacobianMatrixType, typename QuadratureType,
-          typename CallbackFunctor,
-          std::enable_if_t<
-              specfem::data_access::is_chunk_element<VectorFieldType>::value,
-              int> = 0>
-KOKKOS_FORCEINLINE_FUNCTION void
-gradient(const ChunkIndexType &chunk_index,
-         const JacobianMatrixType &jacobian_matrix,
-         const QuadratureType &quadrature, const VectorFieldType &f,
-         const CallbackFunctor &callback) {
+ * @param chunk_index Elements in chunk
+ * @param jacobian_matrix Coordinate transformation matrices
+ * @param quadrature Lagrange polynomial derivatives
+ * @param f Input field
+ * @param callback Invoked with gradient tensor at each quadrature point
+ *
+ * @code
+ * specfem::algorithms::gradient(
+ *   chunk_index, jac, quad, field,
+ *   [](auto idx, auto grad) { /* process gradient */ });
+*@endcode **@ingroup AlgorithmsGradient * /
+    template <typename ChunkIndexType, typename VectorFieldType,
+              typename JacobianMatrixType, typename QuadratureType,
+              typename CallbackFunctor,
+              std::enable_if_t<specfem::data_access::is_chunk_element<
+                                   VectorFieldType>::value,
+                               int> = 0>
+    KOKKOS_FORCEINLINE_FUNCTION void
+    gradient(const ChunkIndexType &chunk_index,
+             const JacobianMatrixType &jacobian_matrix,
+             const QuadratureType &quadrature, const VectorFieldType &f,
+             const CallbackFunctor &callback) {
 
   constexpr specfem::element::dimension_tag dimension_tag =
       VectorFieldType::dimension_tag;
@@ -197,40 +244,37 @@ gradient(const ChunkIndexType &chunk_index,
   constexpr int dimension = specfem::element::dimension<dimension_tag>::dim;
   constexpr bool using_simd = VectorFieldType::simd::using_simd;
 
-  using TensorPointViewType =
+  using TPViewType =
       specfem::datatype::TensorPointViewType<type_real, components, dimension,
                                              using_simd>;
-  using datatype = typename VectorFieldType::simd::datatype;
 
   static_assert(
       std::is_invocable_v<CallbackFunctor,
                           typename ChunkIndexType::iterator_type::index_type,
-                          TensorPointViewType>,
+                          TPViewType>,
       "CallbackFunctor must be invocable with (iterator_index, "
       "TensorPointViewType)");
 
   specfem::execution::for_each_level(
-      chunk_index.get_iterator(),
+      specfem::execution::prefetch_ahead<4>(
+          chunk_index,
+          [&](const auto &prefetch_index) {
+            specfem::assembly::prefetch_on_device(prefetch_index.get_index(),
+                                                  jacobian_matrix);
+          })
+          .get_iterator(),
       [&](const typename ChunkIndexType::iterator_type::index_type
               &iterator_index) {
         const auto index = iterator_index.get_index();
         const auto local_index = iterator_index.get_local_index();
-        datatype df_dxi[components] = { 0.0 };
-        datatype df_dgamma[components] = { 0.0 };
+        TPViewType df_dq;
+        impl::element_accumulate(f, local_index, quadrature, df_dq);
         specfem::point::jacobian_matrix<dimension_tag, false, using_simd>
             point_jacobian_matrix;
         specfem::assembly::load_on_device(index, jacobian_matrix,
                                           point_jacobian_matrix);
-        if constexpr (dimension_tag == specfem::element::dimension_tag::dim3) {
-          datatype df_deta[components] = { 0.0 };
-          callback(iterator_index, impl::element_gradient(
-                                       f, local_index, point_jacobian_matrix,
-                                       quadrature, df_dxi, df_deta, df_dgamma));
-        } else {
-          callback(iterator_index,
-                   impl::element_gradient(f, local_index, point_jacobian_matrix,
-                                          quadrature, df_dxi, df_dgamma));
-        }
+        callback(iterator_index, impl::element_transform<VectorFieldType>(
+                                     point_jacobian_matrix, df_dq));
       });
 }
 
@@ -271,48 +315,42 @@ gradient(const ChunkIndexType &chunk_index,
   constexpr int dimension = specfem::element::dimension<dimension_tag>::dim;
   constexpr bool using_simd = VectorFieldType::simd::using_simd;
 
-  using TensorPointViewType =
+  using TPViewType =
       specfem::datatype::TensorPointViewType<type_real, components, dimension,
                                              using_simd>;
-  using datatype = typename VectorFieldType::simd::datatype;
 
   static_assert(
       std::is_invocable_v<CallbackFunctor,
                           typename ChunkIndexType::iterator_type::index_type,
-                          TensorPointViewType, TensorPointViewType>,
+                          TPViewType, TPViewType>,
       "CallbackFunctor must be invocable with (iterator_index, "
       "TensorPointViewType, TensorPointViewType)");
 
   specfem::execution::for_each_level(
-      chunk_index.get_iterator(),
+      specfem::execution::prefetch_ahead<4>(
+          chunk_index,
+          [&](const auto &prefetch_index) {
+            specfem::assembly::prefetch_on_device(prefetch_index.get_index(),
+                                                  jacobian_matrix);
+          })
+          .get_iterator(),
       [&](const typename ChunkIndexType::iterator_type::index_type
               &iterator_index) {
         const auto index = iterator_index.get_index();
         const auto local_index = iterator_index.get_local_index();
-        datatype df_dxi[components] = { 0.0 };
-        datatype df_dgamma[components] = { 0.0 };
-        datatype dg_dxi[components] = { 0.0 };
-        datatype dg_dgamma[components] = { 0.0 };
+        TPViewType df_dq;
+        TPViewType dg_dq;
+        impl::element_accumulate(f, local_index, quadrature, df_dq);
+        impl::element_accumulate(g, local_index, quadrature, dg_dq);
         specfem::point::jacobian_matrix<dimension_tag, false, using_simd>
             point_jacobian_matrix;
         specfem::assembly::load_on_device(index, jacobian_matrix,
                                           point_jacobian_matrix);
-        if constexpr (dimension_tag == specfem::element::dimension_tag::dim3) {
-          datatype df_deta[components] = { 0.0 };
-          datatype dg_deta[components] = { 0.0 };
-          callback(
-              iterator_index,
-              impl::element_gradient(f, local_index, point_jacobian_matrix,
-                                     quadrature, df_dxi, df_deta, df_dgamma),
-              impl::element_gradient(g, local_index, point_jacobian_matrix,
-                                     quadrature, dg_dxi, dg_deta, dg_dgamma));
-        } else {
-          callback(iterator_index,
-                   impl::element_gradient(f, local_index, point_jacobian_matrix,
-                                          quadrature, df_dxi, df_dgamma),
-                   impl::element_gradient(g, local_index, point_jacobian_matrix,
-                                          quadrature, dg_dxi, dg_dgamma));
-        }
+        callback(iterator_index,
+                 impl::element_transform<VectorFieldType>(point_jacobian_matrix,
+                                                          df_dq),
+                 impl::element_transform<VectorFieldType>(point_jacobian_matrix,
+                                                          dg_dq));
       });
 }
 
@@ -346,36 +384,31 @@ gradient(const ChunkIndexType &chunk_index,
   using TensorPointViewTypeF =
       specfem::datatype::TensorPointViewType<type_real, components, dimension,
                                              using_simd>;
-  using datatypeF = typename VectorFieldType::simd::datatype;
 
   specfem::execution::for_each_level(
-      chunk_index.get_iterator(),
+      specfem::execution::prefetch_ahead<4>(
+          chunk_index,
+          [&](const auto &prefetch_index) {
+            specfem::assembly::prefetch_on_device(prefetch_index.get_index(),
+                                                  jacobian_matrix);
+          })
+          .get_iterator(),
       [&](const typename ChunkIndexType::iterator_type::index_type
               &iterator_index) {
         const auto index = iterator_index.get_index();
         const auto local_index = iterator_index.get_local_index();
-        datatypeF df_dxi[components] = { 0.0 };
-        datatypeF df_dgamma[components] = { 0.0 };
+        TensorPointViewTypeF df_dq;
+        impl::element_accumulate(
+            static_cast<const VectorFieldType &>(field_pack), local_index,
+            quadrature, df_dq);
         specfem::point::jacobian_matrix<dimension_tag, false, using_simd>
             point_jacobian_matrix;
         specfem::assembly::load_on_device(index, jacobian_matrix,
                                           point_jacobian_matrix);
-        if constexpr (dimension_tag == specfem::element::dimension_tag::dim3) {
-          datatypeF df_deta[components] = { 0.0 };
-          callback(iterator_index,
-                   specfem::point::GradientPack<TensorPointViewTypeF>{
-                       impl::element_gradient(
-                           static_cast<const VectorFieldType &>(field_pack),
-                           local_index, point_jacobian_matrix, quadrature,
-                           df_dxi, df_deta, df_dgamma) });
-        } else {
-          callback(iterator_index,
-                   specfem::point::GradientPack<TensorPointViewTypeF>{
-                       impl::element_gradient(
-                           static_cast<const VectorFieldType &>(field_pack),
-                           local_index, point_jacobian_matrix, quadrature,
-                           df_dxi, df_dgamma) });
-        }
+        callback(iterator_index,
+                 specfem::point::GradientPack<TensorPointViewTypeF>{
+                     impl::element_transform<VectorFieldType>(
+                         point_jacobian_matrix, df_dq) });
       });
 }
 
@@ -419,50 +452,37 @@ KOKKOS_FORCEINLINE_FUNCTION void gradient(
   using TensorPointViewTypeG = specfem::datatype::TensorPointViewType<
       type_real, componentsG, dimension, VectorFieldTypeG::simd::using_simd>;
 
-  using datatypeF = typename VectorFieldTypeF::simd::datatype;
-  using datatypeG = typename VectorFieldTypeG::simd::datatype;
-
   specfem::execution::for_each_level(
-      chunk_index.get_iterator(),
+      specfem::execution::prefetch_ahead<4>(
+          chunk_index,
+          [&](const auto &prefetch_index) {
+            specfem::assembly::prefetch_on_device(prefetch_index.get_index(),
+                                                  jacobian_matrix);
+          })
+          .get_iterator(),
       [&](const typename ChunkIndexType::iterator_type::index_type
               &iterator_index) {
         const auto index = iterator_index.get_index();
         const auto local_index = iterator_index.get_local_index();
-        datatypeF df_dxi[componentsF] = { 0.0 };
-        datatypeF df_dgamma[componentsF] = { 0.0 };
-        datatypeG dg_dxi[componentsG] = { 0.0 };
-        datatypeG dg_dgamma[componentsG] = { 0.0 };
+        TensorPointViewTypeF df_dq;
+        TensorPointViewTypeG dg_dq;
+        impl::element_accumulate(
+            static_cast<const VectorFieldTypeF &>(field_pack), local_index,
+            quadrature, df_dq);
+        impl::element_accumulate(
+            static_cast<const VectorFieldTypeG &>(field_pack), local_index,
+            quadrature, dg_dq);
         specfem::point::jacobian_matrix<dimension_tag, false, using_simd>
             point_jacobian_matrix;
         specfem::assembly::load_on_device(index, jacobian_matrix,
                                           point_jacobian_matrix);
-        if constexpr (dimension_tag == specfem::element::dimension_tag::dim3) {
-          datatypeF df_deta[componentsF] = { 0.0 };
-          datatypeG dg_deta[componentsG] = { 0.0 };
-          callback(iterator_index,
-                   specfem::point::GradientPack<TensorPointViewTypeF,
-                                                TensorPointViewTypeG>{
-                       impl::element_gradient(
-                           static_cast<const VectorFieldTypeF &>(field_pack),
-                           local_index, point_jacobian_matrix, quadrature,
-                           df_dxi, df_deta, df_dgamma),
-                       impl::element_gradient(
-                           static_cast<const VectorFieldTypeG &>(field_pack),
-                           local_index, point_jacobian_matrix, quadrature,
-                           dg_dxi, dg_deta, dg_dgamma) });
-        } else {
-          callback(iterator_index,
-                   specfem::point::GradientPack<TensorPointViewTypeF,
-                                                TensorPointViewTypeG>{
-                       impl::element_gradient(
-                           static_cast<const VectorFieldTypeF &>(field_pack),
-                           local_index, point_jacobian_matrix, quadrature,
-                           df_dxi, df_dgamma),
-                       impl::element_gradient(
-                           static_cast<const VectorFieldTypeG &>(field_pack),
-                           local_index, point_jacobian_matrix, quadrature,
-                           dg_dxi, dg_dgamma) });
-        }
+        callback(iterator_index,
+                 specfem::point::GradientPack<TensorPointViewTypeF,
+                                              TensorPointViewTypeG>{
+                     impl::element_transform<VectorFieldTypeF>(
+                         point_jacobian_matrix, df_dq),
+                     impl::element_transform<VectorFieldTypeG>(
+                         point_jacobian_matrix, dg_dq) });
       });
 }
 

--- a/core/specfem/assembly/jacobian_matrix.hpp
+++ b/core/specfem/assembly/jacobian_matrix.hpp
@@ -5,14 +5,15 @@
 namespace specfem::assembly {
 
 /**
- * @brief Spectral element Jacobian matrix data container
+ * @brief Container for spectral element Jacobian matrix components.
  *
- * This class provides storage and data access functions for the Jacobian
- * matrices associated with spectral elements in spectral element mesh. The
- * dimension specific implementations provide data containers for storing
- * individual terms of the Jacobian matrix as well as methods for loading and
- * storing data on device and host.
+ * Stores Jacobian matrix terms for coordinate transformations between
+ * reference and physical element coordinates. Dimension-specific
+ * specializations manage component data on both host and device.
  *
+ * @tparam DimensionTag Spatial dimension (dim2 or dim3)
+ *
+ * @ingroup Assembly
  */
 template <specfem::element::dimension_tag DimensionTag> struct jacobian_matrix;
 
@@ -25,5 +26,7 @@ template <specfem::element::dimension_tag DimensionTag> struct jacobian_matrix;
 // Data access functions
 #include "jacobian_matrix/load_on_device.hpp"
 #include "jacobian_matrix/load_on_host.hpp"
+#include "jacobian_matrix/prefetch_on_device.hpp"
+#include "jacobian_matrix/prefetch_on_host.hpp"
 #include "jacobian_matrix/store_on_device.hpp"
 #include "jacobian_matrix/store_on_host.hpp"

--- a/core/specfem/assembly/jacobian_matrix/dim2/impl_prefetch.hpp
+++ b/core/specfem/assembly/jacobian_matrix/dim2/impl_prefetch.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "specfem/cache_line.hpp"
+#include "specfem/data_access.hpp"
+#include "specfem/enums.hpp"
+#include <Kokkos_Core.hpp>
+#include <type_traits>
+
+namespace specfem::assembly {
+
+/**
+ * @brief Implementation: prefetch 2D Jacobian matrix components.
+ *
+ * Issues prefetch hints for the 5 Jacobian matrix terms (xix, xiz, gammax,
+ * gammaz, jacobian) at a given 2D quadrature point, either on device or host.
+ *
+ * @tparam on_device If true, prefetch device data; otherwise host mirror
+ * @tparam LocalityHint Cache locality hint (default: High)
+ * @tparam IndexType 2D point index (ispec, iz, ix)
+ * @tparam ContainerType Jacobian matrix container
+ *
+ * @param index Quadrature point location
+ * @param container Global Jacobian matrix
+ *
+ * @ingroup JacobianMatrixDataAccess
+ */
+template <
+    bool on_device, typename LocalityHint = specfem::cache_line::High,
+    typename IndexType, typename ContainerType,
+    typename std::enable_if_t<
+        specfem::data_access::is_index_type<IndexType>::value &&
+            IndexType::dimension_tag == specfem::element::dimension_tag::dim2 &&
+            specfem::data_access::is_jacobian_matrix<ContainerType>::value,
+        int> = 0>
+KOKKOS_FORCEINLINE_FUNCTION void impl_prefetch(const IndexType &index,
+                                               const ContainerType &container) {
+
+  const auto &mapping = container.xix.get_mapping();
+  const std::size_t _index = mapping(index.ispec, index.iz, index.ix);
+
+  if constexpr (on_device) {
+    specfem::cache_line::prefetch(&container.xix[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.xiz[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.gammax[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.gammaz[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.jacobian[_index], LocalityHint{});
+  } else {
+    specfem::cache_line::prefetch(&container.h_xix[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.h_xiz[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.h_gammax[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.h_gammaz[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.h_jacobian[_index],
+                                  LocalityHint{});
+  }
+}
+
+} // namespace specfem::assembly

--- a/core/specfem/assembly/jacobian_matrix/dim3/impl_prefetch.hpp
+++ b/core/specfem/assembly/jacobian_matrix/dim3/impl_prefetch.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "specfem/cache_line.hpp"
+#include "specfem/data_access.hpp"
+#include "specfem/enums.hpp"
+#include <Kokkos_Core.hpp>
+#include <type_traits>
+
+namespace specfem::assembly {
+
+/**
+ * @brief Implementation: prefetch 3D Jacobian matrix components.
+ *
+ * Issues prefetch hints for the 10 Jacobian matrix terms (xix, xiy, xiz, etax,
+ * etay, etaz, gammax, gammay, gammaz, jacobian) at a given 3D quadrature point,
+ * either on device or host.
+ *
+ * @tparam on_device If true, prefetch device data; otherwise host mirror
+ * @tparam LocalityHint Cache locality hint (default: High)
+ * @tparam IndexType 3D point index (ispec, iz, iy, ix)
+ * @tparam ContainerType Jacobian matrix container
+ *
+ * @param index Quadrature point location
+ * @param container Global Jacobian matrix
+ *
+ * @ingroup JacobianMatrixDataAccess
+ */
+template <
+    bool on_device, typename LocalityHint = specfem::cache_line::High,
+    typename IndexType, typename ContainerType,
+    typename std::enable_if_t<
+        specfem::data_access::is_index_type<IndexType>::value &&
+            IndexType::dimension_tag == specfem::element::dimension_tag::dim3 &&
+            specfem::data_access::is_jacobian_matrix<ContainerType>::value,
+        int> = 0>
+KOKKOS_FORCEINLINE_FUNCTION void impl_prefetch(const IndexType &index,
+                                               const ContainerType &container) {
+
+  const auto &mapping = container.xix.get_mapping();
+  const std::size_t _index = mapping(index.ispec, index.iz, index.iy, index.ix);
+
+  if constexpr (on_device) {
+    specfem::cache_line::prefetch(&container.xix[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.xiy[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.xiz[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.etax[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.etay[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.etaz[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.gammax[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.gammay[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.gammaz[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.jacobian[_index], LocalityHint{});
+  } else {
+    specfem::cache_line::prefetch(&container.h_xix[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.h_xiy[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.h_xiz[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.h_etax[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.h_etay[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.h_etaz[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.h_gammax[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.h_gammay[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.h_gammaz[_index], LocalityHint{});
+    specfem::cache_line::prefetch(&container.h_jacobian[_index],
+                                  LocalityHint{});
+  }
+}
+
+} // namespace specfem::assembly

--- a/core/specfem/assembly/jacobian_matrix/prefetch_on_device.hpp
+++ b/core/specfem/assembly/jacobian_matrix/prefetch_on_device.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "dim2/impl_prefetch.hpp"
+#include "dim3/impl_prefetch.hpp"
+#include "specfem/cache_line.hpp"
+#include "specfem/data_access.hpp"
+
+namespace specfem::assembly {
+
+/**
+ * @defgroup JacobianMatrixDataAccess
+ *
+ */
+
+/**
+ * @brief Prefetch Jacobian matrix data into device cache.
+ *
+ * Issues prefetch hints for all Jacobian matrix components at the given index.
+ * Call before load_on_device() to ensure data is cache-resident. No-op on CUDA.
+ *
+ * @tparam LocalityHint Cache locality hint (default: High)
+ * @tparam IndexType Point index (@ref specfem::point::index)
+ * @tparam ContainerType Jacobian matrix container
+ *
+ * @param index Quadrature point indices (ispec, iz, [iy,] ix)
+ * @param container Global Jacobian matrix
+ *
+ * @code
+ * specfem::assembly::prefetch_on_device(next_idx, jacobian);
+ * specfem::assembly::load_on_device(idx, jacobian, point_jac);
+ * @endcode
+ *
+ * @ingroup JacobianMatrixDataAccess
+ */
+template <
+    typename LocalityHint = specfem::cache_line::High, typename IndexType,
+    typename ContainerType,
+    typename std::enable_if_t<
+        specfem::data_access::is_index_type<IndexType>::value &&
+            specfem::data_access::is_jacobian_matrix<ContainerType>::value,
+        int> = 0>
+KOKKOS_FORCEINLINE_FUNCTION void
+prefetch_on_device(const IndexType &index, const ContainerType &container) {
+  impl_prefetch<true, LocalityHint>(index, container);
+}
+
+} // namespace specfem::assembly

--- a/core/specfem/assembly/jacobian_matrix/prefetch_on_host.hpp
+++ b/core/specfem/assembly/jacobian_matrix/prefetch_on_host.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "dim2/impl_prefetch.hpp"
+#include "dim3/impl_prefetch.hpp"
+#include "specfem/cache_line.hpp"
+#include "specfem/data_access.hpp"
+
+namespace specfem::assembly {
+
+/**
+ * @defgroup JacobianMatrixDataAccess
+ *
+ */
+
+/**
+ * @brief Prefetch Jacobian matrix data into host cache.
+ *
+ * Issues prefetch hints for all host-mirror Jacobian matrix components at
+ * the given index. Call before load_on_host() to optimize cache usage.
+ * No-op on CUDA.
+ *
+ * @tparam LocalityHint Cache locality hint (default: High)
+ * @tparam IndexType Point index (@ref specfem::point::index)
+ * @tparam ContainerType Jacobian matrix container
+ *
+ * @param index Quadrature point indices (ispec, iz, [iy,] ix)
+ * @param container Global Jacobian matrix
+ *
+ * @code
+ * specfem::assembly::prefetch_on_host(next_idx, jacobian);
+ * specfem::assembly::load_on_host(idx, jacobian, point_jac);
+ * @endcode
+ *
+ * @ingroup JacobianMatrixDataAccess
+ */
+template <
+    typename LocalityHint = specfem::cache_line::High, typename IndexType,
+    typename ContainerType,
+    typename std::enable_if_t<
+        specfem::data_access::is_index_type<IndexType>::value &&
+            specfem::data_access::is_jacobian_matrix<ContainerType>::value,
+        int> = 0>
+void prefetch_on_host(const IndexType &index, const ContainerType &container) {
+  impl_prefetch<false, LocalityHint>(index, container);
+}
+
+} // namespace specfem::assembly

--- a/core/specfem/cache_line.hpp
+++ b/core/specfem/cache_line.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <Kokkos_Core.hpp>
+
+#ifdef _MSC_VER
+#include <intrin.h> // _MM_HINT_* constants
+#endif
+
+namespace specfem {
+namespace cache_line {
+
+/**
+ * @brief Non-temporal prefetch hint: bypass L2/L3 to L1 only.
+ * Useful for data used once or streamed sequentially.
+ */
+struct Nta {
+  // Non-temporal — stream to L1 bypassing L2/L3
+#ifdef _MSC_VER
+  static constexpr auto kHint = _MM_HINT_NTA;
+#else
+  static constexpr auto kHint = 0; // __builtin_prefetch: no temporal locality
+#endif
+};
+
+/**
+ * @brief Low temporal locality prefetch hint: L3/last-level cache only.
+ * For data reused infrequently across large strides.
+ */
+struct Low {
+  // L3 / last-level cache only
+#ifdef _MSC_VER
+  static constexpr auto kHint = _MM_HINT_T2;
+#else
+  static constexpr auto kHint = 1; // __builtin_prefetch: low locality
+#endif
+};
+
+/**
+ * @brief Moderate temporal locality prefetch hint: L2 and above.
+ * For data with medium reuse distance.
+ */
+struct Moderate {
+  // L2 and above
+#ifdef _MSC_VER
+  static constexpr auto kHint = _MM_HINT_T1;
+#else
+  static constexpr auto kHint = 2; // __builtin_prefetch: moderate locality
+#endif
+};
+
+/**
+ * @brief High temporal locality prefetch hint: L1, L2, L3 (default).
+ * For data reused within short windows.
+ */
+struct High {
+  // L1, L2, L3 (default)
+#ifdef _MSC_VER
+  static constexpr auto kHint = _MM_HINT_T0;
+#else
+  static constexpr auto kHint = 3; // __builtin_prefetch: full locality
+#endif
+};
+
+/**
+ * @brief Issue a software prefetch hint for a pointer.
+ *
+ * Brings data into cache with the specified locality hint.
+ * No-op on CUDA. Cross-platform hint mapping for x86 and ARM.
+ *
+ * @tparam LocalityHint Hint type (High, Moderate, Low, Nta)
+ * @tparam T Pointer type
+ * @param ptr Address to prefetch
+ * @param hint Cache locality hint (default: High)
+ *
+ * @code
+ * auto *data = get_data();
+ * specfem::cache_line::prefetch<specfem::cache_line::Moderate>(data);
+ * @endcode
+ */
+template <typename LocalityHint = High, typename T>
+KOKKOS_FORCEINLINE_FUNCTION void prefetch(const T *ptr, LocalityHint = {}) {
+#if defined(KOKKOS_ENABLE_CUDA)
+  (void)ptr;
+#elif defined(_MSC_VER)
+  _mm_prefetch(reinterpret_cast<const char *>(ptr), LocalityHint::kHint);
+#else
+  __builtin_prefetch(ptr, 0, LocalityHint::kHint);
+#endif
+}
+
+} // namespace cache_line
+} // namespace specfem

--- a/core/specfem/compute/impl/stiffness_kernels.hpp
+++ b/core/specfem/compute/impl/stiffness_kernels.hpp
@@ -24,6 +24,24 @@ namespace specfem::compute::impl {
 // Uses more shared memory than scatter but avoids atomic operations.
 // ---------------------------------------------------------------------------
 
+/**
+ * @brief Stiffness computation kernel using gather-based accumulation.
+ *
+ * Two-pass parallel kernel: (1) computes field gradients and stress,
+ * (2) divergence of stress accumulates acceleration. Uses scratch memory
+ * for shared data to avoid atomic operations.
+ *
+ * @tparam NGLL Number of quadrature points per dimension (typically 5 or 6)
+ * @tparam Tags Compilation tags (medium, property, boundary, attenuation,
+ * dimension)
+ *
+ * @code
+ * gather_kernel<5, MyTags> kernel(assembly, istep);
+ * Kokkos::parallel_for(policy, kernel);
+ * @endcode
+ *
+ * @ingroup ComputeKernels
+ */
 template <int NGLL, typename Tags> class gather_kernel {
 public:
   constexpr static auto medium_tag = Tags::medium_tag;
@@ -143,9 +161,6 @@ public:
 
                 const auto field_derivatives =
                     grad_pack.template get_du<PointTags>();
-
-                const auto field_derivatives_velocity =
-                    grad_pack.template get_dv<PointTags>();
 
                 PointDisplacementType point_displacement;
                 specfem::assembly::load_on_device(index, field,

--- a/core/specfem/execution.hpp
+++ b/core/specfem/execution.hpp
@@ -4,18 +4,17 @@
  * @brief Parallel execution abstractions for spectral element computations.
  *
  * Provides Kokkos-based parallel execution policies, chunked domain iterators,
- * and parallel loop abstractions. Supports hierarchical parallelism with
- * team-based and range-based execution patterns for spectral element grids.
+ * and loop abstractions. Supports hierarchical parallelism with team-based and
+ * range-based execution patterns.
  *
  * @code
  * // Parallel loop over domain elements
  * specfem::execution::for_all(domain_iterator, [=](auto index) {
- *   // Process quadrature points in parallel
+ *   // Process quadrature points
  * });
- *
- * // Configure execution policy
- * using policy = specfem::execution::RangePolicy<ParallelConfig>;
  * @endcode
+ *
+ * @ingroup Execution
  */
 namespace specfem::execution {}
 
@@ -27,6 +26,7 @@ namespace specfem::execution {}
 #include "execution/for_each_level.hpp"
 #include "execution/mapped_chunked_domain_iterator.hpp"
 #include "execution/policy.hpp"
+#include "execution/prefetch_ahead.hpp"
 #include "execution/range_iterator.hpp"
 #include "execution/team_thread_md_range_iterator.hpp"
 #include "execution/void_iterator.hpp"

--- a/core/specfem/execution/prefetch_ahead.hpp
+++ b/core/specfem/execution/prefetch_ahead.hpp
@@ -1,0 +1,192 @@
+#pragma once
+
+#include <Kokkos_Core.hpp>
+#include <type_traits>
+#include <utility>
+
+namespace specfem {
+namespace execution {
+
+// ---------------------------------------------------------------------------
+// Type trait: does InnerIterator expose a side-effect-free base_lookup(i)?
+// PrefetchAheadIterator always defines it; plain ChunkElementIterator does not.
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Type trait: check if iterator provides base_lookup() method.
+ *
+ * Used to distinguish prefetch-decorated iterators from plain iterators.
+ * Enables safe composition of multiple prefetch decorators.
+ *
+ * @tparam T Iterator type
+ */
+template <typename T, typename = void>
+struct has_base_lookup : std::false_type {};
+
+/**
+ * @brief Specialization: true if T has base_lookup() method.
+ */
+template <typename T>
+struct has_base_lookup<
+    T, std::void_t<decltype(std::declval<const T &>().base_lookup(
+           std::declval<typename T::policy_index_type>()))>> : std::true_type {
+};
+
+#ifndef KOKKOS_ENABLE_CUDA
+
+// ---------------------------------------------------------------------------
+// PrefetchAheadIterator<K, InnerIterator, PrefetchFn>
+//
+// Inherits InnerIterator — all type aliases, policy_type, tile_size, the
+// implicit cast to base_policy_type, and constructors come for free.
+// Overrides operator()(i) to fire pfetch_fn(base(i+K)) as a side effect,
+// then returns InnerIterator::operator()(i) unchanged.
+//
+// base_lookup(i) provides a side-effect-free path to the bottommost
+// ChunkElementIterator — used by outer wrappers so that their lookahead
+// target does not accidentally trigger inner decoration chains.
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Iterator decorator that issues prefetch requests ahead of iteration.
+ *
+ * Wraps an inner iterator and fires a prefetch function for index i+Lookahead
+ * while computing results for index i. Enables cache-efficient data access
+ * patterns. Transparent pass-through on GPU.
+ *
+ * @tparam Lookahead Number of iterations to prefetch ahead
+ * @tparam InnerIterator Base iterator type to decorate
+ * @tparam PrefetchFn Callable that takes an index and issues prefetch
+ *
+ * @code
+ * auto iter = PrefetchAheadIterator<1, BaseIter, PrefetchFn>(base, pfn);
+ * for (int i = 0; i < N; ++i)
+ *   process(iter(i)); // prefetches i+1 as side effect
+ * @endcode
+ */
+template <int Lookahead, typename InnerIterator, typename PrefetchFn>
+class PrefetchAheadIterator : public InnerIterator {
+public:
+  using index_type = typename InnerIterator::index_type; // unchanged
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  const index_type
+  base_lookup(const typename InnerIterator::policy_index_type &i) const {
+    if constexpr (has_base_lookup<InnerIterator>::value)
+      return InnerIterator::base_lookup(i);
+    else
+      return InnerIterator::operator()(i);
+  }
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  const index_type
+  operator()(const typename InnerIterator::policy_index_type &i) const {
+    pfetch_fn(base_lookup(i + Lookahead));
+    return InnerIterator::operator()(i);
+  }
+
+  PrefetchAheadIterator(const InnerIterator &inner, PrefetchFn pfetch_fn)
+      : InnerIterator(inner), pfetch_fn(std::move(pfetch_fn)) {}
+
+private:
+  PrefetchFn pfetch_fn;
+};
+
+// ---------------------------------------------------------------------------
+// PrefetchChunkIndex<K, InnerChunkIndex, PrefetchFn>
+//
+// Wraps a ChunkElementIndex (or another PrefetchChunkIndex for nesting).
+// get_iterator() returns a PrefetchAheadIterator built from the inner
+// iterator and the stored prefetch function.
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Chunk index wrapper that decorates iterators with prefetch hints.
+ *
+ * Composes with ChunkElementIndex to add prefetch decoration to the returned
+ * iterator. Allows stacking multiple prefetch decorators for different data
+ * or lookahead distances.
+ *
+ * @tparam Lookahead Number of iterations to prefetch ahead
+ * @tparam InnerChunkIndex Base chunk index to decorate
+ * @tparam PrefetchFn Callable that prefetches data for a given index
+ *
+ * @code
+ * auto chunk = PrefetchChunkIndex<1, BaseChunk, PrefetchFn>(base, fn);
+ * // chunk.get_iterator() returns decorated iterator with prefetch
+ * @endcode
+ */
+template <int Lookahead, typename InnerChunkIndex, typename PrefetchFn>
+class PrefetchChunkIndex {
+public:
+  using iterator_type =
+      PrefetchAheadIterator<Lookahead, typename InnerChunkIndex::iterator_type,
+                            PrefetchFn>;
+
+  KOKKOS_INLINE_FUNCTION
+  iterator_type get_iterator() const {
+    return { inner.get_iterator(), pfetch_fn };
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  constexpr auto get_policy_index() const { return inner.get_policy_index(); }
+
+  KOKKOS_INLINE_FUNCTION
+  constexpr auto get_index() const { return inner.get_index(); }
+
+  KOKKOS_INLINE_FUNCTION
+  auto get_range() const { return inner.get_range(); }
+
+  PrefetchChunkIndex(const InnerChunkIndex &inner, PrefetchFn pfetch_fn)
+      : inner(inner), pfetch_fn(std::move(pfetch_fn)) {}
+
+private:
+  InnerChunkIndex inner;
+  PrefetchFn pfetch_fn;
+};
+
+/**
+ * @brief Decorate a chunk index with lookahead prefetch hints.
+ *
+ * Returns a PrefetchChunkIndex whose iterator fires
+ * prefetch_fn(base(i+Lookahead)) while computing results for index i. The
+ * base() accessor bypasses nested decorations, enabling safe composition.
+ *
+ * Multiple decorators can be stacked for different data:
+ * @code
+ * prefetch_ahead<1>(prefetch_ahead<1>(chunk, F_jac), F_props)
+ * // prefetches F_jac(i+1) and F_props(i+1) while computing i
+ * @endcode
+ *
+ * No-op on GPU (KOKKOS_ENABLE_CUDA).
+ *
+ * @tparam Lookahead Iterations to prefetch ahead (default 1)
+ * @tparam ChunkIndexType Chunk index type to decorate
+ * @tparam PrefetchFn Callable(index) that issues prefetch
+ * @param chunk Chunk index to decorate
+ * @param fn Prefetch function
+ * @return Decorated chunk index with prefetch behavior
+ *
+ * @ingroup Execution
+ */
+template <int Lookahead = 1, typename ChunkIndexType, typename PrefetchFn>
+auto prefetch_ahead(const ChunkIndexType &chunk, PrefetchFn &&fn) {
+  return PrefetchChunkIndex<Lookahead, ChunkIndexType,
+                            std::decay_t<PrefetchFn>>{
+    chunk, std::forward<PrefetchFn>(fn)
+  };
+}
+
+#else // KOKKOS_ENABLE_CUDA
+
+// GPU: __builtin_prefetch is a no-op; return a plain copy so the KOKKOS_LAMBDA
+// in for_each_level captures only device-safe types.
+template <int Lookahead = 1, typename ChunkIndexType, typename PrefetchFn>
+ChunkIndexType prefetch_ahead(const ChunkIndexType &chunk, const PrefetchFn &) {
+  return chunk;
+}
+
+#endif // KOKKOS_ENABLE_CUDA
+
+} // namespace execution
+} // namespace specfem

--- a/docs/sections/api/specfem/algorithms/gradient.rst
+++ b/docs/sections/api/specfem/algorithms/gradient.rst
@@ -6,10 +6,3 @@
 .. doxygengroup:: AlgorithmsGradient
     :members:
     :content-only:
-
-Implementation Details
-----------------------
-
-.. doxygenfunction:: specfem::algorithms::impl::element_gradient(const VectorFieldType &f, const specfem::point::index<specfem::element::dimension_tag::dim2, VectorFieldType::using_simd> &local_index, const specfem::point::jacobian_matrix<specfem::element::dimension_tag::dim2, false, VectorFieldType::using_simd> &point_jacobian_matrix, const QuadratureType &lagrange_derivative, typename VectorFieldType::simd::datatype (&df_dxi)[VectorFieldType::components], typename VectorFieldType::simd::datatype (&df_dgamma)[VectorFieldType::components])
-
-.. doxygenfunction:: specfem::algorithms::impl::element_gradient(const VectorFieldType &f, const specfem::point::index<specfem::element::dimension_tag::dim3, VectorFieldType::using_simd> &local_index, const specfem::point::jacobian_matrix<specfem::element::dimension_tag::dim3, false, VectorFieldType::using_simd> &point_jacobian_matrix, const QuadratureType &lagrange_derivative, typename VectorFieldType::simd::datatype (&df_dxi)[VectorFieldType::components], typename VectorFieldType::simd::datatype (&df_deta)[VectorFieldType::components], typename VectorFieldType::simd::datatype (&df_dgamma)[VectorFieldType::components])

--- a/docs/sections/api/specfem/cache_line.rst
+++ b/docs/sections/api/specfem/cache_line.rst
@@ -1,0 +1,30 @@
+.. _specfem_cache_line:
+
+``specfem::cache_line``
+=======================
+
+Cache prefetch hints and utilities for performance optimization.
+
+.. doxygennamespace:: specfem::cache_line
+    :members:
+    :content-only:
+
+Prefetch Hint Types
+^^^^^^^^^^^^^^^^^^^
+
+.. doxygenstruct:: specfem::cache_line::Nta
+    :members:
+
+.. doxygenstruct:: specfem::cache_line::Low
+    :members:
+
+.. doxygenstruct:: specfem::cache_line::Moderate
+    :members:
+
+.. doxygenstruct:: specfem::cache_line::High
+    :members:
+
+Prefetch Function
+^^^^^^^^^^^^^^^^^
+
+.. doxygenfunction:: specfem::cache_line::prefetch

--- a/docs/sections/api/specfem/compute/index.rst
+++ b/docs/sections/api/specfem/compute/index.rst
@@ -35,6 +35,7 @@ Implementation Details
 
     compute_mass_matrix
     compute_stiffness_interaction
+    stiffness_kernels
     compute_source_interaction
     compute_material_derivatives
     compute_coupling

--- a/docs/sections/api/specfem/compute/stiffness_kernels.rst
+++ b/docs/sections/api/specfem/compute/stiffness_kernels.rst
@@ -1,0 +1,12 @@
+.. _specfem_compute_stiffness_kernels:
+
+``specfem::compute::impl`` - Stiffness Kernels
+===============================================
+
+Parallel kernels for stiffness tensor computation and assembly.
+
+Gather Kernel
+^^^^^^^^^^^^^
+
+.. doxygenclass:: specfem::compute::impl::gather_kernel
+    :members:

--- a/docs/sections/api/specfem/execution/index.rst
+++ b/docs/sections/api/specfem/execution/index.rst
@@ -17,5 +17,6 @@
     iterators/team_thread_md_range_iterator
     iterators/chunked_edge_iterator
     iterators/chunked_intersection_iterator
+    pattern/prefetch_ahead
     pattern/for_each_level
     pattern/for_all

--- a/docs/sections/api/specfem/execution/pattern/prefetch_ahead.rst
+++ b/docs/sections/api/specfem/execution/pattern/prefetch_ahead.rst
@@ -1,0 +1,36 @@
+.. _specfem_api_execution_pattern_prefetch_ahead:
+
+``specfem::execution::prefetch_ahead``
+======================================
+
+Lookahead prefetch decorator for cache-efficient iteration.
+
+Overview
+--------
+
+The prefetch_ahead function decorates chunk indices with prefetch operations
+that fire K iterations ahead of the current computation. This enables
+cache-resident data by the time it's needed.
+
+Type Traits
+^^^^^^^^^^^
+
+.. doxygenstruct:: specfem::execution::has_base_lookup
+    :members:
+
+Iterator Decorator
+^^^^^^^^^^^^^^^^^^
+
+.. doxygenclass:: specfem::execution::PrefetchAheadIterator
+    :members:
+
+Chunk Index Wrapper
+^^^^^^^^^^^^^^^^^^^
+
+.. doxygenclass:: specfem::execution::PrefetchChunkIndex
+    :members:
+
+Main Function
+^^^^^^^^^^^^^
+
+.. doxygenfunction:: specfem::execution::prefetch_ahead

--- a/docs/sections/api/specfem/index.rst
+++ b/docs/sections/api/specfem/index.rst
@@ -11,6 +11,7 @@
     assembly/index
     attenuation/index
     boundary_conditions/index
+    cache_line
     chunk_edge/index
     chunk_element/index
     compute/index


### PR DESCRIPTION
## Description

Please describe the changes/features in this pull request.

- Adds lookahead support for specfem execution indices
- Adds prefetch functionality for jacobian matrix

## Issue Number

If there is an issue created for these changes, link it here

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
