### PR TITLE
NCI3D Prep: Pointwise algo + nci accessor

### DIFF
--- a/core/specfem/algorithms/transfer_interpolate.hpp
+++ b/core/specfem/algorithms/transfer_interpolate.hpp
@@ -4,6 +4,9 @@
 #include "specfem/data_access.hpp"
 #include "specfem/enums.hpp"
 #include "specfem/execution.hpp"
+
+#include "specfem/datatype.hpp"
+
 #include <Kokkos_Core.hpp>
 #include <cmath>
 #include <type_traits>
@@ -33,24 +36,89 @@ template <typename XiViewType> struct LagrangeInterpolant {
   }
 };
 
-/**
- * @brief Takes a chunk_edge or chunk_face field and maps it by coordinates.
- *
- * @tparam IndexType chunk_edge or chunk_face index
- * @tparam TransferFunctionType transfer function container type
- (should be of DataClassType transfer_coordinates)
- * @tparam FaceFunctionType The chunk_edge or chunk_face field type
- * @tparam IntersectionReturnCallback the callback function that retrieves the
- pointwise value at each coordinate.
- * @ingroup AlgorithmsTransfer
- */
-template <typename IndexType, typename TransferFunctionType,
-          typename FaceFunctionType, typename IntersectionReturnCallback>
+namespace transfer_interpolate_impl {
+
+template <typename FaceFunctionType, typename PointVectorType,
+          typename LagrangeInterpolatorType>
 KOKKOS_INLINE_FUNCTION void
-transfer_interpolate(const IndexType &chunk_face_index,
-                     const TransferFunctionType &transfer_function,
-                     const FaceFunctionType &edge_function,
-                     const IntersectionReturnCallback &callback);
+interpolate_point(const int &ielem, const type_real &face_coord1,
+                  const type_real &face_coord2,
+                  const FaceFunctionType &face_function,
+                  PointVectorType &result,
+                  const LagrangeInterpolatorType &lagrange_interpolator) {
+  constexpr int ncomp = PointVectorType::components;
+
+  for (int icomp = 0; icomp < ncomp; icomp++) {
+    result(icomp) = 0;
+  }
+
+  if (!std::isnan(face_coord1)) {
+    // to compute interpolants once: precompute second axis
+    type_real coeffs_axis2[FaceFunctionType::ngll];
+    for (int ipoint_axis2 = 0; ipoint_axis2 < FaceFunctionType::ngll;
+         ipoint_axis2++) {
+      coeffs_axis2[ipoint_axis2] =
+          lagrange_interpolator(ipoint_axis2, face_coord2);
+    }
+
+    // interpolate on tensor-product element
+    for (int ipoint_axis1 = 0; ipoint_axis1 < FaceFunctionType::ngll;
+         ipoint_axis1++) {
+      const type_real coeff_axis1 =
+          lagrange_interpolator(ipoint_axis1, face_coord1);
+      for (int ipoint_axis2 = 0; ipoint_axis2 < FaceFunctionType::ngll;
+           ipoint_axis2++) {
+        const type_real transfer_coeff =
+            coeff_axis1 * coeffs_axis2[ipoint_axis2];
+
+        for (int icomp = 0; icomp < ncomp; icomp++) {
+          result(icomp) +=
+              face_function(ielem, ipoint_axis1, ipoint_axis2, icomp) *
+              transfer_coeff;
+        }
+      }
+    }
+  }
+}
+
+template <typename LagrangeInterpolatorType, typename FaceFunctionType,
+          typename PointVectorType>
+KOKKOS_INLINE_FUNCTION void interpolate_point(
+    const int &ielem, const LagrangeInterpolatorType &interpolants,
+    const FaceFunctionType &face_function, PointVectorType &result) {
+  constexpr int ncomp = PointVectorType::components;
+
+  for (int icomp = 0; icomp < ncomp; icomp++) {
+    result(icomp) = 0;
+  }
+
+  if (!std::isnan(interpolants(0, 0))) {
+    // to compute interpolants once: precompute second axis
+    type_real coeffs_axis2[FaceFunctionType::ngll];
+    for (int ipoint_axis2 = 0; ipoint_axis2 < FaceFunctionType::ngll;
+         ipoint_axis2++) {
+      coeffs_axis2[ipoint_axis2] = interpolants(ipoint_axis2, 1);
+    }
+
+    // interpolate on tensor-product element
+    for (int ipoint_axis1 = 0; ipoint_axis1 < FaceFunctionType::ngll;
+         ipoint_axis1++) {
+      const type_real coeff_axis1 = interpolants(ipoint_axis1, 0);
+      for (int ipoint_axis2 = 0; ipoint_axis2 < FaceFunctionType::ngll;
+           ipoint_axis2++) {
+        const type_real transfer_coeff =
+            coeff_axis1 * coeffs_axis2[ipoint_axis2];
+
+        for (int icomp = 0; icomp < ncomp; icomp++) {
+          result(icomp) +=
+              face_function(ielem, ipoint_axis1, ipoint_axis2, icomp) *
+              transfer_coeff;
+        }
+      }
+    }
+  }
+}
+} // namespace transfer_interpolate_impl
 
 template <typename IndexType, typename TransferFunctionType,
           typename FaceFunctionType, typename IntersectionReturnCallback>
@@ -87,14 +155,14 @@ template <typename IndexType, typename TransferFunctionType,
           typename FaceFunctionType, typename IntersectionReturnCallback,
           typename LagrangeInterpolatorType>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<
-    specfem::data_access::is_chunk_face<IndexType>::value, void>
+    specfem::data_access::is_chunk_face<FaceFunctionType>::value &&
+        specfem::data_access::is_chunk_face<IndexType>::value,
+    void>
 transfer_interpolate(const IndexType &chunk_face_index,
                      const TransferFunctionType &transfer_function,
                      const FaceFunctionType &face_function,
                      const IntersectionReturnCallback &callback,
                      const LagrangeInterpolatorType &lagrange_interpolator) {
-  static_assert(specfem::data_access::is_chunk_face<FaceFunctionType>::value,
-                "FaceFunctionType must be a chunk_face data type.");
 
   // TODO future consideration: use load_on_device for coupled field here.
   // We would want it to be a specialization, since we want to transfer more
@@ -112,44 +180,39 @@ transfer_interpolate(const IndexType &chunk_face_index,
           team, num_faces, TransferFunctionType::n_quad_element,
           TransferFunctionType::n_quad_element),
       [&](const auto &index) {
-        const int iedge = index(0);
-        const int iquad1 = index(1);
-        const int iquad2 = index(2);
+        const int &ielem = index(0);
+        const int &iquad1 = index(1);
+        const int &iquad2 = index(2);
 
-        const type_real face_coord1 =
-            transfer_function(iedge, iquad1, iquad2, 0);
-        const type_real face_coord2 =
-            transfer_function(iedge, iquad1, iquad2, 1);
+        const type_real &face_coord1 =
+            transfer_function(ielem, iquad1, iquad2, 0);
+        const type_real &face_coord2 =
+            transfer_function(ielem, iquad1, iquad2, 1);
 
         VectorPointViewType intersection_point_view;
-
-        for (int icomp = 0; icomp < ncomp; icomp++) {
-          intersection_point_view(icomp) = 0;
-        }
-
-        if (!std::isnan(face_coord1)) {
-          for (int ipoint_axis1 = 0; ipoint_axis1 < FaceFunctionType::ngll;
-               ipoint_axis1++) {
-            const type_real coeff_axis1 =
-                lagrange_interpolator(ipoint_axis1, face_coord1);
-            for (int ipoint_axis2 = 0; ipoint_axis2 < FaceFunctionType::ngll;
-                 ipoint_axis2++) {
-
-              const type_real coeff_axis2 =
-                  lagrange_interpolator(ipoint_axis2, face_coord2);
-              const type_real transfer_coeff = coeff_axis1 * coeff_axis2;
-
-              for (int icomp = 0; icomp < ncomp; icomp++) {
-                intersection_point_view(icomp) +=
-                    face_function(iedge, ipoint_axis1, ipoint_axis2, icomp) *
-                    transfer_coeff;
-              }
-            }
-          }
-        }
+        transfer_interpolate_impl::interpolate_point(
+            ielem, face_coord1, face_coord2, face_function,
+            intersection_point_view, lagrange_interpolator);
 
         callback(index, intersection_point_view);
       });
