### PR TITLE
Fix benchmark path in cmake in debug-cuda

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -196,7 +196,7 @@
         "SPECFEM_ENABLE_SIMD": "ON",
         "SPECFEM_INSTALL": "ON",
         "SPECFEM_BUILD_BENCHMARKS": "ON",
-        "BENCHMARKS_BUILD_DIR": "${sourceDir}/benchmarks/build/debug-cuda"
+        "SPECFEM_BENCHMARKS_BUILD_DIR": "${sourceDir}/benchmarks/build/debug-cuda"
       }
     },
     {


### PR DESCRIPTION
This entry was left out during cmake refactor.