### PR TITLE
nonconforming adjacency passthrough in `xdecompose_mesh`

### DIFF
--- a/fortran/decompose_mesh/decompose_mesh_par.F90
+++ b/fortran/decompose_mesh/decompose_mesh_par.F90
@@ -145,4 +145,12 @@ module decompose_mesh_par
   !! side_wd = 21--26: one face is on the boundary
   integer, dimension(:), allocatable :: side_wd
 
+  ! Nonconforming adjacency map
+  integer :: nnonconforming_adjacencies
+  integer, dimension(:), allocatable :: nonconforming_ispec_source, nonconforming_ispec_target
+  integer, dimension(:), allocatable :: nonconforming_adjacency_type
+  integer, dimension(:), allocatable :: nonconforming_adjacency_face
+
+
+
 end module decompose_mesh_par

--- a/fortran/decompose_mesh/read_decompose_mesh_par.F90
+++ b/fortran/decompose_mesh/read_decompose_mesh_par.F90
@@ -64,6 +64,10 @@
   ! wavefield discontinuity interface (optional — skipped when '')
   character(len=MAX_STRING_LEN) :: WAVEFIELD_DISCONTINUITY_INTERFACE_FILE = ''
 
+  ! nonconforming adjacencies
+  character(len=MAX_STRING_LEN) :: NONCONFORMING_ADJACENCIES_FILE = ''
+
+
   end module decompose_mesh_filenames
 
 
@@ -225,6 +229,12 @@
   call read_value_string(WAVEFIELD_DISCONTINUITY_INTERFACE_FILE, 'WAVEFIELD_DISCONTINUITY_INTERFACE_FILE', ier)
   if (ier /= 0) then
     WAVEFIELD_DISCONTINUITY_INTERFACE_FILE = ''
+    ier = 0
+  endif
+
+  call read_value_string(NONCONFORMING_ADJACENCIES_FILE,       'NONCONFORMING_ADJACENCIES_FILE',     ier)
+  if (ier /= 0) then
+    NONCONFORMING_ADJACENCIES_FILE = ''
     ier = 0
   endif
 

--- a/fortran/decompose_mesh/read_mesh_files.F90
+++ b/fortran/decompose_mesh/read_mesh_files.F90
@@ -942,7 +942,8 @@
   if (ier /= 0) stop 'Error allocating array nonconforming_adjacency_face'
 
   do ispec = 1,nnonconforming_adjacencies
-    read(IIN_DB,*) nonconforming_ispec_source(ispec), nonconforming_ispec_target(ispec), nonconforming_adjacency_type(ispec), nonconforming_adjacency_face(ispec)
+    read(IIN_DB,*) nonconforming_ispec_source(ispec), nonconforming_ispec_target(ispec), &
+                   nonconforming_adjacency_type(ispec), nonconforming_adjacency_face(ispec)
   enddo
 
 

--- a/fortran/decompose_mesh/read_mesh_files.F90
+++ b/fortran/decompose_mesh/read_mesh_files.F90
@@ -914,4 +914,38 @@
   !   call close_faults(nodes_coords,nnodes)
   ! endif
 
+
+  ! reads in nonconforming adjacency file
+  if (len_trim(NONCONFORMING_ADJACENCIES_FILE) > 0) then
+    open(unit=IIN_DB, file=trim(NONCONFORMING_ADJACENCIES_FILE), status='old', form='formatted', iostat=ier)
+  else
+    ier = 1
+  endif
+  if (ier /= 0) then
+    nnonconforming_adjacencies = 0
+    print *, '  no NONCONFORMING_ADJACENCIES_FILE file found'
+  else
+    read(IIN_DB,*) nnonconforming_adjacencies
+  endif
+
+  allocate(nonconforming_ispec_source(nnonconforming_adjacencies),stat=ier)
+  if (ier /= 0) call exit_MPI_without_rank('error allocating array nonconforming_ispec_source')
+  if (ier /= 0) stop 'Error allocating array nonconforming_ispec_source'
+  allocate(nonconforming_ispec_target(nnonconforming_adjacencies),stat=ier)
+  if (ier /= 0) call exit_MPI_without_rank('error allocating array nonconforming_ispec_target')
+  if (ier /= 0) stop 'Error allocating array nonconforming_ispec_target'
+  allocate(nonconforming_adjacency_type(nnonconforming_adjacencies),stat=ier)
+  if (ier /= 0) call exit_MPI_without_rank('error allocating array nonconforming_adjacency_type')
+  if (ier /= 0) stop 'Error allocating array nonconforming_adjacency_type'
+  allocate(nonconforming_adjacency_face(nnonconforming_adjacencies),stat=ier)
+  if (ier /= 0) call exit_MPI_without_rank('error allocating array nonconforming_adjacency_face')
+  if (ier /= 0) stop 'Error allocating array nonconforming_adjacency_face'
+
+  do ispec = 1,nnonconforming_adjacencies
+    read(IIN_DB,*) nonconforming_ispec_source(ispec), nonconforming_ispec_target(ispec), nonconforming_adjacency_type(ispec), nonconforming_adjacency_face(ispec)
+  enddo
+
+
+  close(IIN_DB)
+
   end subroutine read_mesh_files

--- a/fortran/decompose_mesh/write_mesh_databases.F90
+++ b/fortran/decompose_mesh/write_mesh_databases.F90
@@ -210,7 +210,10 @@
   !     adjacency format read by read_adjacency_graph.cpp
 
   use decompose_mesh_par, only: nspec, xadj_typed, adjncy_typed, adj_types_global, &
-                                 glob2loc_elmnts, part, elmnts, NGNOD, nnonconforming_adjacencies, nonconforming_ispec_source, nonconforming_ispec_target,nonconforming_adjacency_type,nonconforming_adjacency_face
+                                 glob2loc_elmnts, part, elmnts, NGNOD, &
+                                 nnonconforming_adjacencies, nonconforming_ispec_source, &
+                                 nonconforming_ispec_target,nonconforming_adjacency_type, &
+                                 nonconforming_adjacency_face
 
   implicit none
 
@@ -263,7 +266,8 @@
 
   ! write nonconforming
   do k = 1,nnonconforming_adjacencies
-    write(IIN_database) nonconforming_ispec_source(k), nonconforming_ispec_target(k), nonconforming_adjacency_type(k), nonconforming_adjacency_face(k)
+    write(IIN_database) nonconforming_ispec_source(k), nonconforming_ispec_target(k), &
+                        nonconforming_adjacency_type(k), nonconforming_adjacency_face(k)
   end do
 
 

--- a/fortran/decompose_mesh/write_mesh_databases.F90
+++ b/fortran/decompose_mesh/write_mesh_databases.F90
@@ -210,7 +210,7 @@
   !     adjacency format read by read_adjacency_graph.cpp
 
   use decompose_mesh_par, only: nspec, xadj_typed, adjncy_typed, adj_types_global, &
-                                 glob2loc_elmnts, part, elmnts, NGNOD
+                                 glob2loc_elmnts, part, elmnts, NGNOD, nnonconforming_adjacencies, nonconforming_ispec_source, nonconforming_ispec_target,nonconforming_adjacency_type,nonconforming_adjacency_face
 
   implicit none
 
@@ -239,9 +239,11 @@
     end do
   end do
 
-  write(IIN_database) total_nadj_element
+  ! total conforming + nonconforming adjacencies
+  write(IIN_database) total_nadj_element + nnonconforming_adjacencies
   index = 0
 
+  ! write weakly conforming
   do ispec = 1, nspec
     if (part(ispec) /= ipart) cycle
     ispec_local = glob2loc_elmnts(ispec-1) + 1
@@ -258,6 +260,12 @@
     print *,'Error: index ',index,' /= total_nadj_element ',total_nadj_element,' in partition ',ipart
     stop 'Error in write_adjacency_database (local)'
   endif
+
+  ! write nonconforming
+  do k = 1,nnonconforming_adjacencies
+    write(IIN_database) nonconforming_ispec_source(k), nonconforming_ispec_target(k), nonconforming_adjacency_type(k), nonconforming_adjacency_face(k)
+  end do
+
 
   ! Count MPI (cross-partition) adjacencies
   num_mpi_adjacencies = 0


### PR DESCRIPTION
## Description

Please describe the changes/features in this pull request.

- provides nonconforming adjacency read-in for `xdecompose_mesh`
- `xdecompose_mesh` now extends the adjacency map by passed adjacencies file.

Adjacencies are properly passed through, but current `gmsh2meshfem` workflow provides an incorrect `nonconforming_adjacencies_file` (I'll get that fixed, but it's not in the scope of this PR):
```
[SF++][ ERROR  ][>00000<]: Error during execution: Adjacency graph is not symmetric: edge from 109 to 226 has connection type nonconforming, but reverse edge has connection type strongly_conforming
```

corresponding adjacency in file (wrong)
```
110 227 3 4
227 110 3 4
```

## Issue Number

If there is an issue created for these changes, link it here

#1949

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
