### PR TITLE
1946 - Reduced memory usage option

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -443,7 +443,7 @@ The I/O layer is organized around abstract `reader` and `writer` base classes wi
 
 | Task | Description |
 |---|---|
-| `checkpointing` | Define fixed-stride checkpoint and replay windows |
+| `checkpointing` | Define fixed-stride and subdivided checkpoint replay windows |
 | `wavefield_writer` | Write wavefield snapshots to disk at configured intervals |
 | `wavefield_reader` | Read pre-computed wavefield snapshots (adjoint setup) |
 | `plot_wavefield` | Real-time or file-based wavefield visualization (VTK/PNG/JPG) |

--- a/architecture/core-components/io.md
+++ b/architecture/core-components/io.md
@@ -42,7 +42,7 @@ The I/O layer is organized around abstract `reader` and `writer` base classes wi
 
 | Task | Description |
 |---|---|
-| `checkpointing` | Define fixed-stride checkpoint and replay windows |
+| `checkpointing` | Define fixed-stride and subdivided checkpoint replay windows |
 | `wavefield_writer` | Write wavefield snapshots to disk at configured intervals |
 | `wavefield_reader` | Read pre-computed wavefield snapshots (adjoint setup) |
 | `plot_wavefield` | Real-time or file-based wavefield visualization (VTK/PNG/JPG) |

--- a/benchmarks/src/dim3/homogeneous_viscoelastic_kernel/CMakeFiles/adjoint_config.yaml.in
+++ b/benchmarks/src/dim3/homogeneous_viscoelastic_kernel/CMakeFiles/adjoint_config.yaml.in
@@ -15,6 +15,9 @@ parameters:
 
     solver:
       time-marching:
+        checkpointing:
+          # 1 stores the full 200-step window; values > 1 subdivide it.
+          subdivide-buffer: 1
         time-scheme:
           type: Newmark
           dt: 0.08

--- a/benchmarks/src/dim3/homogeneous_viscoelastic_kernel/CMakeFiles/adjoint_config_mpi.yaml.in
+++ b/benchmarks/src/dim3/homogeneous_viscoelastic_kernel/CMakeFiles/adjoint_config_mpi.yaml.in
@@ -15,6 +15,9 @@ parameters:
 
     solver:
       time-marching:
+        checkpointing:
+          # 1 stores the full 200-step window; values > 1 subdivide it.
+          subdivide-buffer: 1
         time-scheme:
           type: Newmark
           dt: 0.08

--- a/benchmarks/src/dim3/homogeneous_viscoelastic_kernel/README.md
+++ b/benchmarks/src/dim3/homogeneous_viscoelastic_kernel/README.md
@@ -7,6 +7,20 @@ This is a 3D homogeneous halfspace simulation with attenuation enabled. We do _n
 
 The material uses low quality factors so attenuation has a visible impact on the resulting kernel plots.
 
+The adjoint configuration can subdivide each undo-attenuation replay buffer
+under `solver.time-marching.checkpointing`:
+
+```yaml
+checkpointing:
+  subdivide-buffer: 4  # four 64-step leaves for a 256-step window
+```
+
+The default, `subdivide-buffer: 1`, buffers every displacement in a disk
+checkpoint window. Values greater than one retain the forward state between
+smaller displacement buffers. Leaf size is the checkpoint-window length
+divided by `subdivide-buffer`, rounded up when it is not exact. The solver
+derives one full-state checkpoint for each internal leaf boundary.
+
 ## Running the examples
 
 To run any example, you first need to install uv following these

--- a/core/specfem/periodic_tasks/checkpointing.hpp
+++ b/core/specfem/periodic_tasks/checkpointing.hpp
@@ -2,6 +2,7 @@
 
 #include "periodic_task.hpp"
 #include <algorithm>
+#include <cstdint>
 #include <stdexcept>
 #include <utility>
 
@@ -9,11 +10,13 @@ namespace specfem {
 namespace periodic_tasks {
 
 /**
- * @brief Fixed-stride checkpoint schedule for undo attenuation.
+ * @brief Checkpoint replay schedule for undo attenuation.
  *
  * Checkpoints divide the time loop into fixed-size replay windows. The
  * inherited periodic-task interval is the checkpoint stride and is shared
- * with wavefield storage.
+ * with wavefield storage. Each window may be subdivided into bounded
+ * displacement buffers with full forward-state checkpoints retained at the
+ * internal boundaries. One subdivision performs direct full-window replay.
  *
  * @tparam DimensionTag Spatial dimension (dim2 or dim3)
  */
@@ -21,17 +24,19 @@ template <specfem::element::dimension_tag DimensionTag>
 class checkpointing : public periodic_task<DimensionTag> {
 public:
   /**
-   * @brief Construct a fixed-stride checkpoint task.
+   * @brief Construct a checkpoint replay task.
    *
    * @param time_interval Number of time steps in each replay window
+   * @param buffer_subdivisions Requested number of buffer subdivisions
    */
-  explicit checkpointing(const int time_interval)
-      : periodic_task<DimensionTag>(time_interval, false) {
-    if (time_interval < 1) {
-      throw std::invalid_argument(
-          "checkpointing: time interval must be greater than zero");
-    }
-  }
+  explicit checkpointing(const int time_interval,
+                         const int buffer_subdivisions = 1)
+      : periodic_task<DimensionTag>(validate_time_interval(time_interval),
+                                    false),
+        buffer_subdivisions_(std::min(
+            validate_subdivisions(buffer_subdivisions), time_interval)),
+        buffer_steps_((time_interval + buffer_subdivisions_ - 1) /
+                      buffer_subdivisions_) {}
 
   /**
    * @brief Get the replay window starting at a checkpoint.
@@ -47,11 +52,87 @@ public:
   }
 
   /**
-   * @brief Get the maximum number of steps stored in a replay window.
+   * @brief Get the replay-window size before subdivision.
    *
-   * @return Fixed replay-window size
+   * @return Persistent checkpoint interval
    */
   int max_window_size() const { return this->get_time_interval(); }
+
+  /// @brief Get the effective number of subdivisions per replay window.
+  int buffer_subdivisions() const { return buffer_subdivisions_; }
+
+  /// @brief Get the maximum number of displacements in a replay leaf.
+  int buffer_steps() const { return buffer_steps_; }
+
+  /**
+   * @brief Get the internal checkpoint slots needed by an interval.
+   *
+   * @param num_steps Length of the replay interval
+   * @return Number of resident full-state checkpoint slots
+   */
+  int checkpoint_slots(const int num_steps) const {
+    validate_num_steps(num_steps);
+    if (num_steps == 0)
+      return 0;
+    return (num_steps + buffer_steps_ - 1) / buffer_steps_ - 1;
+  }
+
+  /**
+   * @brief Get the first leaf length for an interval.
+   *
+   * The short leaf is placed first so that all later leaves have the maximum
+   * buffer size and the last retained checkpoint is as early as possible.
+   *
+   * @param num_steps Length of the replay interval
+   * @return First leaf length, or zero for a single-leaf interval
+   */
+  int split(const int num_steps) const {
+    validate_num_steps(num_steps);
+    if (num_steps <= buffer_steps_)
+      return 0;
+    const int remainder = num_steps % buffer_steps_;
+    return remainder == 0 ? buffer_steps_ : remainder;
+  }
+
+  /**
+   * @brief Get the forward advances required by replay.
+   *
+   * @param num_steps Length of the replay interval
+   * @return Number of forward time-step advances
+   */
+  std::uint64_t forward_steps(const int num_steps) const {
+    validate_num_steps(num_steps);
+    if (num_steps <= buffer_steps_)
+      return num_steps;
+    return static_cast<std::uint64_t>(2) * num_steps - buffer_steps_;
+  }
+
+private:
+  static int validate_time_interval(const int time_interval) {
+    if (time_interval < 1) {
+      throw std::invalid_argument(
+          "checkpointing: time interval must be greater than zero");
+    }
+    return time_interval;
+  }
+
+  static int validate_subdivisions(const int buffer_subdivisions) {
+    if (buffer_subdivisions < 1) {
+      throw std::invalid_argument(
+          "checkpointing: subdivisions must be positive");
+    }
+    return buffer_subdivisions;
+  }
+
+  void validate_num_steps(const int num_steps) const {
+    if (num_steps < 0 || num_steps > this->get_time_interval()) {
+      throw std::out_of_range(
+          "checkpointing: interval exceeds configured size");
+    }
+  }
+
+  int buffer_subdivisions_;
+  int buffer_steps_;
 };
 
 } // namespace periodic_tasks

--- a/core/specfem/runtime_configuration/setup.cpp
+++ b/core/specfem/runtime_configuration/setup.cpp
@@ -150,8 +150,8 @@ specfem::runtime_configuration::setup::setup(const YAML::Node &parameter_dict) {
           simulation_setup["simulation-mode"]) {
     int number_of_simulation_modes = 0;
     if (const YAML::Node &n_forward = n_simulation_mode["forward"]) {
-      this->solver =
-          std::make_unique<specfem::runtime_configuration::solver>("forward");
+      this->solver = std::make_unique<specfem::runtime_configuration::solver>(
+          specfem::simulation::type::forward, n_solver["time-marching"]);
       simulation = specfem::simulation::type::forward;
       number_of_simulation_modes++;
       bool at_least_one_writer = false; // check if at least one writer is
@@ -221,8 +221,8 @@ specfem::runtime_configuration::setup::setup(const YAML::Node &parameter_dict) {
     }
 
     if (const YAML::Node &n_adjoint = n_simulation_mode["combined"]) {
-      this->solver =
-          std::make_unique<specfem::runtime_configuration::solver>("combined");
+      this->solver = std::make_unique<specfem::runtime_configuration::solver>(
+          specfem::simulation::type::combined, n_solver["time-marching"]);
       number_of_simulation_modes++;
       simulation = specfem::simulation::type::combined;
       const YAML::Node n_writer = n_adjoint["writer"];

--- a/core/specfem/runtime_configuration/solver.hpp
+++ b/core/specfem/runtime_configuration/solver.hpp
@@ -6,6 +6,7 @@
 #include "specfem/utilities.hpp"
 #include <memory>
 #include <string>
+#include <yaml-cpp/yaml.h>
 
 namespace specfem {
 namespace runtime_configuration {
@@ -42,6 +43,28 @@ public:
       : simulation_type(simulation_type) {}
 
   /**
+   * @brief Construct a solver and parse optional checkpointing settings.
+   *
+   * @param simulation_type Type of the simulation
+   * @param time_marching Time-marching YAML node
+   */
+  solver(const specfem::simulation::type simulation_type,
+         const YAML::Node &time_marching)
+      : simulation_type(simulation_type) {
+    const YAML::Node checkpointing = time_marching["checkpointing"];
+    if (!checkpointing)
+      return;
+
+    if (checkpointing["subdivide-buffer"])
+      checkpoint_buffer_subdivisions =
+          checkpointing["subdivide-buffer"].as<int>();
+    if (checkpoint_buffer_subdivisions < 1) {
+      throw std::runtime_error(
+          "checkpointing subdivide-buffer must be greater than zero");
+    }
+  }
+
+  /**
    * @brief Instantiate the solver based on the simulation parameters
    *
    * @tparam qp_type Quadrature points type defining compile time or runtime
@@ -71,6 +94,10 @@ public:
     return this->simulation_type;
   }
 
+  int get_checkpoint_buffer_subdivisions() const {
+    return checkpoint_buffer_subdivisions;
+  }
+
 private:
   static specfem::simulation::type parse(const std::string &simulation_type) {
     if (specfem::utilities::is_forward_string(simulation_type)) {
@@ -83,6 +110,7 @@ private:
   }
 
   specfem::simulation::type simulation_type; ///< Type of the simulation
+  int checkpoint_buffer_subdivisions = 1;
 };
 } // namespace runtime_configuration
 } // namespace specfem

--- a/core/specfem/runtime_configuration/solver.tpp
+++ b/core/specfem/runtime_configuration/solver.tpp
@@ -30,7 +30,7 @@ specfem::runtime_configuration::solver::solver::instantiate(
 
     return std::make_shared<specfem::solver::time_marching<
         specfem::simulation::type::combined_undoatt, DimensionTag, NGLL>>(
-        assembly, time_scheme, tasks);
+        assembly, time_scheme, tasks, this->checkpoint_buffer_subdivisions);
   } else {
     throw std::runtime_error("Simulation type not recognized");
   }

--- a/core/specfem/solver/impl/attenuation_snapshot.hpp
+++ b/core/specfem/solver/impl/attenuation_snapshot.hpp
@@ -1,0 +1,330 @@
+#pragma once
+
+#include "specfem/assembly/attenuation.hpp"
+#include "specfem/assembly/attenuation/impl/attenuation_medium.hpp"
+#include "specfem/datatype/domain_view.hpp"
+#include "specfem/element.hpp"
+#include "specfem/setup.hpp"
+#include "specfem/tag_dispatch.hpp"
+#include <Kokkos_Core.hpp>
+#include <tuple>
+#include <type_traits>
+
+namespace specfem::solver::impl {
+
+/**
+ * @brief True when @p MediumType carries the out-of-plane memory variables that
+ * only exist in three dimensions.
+ *
+ * Two-dimensional attenuation media store three standard-linear-solid memory
+ * variables (\f$ R_\kappa, R_{xx}, R_{xz} \f$) and three strain components;
+ * three-dimensional media add \f$ R_{yy}, R_{zz}, R_{xy}, R_{yz} \f$ and three
+ * more strain components. This concept is the only place the two shapes are
+ * distinguished.
+ *
+ * @tparam MediumType A specfem::assembly::impl::attenuation_medium
+ * specialization
+ */
+template <typename MediumType>
+concept has_three_dimensional_memory_variables =
+    requires(MediumType medium) { medium.memory_variable_Ryy; };
+
+/**
+ * @brief Saved copy of the attenuation state of a single medium.
+ *
+ * Members mirror the medium's own view names, dropping the @c memory_variable_
+ * and @c _att decorations. In two dimensions the out-of-plane members are left
+ * default-constructed and never touched.
+ *
+ * @tparam MediumType The attenuation medium whose views are being saved
+ */
+template <typename MediumType> struct AttenuationSnapshot {
+  using memory_view_type = std::remove_cvref_t<
+      decltype(std::declval<MediumType>().memory_variable_kappa)>;
+  using strain_view_type =
+      std::remove_cvref_t<decltype(std::declval<MediumType>().epsilon_xx_att)>;
+
+  memory_view_type Rkappa;     ///< Bulk memory variable
+  memory_view_type Rxx;        ///< Deviatoric memory variable, xx
+  memory_view_type Rxz;        ///< Deviatoric memory variable, xz
+  memory_view_type Ryy;        ///< Deviatoric memory variable, yy (dim3 only)
+  memory_view_type Rzz;        ///< Deviatoric memory variable, zz (dim3 only)
+  memory_view_type Rxy;        ///< Deviatoric memory variable, xy (dim3 only)
+  memory_view_type Ryz;        ///< Deviatoric memory variable, yz (dim3 only)
+  strain_view_type epsilon_xx; ///< Attenuation strain, xx
+  strain_view_type epsilon_zz; ///< Attenuation strain, zz
+  strain_view_type epsilon_xz; ///< Attenuation strain, xz
+  strain_view_type epsilon_yy; ///< Attenuation strain, yy (dim3 only)
+  strain_view_type epsilon_xy; ///< Attenuation strain, xy (dim3 only)
+  strain_view_type epsilon_yz; ///< Attenuation strain, yz (dim3 only)
+};
+
+/**
+ * @brief One attenuation view, named both on the live medium and in a snapshot.
+ *
+ * @tparam MediumMember   Pointer-to-member type on the attenuation medium
+ * @tparam SnapshotMember Pointer-to-member type on the snapshot
+ */
+template <typename MediumMember, typename SnapshotMember>
+struct AttenuationViewPair {
+  MediumMember on_medium;     ///< The live view the solver integrates
+  SnapshotMember in_snapshot; ///< The saved copy of that view
+};
+
+/**
+ * @brief Build an AttenuationViewPair with deduced member-pointer types.
+ *
+ * Written as a function rather than relying on aggregate class-template
+ * argument deduction, which is not available on every supported host compiler.
+ *
+ * @tparam MediumMember   Pointer-to-member type on the attenuation medium
+ * @tparam SnapshotMember Pointer-to-member type on the snapshot
+ * @param on_medium   Pointer to the view member on the attenuation medium
+ * @param in_snapshot Pointer to the matching member on the snapshot
+ * @return The paired member pointers
+ */
+template <typename MediumMember, typename SnapshotMember>
+constexpr auto make_attenuation_view_pair(MediumMember on_medium,
+                                          SnapshotMember in_snapshot) {
+  return AttenuationViewPair<MediumMember, SnapshotMember>{ on_medium,
+                                                            in_snapshot };
+}
+
+/**
+ * @brief The authoritative list of attenuation views a replay saves and
+ * restores.
+ *
+ * Every save, restore, refresh and reset in this header walks this one list, so
+ * a new memory variable only has to be registered here. Visit order fixes the
+ * order of the allocations and copies that follow.
+ *
+ * @tparam MediumType The attenuation medium whose views are being listed
+ * @return Tuple of six pairs in two dimensions, thirteen in three
+ */
+template <typename MediumType> constexpr auto attenuation_views() {
+  using Snapshot = AttenuationSnapshot<MediumType>;
+
+  auto in_plane = std::make_tuple(
+      make_attenuation_view_pair(&MediumType::memory_variable_kappa,
+                                 &Snapshot::Rkappa),
+      make_attenuation_view_pair(&MediumType::memory_variable_Rxx,
+                                 &Snapshot::Rxx),
+      make_attenuation_view_pair(&MediumType::memory_variable_Rxz,
+                                 &Snapshot::Rxz),
+      make_attenuation_view_pair(&MediumType::epsilon_xx_att,
+                                 &Snapshot::epsilon_xx),
+      make_attenuation_view_pair(&MediumType::epsilon_zz_att,
+                                 &Snapshot::epsilon_zz),
+      make_attenuation_view_pair(&MediumType::epsilon_xz_att,
+                                 &Snapshot::epsilon_xz));
+
+  if constexpr (has_three_dimensional_memory_variables<MediumType>) {
+    return std::tuple_cat(
+        in_plane,
+        std::make_tuple(make_attenuation_view_pair(
+                            &MediumType::memory_variable_Ryy, &Snapshot::Ryy),
+                        make_attenuation_view_pair(
+                            &MediumType::memory_variable_Rzz, &Snapshot::Rzz),
+                        make_attenuation_view_pair(
+                            &MediumType::memory_variable_Rxy, &Snapshot::Rxy),
+                        make_attenuation_view_pair(
+                            &MediumType::memory_variable_Ryz, &Snapshot::Ryz),
+                        make_attenuation_view_pair(&MediumType::epsilon_yy_att,
+                                                   &Snapshot::epsilon_yy),
+                        make_attenuation_view_pair(&MediumType::epsilon_xy_att,
+                                                   &Snapshot::epsilon_xy),
+                        make_attenuation_view_pair(&MediumType::epsilon_yz_att,
+                                                   &Snapshot::epsilon_yz)));
+  } else {
+    return in_plane;
+  }
+}
+
+/**
+ * @brief Apply @p visit to every (live view, saved view) pair of one medium.
+ *
+ * @tparam MediumType   The attenuation medium, const-qualified when it is only
+ *                      being read
+ * @tparam SnapshotType The matching AttenuationSnapshot, const-qualified when
+ *                      it is only being read
+ * @tparam Visitor      Callable as `visit(live_view, saved_view)`
+ * @param medium   Attenuation medium holding the live views
+ * @param snapshot Snapshot holding the saved copies
+ * @param visit    Invoked once per view, in attenuation_views() order
+ */
+template <typename MediumType, typename SnapshotType, typename Visitor>
+void for_each_attenuation_view(MediumType &medium, SnapshotType &snapshot,
+                               Visitor &&visit) {
+  std::apply(
+      [&](const auto &...view) {
+        (visit(medium.*view.on_medium, snapshot.*view.in_snapshot), ...);
+      },
+      attenuation_views<std::remove_cvref_t<MediumType>>());
+}
+
+/**
+ * @brief Apply @p visit to every live attenuation view of one medium.
+ *
+ * @tparam MediumType The attenuation medium holding the views
+ * @tparam Visitor    Callable as `visit(live_view)`
+ * @param medium Attenuation medium holding the live views
+ * @param visit  Invoked once per view, in attenuation_views() order
+ */
+template <typename MediumType, typename Visitor>
+void for_each_attenuation_view(MediumType &medium, Visitor &&visit) {
+  std::apply([&](const auto &...view) { (visit(medium.*view.on_medium), ...); },
+             attenuation_views<std::remove_cvref_t<MediumType>>());
+}
+
+/**
+ * @brief Allocate a same-sized, same-space copy of one attenuation view.
+ *
+ * @tparam ViewType A specfem::datatype::View over the attenuation domain
+ * @param view The view to copy
+ * @return A freshly allocated view holding the same values
+ */
+template <typename ViewType>
+ViewType clone_attenuation_view(const ViewType &view) {
+  ViewType clone(std::string(view.label()) + "_snapshot", view.get_mapping());
+  specfem::datatype::deep_copy(clone, view);
+  return clone;
+}
+
+/**
+ * @brief A saved copy of the whole attenuation state, across every medium.
+ *
+ * The solver keeps exactly one live attenuation state, which the forward replay
+ * and the adjoint sweep take turns owning. This type is how the state that is
+ * not currently live gets parked.
+ *
+ * The three operations are named so that the snapshot is always the subject and
+ * the preposition gives the direction of the copy, which makes the two
+ * mirror-image operations impossible to confuse:
+ *
+ * @code
+ * auto saved = AttenuationState<dim3>::capture_from(assembly.attenuation);
+ * saved.restore_into(assembly.attenuation);  // live  <- saved
+ * saved.refresh_from(assembly.attenuation);  // saved <- live
+ * @endcode
+ *
+ * Move-only: copying would silently double the device memory a replay holds,
+ * and specfem::tag_dispatch::Storage has an unconstrained initializer
+ * constructor that hijacks lvalue copies, so the deleted copy here turns a
+ * confusing template error into a clear one.
+ *
+ * @tparam DimensionTag Spatial dimension (dim2 or dim3)
+ */
+template <specfem::element::dimension_tag DimensionTag> class AttenuationState {
+public:
+  using AttenuationType = specfem::assembly::Attenuation<DimensionTag>;
+
+  AttenuationState() = default;
+
+  AttenuationState(const AttenuationState &) = delete;
+  AttenuationState &operator=(const AttenuationState &) = delete;
+  AttenuationState(AttenuationState &&) = default;
+  AttenuationState &operator=(AttenuationState &&) = default;
+
+  /**
+   * @brief Allocate a snapshot and fill it with the current live state.
+   *
+   * @param attenuation The live attenuation state to copy
+   * @return A snapshot owning its own copy of every view
+   */
+  static AttenuationState capture_from(const AttenuationType &attenuation) {
+    AttenuationState state;
+    state.storage_ = StorageType([&]<typename TagsType>() {
+      const auto &medium =
+          attenuation.attenuation_storage.template get<TagsType>();
+      AttenuationSnapshot<MediumFor<TagsType>> snapshot;
+      specfem::solver::impl::for_each_attenuation_view(
+          medium, snapshot, [](const auto &live, auto &saved) {
+            saved = specfem::solver::impl::clone_attenuation_view(live);
+          });
+      return snapshot;
+    });
+    return state;
+  }
+
+  /**
+   * @brief Copy the saved state back over the live one.
+   *
+   * @param attenuation The live attenuation state to overwrite
+   */
+  void restore_into(AttenuationType &attenuation) const {
+    specfem::tag_dispatch::for_each(
+        AttenuationType::attenuation_medium_combinations,
+        [&]<typename TagsType>() {
+          auto &medium =
+              attenuation.attenuation_storage.template get<TagsType>();
+          specfem::solver::impl::for_each_attenuation_view(
+              medium, storage_.template get<TagsType>(),
+              [](auto &live, const auto &saved) {
+                specfem::datatype::deep_copy(live, saved);
+              });
+        });
+  }
+
+  /**
+   * @brief Overwrite the saved state with the current live one.
+   *
+   * @param attenuation The live attenuation state to read
+   */
+  void refresh_from(const AttenuationType &attenuation) {
+    specfem::tag_dispatch::for_each(
+        AttenuationType::attenuation_medium_combinations,
+        [&]<typename TagsType>() {
+          const auto &medium =
+              attenuation.attenuation_storage.template get<TagsType>();
+          specfem::solver::impl::for_each_attenuation_view(
+              medium, storage_.template get<TagsType>(),
+              [](const auto &live, auto &saved) {
+                specfem::datatype::deep_copy(saved, live);
+              });
+        });
+  }
+
+private:
+  template <typename TagsType>
+  using MediumFor = specfem::assembly::impl::attenuation_medium<
+      TagsType::dimension_tag, TagsType::medium_tag, TagsType::property_tag,
+      TagsType::attenuation_tag>;
+
+  template <typename TagsType>
+  using SnapshotFor = AttenuationSnapshot<MediumFor<TagsType>>;
+
+  using StorageType = specfem::tag_dispatch::TypedStorage<
+      SnapshotFor, decltype(AttenuationType::attenuation_medium_combinations)>;
+
+  StorageType storage_;
+};
+
+/**
+ * @brief Zero every attenuation memory variable and strain component.
+ *
+ * The adjoint wavefield starts each simulation from a quiescent attenuation
+ * state, unlike the forward wavefield, which resumes from a checkpoint.
+ *
+ * @tparam DimensionTag Spatial dimension (dim2 or dim3)
+ * @param attenuation The live attenuation state to clear
+ */
+template <specfem::element::dimension_tag DimensionTag>
+void reset_attenuation_state(
+    specfem::assembly::Attenuation<DimensionTag> &attenuation) {
+  specfem::tag_dispatch::for_each(
+      specfem::assembly::Attenuation<
+          DimensionTag>::attenuation_medium_combinations,
+      [&]<typename TagsType>() {
+        auto &medium = attenuation.attenuation_storage.template get<TagsType>();
+        if (medium.element_range.extent(0) == 0)
+          return;
+
+        specfem::solver::impl::for_each_attenuation_view(
+            medium, [](auto &live) {
+              Kokkos::deep_copy(live, static_cast<type_real>(0));
+            });
+        medium.copy_to_host();
+      });
+}
+
+} // namespace specfem::solver::impl

--- a/core/specfem/solver/impl/checkpointed_replay.hpp
+++ b/core/specfem/solver/impl/checkpointed_replay.hpp
@@ -1,0 +1,323 @@
+#pragma once
+
+#include "specfem/assembly/assembly.hpp"
+#include "specfem/element.hpp"
+#include "specfem/periodic_tasks/periodic_task.hpp"
+#include "specfem/periodic_tasks/wavefield_checkpoint.hpp"
+#include "specfem/setup.hpp"
+#include "specfem/solver/forward_displacement_buffer.hpp"
+#include "specfem/solver/impl/attenuation_snapshot.hpp"
+#include "specfem/solver/mpi_buffers.hpp"
+#include "specfem/tag_dispatch.hpp"
+#include "specfem/timescheme.hpp"
+#include <Kokkos_Core.hpp>
+#include <memory>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Reconstructing the forward wavefield for an attenuating adjoint run
+// ---------------------------------------------------------------------------
+//
+// Computing sensitivity kernels means correlating the adjoint wavefield, which
+// marches backwards in time, against the forward wavefield at the same instant.
+// Without attenuation the forward wavefield can simply be integrated backwards
+// alongside the adjoint one. Attenuation makes that impossible: the physics is
+// dissipative, so running it in reverse amplifies exponentially and leaves the
+// memory variables in an acausal state.
+//
+// So instead of reversing the forward wavefield, we recompute it. A prior
+// forward run wrote its full state to disk periodically; from any of those
+// states the forward physics can be replayed to recover any later instant. The
+// cost is roughly one extra forward simulation, and the memory is bounded by
+// how much of the replay we choose to keep.
+//
+// Vocabulary used throughout this header and its callers:
+//
+//   checkpoint   A full state (wavefield + attenuation memory) written to disk
+//                by the forward run, every NT_DUMP_ATTENUATION steps.
+//   window       The step range one disk checkpoint opens, i.e.
+//                [checkpoint_step, min(checkpoint_step + interval, nstep)).
+//   segment      Any sub-range of a window handled by one recursive call.
+//   leaf         A segment short enough to fit in the displacement buffer. It
+//                is replayed forward once, buffering displacement at every
+//                step, then swept backwards accumulating kernels.
+//   retained
+//   snapshot     A forward state kept in RAM at a segment boundary, so the
+//                right half of a split need not be replayed from the window
+//                start.
+//
+// All scheduling policy -- how long a leaf is, where a segment is cut, how many
+// retained snapshots are affordable -- belongs to
+// specfem::periodic_tasks::wavefield_checkpoint. This file only consumes those
+// decisions.
+//
+// Reference: Komatitsch et al. (2016), and the Fortran implementation in
+// iterate_time_undoatt.F90.
+// ---------------------------------------------------------------------------
+
+namespace specfem::solver::impl {
+
+/**
+ * @brief A half-open range of time steps, [begin_step, end_step).
+ */
+struct StepRange {
+  int begin_step; ///< First step in the range
+  int end_step;   ///< One past the last step in the range
+
+  /// @brief Number of steps the range spans.
+  int num_steps() const { return end_step - begin_step; }
+};
+
+/**
+ * @brief A saved copy of the forward wavefield: displacement, velocity and
+ * acceleration for every medium.
+ *
+ * Move-only, because each instance owns freshly allocated device views and
+ * copying one would silently double the memory a replay holds.
+ *
+ * @tparam DimensionTag Spatial dimension (dim2 or dim3)
+ */
+template <specfem::element::dimension_tag DimensionTag>
+class ForwardFieldSnapshot {
+public:
+  using forward_field_type = specfem::assembly::simulation_field<
+      DimensionTag, specfem::simulation::field_type::forward>;
+
+  ForwardFieldSnapshot() = default;
+
+  ForwardFieldSnapshot(const ForwardFieldSnapshot &) = delete;
+  ForwardFieldSnapshot &operator=(const ForwardFieldSnapshot &) = delete;
+  ForwardFieldSnapshot(ForwardFieldSnapshot &&) = default;
+  ForwardFieldSnapshot &operator=(ForwardFieldSnapshot &&) = default;
+
+  /**
+   * @brief Allocate a snapshot and fill it from the live forward field.
+   *
+   * @param field The forward wavefield to copy
+   */
+  explicit ForwardFieldSnapshot(const forward_field_type &field);
+
+  /**
+   * @brief Copy the saved wavefield back over the live one.
+   *
+   * @param field The forward wavefield to overwrite
+   */
+  void restore_into(forward_field_type &field) const;
+
+private:
+  using ViewType = Kokkos::View<type_real **, Kokkos::LayoutLeft,
+                                Kokkos::DefaultExecutionSpace>;
+
+  struct MediumSnapshot {
+    ViewType displacement;
+    ViewType velocity;
+    ViewType acceleration;
+  };
+
+  specfem::tag_dispatch::Storage<MediumSnapshot,
+                                 decltype(forward_field_type::combinations)>
+      storage_;
+};
+
+/**
+ * @brief Everything a forward replay needs in order to resume from one instant:
+ * the wavefield and the attenuation memory that goes with it.
+ *
+ * @tparam DimensionTag Spatial dimension (dim2 or dim3)
+ */
+template <specfem::element::dimension_tag DimensionTag>
+struct ForwardStateSnapshot {
+  ForwardFieldSnapshot<DimensionTag> fields;  ///< Displacement, velocity, acc.
+  AttenuationState<DimensionTag> attenuation; ///< Memory variables and strains
+
+  /**
+   * @brief Copy the saved forward state back over the live one.
+   *
+   * @param assembly Assembly whose forward field and attenuation are
+   * overwritten
+   */
+  void restore_into(specfem::assembly::assembly<DimensionTag> &assembly) const;
+};
+
+/**
+ * @brief Where a forward replay resumes from: either a disk checkpoint at the
+ * head of a window, or a snapshot retained in memory at a segment boundary.
+ *
+ * Carrying the step alongside the state makes an invariant structural that used
+ * to be implicit: a replay always resumes at exactly the step its origin
+ * describes.
+ *
+ * Holds the snapshot by pointer and does not extend its lifetime. Every origin
+ * is consumed within the scope that owns the snapshot it names.
+ *
+ * @tparam DimensionTag Spatial dimension (dim2 or dim3)
+ */
+template <specfem::element::dimension_tag DimensionTag> class ReplayOrigin {
+public:
+  /**
+   * @brief An origin that reloads the disk checkpoint opening a window.
+   *
+   * @param step Step at which the checkpoint was written
+   * @return The origin
+   */
+  static ReplayOrigin at_window_checkpoint(const int step) {
+    return ReplayOrigin(step, nullptr);
+  }
+
+  /**
+   * @brief An origin that resumes from a snapshot held in memory.
+   *
+   * @param step     Step the snapshot was captured at
+   * @param snapshot The retained state; must outlive this origin
+   * @return The origin
+   */
+  static ReplayOrigin
+  at_snapshot(const int step,
+              const ForwardStateSnapshot<DimensionTag> &snapshot) {
+    return ReplayOrigin(step, &snapshot);
+  }
+
+  /// @brief Step the forward state describes.
+  int step() const { return step_; }
+
+  /// @brief Whether the state has to be reloaded from disk.
+  bool is_window_checkpoint() const { return snapshot_ == nullptr; }
+
+  /// @brief The retained state. Only valid when @ref is_window_checkpoint is
+  /// false.
+  const ForwardStateSnapshot<DimensionTag> &snapshot() const {
+    return *snapshot_;
+  }
+
+private:
+  ReplayOrigin(const int step,
+               const ForwardStateSnapshot<DimensionTag> *snapshot)
+      : step_(step), snapshot_(snapshot) {}
+
+  int step_;
+  const ForwardStateSnapshot<DimensionTag> *snapshot_;
+};
+
+/**
+ * @brief Reconstructs the forward wavefield window by window and correlates it
+ * against the adjoint wavefield to accumulate sensitivity kernels.
+ *
+ * One instance serves a whole adjoint pass; call @ref replay_window once per
+ * window, walking the windows backwards in time. See the discussion at the top
+ * of this header for what a window, a segment and a leaf are.
+ *
+ * @tparam DimensionTag Spatial dimension (dim2 or dim3)
+ * @tparam NGLL Number of GLL points per element edge
+ */
+template <specfem::element::dimension_tag DimensionTag, int NGLL>
+class CheckpointedReplay {
+public:
+  using PeriodicTaskType = specfem::periodic_tasks::periodic_task<DimensionTag>;
+  using ScheduleType =
+      specfem::periodic_tasks::wavefield_checkpoint<DimensionTag>;
+
+  /**
+   * @brief Wire the replay to the solver state it drives.
+   *
+   * Every argument is retained by reference for the lifetime of the replay.
+   *
+   * @param assembly Assembly holding the wavefields and attenuation state
+   * @param mpi_buffers Solver-owned MPI exchange buffers
+   * @param time_scheme Time integration scheme
+   * @param tasks Periodic tasks to run during the adjoint sweep
+   * @param displacement_buffer RAM buffer holding one leaf of forward
+   * displacements
+   * @param checkpoint_reader Reads forward checkpoints back from disk
+   * @param schedule Owns all replay scheduling policy
+   * @param nstep Total number of simulation steps, for progress reporting
+   * @param dt Timestep, passed on to the kernel accumulation
+   */
+  CheckpointedReplay(
+      specfem::assembly::assembly<DimensionTag> &assembly,
+      specfem::solver::MPIBuffers<DimensionTag> &mpi_buffers,
+      specfem::time_scheme::time_scheme &time_scheme,
+      const std::vector<std::shared_ptr<PeriodicTaskType>> &tasks,
+      const specfem::solver::ForwardDisplacementBuffer<DimensionTag>
+          &displacement_buffer,
+      PeriodicTaskType &checkpoint_reader, const ScheduleType &schedule,
+      const int nstep, const type_real dt)
+      : assembly_(assembly), mpi_buffers_(mpi_buffers),
+        time_scheme_(time_scheme), tasks_(tasks),
+        displacement_buffer_(displacement_buffer),
+        checkpoint_reader_(checkpoint_reader), schedule_(schedule),
+        nstep_(nstep), dt_(dt) {}
+
+  /**
+   * @brief Reconstruct one window and accumulate its contribution to the
+   * kernels.
+   *
+   * Windows must be visited backwards in time: the adjoint attenuation state
+   * evolves from the end of the simulation towards the start, and each call
+   * picks up where the window to its right left off.
+   *
+   * @param window Half-open range of steps the disk checkpoint opens
+   */
+  void replay_window(const StepRange &window);
+
+private:
+  /**
+   * @brief Reverse one segment, splitting it recursively when it is longer than
+   * the displacement buffer.
+   *
+   * @param segment Half-open range of steps to reverse
+   * @param origin Forward state to resume from
+   * @param retained_snapshot_budget How many forward states this call may still
+   * keep resident
+   */
+  void replay_segment(const StepRange &segment,
+                      const ReplayOrigin<DimensionTag> &origin,
+                      const int retained_snapshot_budget);
+
+  /**
+   * @brief Replay one leaf forward into the displacement buffer, then sweep it
+   * backwards accumulating kernels.
+   *
+   * @param leaf Half-open range of steps, at most one buffer long
+   * @param origin Forward state to resume from; may sit to the left of the leaf
+   */
+  void replay_buffered_leaf(const StepRange &leaf,
+                            const ReplayOrigin<DimensionTag> &origin);
+
+  /// @brief Put the live forward state back to @p origin.
+  void restore_forward_state(const ReplayOrigin<DimensionTag> &origin);
+
+  /// @brief Copy the live forward state into a new snapshot.
+  ForwardStateSnapshot<DimensionTag> capture_forward_state() const;
+
+  /// @brief Advance the forward wavefield across @p range without buffering.
+  void advance_forward(const StepRange &range);
+
+  /**
+   * @brief Advance the adjoint wavefield one step and correlate it against the
+   * reconstructed forward wavefield currently loaded.
+   *
+   * @param step Global step index being correlated
+   */
+  void accumulate_kernels_at(const int step);
+
+  specfem::assembly::assembly<DimensionTag> &assembly_;
+  specfem::solver::MPIBuffers<DimensionTag> &mpi_buffers_;
+  specfem::time_scheme::time_scheme &time_scheme_;
+  const std::vector<std::shared_ptr<PeriodicTaskType>> &tasks_;
+  const specfem::solver::ForwardDisplacementBuffer<DimensionTag>
+      &displacement_buffer_;
+  PeriodicTaskType &checkpoint_reader_;
+  const ScheduleType &schedule_;
+  int nstep_;
+  type_real dt_;
+
+  StepRange window_{ 0, 0 }; ///< Window currently being replayed
+
+  /// The adjoint attenuation state, parked here while a forward replay borrows
+  /// the one live attenuation container. See @ref replay_buffered_leaf.
+  AttenuationState<DimensionTag> adjoint_attenuation_;
+};
+
+} // namespace specfem::solver::impl
+
+#include "specfem/solver/impl/checkpointed_replay.tpp"

--- a/core/specfem/solver/impl/checkpointed_replay.tpp
+++ b/core/specfem/solver/impl/checkpointed_replay.tpp
@@ -1,0 +1,238 @@
+#pragma once
+
+#include "specfem/compute.tpp"
+#include "specfem/solver/impl/checkpointed_replay.hpp"
+#include "specfem/solver/impl/update_step.hpp"
+#include "specfem/tags.hpp"
+#include <algorithm>
+#include <string>
+
+// ---------------------------------------------------------------------------
+// Snapshots
+// ---------------------------------------------------------------------------
+
+template <specfem::element::dimension_tag DimensionTag>
+specfem::solver::impl::ForwardFieldSnapshot<DimensionTag>::ForwardFieldSnapshot(
+    const forward_field_type &field) {
+  specfem::tag_dispatch::for_each(
+      forward_field_type::combinations, [&]<typename TagsType>() {
+        constexpr auto medium_tag = TagsType::medium_tag;
+        const auto &source = field.template get_field<medium_tag>();
+        if (source.nglob == 0)
+          return;
+
+        auto &destination = storage_.template get<TagsType>();
+        auto clone_field = [](const ViewType &view) {
+          ViewType clone(
+              Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                                 std::string(view.label()) + "_snapshot"),
+              view.extent(0), view.extent(1));
+          Kokkos::deep_copy(clone, view);
+          return clone;
+        };
+        destination.displacement = clone_field(source.get_field());
+        destination.velocity = clone_field(source.get_field_dot());
+        destination.acceleration = clone_field(source.get_field_dot_dot());
+      });
+}
+
+template <specfem::element::dimension_tag DimensionTag>
+void specfem::solver::impl::ForwardFieldSnapshot<DimensionTag>::restore_into(
+    forward_field_type &field) const {
+  specfem::tag_dispatch::for_each(
+      forward_field_type::combinations, [&]<typename TagsType>() {
+        constexpr auto medium_tag = TagsType::medium_tag;
+        auto &destination = field.template get_field<medium_tag>();
+        if (destination.nglob == 0)
+          return;
+
+        const auto &source = storage_.template get<TagsType>();
+        Kokkos::deep_copy(destination.get_field(), source.displacement);
+        Kokkos::deep_copy(destination.get_field_dot(), source.velocity);
+        Kokkos::deep_copy(destination.get_field_dot_dot(), source.acceleration);
+      });
+}
+
+template <specfem::element::dimension_tag DimensionTag>
+void specfem::solver::impl::ForwardStateSnapshot<DimensionTag>::restore_into(
+    specfem::assembly::assembly<DimensionTag> &assembly) const {
+  fields.restore_into(assembly.fields.forward);
+  attenuation.restore_into(assembly.attenuation);
+}
+
+// ---------------------------------------------------------------------------
+// Driving one window
+// ---------------------------------------------------------------------------
+
+template <specfem::element::dimension_tag DimensionTag, int NGLL>
+void specfem::solver::impl::CheckpointedReplay<
+    DimensionTag, NGLL>::replay_window(const StepRange &window) {
+
+  window_ = window;
+
+  // The adjoint wavefield has been marching backwards through the windows to
+  // our right and its attenuation memory is live right now. Park it: the
+  // forward replay below needs the one attenuation container for itself.
+  adjoint_attenuation_ = AttenuationState<DimensionTag>{};
+  adjoint_attenuation_ =
+      AttenuationState<DimensionTag>::capture_from(assembly_.attenuation);
+
+  replay_segment(
+      window,
+      ReplayOrigin<DimensionTag>::at_window_checkpoint(window.begin_step),
+      schedule_.checkpoint_slots(window.num_steps()));
+}
+
+template <specfem::element::dimension_tag DimensionTag, int NGLL>
+void specfem::solver::impl::CheckpointedReplay<DimensionTag, NGLL>::
+    replay_segment(const StepRange &segment,
+                   const ReplayOrigin<DimensionTag> &origin,
+                   const int retained_snapshot_budget) {
+
+  const int num_steps = segment.num_steps();
+  if (num_steps <= 0)
+    return;
+
+  // Short enough to reconstruct in a single pass through the buffer.
+  if (num_steps <= schedule_.buffer_steps()) {
+    replay_buffered_leaf(segment, origin);
+    return;
+  }
+
+  // Nothing left to spend on retained states, so walk the leaves from right to
+  // left, replaying from `origin` every time. Quadratic in forward steps but
+  // needs no extra memory. The current schedule always hands out exactly enough
+  // budget to avoid this, but a stingier one would still terminate correctly.
+  if (retained_snapshot_budget == 0) {
+    for (int leaf_end = segment.end_step; leaf_end > segment.begin_step;
+         leaf_end -= schedule_.buffer_steps()) {
+      const int leaf_begin =
+          std::max(segment.begin_step, leaf_end - schedule_.buffer_steps());
+      replay_buffered_leaf({ leaf_begin, leaf_end }, origin);
+    }
+    return;
+  }
+
+  // Cut the segment in two and reverse the right half first, so that when the
+  // left half runs it can still resume from the origin the whole segment used.
+  const int split_step = segment.begin_step + schedule_.split(num_steps);
+
+  restore_forward_state(origin);
+  advance_forward({ origin.step(), split_step });
+
+  {
+    const ForwardStateSnapshot<DimensionTag> retained = capture_forward_state();
+    replay_segment(
+        { split_step, segment.end_step },
+        ReplayOrigin<DimensionTag>::at_snapshot(split_step, retained),
+        retained_snapshot_budget - 1);
+  } // retained state released here, before the left half runs, so the number
+    // resident at once never exceeds the recursion depth
+
+  replay_segment({ segment.begin_step, split_step }, origin,
+                 retained_snapshot_budget);
+}
+
+template <specfem::element::dimension_tag DimensionTag, int NGLL>
+void specfem::solver::impl::CheckpointedReplay<DimensionTag, NGLL>::
+    replay_buffered_leaf(const StepRange &leaf,
+                         const ReplayOrigin<DimensionTag> &origin) {
+
+  // Resume the forward wavefield and run it up to the leaf. Nothing in this
+  // stretch is buffered -- it is only here to reach the leaf's first step.
+  restore_forward_state(origin);
+  advance_forward({ origin.step(), leaf.begin_step });
+
+  // Replay the leaf itself, keeping every displacement. Displacement alone is
+  // enough: the kernels need only it and the strain, and the strain is
+  // recomputed from its gradient during the backward sweep.
+  for (int step = leaf.begin_step; step < leaf.end_step; ++step) {
+    advance_forward({ step, step + 1 });
+    displacement_buffer_.store(assembly_.fields.forward,
+                               step - leaf.begin_step);
+  }
+
+  // The forward replay is finished with the attenuation container, so hand it
+  // back to the adjoint wavefield before sweeping backwards through the leaf.
+  adjoint_attenuation_.restore_into(assembly_.attenuation);
+  for (int step = leaf.end_step - 1; step >= leaf.begin_step; --step) {
+    displacement_buffer_.load(assembly_.fields.forward, step - leaf.begin_step);
+    accumulate_kernels_at(step);
+  }
+
+  // Park the evolved adjoint attenuation state again for the leaf to our left.
+  // The leaf that opens the window has none, and the next window captures the
+  // live container directly.
+  if (leaf.begin_step != window_.begin_step) {
+    adjoint_attenuation_.refresh_from(assembly_.attenuation);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The forward wavefield
+// ---------------------------------------------------------------------------
+
+template <specfem::element::dimension_tag DimensionTag, int NGLL>
+void specfem::solver::impl::CheckpointedReplay<DimensionTag, NGLL>::
+    restore_forward_state(const ReplayOrigin<DimensionTag> &origin) {
+
+  if (!origin.is_window_checkpoint()) {
+    origin.snapshot().restore_into(assembly_);
+    return;
+  }
+
+  // The reader lands the wavefield in the buffer field and the attenuation
+  // memory directly in its own container, so only the wavefield half needs
+  // moving into place.
+  checkpoint_reader_.run(assembly_, origin.step());
+  specfem::assembly::deep_copy(assembly_.fields.forward,
+                               assembly_.fields.buffer);
+}
+
+template <specfem::element::dimension_tag DimensionTag, int NGLL>
+specfem::solver::impl::ForwardStateSnapshot<DimensionTag>
+specfem::solver::impl::CheckpointedReplay<DimensionTag,
+                                          NGLL>::capture_forward_state() const {
+  return ForwardStateSnapshot<DimensionTag>{
+    ForwardFieldSnapshot<DimensionTag>(assembly_.fields.forward),
+    AttenuationState<DimensionTag>::capture_from(assembly_.attenuation)
+  };
+}
+
+template <specfem::element::dimension_tag DimensionTag, int NGLL>
+void specfem::solver::impl::CheckpointedReplay<
+    DimensionTag, NGLL>::advance_forward(const StepRange &range) {
+  for (int step = range.begin_step; step < range.end_step; ++step) {
+    specfem::solver::impl::apply_forward_step<
+        NGLL, specfem::simulation::field_type::forward, DimensionTag>(
+        time_scheme_, assembly_, mpi_buffers_, step);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The adjoint wavefield
+// ---------------------------------------------------------------------------
+
+template <specfem::element::dimension_tag DimensionTag, int NGLL>
+void specfem::solver::impl::CheckpointedReplay<
+    DimensionTag, NGLL>::accumulate_kernels_at(const int step) {
+
+  // Kernel evaluation reads the reconstructed forward wavefield through the
+  // backward field, which is where the non-attenuating solver leaves it.
+  specfem::assembly::deep_copy(assembly_.fields.backward,
+                               assembly_.fields.forward);
+
+  for (const auto &task : tasks_) {
+    if (task && task->should_run(step + 1)) {
+      task->run(assembly_, step + 1);
+    }
+  }
+
+  specfem::solver::impl::apply_adjoint_step<
+      NGLL, specfem::simulation::field_type::adjoint, DimensionTag>(
+      time_scheme_, assembly_, mpi_buffers_, step);
+  specfem::compute::compute_derivatives<NGLL,
+                                        specfem::tags::Tags<DimensionTag>>(
+      assembly_, dt_);
+  specfem::solver::impl::log_time_marching_progress(step, nstep_);
+}

--- a/core/specfem/solver/time_marching.hpp
+++ b/core/specfem/solver/time_marching.hpp
@@ -208,9 +208,11 @@ public:
       const specfem::assembly::assembly<dimension_tag> &assembly,
       const std::shared_ptr<specfem::time_scheme::time_scheme> time_scheme,
       const std::vector<std::shared_ptr<
-          specfem::periodic_tasks::periodic_task<dimension_tag>>> &tasks)
+          specfem::periodic_tasks::periodic_task<dimension_tag>>> &tasks,
+      int checkpoint_buffer_subdivisions = 1)
       : assembly(assembly), time_scheme(time_scheme), tasks(tasks),
-        mpi_buffers(specfem::solver::make_mpi_buffers(this->assembly)) {}
+        mpi_buffers(specfem::solver::make_mpi_buffers(this->assembly)),
+        checkpoint_buffer_subdivisions(checkpoint_buffer_subdivisions) {}
 
   /**
    * @brief Execute adjoint pass with windowed forward replay.
@@ -224,6 +226,7 @@ private:
       std::shared_ptr<specfem::periodic_tasks::periodic_task<dimension_tag>>>
       tasks;
   specfem::solver::MPIBuffers<dimension_tag> mpi_buffers;
+  int checkpoint_buffer_subdivisions;
 };
 
 } // namespace solver

--- a/core/specfem/solver/time_marching/combined_undoatt.tpp
+++ b/core/specfem/solver/time_marching/combined_undoatt.tpp
@@ -1,241 +1,30 @@
 #pragma once
 
-#include "specfem/compute.tpp"
 #include "specfem/logger.hpp"
 #include "specfem/periodic_tasks/wavefield_checkpoint.hpp"
 #include "specfem/periodic_tasks/wavefield_reader.hpp"
 #include "specfem/solver/forward_displacement_buffer.hpp"
+#include "specfem/solver/impl/attenuation_snapshot.hpp"
+#include "specfem/solver/impl/checkpointed_replay.hpp"
 #include "specfem/solver/impl/update_medium.hpp"
-#include "specfem/solver/impl/update_step.hpp"
 #include "specfem/solver/time_marching.hpp"
 #include "specfem/tags.hpp"
-#include <Kokkos_Core.hpp>
-#include <functional>
-#include <memory>
-#include <type_traits>
-#include <utility>
-#include <vector>
-
-namespace specfem::solver::combined_undoatt_impl {
-
-template <typename ViewType> ViewType clone_view(const ViewType &view) {
-  ViewType clone(std::string(view.label()) + "_undo_att_snapshot",
-                 view.get_mapping());
-  specfem::datatype::deep_copy(clone, view);
-  return clone;
-}
-
-template <typename MediumType> struct attenuation_memory_snapshot {
-  using memory_view_type = std::remove_cvref_t<
-      decltype(std::declval<MediumType>().memory_variable_kappa)>;
-  using strain_view_type =
-      std::remove_cvref_t<decltype(std::declval<MediumType>().epsilon_xx_att)>;
-
-  memory_view_type Rkappa;
-  memory_view_type Rxx;
-  memory_view_type Rxz;
-  memory_view_type Ryy;
-  memory_view_type Rzz;
-  memory_view_type Rxy;
-  memory_view_type Ryz;
-  strain_view_type epsilon_xx;
-  strain_view_type epsilon_zz;
-  strain_view_type epsilon_xz;
-  strain_view_type epsilon_yy;
-  strain_view_type epsilon_xy;
-  strain_view_type epsilon_yz;
-};
-
-template <typename TagsType>
-using attenuation_memory_snapshot_for_tags =
-    attenuation_memory_snapshot<specfem::assembly::impl::attenuation_medium<
-        TagsType::dimension_tag, TagsType::medium_tag, TagsType::property_tag,
-        TagsType::attenuation_tag>>;
-
-template <typename MediumType>
-auto save_attenuation_memory(const MediumType &medium) {
-  attenuation_memory_snapshot<MediumType> snapshot{
-    clone_view(medium.memory_variable_kappa),
-    clone_view(medium.memory_variable_Rxx),
-    clone_view(medium.memory_variable_Rxz),
-    {},
-    {},
-    {},
-    {},
-    clone_view(medium.epsilon_xx_att),
-    clone_view(medium.epsilon_zz_att),
-    clone_view(medium.epsilon_xz_att),
-    {},
-    {},
-    {}
-  };
-
-  if constexpr (requires { medium.memory_variable_Ryy; }) {
-    snapshot.Ryy = clone_view(medium.memory_variable_Ryy);
-    snapshot.Rzz = clone_view(medium.memory_variable_Rzz);
-    snapshot.Rxy = clone_view(medium.memory_variable_Rxy);
-    snapshot.Ryz = clone_view(medium.memory_variable_Ryz);
-    snapshot.epsilon_yy = clone_view(medium.epsilon_yy_att);
-    snapshot.epsilon_xy = clone_view(medium.epsilon_xy_att);
-    snapshot.epsilon_yz = clone_view(medium.epsilon_yz_att);
-  }
-
-  return snapshot;
-}
-
-template <typename MediumType>
-void restore_attenuation_memory(
-    MediumType &medium,
-    const attenuation_memory_snapshot<MediumType> &snapshot) {
-  specfem::datatype::deep_copy(medium.memory_variable_kappa, snapshot.Rkappa);
-  specfem::datatype::deep_copy(medium.memory_variable_Rxx, snapshot.Rxx);
-  specfem::datatype::deep_copy(medium.memory_variable_Rxz, snapshot.Rxz);
-  specfem::datatype::deep_copy(medium.epsilon_xx_att, snapshot.epsilon_xx);
-  specfem::datatype::deep_copy(medium.epsilon_zz_att, snapshot.epsilon_zz);
-  specfem::datatype::deep_copy(medium.epsilon_xz_att, snapshot.epsilon_xz);
-
-  if constexpr (requires { medium.memory_variable_Ryy; }) {
-    specfem::datatype::deep_copy(medium.memory_variable_Ryy, snapshot.Ryy);
-    specfem::datatype::deep_copy(medium.memory_variable_Rzz, snapshot.Rzz);
-    specfem::datatype::deep_copy(medium.memory_variable_Rxy, snapshot.Rxy);
-    specfem::datatype::deep_copy(medium.memory_variable_Ryz, snapshot.Ryz);
-    specfem::datatype::deep_copy(medium.epsilon_yy_att, snapshot.epsilon_yy);
-    specfem::datatype::deep_copy(medium.epsilon_xy_att, snapshot.epsilon_xy);
-    specfem::datatype::deep_copy(medium.epsilon_yz_att, snapshot.epsilon_yz);
-  }
-}
-
-template <typename MediumType>
-void update_attenuation_snapshot(
-    const MediumType &medium,
-    attenuation_memory_snapshot<MediumType> &snapshot) {
-  specfem::datatype::deep_copy(snapshot.Rkappa, medium.memory_variable_kappa);
-  specfem::datatype::deep_copy(snapshot.Rxx, medium.memory_variable_Rxx);
-  specfem::datatype::deep_copy(snapshot.Rxz, medium.memory_variable_Rxz);
-  specfem::datatype::deep_copy(snapshot.epsilon_xx, medium.epsilon_xx_att);
-  specfem::datatype::deep_copy(snapshot.epsilon_zz, medium.epsilon_zz_att);
-  specfem::datatype::deep_copy(snapshot.epsilon_xz, medium.epsilon_xz_att);
-
-  if constexpr (requires { medium.memory_variable_Ryy; }) {
-    specfem::datatype::deep_copy(snapshot.Ryy, medium.memory_variable_Ryy);
-    specfem::datatype::deep_copy(snapshot.Rzz, medium.memory_variable_Rzz);
-    specfem::datatype::deep_copy(snapshot.Rxy, medium.memory_variable_Rxy);
-    specfem::datatype::deep_copy(snapshot.Ryz, medium.memory_variable_Ryz);
-    specfem::datatype::deep_copy(snapshot.epsilon_yy, medium.epsilon_yy_att);
-    specfem::datatype::deep_copy(snapshot.epsilon_xy, medium.epsilon_xy_att);
-    specfem::datatype::deep_copy(snapshot.epsilon_yz, medium.epsilon_yz_att);
-  }
-}
-
-template <specfem::element::dimension_tag DimensionTag>
-class forward_field_snapshot {
-private:
-  using forward_field_type = specfem::assembly::simulation_field<
-      DimensionTag, specfem::simulation::field_type::forward>;
-  using ViewType = Kokkos::View<type_real **, Kokkos::LayoutLeft,
-                                Kokkos::DefaultExecutionSpace>;
-
-  struct medium_snapshot {
-    ViewType displacement;
-    ViewType velocity;
-    ViewType acceleration;
-  };
-
-public:
-  explicit forward_field_snapshot(const forward_field_type &field) {
-    specfem::tag_dispatch::for_each(
-        forward_field_type::combinations, [&]<typename TagsType>() {
-          constexpr auto medium_tag = TagsType::medium_tag;
-          const auto &source = field.template get_field<medium_tag>();
-          if (source.nglob == 0)
-            return;
-
-          auto &destination = storage_.template get<TagsType>();
-          auto clone_field = [](const ViewType &view) {
-            ViewType clone(Kokkos::view_alloc(Kokkos::WithoutInitializing,
-                                              std::string(view.label()) +
-                                                  "_revolve_checkpoint"),
-                           view.extent(0), view.extent(1));
-            Kokkos::deep_copy(clone, view);
-            return clone;
-          };
-          destination.displacement = clone_field(source.get_field());
-          destination.velocity = clone_field(source.get_field_dot());
-          destination.acceleration = clone_field(source.get_field_dot_dot());
-        });
-  }
-
-  void restore(forward_field_type &field) const {
-    specfem::tag_dispatch::for_each(
-        forward_field_type::combinations, [&]<typename TagsType>() {
-          constexpr auto medium_tag = TagsType::medium_tag;
-          auto &destination = field.template get_field<medium_tag>();
-          if (destination.nglob == 0)
-            return;
-
-          const auto &source = storage_.template get<TagsType>();
-          Kokkos::deep_copy(destination.get_field(), source.displacement);
-          Kokkos::deep_copy(destination.get_field_dot(), source.velocity);
-          Kokkos::deep_copy(destination.get_field_dot_dot(),
-                            source.acceleration);
-        });
-  }
-
-private:
-  specfem::tag_dispatch::Storage<medium_snapshot,
-                                 decltype(forward_field_type::combinations)>
-      storage_;
-};
-
-template <typename MediumType>
-void reset_attenuation_memory(MediumType &medium) {
-  Kokkos::deep_copy(medium.memory_variable_kappa, static_cast<type_real>(0));
-  Kokkos::deep_copy(medium.memory_variable_Rxx, static_cast<type_real>(0));
-  Kokkos::deep_copy(medium.memory_variable_Rxz, static_cast<type_real>(0));
-  Kokkos::deep_copy(medium.epsilon_xx_att, static_cast<type_real>(0));
-  Kokkos::deep_copy(medium.epsilon_zz_att, static_cast<type_real>(0));
-  Kokkos::deep_copy(medium.epsilon_xz_att, static_cast<type_real>(0));
-
-  if constexpr (requires { medium.memory_variable_Ryy; }) {
-    Kokkos::deep_copy(medium.memory_variable_Ryy, static_cast<type_real>(0));
-    Kokkos::deep_copy(medium.memory_variable_Rzz, static_cast<type_real>(0));
-    Kokkos::deep_copy(medium.memory_variable_Rxy, static_cast<type_real>(0));
-    Kokkos::deep_copy(medium.memory_variable_Ryz, static_cast<type_real>(0));
-    Kokkos::deep_copy(medium.epsilon_yy_att, static_cast<type_real>(0));
-    Kokkos::deep_copy(medium.epsilon_xy_att, static_cast<type_real>(0));
-    Kokkos::deep_copy(medium.epsilon_yz_att, static_cast<type_real>(0));
-  }
-
-  medium.copy_to_host();
-}
-
-} // namespace specfem::solver::combined_undoatt_impl
+#include <sstream>
+#include <stdexcept>
 
 // ---------------------------------------------------------------------------
 // time_marching<combined_undoatt>::run()
 // ---------------------------------------------------------------------------
-// Algorithm mirrors Fortran iterate_time_undoatt.F90 exactly:
 //
-//   PRECONDITION:
-//     A prior forward simulation has written full snapshots of wavefield +
-//     attenuation memory variables at checkpoint steps.
+// The adjoint pass of an attenuating simulation. Because dissipative physics
+// cannot be integrated backwards, the forward wavefield is not reversed here --
+// it is reconstructed, window by window, from checkpoints a prior forward run
+// wrote to disk. specfem::solver::impl::CheckpointedReplay does that work and
+// explains how; this function sets it up and hands it one window at a time,
+// last window first.
 //
-//   ADJOINT PASS (subset-by-subset backward):
-//     For each subset window (from the last to the first):
-//       (A) Save the current adjoint attenuation memory variables, then load
-//           the checkpoint into fields.buffer + attenuation so forward replay
-//           uses the loaded b_R_xx, b_R_xz, b_R_kappa.
-//       (B) Replay forward physics over the subset, storing b_displ in the
-//           RAM buffer at each step (matching Fortran
-//           b_displ_elastic_buffer(:,:,it)).
-//       (C) Sweep backward through the window: restore b_displ from the
-//           RAM buffer, advance the adjoint wavefield one step, then call
-//           compute_derivatives using (adjoint, forward) pairing.
-//           The compute_derivatives call recomputes b_epsilondev on-the-fly
-//           from grad(b_displ), matching Fortran compute_kernels_el lines
-//           103-120 (UNDO_ATTENUATION branch).
-//     Restore the adjoint attenuation memory variables before the adjoint
-//     sweep.
+// PRECONDITION: a prior forward simulation wrote checkpoints of the wavefield
+// and the attenuation memory variables every NT_DUMP_ATTENUATION steps.
 // ---------------------------------------------------------------------------
 template <specfem::element::dimension_tag DimensionTag, int NGLL>
 void specfem::solver::time_marching<specfem::simulation::type::combined_undoatt,
@@ -250,26 +39,27 @@ void specfem::solver::time_marching<specfem::simulation::type::combined_undoatt,
         "Add a wavefield reader that points to forward checkpoints.");
   }
 
-  // ------------------------------------------------------------------
-  // Disk checkpoints delimit replay windows. A configured window can be
-  // subdivided into smaller displacement buffers with retained boundary state.
-  // ------------------------------------------------------------------
   const int checkpoint_interval = checkpoint_reader->get_time_interval();
   if (checkpoint_interval <= 0) {
     throw std::runtime_error(
         "combined_undoatt solver: wavefield reader time-interval must be > 0 "
         "(this is NT_DUMP_ATTENUATION). Set it in the wavefield config.");
   }
-  const specfem::periodic_tasks::wavefield_checkpoint<DimensionTag>
-      wavefield_checkpoint_task(checkpoint_interval,
-                                checkpoint_buffer_subdivisions);
+
+  // Disk checkpoints delimit the replay windows. Each window can be subdivided
+  // into smaller displacement buffers, with forward state retained in memory at
+  // the internal boundaries.
+  const specfem::periodic_tasks::wavefield_checkpoint<DimensionTag> schedule(
+      checkpoint_interval, checkpoint_buffer_subdivisions);
+
+  const int nstep = time_scheme->get_max_timestep();
+  const type_real dt = time_scheme->get_timestep();
 
   // ------------------------------------------------------------------
-  // Mass matrix initialization (same as forward::run()).
-  // Both forward and adjoint fields need mass matrices.
+  // Mass matrices, for both the forward and the adjoint wavefield. The forward
+  // wavefield carries one medium the adjoint one does not, so the two sets
+  // differ.
   // ------------------------------------------------------------------
-  const auto mass_dt = time_scheme->get_timestep();
-
   specfem::tag_dispatch::for_each(
       specfem::tag_dispatch::dimension_set<DimensionTag>{} *
           MEDIUM_SET(acoustic, elastic, elastic_psv, elastic_sh, poroelastic,
@@ -277,7 +67,7 @@ void specfem::solver::time_marching<specfem::simulation::type::combined_undoatt,
       [&]<typename ElementTags>() {
         specfem::solver::impl::init_medium_mass<
             NGLL, specfem::tags::expand<ElementTags, forward_ft>>(
-            assembly, mpi_buffers, mass_dt);
+            assembly, mpi_buffers, dt);
       });
 
   specfem::tag_dispatch::for_each(
@@ -286,42 +76,23 @@ void specfem::solver::time_marching<specfem::simulation::type::combined_undoatt,
       [&]<typename ElementTags>() {
         specfem::solver::impl::init_medium_mass<
             NGLL, specfem::tags::expand<ElementTags, adjoint_ft>>(
-            assembly, mpi_buffers, mass_dt);
+            assembly, mpi_buffers, dt);
       });
 
   mpi_buffers
       .template reset<specfem::data_access::DataClassType::mass_matrix>();
 
-  const int nstep = time_scheme->get_max_timestep();
+  // One buffer, sized for the longest leaf any window can produce, reused by
+  // every window.
+  specfem::solver::ForwardDisplacementBuffer<DimensionTag> displacement_buffer;
+  displacement_buffer.allocate(schedule.buffer_steps(),
+                               assembly.fields.forward);
 
-  // Pre-allocate the RAM displacement buffer for the largest possible window.
-  specfem::solver::ForwardDisplacementBuffer<DimensionTag> displ_buffer;
-  displ_buffer.allocate(wavefield_checkpoint_task.buffer_steps(),
-                        assembly.fields.forward);
-
-  // ================================================================
-  // Adjoint pass — windowed forward replay + kernel accumulation
-  // Matches Fortran: SIMULATION_TYPE == 3 branch of iterate_time_undoatt
-  // ================================================================
   specfem::Logger::info(" -- UNDO_ATTENUATION: adjoint pass -- ");
 
-  // Capture the constant timestep for use in compute_derivatives calls below.
-  // time_scheme->get_timestep() == dt from iterate_forward() (same value).
-  const type_real dt = time_scheme->get_timestep();
-
-  // The adjoint pass starts from a fresh adjoint attenuation state, while each
-  // forward replay window temporarily loads checkpointed forward attenuation
-  // into the same container.
-  specfem::tag_dispatch::for_each(
-      assembly.attenuation.attenuation_medium_combinations,
-      [&]<typename TagsType>() {
-        auto &medium =
-            assembly.attenuation.attenuation_storage.template get<TagsType>();
-        if (medium.element_range.extent(0) > 0) {
-          specfem::solver::combined_undoatt_impl::reset_attenuation_memory(
-              medium);
-        }
-      });
+  // The adjoint wavefield starts quiescent. Each forward replay will borrow
+  // this same container and hand it back; see CheckpointedReplay.
+  specfem::solver::impl::reset_attenuation_state(assembly.attenuation);
 
   for (const auto &task : tasks) {
     if (task) {
@@ -329,200 +100,35 @@ void specfem::solver::time_marching<specfem::simulation::type::combined_undoatt,
     }
   }
 
-  using AttenuationSnapshotType = specfem::tag_dispatch::TypedStorage<
-      specfem::solver::combined_undoatt_impl::
-          attenuation_memory_snapshot_for_tags,
-      decltype(assembly.attenuation.attenuation_medium_combinations)>;
-
-  // Iterate backward over subsets: last subset first, first subset last.
-  // Each subset window covers [checkpoint_step, window_end).
-  // We iterate over checkpoint steps in reverse order.
-  const int num_checkpoints =
-      (nstep + checkpoint_interval - 1) / checkpoint_interval;
-
-  using FieldSnapshot =
-      specfem::solver::combined_undoatt_impl::forward_field_snapshot<
-          DimensionTag>;
-  using ForwardState = std::pair<FieldSnapshot, AttenuationSnapshotType>;
-
   std::ostringstream strategy_message;
-  strategy_message << "Checkpoint replay: "
-                   << wavefield_checkpoint_task.buffer_subdivisions()
+  strategy_message << "Checkpoint replay: " << schedule.buffer_subdivisions()
                    << " buffer subdivisions, "
-                   << wavefield_checkpoint_task.checkpoint_slots(
-                          checkpoint_interval)
-                   << " in-memory checkpoints, "
-                   << wavefield_checkpoint_task.buffer_steps()
+                   << schedule.checkpoint_slots(checkpoint_interval)
+                   << " retained snapshots, " << schedule.buffer_steps()
                    << " buffered displacement steps";
   specfem::Logger::info(strategy_message.str());
 
-  for (int subset_idx = num_checkpoints - 1; subset_idx >= 0; --subset_idx) {
-    const int checkpoint_step = subset_idx * checkpoint_interval;
-    const auto [win_start, win_end] =
-        wavefield_checkpoint_task.replay_window(checkpoint_step, nstep);
+  specfem::solver::impl::CheckpointedReplay<DimensionTag, NGLL> replay(
+      assembly, mpi_buffers, *time_scheme, tasks, displacement_buffer,
+      *checkpoint_reader, schedule, nstep, dt);
 
-    AttenuationSnapshotType adjoint_attenuation_snapshot(
-        [&]<typename TagsType>() {
-          auto &medium =
-              assembly.attenuation.attenuation_storage.template get<TagsType>();
-          return specfem::solver::combined_undoatt_impl::
-              save_attenuation_memory(medium);
-        });
+  // Walk the windows backwards in time, last checkpoint first. The adjoint
+  // wavefield flows from one window into the next.
+  const int num_windows =
+      (nstep + checkpoint_interval - 1) / checkpoint_interval;
 
-    const int checkpoint_slots =
-        wavefield_checkpoint_task.checkpoint_slots(win_end - win_start);
-    std::vector<std::unique_ptr<ForwardState>> slots(checkpoint_slots);
-    std::vector<int> free_slots;
-    for (int slot = 0; slot < checkpoint_slots; ++slot)
-      free_slots.push_back(slot);
-
-    auto restore_adjoint_attenuation = [&]() {
-      specfem::tag_dispatch::for_each(
-          assembly.attenuation.attenuation_medium_combinations,
-          [&]<typename TagsType>() {
-            auto &medium = assembly.attenuation.attenuation_storage
-                               .template get<TagsType>();
-            specfem::solver::combined_undoatt_impl::restore_attenuation_memory(
-                medium, adjoint_attenuation_snapshot.template get<TagsType>());
-          });
-    };
-
-    auto update_adjoint_attenuation = [&]() {
-      specfem::tag_dispatch::for_each(
-          assembly.attenuation.attenuation_medium_combinations,
-          [&]<typename TagsType>() {
-            const auto &medium = assembly.attenuation.attenuation_storage
-                                     .template get<TagsType>();
-            specfem::solver::combined_undoatt_impl::update_attenuation_snapshot(
-                medium, adjoint_attenuation_snapshot.template get<TagsType>());
-          });
-    };
-
-    auto save_state = [&]() {
-      FieldSnapshot field_snapshot(assembly.fields.forward);
-      AttenuationSnapshotType attenuation_snapshot([&]<typename TagsType>() {
-        auto &medium =
-            assembly.attenuation.attenuation_storage.template get<TagsType>();
-        return specfem::solver::combined_undoatt_impl::save_attenuation_memory(
-            medium);
-      });
-      return std::make_unique<ForwardState>(std::move(field_snapshot),
-                                            std::move(attenuation_snapshot));
-    };
-
-    auto restore_state = [&](int slot) {
-      slots[slot]->first.restore(assembly.fields.forward);
-      specfem::tag_dispatch::for_each(
-          assembly.attenuation.attenuation_medium_combinations,
-          [&]<typename TagsType>() {
-            auto &medium = assembly.attenuation.attenuation_storage
-                               .template get<TagsType>();
-            specfem::solver::combined_undoatt_impl::restore_attenuation_memory(
-                medium, slots[slot]->second.template get<TagsType>());
-          });
-    };
-
-    auto restore_base = [&](int slot) {
-      if (slot >= 0) {
-        restore_state(slot);
-      } else {
-        checkpoint_reader->run(assembly, checkpoint_step);
-        specfem::assembly::deep_copy(assembly.fields.forward,
-                                     assembly.fields.buffer);
-      }
-    };
-
-    auto advance = [&](int start, int count) {
-      for (int offset = 0; offset < count; ++offset) {
-        specfem::solver::impl::apply_forward_step<NGLL, forward_ft,
-                                                  DimensionTag>(
-            *time_scheme, assembly, mpi_buffers, start + offset);
-      }
-    };
-
-    auto correlate_adjoint_state = [&](int global_istep) {
-      specfem::assembly::deep_copy(assembly.fields.backward,
-                                   assembly.fields.forward);
-
-      // Run periodic tasks that should execute at this step.
-      for (const auto &task : tasks) {
-        if (task && task->should_run(global_istep + 1)) {
-          task->run(assembly, global_istep + 1);
-        }
-      }
-
-      specfem::solver::impl::apply_adjoint_step<NGLL, adjoint_ft, DimensionTag>(
-          *time_scheme, assembly, mpi_buffers, global_istep);
-      specfem::compute::compute_derivatives<NGLL,
-                                            specfem::tags::Tags<DimensionTag>>(
-          assembly, dt);
-      specfem::solver::impl::log_time_marching_progress(global_istep, nstep);
-    };
-
-    auto reverse_buffered_leaf = [&](int base_start, int leaf_start,
-                                     int leaf_end, int base_slot) {
-      restore_base(base_slot);
-      advance(base_start, leaf_start - base_start);
-      for (int step = leaf_start; step < leaf_end; ++step) {
-        advance(step, 1);
-        displ_buffer.store(assembly.fields.forward, step - leaf_start);
-      }
-
-      restore_adjoint_attenuation();
-      for (int step = leaf_end - 1; step >= leaf_start; --step) {
-        displ_buffer.load(assembly.fields.forward, step - leaf_start);
-        correlate_adjoint_state(step);
-      }
-      if (leaf_start != win_start)
-        update_adjoint_attenuation();
-    };
+  for (int window_index = num_windows - 1; window_index >= 0; --window_index) {
+    const auto [begin_step, end_step] =
+        schedule.replay_window(window_index * checkpoint_interval, nstep);
 
     std::ostringstream message;
-    message << "Running checkpoint replay for subset " << subset_idx + 1
-            << " / " << num_checkpoints << " ("
-            << wavefield_checkpoint_task.forward_steps(win_end - win_start)
+    message << "Running checkpoint replay for window " << window_index + 1
+            << " / " << num_windows << " ("
+            << schedule.forward_steps(end_step - begin_step)
             << " forward steps)";
     specfem::Logger::info(message.str());
 
-    if (checkpoint_slots == 0) {
-      reverse_buffered_leaf(win_start, win_start, win_end, -1);
-    } else {
-      std::function<void(int, int, int, int)> reverse_interval;
-      reverse_interval = [&](int start, int end, int available, int base_slot) {
-        const int length = end - start;
-        if (length <= 0)
-          return;
-
-        if (length <= wavefield_checkpoint_task.buffer_steps()) {
-          reverse_buffered_leaf(start, start, end, base_slot);
-          return;
-        }
-
-        if (available == 0) {
-          for (int leaf_end = end; leaf_end > start;
-               leaf_end -= wavefield_checkpoint_task.buffer_steps()) {
-            const int leaf_start =
-                std::max(start,
-                         leaf_end - wavefield_checkpoint_task.buffer_steps());
-            reverse_buffered_leaf(start, leaf_start, leaf_end, base_slot);
-          }
-          return;
-        }
-
-        const int left_length = wavefield_checkpoint_task.split(length);
-        restore_base(base_slot);
-        advance(start, left_length);
-        const int split_slot = free_slots.back();
-        free_slots.pop_back();
-        slots[split_slot] = save_state();
-
-        reverse_interval(start + left_length, end, available - 1, split_slot);
-        slots[split_slot].reset();
-        free_slots.push_back(split_slot);
-        reverse_interval(start, start + left_length, available, base_slot);
-      };
-      reverse_interval(win_start, win_end, checkpoint_slots, -1);
-    }
+    replay.replay_window({ begin_step, end_step });
   }
 
   for (const auto &task : tasks) {

--- a/core/specfem/solver/time_marching/combined_undoatt.tpp
+++ b/core/specfem/solver/time_marching/combined_undoatt.tpp
@@ -10,8 +10,11 @@
 #include "specfem/solver/time_marching.hpp"
 #include "specfem/tags.hpp"
 #include <Kokkos_Core.hpp>
+#include <functional>
+#include <memory>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 namespace specfem::solver::combined_undoatt_impl {
 
@@ -100,9 +103,89 @@ void restore_attenuation_memory(
     specfem::datatype::deep_copy(medium.epsilon_xy_att, snapshot.epsilon_xy);
     specfem::datatype::deep_copy(medium.epsilon_yz_att, snapshot.epsilon_yz);
   }
-
-  medium.copy_to_host();
 }
+
+template <typename MediumType>
+void update_attenuation_snapshot(
+    const MediumType &medium,
+    attenuation_memory_snapshot<MediumType> &snapshot) {
+  specfem::datatype::deep_copy(snapshot.Rkappa, medium.memory_variable_kappa);
+  specfem::datatype::deep_copy(snapshot.Rxx, medium.memory_variable_Rxx);
+  specfem::datatype::deep_copy(snapshot.Rxz, medium.memory_variable_Rxz);
+  specfem::datatype::deep_copy(snapshot.epsilon_xx, medium.epsilon_xx_att);
+  specfem::datatype::deep_copy(snapshot.epsilon_zz, medium.epsilon_zz_att);
+  specfem::datatype::deep_copy(snapshot.epsilon_xz, medium.epsilon_xz_att);
+
+  if constexpr (requires { medium.memory_variable_Ryy; }) {
+    specfem::datatype::deep_copy(snapshot.Ryy, medium.memory_variable_Ryy);
+    specfem::datatype::deep_copy(snapshot.Rzz, medium.memory_variable_Rzz);
+    specfem::datatype::deep_copy(snapshot.Rxy, medium.memory_variable_Rxy);
+    specfem::datatype::deep_copy(snapshot.Ryz, medium.memory_variable_Ryz);
+    specfem::datatype::deep_copy(snapshot.epsilon_yy, medium.epsilon_yy_att);
+    specfem::datatype::deep_copy(snapshot.epsilon_xy, medium.epsilon_xy_att);
+    specfem::datatype::deep_copy(snapshot.epsilon_yz, medium.epsilon_yz_att);
+  }
+}
+
+template <specfem::element::dimension_tag DimensionTag>
+class forward_field_snapshot {
+private:
+  using forward_field_type = specfem::assembly::simulation_field<
+      DimensionTag, specfem::simulation::field_type::forward>;
+  using ViewType = Kokkos::View<type_real **, Kokkos::LayoutLeft,
+                                Kokkos::DefaultExecutionSpace>;
+
+  struct medium_snapshot {
+    ViewType displacement;
+    ViewType velocity;
+    ViewType acceleration;
+  };
+
+public:
+  explicit forward_field_snapshot(const forward_field_type &field) {
+    specfem::tag_dispatch::for_each(
+        forward_field_type::combinations, [&]<typename TagsType>() {
+          constexpr auto medium_tag = TagsType::medium_tag;
+          const auto &source = field.template get_field<medium_tag>();
+          if (source.nglob == 0)
+            return;
+
+          auto &destination = storage_.template get<TagsType>();
+          auto clone_field = [](const ViewType &view) {
+            ViewType clone(Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                                              std::string(view.label()) +
+                                                  "_revolve_checkpoint"),
+                           view.extent(0), view.extent(1));
+            Kokkos::deep_copy(clone, view);
+            return clone;
+          };
+          destination.displacement = clone_field(source.get_field());
+          destination.velocity = clone_field(source.get_field_dot());
+          destination.acceleration = clone_field(source.get_field_dot_dot());
+        });
+  }
+
+  void restore(forward_field_type &field) const {
+    specfem::tag_dispatch::for_each(
+        forward_field_type::combinations, [&]<typename TagsType>() {
+          constexpr auto medium_tag = TagsType::medium_tag;
+          auto &destination = field.template get_field<medium_tag>();
+          if (destination.nglob == 0)
+            return;
+
+          const auto &source = storage_.template get<TagsType>();
+          Kokkos::deep_copy(destination.get_field(), source.displacement);
+          Kokkos::deep_copy(destination.get_field_dot(), source.velocity);
+          Kokkos::deep_copy(destination.get_field_dot_dot(),
+                            source.acceleration);
+        });
+  }
+
+private:
+  specfem::tag_dispatch::Storage<medium_snapshot,
+                                 decltype(forward_field_type::combinations)>
+      storage_;
+};
 
 template <typename MediumType>
 void reset_attenuation_memory(MediumType &medium) {
@@ -166,19 +249,15 @@ void specfem::solver::time_marching<specfem::simulation::type::combined_undoatt,
   // ------------------------------------------------------------------
   using CheckpointReader = specfem::periodic_tasks::periodic_task<DimensionTag>;
 
-  CheckpointReader *checkpoint_reader = nullptr;
-
-  auto is_checkpoint_task = [](const auto &task,
-                               const CheckpointReader *reader) {
-    return task.get() == reader;
-  };
-
-  for (const auto &task : tasks) {
-    if (!checkpoint_reader && task &&
-        task->get_type() == specfem::periodic_tasks::type::wavefield_reader) {
-      checkpoint_reader = task.get();
+  CheckpointReader *const checkpoint_reader = [&]() -> CheckpointReader * {
+    for (const auto &task : tasks) {
+      if (task &&
+          task->get_type() == specfem::periodic_tasks::type::wavefield_reader) {
+        return task.get();
+      }
     }
-  }
+    return nullptr;
+  }();
 
   if (!checkpoint_reader) {
     throw std::runtime_error(
@@ -187,8 +266,8 @@ void specfem::solver::time_marching<specfem::simulation::type::combined_undoatt,
   }
 
   // ------------------------------------------------------------------
-  // Wavefield storage and checkpoint replay use the same periodic interval,
-  // matching NT_DUMP_ATTENUATION in Fortran.
+  // Disk checkpoints delimit replay windows. A configured window can be
+  // subdivided into smaller displacement buffers with retained boundary state.
   // ------------------------------------------------------------------
   const int checkpoint_interval = checkpoint_reader->get_time_interval();
   if (checkpoint_interval <= 0) {
@@ -196,8 +275,8 @@ void specfem::solver::time_marching<specfem::simulation::type::combined_undoatt,
         "combined_undoatt solver: wavefield reader time-interval must be > 0 "
         "(this is NT_DUMP_ATTENUATION). Set it in the wavefield config.");
   }
-  const specfem::periodic_tasks::checkpointing<DimensionTag>
-      checkpointing_task(checkpoint_interval);
+  const specfem::periodic_tasks::checkpointing<DimensionTag> checkpointing_task(
+      checkpoint_interval, checkpoint_buffer_subdivisions);
 
   // ------------------------------------------------------------------
   // Mass matrix initialization (same as forward::run()).
@@ -231,7 +310,7 @@ void specfem::solver::time_marching<specfem::simulation::type::combined_undoatt,
 
   // Pre-allocate the RAM displacement buffer for the largest possible window.
   specfem::solver::ForwardDisplacementBuffer<DimensionTag> displ_buffer;
-  displ_buffer.allocate(checkpointing_task.max_window_size(),
+  displ_buffer.allocate(checkpointing_task.buffer_steps(),
                         assembly.fields.forward);
 
   // ================================================================
@@ -259,31 +338,40 @@ void specfem::solver::time_marching<specfem::simulation::type::combined_undoatt,
       });
 
   for (const auto &task : tasks) {
-    if (task && !is_checkpoint_task(task, checkpoint_reader)) {
+    if (task &&
+        task->get_type() != specfem::periodic_tasks::type::wavefield_reader) {
       task->initialize(assembly);
     }
   }
 
-  // Iterate backward over subsets: last subset first, first subset last.
-  // Each subset window covers [checkpoint_step, window_end).
-  // We iterate over checkpoint steps in reverse order.
+  using AttenuationSnapshotType = specfem::tag_dispatch::TypedStorage<
+      specfem::solver::combined_undoatt_impl::
+          attenuation_memory_snapshot_for_tags,
+      decltype(assembly.attenuation.attenuation_medium_combinations)>;
+
   int num_checkpoints = 0;
   for (int cs = 0; cs < nstep; cs += checkpoint_interval)
     num_checkpoints++;
+
+  using FieldSnapshot =
+      specfem::solver::combined_undoatt_impl::forward_field_snapshot<
+          DimensionTag>;
+  using ForwardState = std::pair<FieldSnapshot, AttenuationSnapshotType>;
+
+  std::ostringstream strategy_message;
+  strategy_message << "Checkpoint replay: "
+                   << checkpointing_task.buffer_subdivisions()
+                   << " buffer subdivisions, "
+                   << checkpointing_task.checkpoint_slots(checkpoint_interval)
+                   << " in-memory checkpoints, "
+                   << checkpointing_task.buffer_steps()
+                   << " buffered displacement steps";
+  specfem::Logger::info(strategy_message.str());
 
   for (int subset_idx = num_checkpoints - 1; subset_idx >= 0; --subset_idx) {
     const int checkpoint_step = subset_idx * checkpoint_interval;
     const auto [win_start, win_end] =
         checkpointing_task.replay_window(checkpoint_step, nstep);
-    const int window_size = win_end - win_start;
-
-    // ---- (A) Load checkpoint from disk --------------------------------
-    // Preserve the live adjoint attenuation memory variables before loading the
-    // checkpoint, because the reader overwrites assembly.attenuation in-place.
-    using AttenuationSnapshotType = specfem::tag_dispatch::TypedStorage<
-        specfem::solver::combined_undoatt_impl::
-            attenuation_memory_snapshot_for_tags,
-        decltype(assembly.attenuation.attenuation_medium_combinations)>;
 
     AttenuationSnapshotType adjoint_attenuation_snapshot(
         [&]<typename TagsType>() {
@@ -293,89 +381,166 @@ void specfem::solver::time_marching<specfem::simulation::type::combined_undoatt,
               save_attenuation_memory(medium);
         });
 
-    // Loads into fields.buffer (kinematic) and assembly.attenuation (R_xx etc.)
-    checkpoint_reader->run(assembly, checkpoint_step);
+    const int checkpoint_slots =
+        checkpointing_task.checkpoint_slots(win_end - win_start);
+    std::vector<std::unique_ptr<ForwardState>> slots(checkpoint_slots);
+    std::vector<int> free_slots;
+    for (int slot = 0; slot < checkpoint_slots; ++slot)
+      free_slots.push_back(slot);
 
-    std::ostringstream message;
-    message << "Running forward simulation for subset " << subset_idx + 1
-            << " / " << num_checkpoints;
-    specfem::Logger::info(message.str());
+    auto restore_adjoint_attenuation = [&]() {
+      specfem::tag_dispatch::for_each(
+          assembly.attenuation.attenuation_medium_combinations,
+          [&]<typename TagsType>() {
+            auto &medium = assembly.attenuation.attenuation_storage
+                               .template get<TagsType>();
+            specfem::solver::combined_undoatt_impl::restore_attenuation_memory(
+                medium, adjoint_attenuation_snapshot.template get<TagsType>());
+          });
+    };
 
-    // Copy loaded buffer -> fields.forward (b_displ, b_veloc, b_accel)
-    specfem::assembly::deep_copy(assembly.fields.forward,
-                                 assembly.fields.buffer);
+    auto update_adjoint_attenuation = [&]() {
+      specfem::tag_dispatch::for_each(
+          assembly.attenuation.attenuation_medium_combinations,
+          [&]<typename TagsType>() {
+            const auto &medium = assembly.attenuation.attenuation_storage
+                                     .template get<TagsType>();
+            specfem::solver::combined_undoatt_impl::update_attenuation_snapshot(
+                medium, adjoint_attenuation_snapshot.template get<TagsType>());
+          });
+    };
 
-    // assembly.attenuation now holds the loaded forward checkpoint memory
-    // variables, so update_medium<forward> replays the attenuating forward
-    // physics from the checkpoint state.
+    auto save_state = [&]() {
+      FieldSnapshot field_snapshot(assembly.fields.forward);
+      AttenuationSnapshotType attenuation_snapshot([&]<typename TagsType>() {
+        auto &medium =
+            assembly.attenuation.attenuation_storage.template get<TagsType>();
+        return specfem::solver::combined_undoatt_impl::save_attenuation_memory(
+            medium);
+      });
+      return std::make_unique<ForwardState>(std::move(field_snapshot),
+                                            std::move(attenuation_snapshot));
+    };
 
-    // ---- (B) Forward replay over the subset ---------------------------
-    // Re-run the forward physics over [win_start, win_end), buffering b_displ.
-    // Equivalent to Fortran phase 1 inside the subset loop.
-    for (int k = 0; k < window_size; ++k) {
-      const int sub_istep = win_start + k;
+    auto restore_state = [&](int slot) {
+      slots[slot]->first.restore(assembly.fields.forward);
+      specfem::tag_dispatch::for_each(
+          assembly.attenuation.attenuation_medium_combinations,
+          [&]<typename TagsType>() {
+            auto &medium = assembly.attenuation.attenuation_storage
+                               .template get<TagsType>();
+            specfem::solver::combined_undoatt_impl::restore_attenuation_memory(
+                medium, slots[slot]->second.template get<TagsType>());
+          });
+    };
 
-      specfem::solver::impl::apply_forward_step<NGLL, forward_ft, DimensionTag>(
-          *time_scheme, assembly, mpi_buffers, sub_istep);
+    auto restore_base = [&](int slot) {
+      if (slot >= 0) {
+        restore_state(slot);
+      } else {
+        checkpoint_reader->run(assembly, checkpoint_step);
+        specfem::assembly::deep_copy(assembly.fields.forward,
+                                     assembly.fields.buffer);
+      }
+    };
 
-      // Store b_displ at slot k (forward order)
-      displ_buffer.store(assembly.fields.forward, k);
-    }
+    auto advance = [&](int start, int count) {
+      for (int offset = 0; offset < count; ++offset) {
+        specfem::solver::impl::apply_forward_step<NGLL, forward_ft,
+                                                  DimensionTag>(
+            *time_scheme, assembly, mpi_buffers, start + offset);
+      }
+    };
 
-    // Restore the live adjoint attenuation state after forward replay.
-    specfem::tag_dispatch::for_each(
-        assembly.attenuation.attenuation_medium_combinations,
-        [&]<typename TagsType>() {
-          auto &medium =
-              assembly.attenuation.attenuation_storage.template get<TagsType>();
-          specfem::solver::combined_undoatt_impl::restore_attenuation_memory(
-              medium, adjoint_attenuation_snapshot.template get<TagsType>());
-        });
-
-    // ---- (C) Adjoint sweep (reversed) ---------------------------------
-    // Equivalent to Fortran phase 2 inside the subset loop.
-    for (int k = window_size - 1; k >= 0; --k) {
-      const int global_istep = win_start + k;
-
-      // Restore b_displ at this sub-step (reversed order).
-      // After this call, assembly.fields.forward.displacement = b_displ[k].
-      // We then copy it into fields.backward so that compute_derivatives
-      // (which hardcodes reading assembly.fields.backward) picks up the
-      // replayed forward displacement. compute_material_derivatives only reads
-      // backward.displacement, so velocity/acceleration are irrelevant here.
-      // This matches Fortran compute_kernels_el lines 103-120
-      // (UNDO_ATTENUATION_AND_OR_PML branch).
-      displ_buffer.load(assembly.fields.forward, k);
+    auto correlate_adjoint_state = [&](int global_istep) {
       specfem::assembly::deep_copy(assembly.fields.backward,
                                    assembly.fields.forward);
 
-      // Run non-checkpoint periodic tasks that should execute at this step.
       for (const auto &task : tasks) {
-        if (task && !is_checkpoint_task(task, checkpoint_reader) &&
+        if (task &&
+            task->get_type() !=
+                specfem::periodic_tasks::type::wavefield_reader &&
             task->should_run(global_istep + 1)) {
           task->run(assembly, global_istep + 1);
         }
       }
 
-      // Advance adjoint wavefield one step forward.
       specfem::solver::impl::apply_adjoint_step<NGLL, adjoint_ft, DimensionTag>(
           *time_scheme, assembly, mpi_buffers, global_istep);
-
-      // Accumulate Fréchet kernels.
-      // assembly.fields.backward now holds b_displ (copied from the RAM
-      // buffer via fields.forward). compute_derivatives computes
-      // grad(b_displ) on-the-fly and correlates with the adjoint field to
-      // accumulate rho_kl, mu_kl, kappa_kl.
       specfem::compute::compute_derivatives<NGLL,
                                             specfem::tags::Tags<DimensionTag>>(
           assembly, dt);
-
       specfem::solver::impl::log_time_marching_progress(global_istep, nstep);
+    };
+
+    auto reverse_buffered_leaf = [&](int base_start, int leaf_start,
+                                     int leaf_end, int base_slot) {
+      restore_base(base_slot);
+      advance(base_start, leaf_start - base_start);
+      for (int step = leaf_start; step < leaf_end; ++step) {
+        advance(step, 1);
+        displ_buffer.store(assembly.fields.forward, step - leaf_start);
+      }
+
+      restore_adjoint_attenuation();
+      for (int step = leaf_end - 1; step >= leaf_start; --step) {
+        displ_buffer.load(assembly.fields.forward, step - leaf_start);
+        correlate_adjoint_state(step);
+      }
+      if (leaf_start != win_start)
+        update_adjoint_attenuation();
+    };
+
+    std::ostringstream message;
+    message << "Running checkpoint replay for subset " << subset_idx + 1
+            << " / " << num_checkpoints << " ("
+            << checkpointing_task.forward_steps(win_end - win_start)
+            << " forward steps)";
+    specfem::Logger::info(message.str());
+
+    if (checkpoint_slots == 0) {
+      reverse_buffered_leaf(win_start, win_start, win_end, -1);
+    } else {
+      std::function<void(int, int, int, int)> reverse_interval;
+      reverse_interval = [&](int start, int end, int available, int base_slot) {
+        const int length = end - start;
+        if (length <= 0)
+          return;
+
+        if (length <= checkpointing_task.buffer_steps()) {
+          reverse_buffered_leaf(start, start, end, base_slot);
+          return;
+        }
+
+        if (available == 0) {
+          for (int leaf_end = end; leaf_end > start;
+               leaf_end -= checkpointing_task.buffer_steps()) {
+            const int leaf_start =
+                std::max(start, leaf_end - checkpointing_task.buffer_steps());
+            reverse_buffered_leaf(start, leaf_start, leaf_end, base_slot);
+          }
+          return;
+        }
+
+        const int left_length = checkpointing_task.split(length);
+        restore_base(base_slot);
+        advance(start, left_length);
+        const int split_slot = free_slots.back();
+        free_slots.pop_back();
+        slots[split_slot] = save_state();
+
+        reverse_interval(start + left_length, end, available - 1, split_slot);
+        slots[split_slot].reset();
+        free_slots.push_back(split_slot);
+        reverse_interval(start, start + left_length, available, base_slot);
+      };
+      reverse_interval(win_start, win_end, checkpoint_slots, -1);
     }
   }
 
   for (const auto &task : tasks) {
-    if (task && !is_checkpoint_task(task, checkpoint_reader)) {
+    if (task &&
+        task->get_type() != specfem::periodic_tasks::type::wavefield_reader) {
       task->finalize(assembly);
     }
   }

--- a/tests/unit-tests/periodic_tasks/checkpointing.cpp
+++ b/tests/unit-tests/periodic_tasks/checkpointing.cpp
@@ -32,4 +32,37 @@ TEST(Checkpointing, RejectsInvalidInterval) {
   EXPECT_THROW(checkpointing(0), std::invalid_argument);
 }
 
+TEST(Checkpointing, CreatesSubdividedReplaySchedule) {
+  const checkpointing task(256, 4);
+
+  EXPECT_EQ(task.buffer_subdivisions(), 4);
+  EXPECT_EQ(task.buffer_steps(), 64);
+  EXPECT_EQ(task.checkpoint_slots(256), 3);
+  EXPECT_EQ(task.split(256), 64);
+  EXPECT_EQ(task.forward_steps(256), 448U);
+}
+
+TEST(Checkpointing, FallsBackToFullWindowReplay) {
+  const checkpointing task(256, 1);
+
+  EXPECT_EQ(task.buffer_subdivisions(), 1);
+  EXPECT_EQ(task.buffer_steps(), 256);
+  EXPECT_EQ(task.checkpoint_slots(256), 0);
+  EXPECT_EQ(task.split(256), 0);
+  EXPECT_EQ(task.forward_steps(256), 256U);
+}
+
+TEST(Checkpointing, PlacesShortSubdivisionFirst) {
+  const checkpointing task(256, 5);
+
+  EXPECT_EQ(task.buffer_steps(), 52);
+  EXPECT_EQ(task.checkpoint_slots(256), 4);
+  EXPECT_EQ(task.split(256), 48);
+  EXPECT_EQ(task.forward_steps(256), 460U);
+}
+
+TEST(Checkpointing, RejectsInvalidSubdivisions) {
+  EXPECT_THROW(checkpointing(4, 0), std::invalid_argument);
+}
+
 } // namespace


### PR DESCRIPTION
# Overview

This PR improves undo-attenuation checkpoint replay and separates checkpoint
loading from ordinary periodic tasks.

- Renames the replay scheduler to `wavefield_checkpoint`.
- Passes the checkpoint reader explicitly to the undo-attenuation solver
  instead of discovering and filtering it from the periodic-task vector.
- Adds configurable in-memory replay subdivision through
  `checkpointing.subdivide-buffer`.
- Retains full forward state at subdivision boundaries, allowing smaller
  displacement buffers in exchange for additional forward replay.

## Benchmark results

The 3D homogeneous viscoelastic-kernel benchmark was run with an 800-step
simulation and a 400-step disk-checkpoint interval.

| `subdivide-buffer` | Buffer steps | In-memory checkpoints | Forward steps | Solver time | Peak RSS |
|---:|---:|---:|---:|---:|---:|
| 1 | 400 | 0 | 800 | 95.23 s | 2.79 GiB |
| 3 | 134 | 2 | 1,332 | 119.27 s | 2.10 GiB |

Using three subdivisions reduced peak RSS by **24.6%** (approximately
**0.69 GiB**) while increasing solver time by **25.2%**. The previous run with
a 200-step checkpoint interval and `subdivide-buffer: 1` took 94.08 seconds,
so increasing the interval to 400 without subdivision had little timing
impact.

Each configuration was run once using the release/serial build on an Apple M4
with macOS 26.5.2, so timings should be treated as indicative.

## Numerical validation

- Kernel coordinates `X`, `Y`, and `Z` are bitwise identical between replay
  strategies.
- The worst relative L2 kernel difference is `1.04e-8`.
- The worst absolute kernel difference is `8.67e-19`.

These differences are consistent with floating-point ordering effects from the
alternative replay schedule.

## Validation

- The release solver build passes.
- All seven `WavefieldCheckpoint` unit tests pass.
- Both benchmark configurations complete successfully.
- `clang-format` and `git diff --check` pass.