+}
+
+template <typename IndexType, typename TransferFunctionType,
+          typename FaceFunctionType, typename PointwiseReturnType>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<
+    specfem::data_access::is_chunk_face<FaceFunctionType>::value &&
+        specfem::data_access::is_point<IndexType>::value,
+    void>
+transfer_interpolate(const IndexType &point_index,
+                     const TransferFunctionType &transfer_function,
+                     const FaceFunctionType &face_function,
+                     PointwiseReturnType &self_mapped_field) {
+
+  const int &ielem = point_index.iface;
+
+  transfer_interpolate_impl::interpolate_point(
+      ielem, transfer_function.interpolants, face_function, self_mapped_field);
 }
 } // namespace specfem::algorithms
 

--- a/core/specfem/chunk_edge/nonconforming_interface.hpp
+++ b/core/specfem/chunk_edge/nonconforming_interface.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "specfem/data_access/accessor.hpp"
+#include "specfem/data_access/data_class.hpp"
+#include "specfem/element/tags.hpp"
+#include "specfem/element_connections/tags.hpp"
 #include "specfem/element_coupling/tags.hpp"
 namespace specfem::chunk_edge {
 
@@ -30,7 +34,7 @@ template <specfem::element::dimension_tag DimensionTag, int NumberElements,
           specfem::element_coupling::flux_scheme_tag FluxSchemeTag,
           typename MemorySpace =
               Kokkos::DefaultExecutionSpace::scratch_memory_space,
-          typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged> >
+          typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged>>
 struct transfer_function;
 
 /**
@@ -196,7 +200,7 @@ template <specfem::element::dimension_tag DimensionTag,
           int NumberElements, int NQuadIntersection,
           typename MemorySpace =
               Kokkos::DefaultExecutionSpace::scratch_memory_space,
-          typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged> >
+          typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged>>
 struct intersection_factor;
 
 /**
@@ -313,7 +317,7 @@ template <specfem::element::dimension_tag DimensionTag,
           int NumberElements, int NQuadIntersection,
           typename MemorySpace =
               Kokkos::DefaultExecutionSpace::scratch_memory_space,
-          typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged> >
+          typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged>>
 struct intersection_normal;
 
 /**
@@ -429,16 +433,16 @@ struct NonconformingAccessorPack
 
   /// Spatial dimension inherited from first accessor
   constexpr static auto dimension_tag =
-      std::tuple_element_t<0, std::tuple<Accessors...> >::dimension_tag;
+      std::tuple_element_t<0, std::tuple<Accessors...>>::dimension_tag;
   /// Interface medium type inherited from first accessor
   constexpr static auto interface_tag =
-      std::tuple_element_t<0, std::tuple<Accessors...> >::interface_tag;
+      std::tuple_element_t<0, std::tuple<Accessors...>>::interface_tag;
   /// Boundary condition tag inherited from first accessor
   constexpr static auto boundary_tag =
-      std::tuple_element_t<0, std::tuple<Accessors...> >::boundary_tag;
+      std::tuple_element_t<0, std::tuple<Accessors...>>::boundary_tag;
   /// Flux scheme tag inherited from first accessor
   constexpr static auto flux_scheme_tag =
-      std::tuple_element_t<0, std::tuple<Accessors...> >::flux_scheme_tag;
+      std::tuple_element_t<0, std::tuple<Accessors...>>::flux_scheme_tag;
   /// Number of packed accessor types
   constexpr static size_t n_accessors = sizeof...(Accessors);
   /// Tuple type containing all packed accessors
@@ -455,7 +459,7 @@ struct NonconformingAccessorPack
       (std::is_same_v<std::integral_constant<specfem::element::dimension_tag,
                                              Accessors::dimension_tag>,
                       std::integral_constant<specfem::element::dimension_tag,
-                                             dimension_tag> > &&
+                                             dimension_tag>> &&
        ...),
       "All Accessors in NonconformingAccessorPack must have the same "
       "dimension_tag");
@@ -465,7 +469,7 @@ struct NonconformingAccessorPack
            std::integral_constant<specfem::element_coupling::interface_tag,
                                   Accessors::interface_tag>,
            std::integral_constant<specfem::element_coupling::interface_tag,
-                                  interface_tag> > &&
+                                  interface_tag>> &&
        ...),
       "All Accessors in NonconformingAccessorPack must have the same "
       "interface_tag");
@@ -474,7 +478,7 @@ struct NonconformingAccessorPack
       (std::is_same_v<std::integral_constant<specfem::element::boundary_tag,
                                              Accessors::boundary_tag>,
                       std::integral_constant<specfem::element::boundary_tag,
-                                             boundary_tag> > &&
+                                             boundary_tag>> &&
        ...),
       "All Accessors in NonconformingAccessorPack must have the same "
       "boundary_tag");
@@ -484,7 +488,7 @@ struct NonconformingAccessorPack
            std::integral_constant<specfem::element_coupling::flux_scheme_tag,
                                   Accessors::flux_scheme_tag>,
            std::integral_constant<specfem::element_coupling::flux_scheme_tag,
-                                  flux_scheme_tag> > &&
+                                  flux_scheme_tag>> &&
        ...),
       "All Accessors in NonconformingAccessorPack must have the same "
       "flux_scheme_tag");
@@ -543,7 +547,7 @@ using coupling_terms_pack = NonconformingAccessorPack<
                               FluxSchemeTag, NumberElements, NQuadIntersection,
                               NQuadElement>,
     intersection_normal<DimensionTag, InterfaceTag, BoundaryTag, FluxSchemeTag,
-                        NumberElements, NQuadIntersection> >;
+                        NumberElements, NQuadIntersection>>;
 
 /**
  * @brief Type alias for integral data accessor pack
@@ -558,6 +562,6 @@ template <specfem::element::dimension_tag DimensionTag,
           int NumberElements, int NQuadIntersection>
 using integral_data_pack = NonconformingAccessorPack<
     intersection_factor<DimensionTag, InterfaceTag, BoundaryTag, FluxSchemeTag,
-                        NumberElements, NQuadIntersection> >;
+                        NumberElements, NQuadIntersection>>;
 
 } // namespace specfem::chunk_edge

--- a/core/specfem/data_access/accessor.hpp
+++ b/core/specfem/data_access/accessor.hpp
@@ -38,6 +38,22 @@ struct is_accessor<
                                        specfem::datatype::AccessorType>>>
     : std::true_type {};
 
+/**
+ * @brief Type trait to detect a codimension-1 accessor type (chunk_edge for
+ * dim2, chunk_face for dim3).
+ */
+template <typename T, typename = void>
+struct is_codim1_chunk : std::false_type {};
+
+template <typename T>
+struct is_codim1_chunk<
+    T, std::enable_if_t<
+           (T::accessor_type == specfem::datatype::AccessorType::chunk_edge &&
+            T::dimension_tag == specfem::element::dimension_tag::dim2) ||
+           (T::accessor_type == specfem::datatype::AccessorType::chunk_face &&
+            T::dimension_tag == specfem::element::dimension_tag::dim3)>>
+    : std::true_type {};
+
 } // namespace specfem::data_access
 
 #include "accessor/chunk_edge.hpp"

