### PR TITLE
Issue 1946 Part 1: add undo attenuation configuration

### DIFF
--- a/core/specfem/program/dim2/program.cpp
+++ b/core/specfem/program/dim2/program.cpp
@@ -48,6 +48,7 @@ void program_2d(
   const auto mesh = specfem::io::read_2d_mesh(
       database_filename, setup.get_elastic_wave_type(),
       setup.get_electromagnetic_wave_type(), setup.get_attenuation_setup());
+  setup.resolve_combined_simulation_type(mesh.materials.has_attenuation());
 
   // mesh.print() always called (not wrapped in lambda function) because it
   // requires collective communication

--- a/core/specfem/program/dim3/program.cpp
+++ b/core/specfem/program/dim3/program.cpp
@@ -34,7 +34,6 @@ void program_3d(
   });
 
   // Get simulation parameters
-  const specfem::simulation::type simulation_type = setup.get_simulation_type();
   const type_real dt = setup.get_dt();
   const int nsteps = setup.get_nsteps();
   // --------------------------------------------------------------
@@ -46,6 +45,9 @@ void program_3d(
   auto mesh_start_time = std::chrono::system_clock::now();
   const auto mesh = specfem::io::read_3d_mesh(database_filename,
                                               setup.get_attenuation_setup());
+  setup.resolve_combined_simulation_type(mesh.materials.has_attenuation());
+  const specfem::simulation::type simulation_type = setup.get_simulation_type();
+
   const std::chrono::duration<double> mesh_read_time =
       std::chrono::system_clock::now() - mesh_start_time;
   specfem::Logger::info([&](std::ostringstream &oss) {

--- a/core/specfem/runtime_configuration/setup.cpp
+++ b/core/specfem/runtime_configuration/setup.cpp
@@ -225,24 +225,29 @@ specfem::runtime_configuration::setup::setup(const YAML::Node &parameter_dict) {
           std::make_unique<specfem::runtime_configuration::solver>("combined");
       number_of_simulation_modes++;
       simulation = specfem::simulation::type::combined;
-      if (const YAML::Node &n_reader = n_adjoint["reader"]) {
-        if (const YAML::Node &n_wavefield = n_reader["wavefield"]) {
-          this->wavefield =
-              std::make_unique<specfem::runtime_configuration::wavefield>(
-                  n_wavefield, specfem::simulation::type::combined);
-        } else {
-          std::ostringstream message;
-          message << "Error reading adjoint reader configuration. \n"
-                  << "Wavefield reader must be specified. \n";
-          throw std::runtime_error(message.str());
+      const YAML::Node n_writer = n_adjoint["writer"];
+      const YAML::Node n_wavefield_reader = [&]() -> YAML::Node {
+        if (n_adjoint["reader"]) {
+          return n_adjoint["reader"]["wavefield"];
         }
+        if (n_writer) {
+          return n_writer["wavefield"];
+        }
+        return YAML::Node();
+      }();
+
+      if (n_wavefield_reader) {
+        this->wavefield =
+            std::make_unique<specfem::runtime_configuration::wavefield>(
+                n_wavefield_reader, specfem::simulation::type::combined);
       } else {
         std::ostringstream message;
-        message << "Error reading adjoint reader configuration. \n";
+        message << "Error reading combined reader configuration. \n"
+                << "Wavefield reader must be specified. \n";
         throw std::runtime_error(message.str());
       }
 
-      if (const YAML::Node &n_writer = n_adjoint["writer"]) {
+      if (n_writer) {
         if (const YAML::Node &n_seismogram = n_writer["seismogram"]) {
           std::ostringstream message;
           message
@@ -328,12 +333,12 @@ specfem::runtime_configuration::setup::setup(const YAML::Node &parameter_dict) {
 // Explicit template instantiations for instantiate_timescheme
 template std::shared_ptr<specfem::time_scheme::time_scheme>
 specfem::runtime_configuration::setup::instantiate_timescheme<
-    specfem::assembly::fields<specfem::element::dimension_tag::dim2> >(
+    specfem::assembly::fields<specfem::element::dimension_tag::dim2>>(
     specfem::assembly::fields<specfem::element::dimension_tag::dim2> &fields)
     const;
 
 template std::shared_ptr<specfem::time_scheme::time_scheme>
 specfem::runtime_configuration::setup::instantiate_timescheme<
-    specfem::assembly::fields<specfem::element::dimension_tag::dim3> >(
+    specfem::assembly::fields<specfem::element::dimension_tag::dim3>>(
     specfem::assembly::fields<specfem::element::dimension_tag::dim3> &fields)
     const;

--- a/core/specfem/runtime_configuration/setup.hpp
+++ b/core/specfem/runtime_configuration/setup.hpp
@@ -408,6 +408,31 @@ public:
   }
 
   /**
+   * @brief Resolve a parsed combined run to the appropriate combined variant.
+   *
+   * Combined simulations with attenuating materials use the
+   * exact-forward-replay undo-attenuation algorithm; non-attenuating combined
+   * simulations use the standard backward-reconstruction algorithm.
+   */
+  void resolve_combined_simulation_type(const bool has_attenuation) {
+    if (this->get_simulation_type() != specfem::simulation::type::combined) {
+      return;
+    }
+
+    const auto resolved = has_attenuation
+                              ? specfem::simulation::type::combined_undoatt
+                              : specfem::simulation::type::combined;
+    this->solver->set_simulation_type(resolved);
+    this->time_scheme->set_simulation_type(resolved);
+    if (this->wavefield) {
+      this->wavefield->set_simulation_type(resolved);
+    }
+    if (this->kernel) {
+      this->kernel->set_simulation_type(resolved);
+    }
+  }
+
+  /**
    * @brief Create solver instance with specified parameters.
    *
    * @tparam NGLL Number of Gauss-Lobatto-Legendre points per element dimension
@@ -454,7 +479,9 @@ public:
     return (
         ((this->wavefield != nullptr) &&
          (this->wavefield->is_for_adjoint_simulations())) ||
-        (this->get_simulation_type() == specfem::simulation::type::combined));
+        (this->get_simulation_type() == specfem::simulation::type::combined) ||
+        (this->get_simulation_type() ==
+         specfem::simulation::type::combined_undoatt));
   }
 
   /**

--- a/core/specfem/runtime_configuration/solver.hpp
+++ b/core/specfem/runtime_configuration/solver.hpp
@@ -21,13 +21,24 @@ public:
    *
    * @param simulation_type Type of the simulation (forward or combined)
    */
-  solver(const char *simulation_type) : simulation_type(simulation_type) {}
+  solver(const char *simulation_type)
+      : simulation_type(
+            specfem::runtime_configuration::solver::parse(simulation_type)) {}
   /**
    * @brief Construct a new solver object
    *
    * @param simulation_type Type of the simulation (forward or combined)
    */
   solver(const std::string &simulation_type)
+      : simulation_type(
+            specfem::runtime_configuration::solver::parse(simulation_type)) {}
+
+  /**
+   * @brief Construct a new solver object.
+   *
+   * @param simulation_type Type of the simulation
+   */
+  solver(const specfem::simulation::type simulation_type)
       : simulation_type(simulation_type) {}
 
   /**
@@ -42,13 +53,13 @@ public:
    * @return std::shared_ptr<specfem::solver::solver> Solver object
    */
   template <int NGLL, specfem::element::dimension_tag DimensionTag>
-  std::shared_ptr<specfem::solver::solver>
-  instantiate(const type_real dt,
-              const specfem::assembly::assembly<DimensionTag> &assembly,
-              std::shared_ptr<specfem::time_scheme::time_scheme> time_scheme,
-              const std::vector<std::shared_ptr<
-                  specfem::periodic_tasks::periodic_task<DimensionTag> > >
-                  &tasks) const;
+  std::shared_ptr<specfem::solver::solver> instantiate(
+      const type_real dt,
+      const specfem::assembly::assembly<DimensionTag> &assembly,
+      std::shared_ptr<specfem::time_scheme::time_scheme> time_scheme,
+      const std::vector<
+          std::shared_ptr<specfem::periodic_tasks::periodic_task<DimensionTag>>>
+          &tasks) const;
 
   /**
    * @brief Get the type of the simulation (forward or combined)
@@ -56,18 +67,28 @@ public:
    * @return specfem::simulation::type Type of the simulation
    */
   inline specfem::simulation::type get_simulation_type() const {
-    if (specfem::utilities::is_forward_string(this->simulation_type)) {
-      return specfem::simulation::type::forward;
-    } else if (specfem::utilities::is_combined_string(this->simulation_type)) {
-      return specfem::simulation::type::combined;
-    } else {
-      throw std::runtime_error("Unknown simulation type");
-    }
+    return this->simulation_type;
+  }
+
+  /**
+   * @brief Update the resolved simulation type.
+   */
+  void set_simulation_type(const specfem::simulation::type simulation_type) {
+    this->simulation_type = simulation_type;
   }
 
 private:
-  std::string simulation_type; ///< Type of the simulation (forward or
-                               ///< combined)
+  static specfem::simulation::type parse(const std::string &simulation_type) {
+    if (specfem::utilities::is_forward_string(simulation_type)) {
+      return specfem::simulation::type::forward;
+    } else if (specfem::utilities::is_combined_string(simulation_type)) {
+      return specfem::simulation::type::combined;
+    } else {
+      throw std::runtime_error("Unknown simulation type: " + simulation_type);
+    }
+  }
+
+  specfem::simulation::type simulation_type; ///< Type of the simulation
 };
 } // namespace runtime_configuration
 } // namespace specfem

--- a/core/specfem/runtime_configuration/solver.tpp
+++ b/core/specfem/runtime_configuration/solver.tpp
@@ -14,16 +14,22 @@ specfem::runtime_configuration::solver::solver::instantiate(
     const std::vector<std::shared_ptr<specfem::periodic_tasks::periodic_task<DimensionTag>>> &tasks)
     const {
 
-  if (specfem::utilities::is_forward_string(this->simulation_type)) {
+  if (this->simulation_type == specfem::simulation::type::forward) {
     return std::make_shared<
         specfem::solver::time_marching<specfem::simulation::type::forward,
                                        DimensionTag, NGLL> >(
         time_scheme, tasks, assembly);
-  } else if (specfem::utilities::is_combined_string(this->simulation_type)) {
+  } else if (this->simulation_type == specfem::simulation::type::combined) {
 
     return std::make_shared<
         specfem::solver::time_marching<specfem::simulation::type::combined,
                                        DimensionTag, NGLL> >(
+        assembly, time_scheme, tasks);
+  } else if (this->simulation_type ==
+             specfem::simulation::type::combined_undoatt) {
+
+    return std::make_shared<specfem::solver::time_marching<
+        specfem::simulation::type::combined_undoatt, DimensionTag, NGLL> >(
         assembly, time_scheme, tasks);
   } else {
     throw std::runtime_error("Simulation type not recognized");

--- a/core/specfem/runtime_configuration/writer/wavefield.cpp
+++ b/core/specfem/runtime_configuration/writer/wavefield.cpp
@@ -90,7 +90,9 @@ specfem::runtime_configuration::wavefield::instantiate_wavefield_writer()
   const std::shared_ptr<specfem::periodic_tasks::periodic_task<DimensionTag>>
       writer = [&]()
       -> std::shared_ptr<specfem::periodic_tasks::periodic_task<DimensionTag>> {
-    if (this->simulation_type == specfem::simulation::type::forward) {
+    const bool needs_writer =
+        (this->simulation_type == specfem::simulation::type::forward);
+    if (needs_writer) {
       if (specfem::utilities::is_hdf5_string(this->output_format)) {
         return std::make_shared<specfem::periodic_tasks::wavefield_writer<
             DimensionTag, specfem::io_backends::HDF5>>(
@@ -135,7 +137,11 @@ specfem::runtime_configuration::wavefield::instantiate_wavefield_reader()
   const std::shared_ptr<specfem::periodic_tasks::periodic_task<DimensionTag>>
       reader = [&]()
       -> std::shared_ptr<specfem::periodic_tasks::periodic_task<DimensionTag>> {
-    if (this->simulation_type == specfem::simulation::type::combined) {
+    // combined_undoatt adjoint pass reads checkpoints written by forward pass
+    const bool needs_reader =
+        (this->simulation_type == specfem::simulation::type::combined) ||
+        (this->simulation_type == specfem::simulation::type::combined_undoatt);
+    if (needs_reader) {
       if (specfem::utilities::is_hdf5_string(this->output_format)) {
         return std::make_shared<specfem::periodic_tasks::wavefield_reader<
             DimensionTag, specfem::io_backends::HDF5>>(

--- a/core/specfem/runtime_configuration/writer/wavefield.hpp
+++ b/core/specfem/runtime_configuration/writer/wavefield.hpp
@@ -58,7 +58,7 @@ public:
    * writer object
    */
   template <specfem::element::dimension_tag DimensionTag>
-  std::shared_ptr<specfem::periodic_tasks::periodic_task<DimensionTag> >
+  std::shared_ptr<specfem::periodic_tasks::periodic_task<DimensionTag>>
   instantiate_wavefield_writer() const;
 
   /**
@@ -68,7 +68,7 @@ public:
    * reader object
    */
   template <specfem::element::dimension_tag DimensionTag>
-  std::shared_ptr<specfem::periodic_tasks::periodic_task<DimensionTag> >
+  std::shared_ptr<specfem::periodic_tasks::periodic_task<DimensionTag>>
   instantiate_wavefield_reader() const;
 
   inline specfem::simulation::type get_simulation_type() const {
@@ -77,6 +77,13 @@ public:
 
   inline bool is_for_adjoint_simulations() const {
     return this->for_adjoint_simulations;
+  }
+
+  /**
+   * @brief Update the resolved simulation type.
+   */
+  void set_simulation_type(const specfem::simulation::type simulation) {
+    this->simulation_type = simulation;
   }
 
 private:

--- a/core/specfem/simulation.hpp
+++ b/core/specfem/simulation.hpp
@@ -19,8 +19,9 @@ namespace simulation {
  * @brief Simulation execution types.
  */
 enum class type {
-  forward, ///< Forward simulation only
-  combined ///< Combined forward and adjoint simulation
+  forward,         ///< Forward simulation only
+  combined,        ///< Combined forward and adjoint simulation
+  combined_undoatt ///< Adjoint with exact forward replay (UNDO_ATTENUATION)
 };
 
 /**
@@ -122,7 +123,8 @@ inline std::string to_string(specfem::simulation::field_type field) {
 
 /**
  * @brief Simulation type traits template.
- * @tparam SimulationType Simulation type (forward or combined)
+ * @tparam SimulationType Simulation type (forward, combined, or
+ * combined_undoatt)
  */
 template <specfem::simulation::type SimulationType> class simulation;
 
@@ -140,6 +142,19 @@ public:
 template <> class simulation<specfem::simulation::type::combined> {
 public:
   static constexpr auto simulation_type = specfem::simulation::type::combined;
+};
+
+/**
+ * @brief Undo-attenuation simulation type traits.
+ *
+ * Runs a full forward pass (with checkpointing) followed by an adjoint pass
+ * in which the forward wavefield is replayed exactly from saved snapshots,
+ * matching the Fortran UNDO_ATTENUATION_AND_OR_PML strategy.
+ */
+template <> class simulation<specfem::simulation::type::combined_undoatt> {
+public:
+  static constexpr auto simulation_type =
+      specfem::simulation::type::combined_undoatt;
 };
 
 } // namespace simulation


### PR DESCRIPTION
## Description

- For `specfem_config.yaml` use `combined` for both elastic and viscoelastic
- When material contains attenuation, `undo_attenuation` will be automatically enabled
- Internally, use `combined` for elastic and `combined_undoatt` for viscoelastic

## Issue Number

Adds to #1946

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms
