### PR TITLE
Issue 85 - Adds stability checks on simulation

### DIFF
--- a/core/specfem/constants.hpp
+++ b/core/specfem/constants.hpp
@@ -52,6 +52,14 @@ const type_real COURANT_NUMBER_SUGGESTED = 0.5;
 const type_real NPTS_PER_WAVELENGTH = 5;
 
 /**
+ * @brief Displacement stability threshold for divergence detection.
+ *
+ * The solver aborts if max |displacement| exceeds this value during
+ * time marching, indicating a diverging solution.
+ */
+const type_real STABILITY_THRESHOLD = 1e10;
+
+/**
  * @brief Number of frequencies used for evaluating attenuation objective
  *
  */

--- a/core/specfem/periodic_tasks/stability_check.cpp
+++ b/core/specfem/periodic_tasks/stability_check.cpp
@@ -17,12 +17,8 @@ void specfem::periodic_tasks::stability_check<DimensionTag>::run(
   type_real local_max_displacement = 0;
 
   auto check_medium = [&]<typename TagsType>() {
-    // Skip combinations belonging to a different dimension
-    if constexpr (TagsType::dimension_tag != DimensionTag)
-      return;
-
     constexpr int num_components =
-        specfem::element::attributes<DimensionTag,
+        specfem::element::attributes<TagsType::dimension_tag,
                                      TagsType::medium_tag>::components;
     const auto &medium_field =
         forward_field.template get_field<TagsType::medium_tag>();
@@ -43,14 +39,16 @@ void specfem::periodic_tasks::stability_check<DimensionTag>::run(
     local_max_displacement = std::max(local_max_displacement, medium_max);
   };
 
-  // Single for_each covers all dimensions; the constexpr guard skips
-  // combinations that don't belong to DimensionTag, preventing invalid
-  // get_field<> instantiations (e.g. get_field<elastic> on sim_field<dim2>).
-  specfem::tag_dispatch::for_each(DIMENSION_SET(dim2, dim3) *
-                                      MEDIUM_SET(elastic_psv, elastic_sh,
-                                                 acoustic, poroelastic,
-                                                 elastic_psv_t, elastic),
-                                  check_medium);
+  if constexpr (DimensionTag == specfem::element::dimension_tag::dim2) {
+    specfem::tag_dispatch::for_each(
+        DIMENSION_SET(dim2) * MEDIUM_SET(elastic_psv, elastic_sh, acoustic,
+                                         poroelastic, elastic_psv_t),
+        check_medium);
+  } else {
+    static_assert(DimensionTag == specfem::element::dimension_tag::dim3);
+    specfem::tag_dispatch::for_each(
+        DIMENSION_SET(dim3) * MEDIUM_SET(elastic, acoustic), check_medium);
+  }
 
   // Reduce across MPI ranks
   const auto comm = specfem::MPI::communicator();

--- a/core/specfem/periodic_tasks/stability_check.cpp
+++ b/core/specfem/periodic_tasks/stability_check.cpp
@@ -1,0 +1,77 @@
+#include "stability_check.hpp"
+#include "specfem/assembly/assembly.hpp"
+#include "specfem/constants.hpp"
+#include "specfem/element/attributes.hpp"
+#include "specfem/mpi.hpp"
+#include "specfem/program/abort.hpp"
+#include "specfem/tag_dispatch.hpp"
+#include <Kokkos_Core.hpp>
+#include <algorithm>
+#include <cmath>
+#include <sstream>
+
+template <specfem::element::dimension_tag DimensionTag>
+void specfem::periodic_tasks::stability_check<DimensionTag>::run(
+    specfem::assembly::assembly<DimensionTag> &assembly, const int istep) {
+  const auto &forward_field = assembly.fields.forward;
+  type_real local_max_displacement = 0;
+
+  auto check_medium = [&]<typename TagsType>() {
+    // Skip combinations belonging to a different dimension
+    if constexpr (TagsType::dimension_tag != DimensionTag)
+      return;
+
+    constexpr int num_components =
+        specfem::element::attributes<DimensionTag,
+                                     TagsType::medium_tag>::components;
+    const auto &medium_field =
+        forward_field.template get_field<TagsType::medium_tag>();
+    if (medium_field.nglob == 0)
+      return;
+    const auto displacement = medium_field.get_field();
+    type_real medium_max = 0;
+    Kokkos::parallel_reduce(
+        "specfem::periodic_tasks::stability_check",
+        Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0,
+                                                           medium_field.nglob),
+        KOKKOS_LAMBDA(int iglob, type_real &lmax) {
+          for (int icomp = 0; icomp < num_components; ++icomp)
+            lmax = Kokkos::max(lmax, Kokkos::fabs(displacement(iglob, icomp)));
+        },
+        Kokkos::Max<type_real>(medium_max));
+    Kokkos::fence();
+    local_max_displacement = std::max(local_max_displacement, medium_max);
+  };
+
+  // Single for_each covers all dimensions; the constexpr guard skips
+  // combinations that don't belong to DimensionTag, preventing invalid
+  // get_field<> instantiations (e.g. get_field<elastic> on sim_field<dim2>).
+  specfem::tag_dispatch::for_each(DIMENSION_SET(dim2, dim3) *
+                                      MEDIUM_SET(elastic_psv, elastic_sh,
+                                                 acoustic, poroelastic,
+                                                 elastic_psv_t, elastic),
+                                  check_medium);
+
+  // Reduce across MPI ranks
+  const auto comm = specfem::MPI::communicator();
+  SPECFEM_MPI_SAFECALL(MPI_Allreduce(MPI_IN_PLACE, &local_max_displacement, 1,
+                                     SPECFEM_MPI_TYPE_REAL, MPI_MAX, comm));
+
+  if (!std::isfinite(local_max_displacement) ||
+      local_max_displacement > specfem::constants::STABILITY_THRESHOLD) {
+    std::ostringstream error_message;
+    error_message << "Solution is diverging at time step " << istep << "!\n"
+                  << "  max |displacement| = " << local_max_displacement << "\n"
+                  << "  Stability threshold = "
+                  << specfem::constants::STABILITY_THRESHOLD << "\n"
+                  << "  Verify that dt satisfies the CFL condition and that\n"
+                  << "  source parameters are physically reasonable.";
+    specfem_abort(error_message.str(), 30);
+  }
+}
+
+// Explicit template instantiations
+template class specfem::periodic_tasks::stability_check<
+    specfem::element::dimension_tag::dim2>;
+template class specfem::periodic_tasks::stability_check<
+    specfem::element::dimension_tag::dim3>;

--- a/core/specfem/periodic_tasks/stability_check.cpp
+++ b/core/specfem/periodic_tasks/stability_check.cpp
@@ -10,6 +10,37 @@
 #include <cmath>
 #include <sstream>
 
+namespace specfem::periodic_tasks::impl {
+
+template <typename TagsType>
+void get_max_displacement(
+    const specfem::assembly::assembly<TagsType::dimension_tag> &assembly,
+    type_real &local_max_displacement) {
+
+  constexpr auto num_components =
+      specfem::element::attributes<TagsType::dimension_tag,
+                                   TagsType::medium_tag>::components;
+  const auto &forward_field = assembly.fields.forward;
+  const auto &medium_field =
+      forward_field.template get_field<TagsType::medium_tag>();
+  if (medium_field.nglob == 0)
+    return;
+  const auto displacement = medium_field.get_field();
+  type_real medium_max = 0;
+  Kokkos::parallel_reduce(
+      "specfem::periodic_tasks::stability_check",
+      Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, medium_field.nglob),
+      KOKKOS_LAMBDA(int iglob, type_real &lmax) {
+        for (int icomp = 0; icomp < num_components; ++icomp)
+          lmax = Kokkos::max(lmax, Kokkos::fabs(displacement(iglob, icomp)));
+      },
+      Kokkos::Max<type_real>(medium_max));
+  Kokkos::fence();
+  local_max_displacement = std::max(local_max_displacement, medium_max);
+}
+
+} // namespace specfem::periodic_tasks::impl
+
 template <specfem::element::dimension_tag DimensionTag>
 void specfem::periodic_tasks::stability_check<DimensionTag>::run(
     specfem::assembly::assembly<DimensionTag> &assembly, const int istep) {
@@ -17,26 +48,8 @@ void specfem::periodic_tasks::stability_check<DimensionTag>::run(
   type_real local_max_displacement = 0;
 
   auto check_medium = [&]<typename TagsType>() {
-    constexpr int num_components =
-        specfem::element::attributes<TagsType::dimension_tag,
-                                     TagsType::medium_tag>::components;
-    const auto &medium_field =
-        forward_field.template get_field<TagsType::medium_tag>();
-    if (medium_field.nglob == 0)
-      return;
-    const auto displacement = medium_field.get_field();
-    type_real medium_max = 0;
-    Kokkos::parallel_reduce(
-        "specfem::periodic_tasks::stability_check",
-        Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0,
-                                                           medium_field.nglob),
-        KOKKOS_LAMBDA(int iglob, type_real &lmax) {
-          for (int icomp = 0; icomp < num_components; ++icomp)
-            lmax = Kokkos::max(lmax, Kokkos::fabs(displacement(iglob, icomp)));
-        },
-        Kokkos::Max<type_real>(medium_max));
-    Kokkos::fence();
-    local_max_displacement = std::max(local_max_displacement, medium_max);
+    specfem::periodic_tasks::impl::get_max_displacement<TagsType>(
+        assembly, local_max_displacement);
   };
 
   if constexpr (DimensionTag == specfem::element::dimension_tag::dim2) {

--- a/core/specfem/periodic_tasks/stability_check.hpp
+++ b/core/specfem/periodic_tasks/stability_check.hpp
@@ -1,0 +1,31 @@
+#pragma once
+#include "periodic_task.hpp"
+
+namespace specfem {
+namespace periodic_tasks {
+
+/**
+ * @brief Periodic divergence / stability check for the forward time loop.
+ *
+ * Every `check_interval` steps, computes the global max |displacement|
+ * across all media and MPI ranks. Aborts if the value is non-finite or
+ * exceeds `specfem::constants::STABILITY_THRESHOLD`.
+ *
+ * @tparam DimensionTag Spatial dimension (dim2 or dim3)
+ */
+template <specfem::element::dimension_tag DimensionTag>
+class stability_check : public periodic_task<DimensionTag> {
+public:
+  /**
+   * @brief Construct a stability check task.
+   * @param check_interval Number of time steps between checks.
+   */
+  explicit stability_check(int check_interval)
+      : periodic_task<DimensionTag>(check_interval) {}
+
+  void run(specfem::assembly::assembly<DimensionTag> &assembly,
+           const int istep) override;
+};
+
+} // namespace periodic_tasks
+} // namespace specfem

--- a/core/specfem/program/dim2/program.cpp
+++ b/core/specfem/program/dim2/program.cpp
@@ -1,13 +1,17 @@
 #include "program.hpp"
 #include "specfem/assembly/assembly.hpp"
+#include "specfem/constants.hpp"
 #include "specfem/element.hpp"
 #include "specfem/io.hpp"
 #include "specfem/logger.hpp"
 #include "specfem/mesh.hpp"
+#include "specfem/periodic_tasks/stability_check.hpp"
+#include "specfem/program/abort.hpp"
 #include "specfem/receivers.hpp"
 #include "specfem/solver.hpp"
 #include "specfem/source.hpp"
 #include "specfem/timescheme.hpp"
+#include <algorithm>
 
 namespace specfem::program {
 
@@ -106,6 +110,38 @@ void program_2d(
   // because it requires collective communication
   specfem::Logger::info(assembly.print());
 
+  // --------------------------------------------------------------
+
+  // --------------------------------------------------------------
+  //                   CFL Condition Check
+  // --------------------------------------------------------------
+  {
+    const type_real cfl =
+        dt * assembly.info.v.max / assembly.info.gll_distance.min;
+    specfem::Logger::info([&](std::ostringstream &oss) {
+      oss << "CFL Condition Check:\n"
+          << "-------------------------------\n"
+          << " CFL number: ............. " << cfl << "\n"
+          << " Maximum CFL (Cmax): ..... "
+          << specfem::constants::COURANT_NUMBER_SUGGESTED << "\n";
+    });
+    if (cfl > specfem::constants::COURANT_NUMBER_SUGGESTED) {
+      std::ostringstream msg;
+      msg << "CFL condition violated!\n"
+          << "  CFL = " << cfl
+          << " > Cmax = " << specfem::constants::COURANT_NUMBER_SUGGESTED
+          << "\n"
+          << "  Current dt = " << dt << "\n"
+          << "  Suggested dt (satisfies CFL): "
+          << assembly.info.suggested_time_step << "\n"
+          << "  Please update the 'dt' parameter in your configuration.";
+      specfem_abort(msg.str(), 30);
+    }
+  }
+  // Divergence check — runs ~100 times over the full simulation
+  tasks.push_back(
+      std::make_shared<specfem::periodic_tasks::stability_check<
+          specfem::element::dimension_tag::dim2>>(std::max(10, nsteps / 100)));
   // --------------------------------------------------------------
 
   // --------------------------------------------------------------

--- a/core/specfem/program/dim3/program.cpp
+++ b/core/specfem/program/dim3/program.cpp
@@ -1,13 +1,17 @@
 #include "program.hpp"
 #include "specfem/assembly/assembly.hpp"
+#include "specfem/constants.hpp"
 #include "specfem/element.hpp"
 #include "specfem/io.hpp"
 #include "specfem/logger.hpp"
 #include "specfem/mesh.hpp"
+#include "specfem/periodic_tasks/stability_check.hpp"
+#include "specfem/program/abort.hpp"
 #include "specfem/receivers.hpp"
 #include "specfem/solver.hpp"
 #include "specfem/source.hpp"
 #include "specfem/timescheme.hpp"
+#include <algorithm>
 
 namespace specfem::program {
 
@@ -110,6 +114,38 @@ void program_3d(
   // because it requires collective communication
   specfem::Logger::info(assembly.print());
 
+  // --------------------------------------------------------------
+
+  // --------------------------------------------------------------
+  //                   CFL Condition Check
+  // --------------------------------------------------------------
+  {
+    const type_real cfl =
+        dt * assembly.info.v.max / assembly.info.gll_distance.min;
+    specfem::Logger::info([&](std::ostringstream &oss) {
+      oss << "CFL Condition Check:\n"
+          << "-------------------------------\n"
+          << " CFL number: ............. " << cfl << "\n"
+          << " Maximum CFL (Cmax): ..... "
+          << specfem::constants::COURANT_NUMBER_SUGGESTED << "\n";
+    });
+    if (cfl > specfem::constants::COURANT_NUMBER_SUGGESTED) {
+      std::ostringstream msg;
+      msg << "CFL condition violated!\n"
+          << "  CFL = " << cfl
+          << " > Cmax = " << specfem::constants::COURANT_NUMBER_SUGGESTED
+          << "\n"
+          << "  Current dt = " << dt << "\n"
+          << "  Suggested dt (satisfies CFL): "
+          << assembly.info.suggested_time_step << "\n"
+          << "  Please update the 'dt' parameter in your configuration.";
+      specfem_abort(msg.str(), 30);
+    }
+  }
+  // Divergence check — runs ~100 times over the full simulation
+  tasks.push_back(
+      std::make_shared<specfem::periodic_tasks::stability_check<
+          specfem::element::dimension_tag::dim3>>(std::max(10, nsteps / 100)));
   // --------------------------------------------------------------
 
   // --------------------------------------------------------------


### PR DESCRIPTION
## Description

Please describe the changes/features in this pull request.

- [x] Check CFL condition and error with suggested dt if CFL is violated
- [x] Adds a divergence check every few timesteps
- [x] Computing energy is expensive, so this just follows checking the abs(displ) as 2D/3D fortran 


## Issue Number

Closes #85 
Closes #1705 

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