--- a/core/specfem/point/nonconforming_interface3d.hpp
+++ b/core/specfem/point/nonconforming_interface3d.hpp
@@ -1,0 +1,107 @@
+#pragma once
+
+#include "specfem/data_access/accessor.hpp"
+#include "specfem/datatype/point_view.hpp"
+#include "specfem/element/tags.hpp"
+#include "specfem/element_connections/tags.hpp"
+#include "specfem/element_coupling/tags.hpp"
+
+namespace specfem::point {
+
+/**
+ * @brief Template accessor for face node location in coupled local coordinates.
+ *
+ * @tparam DimensionTag
+ * @tparam NGLL number of quadrature points, used only for the interpolants
+ * @tparam InterfaceTag
+ * @tparam BoundaryTag
+ * @tparam FluxSchemeTag
+ * @tparam MemorySpace
+ * @tparam MemoryTraits
+ */
+template <specfem::element::dimension_tag DimensionTag,
+          int NGLL /*Only for interpolants*/,
+          specfem::element_coupling::interface_tag InterfaceTag,
+          specfem::element::boundary_tag BoundaryTag,
+          specfem::element_coupling::flux_scheme_tag FluxSchemeTag>
+struct nonconforming_interface;
+
+template <int NGLL, specfem::element_coupling::interface_tag InterfaceTag,
+          specfem::element::boundary_tag BoundaryTag,
+          specfem::element_coupling::flux_scheme_tag FluxSchemeTag>
+struct nonconforming_interface<specfem::element::dimension_tag::dim3, NGLL,
+                               InterfaceTag, BoundaryTag, FluxSchemeTag>
+    : public specfem::data_access::Accessor<
+          specfem::datatype::AccessorType::point,
+          specfem::data_access::DataClassType::nonconforming_interface,
+          specfem::element::dimension_tag::dim3, false /*UseSIMD*/> {
+
+public:
+  /// Spatial dimension (2D for this specialization)
+  static constexpr auto dimension_tag = specfem::element::dimension_tag::dim3;
+  /// Interface medium type tag
+  static constexpr auto interface_tag = InterfaceTag;
+  /// Boundary condition tag
+  static constexpr auto boundary_tag = BoundaryTag;
+  /// Flux scheme tag
+  static constexpr auto flux_scheme_tag = FluxSchemeTag;
+  /// Connection type for nonconforming interfaces
+  static constexpr auto connection_tag =
+      specfem::element_connections::type::nonconforming;
+
+  static constexpr int ndim = specfem::element::dimension<dimension_tag>::dim;
+  vector_type<type_real, ndim - 1> coupled_coordinates;
+  scalar_type<type_real> face_factor;
+  vector_type<type_real, ndim> face_normal;
+
+  // ========================= START TEMPORARY =========================
+  tensor_type<type_real, NGLL, ndim - 1> interpolants;
+
+  /**
+   * @brief Populates the interpolants.
+   */
+  template <typename LagrangeInterpolantType>
+  KOKKOS_INLINE_FUNCTION void
+  set_interpolants(const LagrangeInterpolantType &lagrange_interpolant) {
+    // populate interpolants array.
+    for (int igll = 0; igll < NGLL; igll++) {
+      for (int idim = 0; idim < ndim - 1; idim++) {
+        interpolants(igll, idim) =
+            lagrange_interpolant(igll, coupled_coordinates(idim));
+      }
+    }
+  }
+  template <typename LagrangeInterpolantType>
+  KOKKOS_INLINE_FUNCTION nonconforming_interface(
+      const vector_type<type_real, ndim - 1> &coupled_coordinates,
+      const scalar_type<type_real> &face_factor,
+      const vector_type<type_real, ndim> &face_normal,
+      const LagrangeInterpolantType &lagrange_interpolant)
+      : coupled_coordinates(coupled_coordinates), face_factor(face_factor),
+        face_normal(face_normal) {
+    set_interpolants(lagrange_interpolant);
+  }
+
+  // =========================  END TEMPORARY  =========================
+
+  KOKKOS_INLINE_FUNCTION nonconforming_interface(
+      const vector_type<type_real, ndim - 1> &coupled_coordinates,
+      const scalar_type<type_real> &face_factor,
+      const vector_type<type_real, ndim> &face_normal)
+      : coupled_coordinates(coupled_coordinates), face_factor(face_factor),
+        face_normal(face_normal) {}
+
+  /**
+   * @brief Default constructor.
+   */
+  KOKKOS_INLINE_FUNCTION
+  nonconforming_interface() = default;
+
+  /**
+   * @brief Get shared memory size requirement
+   * @return Size in bytes needed for scratch memory
+   */
+  constexpr static int shmem_size() { return 0; }
+};
+
+} // namespace specfem::point

--- a/tests/unit-tests/algorithms/dim3/transfer_interpolate.cpp
+++ b/tests/unit-tests/algorithms/dim3/transfer_interpolate.cpp
@@ -5,6 +5,7 @@
 #include "specfem/datatype/chunk_face_view.hpp"
 #include "specfem/element/attributes.hpp"
 #include "specfem/element_coupling/attributes.hpp"
+#include "specfem/point/nonconforming_interface3d.hpp"
 #include "specfem/setup.hpp"
 #include "utilities/include/fixture/nonconforming_interface.hpp"
 
@@ -188,10 +189,15 @@ void execute(const TransferCoordinates &transfer_coordinates,
   constexpr int league_size = (stack_size + chunk_size - 1) / chunk_size;
 
   // ======= Declare Kernel Container Types
-  using ContainerTransferCoordinates = specfem::chunk_face::coupled_coordinates<
-      dimension_tag, chunk_size, ngll_sample_face, interface_tag, boundary_tag,
-      flux_scheme_tag, Kokkos::DefaultExecutionSpace, Kokkos::MemoryTraits<>,
-      Kokkos::LayoutRight>;
+  using ContainerTransferCoordinatesChunk =
+      specfem::chunk_face::coupled_coordinates<
+          dimension_tag, chunk_size, ngll_sample_face, interface_tag,
+          boundary_tag, flux_scheme_tag, Kokkos::DefaultExecutionSpace,
+          Kokkos::MemoryTraits<>, Kokkos::LayoutRight>;
+  using ContainerTransferCoordinatesPoint =
+      specfem::point::nonconforming_interface<dimension_tag, ngll_sample_face,
+                                              interface_tag, boundary_tag,
+                                              flux_scheme_tag>;
 
   using ContainerFunctionCoupled = specfem::datatype::VectorChunkFaceViewType<
       type_real, dimension_tag, chunk_size, ngll_coupled_face,
@@ -215,7 +221,8 @@ void execute(const TransferCoordinates &transfer_coordinates,
       face_function.template get_chunkwise_view<chunk_size>();
   const auto transfer_coord_view =
       transfer_coordinates.template get_chunkwise_view<chunk_size>();
-  ResultViewType result_view("result_view");
+  ResultViewType result_view_chunk("result_view_chunk");
+  ResultViewType result_view_point("result_view_point");
 
   Kokkos::parallel_for(
       "transfer_interpolate_test",
@@ -226,89 +233,150 @@ void execute(const TransferCoordinates &transfer_coordinates,
         const int this_chunk_size =
             std::min(chunk_size, stack_size - this_chunk_start);
 
-        const ContainerTransferCoordinates TF(
-            Kokkos::subview(transfer_coord_view, ichunk, Kokkos::ALL(),
-                            Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()));
         const ContainerFunctionCoupled F(
             Kokkos::subview(function_view, ichunk, Kokkos::ALL(), Kokkos::ALL(),
                             Kokkos::ALL(), Kokkos::ALL()));
 
+        // ==========================
+        // chunk transfer_interpolate
+        // ==========================
+
+        const ContainerTransferCoordinatesChunk TF(
+            Kokkos::subview(transfer_coord_view, ichunk, Kokkos::ALL(),
+                            Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()));
         specfem::algorithms::transfer_interpolate(
             ChunkFaceIndex(this_chunk_size, team_member), TF, F,
             [&](const auto &index, const auto &point) {
               for (int icomp = 0; icomp < FaceFunction::num_components;
                    ++icomp) {
-                result_view(this_chunk_start + index(0), index(1), index(2),
-                            icomp) = point(icomp);
-                // Kokkos::single(Kokkos::PerTeam(team_member), [&]() {
-                //   result_view(index(0), index(1), icomp) = point(icomp);
-                // });
+                result_view_chunk(this_chunk_start + index(0), index(1),
+                                  index(2), icomp) = point(icomp);
               }
             },
             interpolator);
+
+        // ==========================
+        // point transfer_interpolate
+        // ==========================
+        specfem::execution::for_each_level(
+            specfem::execution::TeamThreadMDRangeIterator(
+                team_member, this_chunk_size, ngll_sample_face,
+                ngll_sample_face),
+            [&](const auto &index) {
+              specfem::point::face_index<dimension_tag> mocked_point_index(
+                  0, index(0), index(1), index(2), 0, 0, 0,
+                  specfem::mesh_entity::dim3::type::back);
+
+              using SelfFieldType = specfem::datatype::VectorPointViewType<
+                  type_real, FaceFunction::num_components,
+                  false /*using_simd*/>;
+
+              SelfFieldType self_field;
+
+              const ContainerTransferCoordinatesPoint NCI(
+                  { transfer_coord_view(ichunk, index(0), index(1), index(2),
+                                        0),
+                    transfer_coord_view(ichunk, index(0), index(1), index(2),
+                                        1) },
+                  { 1.0 }, { 0, 0, 0 }, interpolator);
+
+              specfem::algorithms::transfer_interpolate(mocked_point_index, NCI,
+                                                        F, self_field);
+
+              for (int icomp = 0; icomp < FaceFunction::num_components;
+                   ++icomp) {
+                result_view_point(this_chunk_start + index(0), index(1),
+                                  index(2), icomp) = self_field(icomp);
+              }
+            });
       });
 
   Kokkos::fence();
 
-  auto result_host =
-      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), result_view);
-
   std::ostringstream fail_log;
-  int num_fails = 0;
+  int num_fails;
+  const auto validate_view = [&](const ResultViewType &result_view) {
+    auto result_host =
+        Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), result_view);
+    num_fails = 0;
+    fail_log = std::ostringstream();
+    for (int istack = 0; istack < stack_size; istack++) {
+      std::ostringstream index_fail_log;
+      int num_fails_at_index = 0;
 
-  for (int istack = 0; istack < stack_size; istack++) {
-    std::ostringstream index_fail_log;
-    int num_fails_at_index = 0;
-
-    for (int ipoint_axis1 = 0; ipoint_axis1 < ngll_sample_face;
-         ipoint_axis1++) {
-      for (int ipoint_axis2 = 0; ipoint_axis2 < ngll_sample_face;
-           ipoint_axis2++) {
-        for (int icomp = 0; icomp < FaceFunction::num_components; icomp++) {
-          if (!specfem::utilities::is_close(
-                  result_host(istack, ipoint_axis1, ipoint_axis2, icomp),
-                  expected[istack][ipoint_axis1][ipoint_axis2][icomp])) {
-            num_fails++;
-            num_fails_at_index++;
-            index_fail_log
-                << "  - face point (" << ipoint_axis1 << ", " << ipoint_axis2
-                << ") @ local coordinates ("
-                << transfer_coordinates(istack, ipoint_axis1, ipoint_axis2, 0)
-                << ", "
-                << transfer_coordinates(istack, ipoint_axis1, ipoint_axis2, 1)
-                << "), component " << icomp << "\n     expected: "
-                << expected[istack][ipoint_axis1][ipoint_axis2][icomp]
-                << "\n          got: "
-                << result_host(istack, ipoint_axis1, ipoint_axis2, icomp)
-                << std::endl;
+      for (int ipoint_axis1 = 0; ipoint_axis1 < ngll_sample_face;
+           ipoint_axis1++) {
+        for (int ipoint_axis2 = 0; ipoint_axis2 < ngll_sample_face;
+             ipoint_axis2++) {
+          for (int icomp = 0; icomp < FaceFunction::num_components; icomp++) {
+            if (!specfem::utilities::is_close(
+                    result_host(istack, ipoint_axis1, ipoint_axis2, icomp),
+                    expected[istack][ipoint_axis1][ipoint_axis2][icomp])) {
+              num_fails++;
+              num_fails_at_index++;
+              index_fail_log
+                  << "  - face point (" << ipoint_axis1 << ", " << ipoint_axis2
+                  << ") @ local coordinates ("
+                  << transfer_coordinates(istack, ipoint_axis1, ipoint_axis2, 0)
+                  << ", "
+                  << transfer_coordinates(istack, ipoint_axis1, ipoint_axis2, 1)
+                  << "), component " << icomp << "\n     expected: "
+                  << expected[istack][ipoint_axis1][ipoint_axis2][icomp]
+                  << "\n          got: "
+                  << result_host(istack, ipoint_axis1, ipoint_axis2, icomp)
+                  << std::endl;
+            }
           }
         }
       }
-    }
 
-    if (num_fails_at_index > 0) {
-      int ichunk = istack / chunk_size;
-      fail_log << num_fails_at_index << " fails at face " << istack
-               << "(local index " << istack - (ichunk * chunk_size)
-               << " of chunk " << ichunk << ")\n"
-               << index_fail_log.str();
+      if (num_fails_at_index > 0) {
+        int ichunk = istack / chunk_size;
+        fail_log << num_fails_at_index << " fails at face " << istack
+                 << "(local index " << istack - (ichunk * chunk_size)
+                 << " of chunk " << ichunk << ")\n"
+                 << index_fail_log.str();
+      }
+    }
+  };
+
+  {
+    validate_view(result_view_chunk);
+    if (num_fails > 0) {
+      std::ostringstream oss;
+      oss << "============================================\n"
+          << "transfer_interpolate failed\n"
+          << "Chunkwise-transfer failure\n"
+          << "-- Transfer function --\n"
+          << TransferCoordinates::description() << std::endl
+          << "-- Edge Function --\n"
+          << FaceFunction::description() << std::endl;
+      if (!execution_description.empty()) {
+        oss << "-- Execution Description --\n"
+            << execution_description << std::endl;
+      }
+      oss << "============================================\n" << fail_log.str();
+      ADD_FAILURE() << oss.str();
     }
   }
-
-  if (num_fails > 0) {
-    std::ostringstream oss;
-    oss << "============================================\n"
-        << "transfer_interpolate failed\n"
-        << "-- Transfer function --\n"
-        << TransferCoordinates::description() << std::endl
-        << "-- Edge Function --\n"
-        << FaceFunction::description() << std::endl;
-    if (!execution_description.empty()) {
-      oss << "-- Execution Description --\n"
-          << execution_description << std::endl;
+  {
+    validate_view(result_view_point);
+    if (num_fails > 0) {
+      std::ostringstream oss;
+      oss << "============================================\n"
+          << "transfer_interpolate failed\n"
+          << "Pointwise-transfer failure\n"
+          << "-- Transfer function --\n"
+          << TransferCoordinates::description() << std::endl
+          << "-- Edge Function --\n"
+          << FaceFunction::description() << std::endl;
+      if (!execution_description.empty()) {
+        oss << "-- Execution Description --\n"
+            << execution_description << std::endl;
+      }
+      oss << "============================================\n" << fail_log.str();
+      ADD_FAILURE() << oss.str();
     }
-    oss << "============================================\n" << fail_log.str();
-    ADD_FAILURE() << oss.str();
   }
 }
 } // namespace transfer_interpolate

--- a/tests/unit-tests/algorithms/dim3/transfer_interpolate.cpp
+++ b/tests/unit-tests/algorithms/dim3/transfer_interpolate.cpp
@@ -1,5 +1,4 @@
 #include "specfem/algorithms/transfer_interpolate.hpp"
-#include "Kokkos_Core_fwd.hpp"
 #include "specfem/chunk_face/nonconforming_interface.hpp"
 
 #include "specfem/datatype/accessor_type.hpp"

--- a/tests/unit-tests/algorithms/dim3/transfer_interpolate.cpp
+++ b/tests/unit-tests/algorithms/dim3/transfer_interpolate.cpp
@@ -195,7 +195,7 @@ void execute(const TransferCoordinates &transfer_coordinates,
           boundary_tag, flux_scheme_tag, Kokkos::DefaultExecutionSpace,
           Kokkos::MemoryTraits<>, Kokkos::LayoutRight>;
   using ContainerTransferCoordinatesPoint =
-      specfem::point::nonconforming_interface<dimension_tag, ngll_sample_face,
+      specfem::point::nonconforming_interface<dimension_tag, ngll_coupled_face,
                                               interface_tag, boundary_tag,
                                               flux_scheme_tag>;
 


### PR DESCRIPTION
## Description

These changes are split from the initially made PR #1889

- modifications to `algorithms/transfer_interpolate.hpp` to allow pointwise interpolation.
- adds `nonconforming_interface` to `specfem::point` namespace. Still unsure about the file naming (`specfem/point/nonconforming_interface3d.hpp`).

  **NOTE**: this is not tested, but will be with the other changes from #1889.

Also adds *tiny* changes:
- changes to `chunk_edge/nonconforming_interface.hpp` includes to not require any `#include` statements prior to its import (imports should be self-contained, now).
- `data_access/accessor.hpp`: adds type trait `specfem::data_access::is_codim1_chunk<T>` to simplify, into one line, the question "Is `T` a `chunk_edge` (in 2D) or `chunk_face` (in 3D)?"

## Issue Number

#1890

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
