### PR TITLE
Make point::jacobian_matrix relocatable (fixes #2008)

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check GNU and Cmake versions
         run: gcc --version && cmake --version
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Configure Serial build
         run: cmake --preset debug
       - name: Build
@@ -28,7 +28,7 @@ jobs:
       - name: Check GNU and Cmake versions
         run: gcc --version && cmake --version
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Configure Serial build
         run: cmake --preset release
       - name: Build

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Check GNU and Cmake versions
         run: gcc --version && cmake --version
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Configure
         run: cmake --preset release
       - name: Build
@@ -33,7 +33,7 @@ jobs:
       - name: Check GNU and Cmake versions
         run: gcc --version && cmake --version
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Configure
         run: cmake --preset release-openmp
       - name: Build
@@ -53,7 +53,7 @@ jobs:
       - name: Check GNU and Cmake versions
         run: gcc --version && cmake --version
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Configure
         run: cmake --preset release-io
       - name: Build

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -25,6 +25,27 @@ jobs:
       - name: Run all tests
         run: cd build/release/tests/unit-tests
           && ctest --verbose
+  # Threaded backend. Kokkos bit-copies point types into per-thread reduction
+  # scratch, which Serial never exercises -- see issue #2008.
+  build-and-test-openmp:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check GNU and Cmake versions
+        run: gcc --version && cmake --version
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Configure
+        run: cmake --preset release-openmp
+      - name: Build
+        run: cmake --build --preset release-openmp -j 2
+      # Covers integration-tests too: the Newmark moment-tensor cases in #2008
+      # only crashed there.
+      - name: Run all tests
+        run: cd build/release-openmp/tests
+          && ctest --verbose
+        env:
+          OMP_NUM_THREADS: 2
+          OMP_PROC_BIND: spread
   # This job is for building and testing with IO dependencies like HDF5 and ADIOS2
   build-and-test-with-io-dependencies:
     runs-on: ubuntu-latest

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -38,19 +38,13 @@
     {
       "name": "release-openmp",
       "displayName": "Release -- OpenMP backend, SIMD disabled",
+      "inherits": "release-nosimd",
       "binaryDir": "build/release-openmp",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_INSTALL_PREFIX": "${sourceDir}/bin/release-openmp",
         "Kokkos_ENABLE_SERIAL": "OFF",
         "Kokkos_ENABLE_OPENMP": "ON",
-        "Kokkos_ARCH_NATIVE": "OFF",
-        "Kokkos_ENABLE_AGGRESSIVE_VECTORIZATION": "ON",
         "Kokkos_ENABLE_ATOMICS_BYPASS": "OFF",
-        "SPECFEM_BUILD_TESTS": "ON",
-        "SPECFEM_ENABLE_SIMD": "OFF",
-        "SPECFEM_INSTALL": "ON",
-        "SPECFEM_BUILD_BENCHMARKS": "ON",
         "SPECFEM_BENCHMARKS_BUILD_DIR": "${sourceDir}/benchmarks/build/release-openmp"
       }
     },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -36,6 +36,25 @@
       }
     },
     {
+      "name": "release-openmp",
+      "displayName": "Release -- OpenMP backend, SIMD disabled",
+      "binaryDir": "build/release-openmp",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/bin/release-openmp",
+        "Kokkos_ENABLE_SERIAL": "OFF",
+        "Kokkos_ENABLE_OPENMP": "ON",
+        "Kokkos_ARCH_NATIVE": "OFF",
+        "Kokkos_ENABLE_AGGRESSIVE_VECTORIZATION": "ON",
+        "Kokkos_ENABLE_ATOMICS_BYPASS": "OFF",
+        "SPECFEM_BUILD_TESTS": "ON",
+        "SPECFEM_ENABLE_SIMD": "OFF",
+        "SPECFEM_INSTALL": "ON",
+        "SPECFEM_BUILD_BENCHMARKS": "ON",
+        "SPECFEM_BENCHMARKS_BUILD_DIR": "${sourceDir}/benchmarks/build/release-openmp"
+      }
+    },
+    {
       "name": "release-cuda",
       "displayName": "Release -- CUDA enabled",
       "binaryDir": "build/release-cuda",
@@ -361,6 +380,13 @@
     {
       "name": "release-nosimd",
       "configurePreset": "release-nosimd",
+      "targets": [
+        "all"
+      ]
+    },
+    {
+      "name": "release-openmp",
+      "configurePreset": "release-openmp",
       "targets": [
         "all"
       ]

--- a/core/specfem/algorithms/gradient.hpp
+++ b/core/specfem/algorithms/gradient.hpp
@@ -73,11 +73,11 @@ KOKKOS_FORCEINLINE_FUNCTION auto element_gradient(
   TensorPointViewType df;
 
   for (int icomponent = 0; icomponent < components; ++icomponent) {
-    df(icomponent, 0) = point_jacobian_matrix.xix * df_dxi[icomponent] +
-                        point_jacobian_matrix.gammax * df_dgamma[icomponent];
+    df(icomponent, 0) = point_jacobian_matrix.xix() * df_dxi[icomponent] +
+                        point_jacobian_matrix.gammax() * df_dgamma[icomponent];
 
-    df(icomponent, 1) = point_jacobian_matrix.xiz * df_dxi[icomponent] +
-                        point_jacobian_matrix.gammaz * df_dgamma[icomponent];
+    df(icomponent, 1) = point_jacobian_matrix.xiz() * df_dxi[icomponent] +
+                        point_jacobian_matrix.gammaz() * df_dgamma[icomponent];
   }
   return df;
 }
@@ -141,17 +141,17 @@ KOKKOS_FORCEINLINE_FUNCTION auto element_gradient(
   TensorPointViewType df;
 
   for (int icomponent = 0; icomponent < components; ++icomponent) {
-    df(icomponent, 0) = point_jacobian_matrix.xix * df_dxi[icomponent] +
-                        point_jacobian_matrix.etax * df_deta[icomponent] +
-                        point_jacobian_matrix.gammax * df_dgamma[icomponent];
+    df(icomponent, 0) = point_jacobian_matrix.xix() * df_dxi[icomponent] +
+                        point_jacobian_matrix.etax() * df_deta[icomponent] +
+                        point_jacobian_matrix.gammax() * df_dgamma[icomponent];
 
-    df(icomponent, 1) = point_jacobian_matrix.xiy * df_dxi[icomponent] +
-                        point_jacobian_matrix.etay * df_deta[icomponent] +
-                        point_jacobian_matrix.gammay * df_dgamma[icomponent];
+    df(icomponent, 1) = point_jacobian_matrix.xiy() * df_dxi[icomponent] +
+                        point_jacobian_matrix.etay() * df_deta[icomponent] +
+                        point_jacobian_matrix.gammay() * df_dgamma[icomponent];
 
-    df(icomponent, 2) = point_jacobian_matrix.xiz * df_dxi[icomponent] +
-                        point_jacobian_matrix.etaz * df_deta[icomponent] +
-                        point_jacobian_matrix.gammaz * df_dgamma[icomponent];
+    df(icomponent, 2) = point_jacobian_matrix.xiz() * df_dxi[icomponent] +
+                        point_jacobian_matrix.etaz() * df_deta[icomponent] +
+                        point_jacobian_matrix.gammaz() * df_dgamma[icomponent];
   }
   return df;
 }

--- a/core/specfem/algorithms/interpolate.hpp
+++ b/core/specfem/algorithms/interpolate.hpp
@@ -4,6 +4,7 @@
 #include "specfem/execution.hpp"
 #include "specfem/setup.hpp"
 #include <Kokkos_Core.hpp>
+#include <type_traits>
 
 /**
  * @file interpolate.hpp
@@ -81,12 +82,18 @@ interpolate_function(const PolynomialViewType &polynomial,
   const int N = polynomial.extent(0);
   using T = typename FunctionViewType::value_type;
 
+  // `Kokkos::Sum<T>` bit-copies the reduction scalar out of per-thread scratch
+  // on threaded backends, so a `T` holding pointers into itself dangles once
+  // that scratch is freed -- see issue #2008.
+  static_assert(std::is_trivially_copyable_v<T>,
+                "Reduction scalar must be trivially copyable");
+
   T result(0.0);
 
   impl::InterpolateFunctor functor(polynomial, function);
 
   Kokkos::parallel_reduce(
-      Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2> >({ 0, 0 }, { N, N }),
+      Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>>({ 0, 0 }, { N, N }),
       functor, Kokkos::Sum<T>(result));
 
   return result;
@@ -119,10 +126,16 @@ interpolate_function(const PolynomialViewType &polynomial,
   const int N = polynomial.extent(0);
   using T = typename FunctionViewType::value_type;
 
+  // `Kokkos::Sum<T>` bit-copies the reduction scalar out of per-thread scratch
+  // on threaded backends, so a `T` holding pointers into itself dangles once
+  // that scratch is freed -- see issue #2008.
+  static_assert(std::is_trivially_copyable_v<T>,
+                "Reduction scalar must be trivially copyable");
+
   T result(0.0);
   impl::InterpolateFunctor functor(polynomial, function);
 
-  Kokkos::parallel_reduce(Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<3> >(
+  Kokkos::parallel_reduce(Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<3>>(
                               { 0, 0, 0 }, { N, N, N }),
                           functor, Kokkos::Sum<T>(result));
 

--- a/core/specfem/algorithms/locate_point/dim2/locate_point_impl.cpp
+++ b/core/specfem/algorithms/locate_point/dim2/locate_point_impl.cpp
@@ -106,8 +106,8 @@ std::tuple<type_real, type_real> get_local_coordinates(
     type_real dx = -(loc.x - global.x);
     type_real dz = -(loc.z - global.z);
 
-    type_real dxi = jacobian.xix * dx + jacobian.xiz * dz;
-    type_real dgamma = jacobian.gammax * dx + jacobian.gammaz * dz;
+    type_real dxi = jacobian.xix() * dx + jacobian.xiz() * dz;
+    type_real dgamma = jacobian.gammax() * dx + jacobian.gammaz() * dz;
 
     xi += dxi;
     gamma += dgamma;
@@ -156,16 +156,16 @@ std::pair<type_real, bool> get_local_edge_coordinate(
        &jacobian]() -> std::tuple<type_real &, type_real &, type_real &> {
     if (mesh_entity == specfem::mesh_entity::dim2::type::bottom) {
       gamma = -1;
-      return { xi, jacobian.xix, jacobian.xiz };
+      return { xi, jacobian.xix(), jacobian.xiz() };
     } else if (mesh_entity == specfem::mesh_entity::dim2::type::right) {
       xi = 1;
-      return { gamma, jacobian.gammax, jacobian.gammaz };
+      return { gamma, jacobian.gammax(), jacobian.gammaz() };
     } else if (mesh_entity == specfem::mesh_entity::dim2::type::top) {
       gamma = 1;
-      return { xi, jacobian.xix, jacobian.xiz };
+      return { xi, jacobian.xix(), jacobian.xiz() };
     } else {
       xi = -1;
-      return { gamma, jacobian.gammax, jacobian.gammaz };
+      return { gamma, jacobian.gammax(), jacobian.gammaz() };
     }
   }();
   edgecoord = coord;
@@ -249,8 +249,8 @@ std::tuple<type_real, type_real> get_best_location(
     type_real dx = -(loc.x - global.x);
     type_real dz = -(loc.z - global.z);
 
-    type_real dxi = jacobian.xix * dx + jacobian.xiz * dz;
-    type_real dgamma = jacobian.gammax * dx + jacobian.gammaz * dz;
+    type_real dxi = jacobian.xix() * dx + jacobian.xiz() * dz;
+    type_real dgamma = jacobian.gammax() * dx + jacobian.gammaz() * dz;
 
     xi += dxi;
     gamma += dgamma;

--- a/core/specfem/algorithms/locate_point/dim3/locate_point_impl.cpp
+++ b/core/specfem/algorithms/locate_point/dim3/locate_point_impl.cpp
@@ -448,8 +448,12 @@ std::pair<std::pair<type_real, type_real>, bool> get_local_face_coordinate(
         jacobian_facecoord2z] = [&xi, &gamma, &eta, &mesh_entity, &jacobian]()
       -> std::tuple<type_real &, type_real &, type_real &, type_real &,
                     type_real &, type_real &, type_real &, type_real &> {
-    if (mesh_entity == specfem::mesh_entity::dim3::type::bottom) {
-      gamma = -1;
+    // Each face pair (bottom/top, left/right, front/back) frees the same two
+    // reference coordinates and constrains the third to -1 or +1; only that
+    // sign differs within a pair.
+    if (mesh_entity == specfem::mesh_entity::dim3::type::bottom ||
+        mesh_entity == specfem::mesh_entity::dim3::type::top) {
+      gamma = (mesh_entity == specfem::mesh_entity::dim3::type::top) ? 1 : -1;
       return { xi,
                eta,
                jacobian.xix(),
@@ -458,18 +462,9 @@ std::pair<std::pair<type_real, type_real>, bool> get_local_face_coordinate(
                jacobian.etax(),
                jacobian.etay(),
                jacobian.etaz() };
-    } else if (mesh_entity == specfem::mesh_entity::dim3::type::top) {
-      gamma = 1;
-      return { xi,
-               eta,
-               jacobian.xix(),
-               jacobian.xiy(),
-               jacobian.xiz(),
-               jacobian.etax(),
-               jacobian.etay(),
-               jacobian.etaz() };
-    } else if (mesh_entity == specfem::mesh_entity::dim3::type::left) {
-      xi = -1;
+    } else if (mesh_entity == specfem::mesh_entity::dim3::type::left ||
+               mesh_entity == specfem::mesh_entity::dim3::type::right) {
+      xi = (mesh_entity == specfem::mesh_entity::dim3::type::right) ? 1 : -1;
       return { eta,
                gamma,
                jacobian.etax(),
@@ -478,28 +473,8 @@ std::pair<std::pair<type_real, type_real>, bool> get_local_face_coordinate(
                jacobian.gammax(),
                jacobian.gammay(),
                jacobian.gammaz() };
-    } else if (mesh_entity == specfem::mesh_entity::dim3::type::right) {
-      xi = 1;
-      return { eta,
-               gamma,
-               jacobian.etax(),
-               jacobian.etay(),
-               jacobian.etaz(),
-               jacobian.gammax(),
-               jacobian.gammay(),
-               jacobian.gammaz() };
-    } else if (mesh_entity == specfem::mesh_entity::dim3::type::front) {
-      eta = -1;
-      return { xi,
-               gamma,
-               jacobian.xix(),
-               jacobian.xiy(),
-               jacobian.xiz(),
-               jacobian.gammax(),
-               jacobian.gammay(),
-               jacobian.gammaz() };
-    } else { // back
-      eta = 1;
+    } else { // front / back
+      eta = (mesh_entity == specfem::mesh_entity::dim3::type::back) ? 1 : -1;
       return { xi,
                gamma,
                jacobian.xix(),

--- a/core/specfem/algorithms/locate_point/dim3/locate_point_impl.cpp
+++ b/core/specfem/algorithms/locate_point/dim3/locate_point_impl.cpp
@@ -148,11 +148,12 @@ std::tuple<type_real, type_real, type_real> get_local_coordinates(
     }
 
     // Compute the change in local coordinates using the Jacobian
-    type_real dxi = jacobian.xix * dx + jacobian.xiy * dy + jacobian.xiz * dz;
+    type_real dxi =
+        jacobian.xix() * dx + jacobian.xiy() * dy + jacobian.xiz() * dz;
     type_real deta =
-        jacobian.etax * dx + jacobian.etay * dy + jacobian.etaz * dz;
-    type_real dgamma =
-        jacobian.gammax * dx + jacobian.gammay * dy + jacobian.gammaz * dz;
+        jacobian.etax() * dx + jacobian.etay() * dy + jacobian.etaz() * dz;
+    type_real dgamma = jacobian.gammax() * dx + jacobian.gammay() * dy +
+                       jacobian.gammaz() * dz;
 
     // decreases step length if step is large
     if ((dxi * dxi + deta * deta + dgamma * dgamma) >
@@ -218,11 +219,11 @@ std::tuple<type_real, type_real, type_real> get_local_coordinates(
 
         // Compute the change in local coordinates using the Jacobian
         type_real dxi =
-            jacobian.xix * dx + jacobian.xiy * dy + jacobian.xiz * dz;
+            jacobian.xix() * dx + jacobian.xiy() * dy + jacobian.xiz() * dz;
         type_real deta =
-            jacobian.etax * dx + jacobian.etay * dy + jacobian.etaz * dz;
-        type_real dgamma =
-            jacobian.gammax * dx + jacobian.gammay * dy + jacobian.gammaz * dz;
+            jacobian.etax() * dx + jacobian.etay() * dy + jacobian.etaz() * dz;
+        type_real dgamma = jacobian.gammax() * dx + jacobian.gammay() * dy +
+                           jacobian.gammaz() * dz;
 
         // decreases step length if step is large
         if ((dxi * dxi + deta * deta + dgamma * dgamma) >
@@ -449,36 +450,64 @@ std::pair<std::pair<type_real, type_real>, bool> get_local_face_coordinate(
                     type_real &, type_real &, type_real &, type_real &> {
     if (mesh_entity == specfem::mesh_entity::dim3::type::bottom) {
       gamma = -1;
-      return { xi,           eta,           jacobian.xix,  jacobian.xiy,
-               jacobian.xiz, jacobian.etax, jacobian.etay, jacobian.etaz };
+      return { xi,
+               eta,
+               jacobian.xix(),
+               jacobian.xiy(),
+               jacobian.xiz(),
+               jacobian.etax(),
+               jacobian.etay(),
+               jacobian.etaz() };
     } else if (mesh_entity == specfem::mesh_entity::dim3::type::top) {
       gamma = 1;
-      return { xi,           eta,           jacobian.xix,  jacobian.xiy,
-               jacobian.xiz, jacobian.etax, jacobian.etay, jacobian.etaz };
+      return { xi,
+               eta,
+               jacobian.xix(),
+               jacobian.xiy(),
+               jacobian.xiz(),
+               jacobian.etax(),
+               jacobian.etay(),
+               jacobian.etaz() };
     } else if (mesh_entity == specfem::mesh_entity::dim3::type::left) {
       xi = -1;
-      return {
-        eta,           gamma,           jacobian.etax,   jacobian.etay,
-        jacobian.etaz, jacobian.gammax, jacobian.gammay, jacobian.gammaz
-      };
+      return { eta,
+               gamma,
+               jacobian.etax(),
+               jacobian.etay(),
+               jacobian.etaz(),
+               jacobian.gammax(),
+               jacobian.gammay(),
+               jacobian.gammaz() };
     } else if (mesh_entity == specfem::mesh_entity::dim3::type::right) {
       xi = 1;
-      return {
-        eta,           gamma,           jacobian.etax,   jacobian.etay,
-        jacobian.etaz, jacobian.gammax, jacobian.gammay, jacobian.gammaz
-      };
+      return { eta,
+               gamma,
+               jacobian.etax(),
+               jacobian.etay(),
+               jacobian.etaz(),
+               jacobian.gammax(),
+               jacobian.gammay(),
+               jacobian.gammaz() };
     } else if (mesh_entity == specfem::mesh_entity::dim3::type::front) {
       eta = -1;
-      return {
-        xi,           gamma,           jacobian.xix,    jacobian.xiy,
-        jacobian.xiz, jacobian.gammax, jacobian.gammay, jacobian.gammaz
-      };
+      return { xi,
+               gamma,
+               jacobian.xix(),
+               jacobian.xiy(),
+               jacobian.xiz(),
+               jacobian.gammax(),
+               jacobian.gammay(),
+               jacobian.gammaz() };
     } else { // back
       eta = 1;
-      return {
-        xi,           gamma,           jacobian.xix,    jacobian.xiy,
-        jacobian.xiz, jacobian.gammax, jacobian.gammay, jacobian.gammaz
-      };
+      return { xi,
+               gamma,
+               jacobian.xix(),
+               jacobian.xiy(),
+               jacobian.xiz(),
+               jacobian.gammax(),
+               jacobian.gammay(),
+               jacobian.gammaz() };
     }
   }();
   facecoord1 = coord.first;

--- a/core/specfem/algorithms/locate_point/dim3/project_onto_surface.cpp
+++ b/core/specfem/algorithms/locate_point/dim3/project_onto_surface.cpp
@@ -103,10 +103,10 @@ specfem::algorithms::project_onto_surface(
 
       // Select the two free reference coordinates for this face and the inverse
       // Jacobian rows that map a horizontal (x, y) residual into their updates.
-      // free1/free2 alias xi/eta/gamma and j1x..j2y alias members of
-      // `jacobian`; because `jacobian` is reassigned in place below (same
-      // object, members updated), those references stay valid across
-      // iterations.
+      // free1/free2 alias xi/eta/gamma and j1x..j2y alias components of
+      // `jacobian`'s tensor; because `jacobian` is reassigned in place below
+      // (same object, components overwritten), those references stay valid
+      // across iterations.
       auto [free1, free2, j1x, j1y, j2x, j2y] =
           [&xi, &eta, &gamma, &face,
            &jacobian]() -> std::tuple<type_real &, type_real &, type_real &,
@@ -114,16 +114,28 @@ specfem::algorithms::project_onto_surface(
         using specfem::mesh_entity::dim3::type;
         if (face == type::bottom || face == type::top) {
           gamma = (face == type::top) ? type_real(1) : type_real(-1);
-          return { xi,           eta,           jacobian.xix,
-                   jacobian.xiy, jacobian.etax, jacobian.etay };
+          return { xi,
+                   eta,
+                   jacobian.xix(),
+                   jacobian.xiy(),
+                   jacobian.etax(),
+                   jacobian.etay() };
         } else if (face == type::left || face == type::right) {
           xi = (face == type::right) ? type_real(1) : type_real(-1);
-          return { eta,           gamma,           jacobian.etax,
-                   jacobian.etay, jacobian.gammax, jacobian.gammay };
+          return { eta,
+                   gamma,
+                   jacobian.etax(),
+                   jacobian.etay(),
+                   jacobian.gammax(),
+                   jacobian.gammay() };
         } else { // front or back
           eta = (face == type::back) ? type_real(1) : type_real(-1);
-          return { xi,           gamma,           jacobian.xix,
-                   jacobian.xiy, jacobian.gammax, jacobian.gammay };
+          return { xi,
+                   gamma,
+                   jacobian.xix(),
+                   jacobian.xiy(),
+                   jacobian.gammax(),
+                   jacobian.gammay() };
         }
       }();
 

--- a/core/specfem/assembly/compute_source_array/dim2/impl/compute_source_array_from_tensor.cpp
+++ b/core/specfem/assembly/compute_source_array/dim2/impl/compute_source_array_from_tensor.cpp
@@ -69,11 +69,11 @@ void compute_source_array_from_tensor_and_element_jacobian(
 
       // Compute the derivatives at the source location
       type_real dsrc_dx =
-          (hpxi_source(ix) * derivatives_source.xix) * hgamma_source(iz) +
-          hxi_source(ix) * (hpgamma_source(iz) * derivatives_source.gammax);
+          (hpxi_source(ix) * derivatives_source.xix()) * hgamma_source(iz) +
+          hxi_source(ix) * (hpgamma_source(iz) * derivatives_source.gammax());
       type_real dsrc_dz =
-          (hpxi_source(ix) * derivatives_source.xiz) * hgamma_source(iz) +
-          hxi_source(ix) * (hpgamma_source(iz) * derivatives_source.gammaz);
+          (hpxi_source(ix) * derivatives_source.xiz()) * hgamma_source(iz) +
+          hxi_source(ix) * (hpgamma_source(iz) * derivatives_source.gammaz());
 
       for (int i = 0; i < ncomponents; ++i) {
         source_array(i, iz, ix) =

--- a/core/specfem/assembly/compute_source_array/dim3/impl/compute_source_array_from_tensor.cpp
+++ b/core/specfem/assembly/compute_source_array/dim3/impl/compute_source_array_from_tensor.cpp
@@ -77,26 +77,26 @@ void compute_source_array_from_tensor_and_element_jacobian(
 
         // Compute the derivatives at the source location
         type_real dsrc_dx =
-            (hpxi_source(ix) * derivatives_source.xix) * heta_source(iy) *
+            (hpxi_source(ix) * derivatives_source.xix()) * heta_source(iy) *
                 hgamma_source(iz) +
-            hxi_source(ix) * (hpeta_source(iy) * derivatives_source.etax) *
+            hxi_source(ix) * (hpeta_source(iy) * derivatives_source.etax()) *
                 hgamma_source(iz) +
             hxi_source(ix) * heta_source(iy) *
-                (hpgamma_source(iz) * derivatives_source.gammax);
+                (hpgamma_source(iz) * derivatives_source.gammax());
         type_real dsrc_dy =
-            (hpxi_source(ix) * derivatives_source.xiy) * heta_source(iy) *
+            (hpxi_source(ix) * derivatives_source.xiy()) * heta_source(iy) *
                 hgamma_source(iz) +
-            hxi_source(ix) * (hpeta_source(iy) * derivatives_source.etay) *
+            hxi_source(ix) * (hpeta_source(iy) * derivatives_source.etay()) *
                 hgamma_source(iz) +
             hxi_source(ix) * heta_source(iy) *
-                (hpgamma_source(iz) * derivatives_source.gammay);
+                (hpgamma_source(iz) * derivatives_source.gammay());
         type_real dsrc_dz =
-            (hpxi_source(ix) * derivatives_source.xiz) * heta_source(iy) *
+            (hpxi_source(ix) * derivatives_source.xiz()) * heta_source(iy) *
                 hgamma_source(iz) +
-            hxi_source(ix) * (hpeta_source(iy) * derivatives_source.etaz) *
+            hxi_source(ix) * (hpeta_source(iy) * derivatives_source.etaz()) *
                 hgamma_source(iz) +
             hxi_source(ix) * heta_source(iy) *
-                (hpgamma_source(iz) * derivatives_source.gammaz);
+                (hpgamma_source(iz) * derivatives_source.gammaz());
 
         for (int i = 0; i < ncomponents; ++i) {
           source_array(i, iz, iy, ix) = source_tensor(i, 0) * dsrc_dx +

--- a/core/specfem/assembly/jacobian_matrix/dim2/impl_load.hpp
+++ b/core/specfem/assembly/jacobian_matrix/dim2/impl_load.hpp
@@ -41,29 +41,29 @@ KOKKOS_FORCEINLINE_FUNCTION void impl_load(const IndexType &index,
   const auto mask = index.template get_mask<simd>();
 
   if constexpr (on_device) {
-    point.xix = Kokkos::Experimental::simd_partial_load(&container.xix[_index],
-                                                        mask, tag_type());
-    point.gammax = Kokkos::Experimental::simd_partial_load(
+    point.xix() = Kokkos::Experimental::simd_partial_load(
+        &container.xix[_index], mask, tag_type());
+    point.gammax() = Kokkos::Experimental::simd_partial_load(
         &container.gammax[_index], mask, tag_type());
-    point.xiz = Kokkos::Experimental::simd_partial_load(&container.xiz[_index],
-                                                        mask, tag_type());
-    point.gammaz = Kokkos::Experimental::simd_partial_load(
+    point.xiz() = Kokkos::Experimental::simd_partial_load(
+        &container.xiz[_index], mask, tag_type());
+    point.gammaz() = Kokkos::Experimental::simd_partial_load(
         &container.gammaz[_index], mask, tag_type());
     if constexpr (StoreJacobian) {
-      point.jacobian = Kokkos::Experimental::simd_partial_load(
+      point.jacobian() = Kokkos::Experimental::simd_partial_load(
           &container.jacobian[_index], mask, tag_type());
     }
   } else {
-    point.xix = Kokkos::Experimental::simd_partial_load(
+    point.xix() = Kokkos::Experimental::simd_partial_load(
         &container.h_xix[_index], mask, tag_type());
-    point.gammax = Kokkos::Experimental::simd_partial_load(
+    point.gammax() = Kokkos::Experimental::simd_partial_load(
         &container.h_gammax[_index], mask, tag_type());
-    point.xiz = Kokkos::Experimental::simd_partial_load(
+    point.xiz() = Kokkos::Experimental::simd_partial_load(
         &container.h_xiz[_index], mask, tag_type());
-    point.gammaz = Kokkos::Experimental::simd_partial_load(
+    point.gammaz() = Kokkos::Experimental::simd_partial_load(
         &container.h_gammaz[_index], mask, tag_type());
     if constexpr (StoreJacobian) {
-      point.jacobian = Kokkos::Experimental::simd_partial_load(
+      point.jacobian() = Kokkos::Experimental::simd_partial_load(
           &container.h_jacobian[_index], mask, tag_type());
     }
   }
@@ -97,20 +97,20 @@ KOKKOS_FORCEINLINE_FUNCTION void impl_load(const IndexType &index,
   const std::size_t _index = mapping(ispec, iz, ix);
 
   if constexpr (on_device) {
-    point.xix = container.xix.get_base_view().data()[_index];
-    point.gammax = container.gammax.get_base_view().data()[_index];
-    point.xiz = container.xiz.get_base_view().data()[_index];
-    point.gammaz = container.gammaz.get_base_view().data()[_index];
+    point.xix() = container.xix.get_base_view().data()[_index];
+    point.gammax() = container.gammax.get_base_view().data()[_index];
+    point.xiz() = container.xiz.get_base_view().data()[_index];
+    point.gammaz() = container.gammaz.get_base_view().data()[_index];
     if constexpr (StoreJacobian) {
-      point.jacobian = container.jacobian.get_base_view().data()[_index];
+      point.jacobian() = container.jacobian.get_base_view().data()[_index];
     }
   } else {
-    point.xix = container.h_xix[_index];
-    point.gammax = container.h_gammax[_index];
-    point.xiz = container.h_xiz[_index];
-    point.gammaz = container.h_gammaz[_index];
+    point.xix() = container.h_xix[_index];
+    point.gammax() = container.h_gammax[_index];
+    point.xiz() = container.h_xiz[_index];
+    point.gammaz() = container.h_gammaz[_index];
     if constexpr (StoreJacobian) {
-      point.jacobian = container.h_jacobian[_index];
+      point.jacobian() = container.h_jacobian[_index];
     }
   }
 }

--- a/core/specfem/assembly/jacobian_matrix/dim2/impl_store.hpp
+++ b/core/specfem/assembly/jacobian_matrix/dim2/impl_store.hpp
@@ -42,31 +42,33 @@ inline void impl_store(const IndexType &index, const ContainerType &derivatives,
 
   if constexpr (on_device) {
     Kokkos::Experimental::simd_partial_store(
-        jacobian_matrix.xix, &derivatives.xix[_index], mask, tag_type());
+        jacobian_matrix.xix(), &derivatives.xix[_index], mask, tag_type());
+    Kokkos::Experimental::simd_partial_store(jacobian_matrix.gammax(),
+                                             &derivatives.gammax[_index], mask,
+                                             tag_type());
     Kokkos::Experimental::simd_partial_store(
-        jacobian_matrix.gammax, &derivatives.gammax[_index], mask, tag_type());
-    Kokkos::Experimental::simd_partial_store(
-        jacobian_matrix.xiz, &derivatives.xiz[_index], mask, tag_type());
-    Kokkos::Experimental::simd_partial_store(
-        jacobian_matrix.gammaz, &derivatives.gammaz[_index], mask, tag_type());
+        jacobian_matrix.xiz(), &derivatives.xiz[_index], mask, tag_type());
+    Kokkos::Experimental::simd_partial_store(jacobian_matrix.gammaz(),
+                                             &derivatives.gammaz[_index], mask,
+                                             tag_type());
     if constexpr (StoreJacobian) {
-      Kokkos::Experimental::simd_partial_store(jacobian_matrix.jacobian,
+      Kokkos::Experimental::simd_partial_store(jacobian_matrix.jacobian(),
                                                &derivatives.jacobian[_index],
                                                mask, tag_type());
     }
   } else {
     Kokkos::Experimental::simd_partial_store(
-        jacobian_matrix.xix, &derivatives.h_xix[_index], mask, tag_type());
-    Kokkos::Experimental::simd_partial_store(jacobian_matrix.gammax,
+        jacobian_matrix.xix(), &derivatives.h_xix[_index], mask, tag_type());
+    Kokkos::Experimental::simd_partial_store(jacobian_matrix.gammax(),
                                              &derivatives.h_gammax[_index],
                                              mask, tag_type());
     Kokkos::Experimental::simd_partial_store(
-        jacobian_matrix.xiz, &derivatives.h_xiz[_index], mask, tag_type());
-    Kokkos::Experimental::simd_partial_store(jacobian_matrix.gammaz,
+        jacobian_matrix.xiz(), &derivatives.h_xiz[_index], mask, tag_type());
+    Kokkos::Experimental::simd_partial_store(jacobian_matrix.gammaz(),
                                              &derivatives.h_gammaz[_index],
                                              mask, tag_type());
     if constexpr (StoreJacobian) {
-      Kokkos::Experimental::simd_partial_store(jacobian_matrix.jacobian,
+      Kokkos::Experimental::simd_partial_store(jacobian_matrix.jacobian(),
                                                &derivatives.h_jacobian[_index],
                                                mask, tag_type());
     }
@@ -100,20 +102,20 @@ inline void impl_store(const IndexType &index, const ContainerType &derivatives,
   const std::size_t _index = mapping(ispec, iz, ix);
 
   if constexpr (on_device) {
-    derivatives.xix[_index] = jacobian_matrix.xix;
-    derivatives.gammax[_index] = jacobian_matrix.gammax;
-    derivatives.xiz[_index] = jacobian_matrix.xiz;
-    derivatives.gammaz[_index] = jacobian_matrix.gammaz;
+    derivatives.xix[_index] = jacobian_matrix.xix();
+    derivatives.gammax[_index] = jacobian_matrix.gammax();
+    derivatives.xiz[_index] = jacobian_matrix.xiz();
+    derivatives.gammaz[_index] = jacobian_matrix.gammaz();
     if constexpr (StoreJacobian) {
-      derivatives.jacobian[_index] = jacobian_matrix.jacobian;
+      derivatives.jacobian[_index] = jacobian_matrix.jacobian();
     }
   } else {
-    derivatives.h_xix[_index] = jacobian_matrix.xix;
-    derivatives.h_gammax[_index] = jacobian_matrix.gammax;
-    derivatives.h_xiz[_index] = jacobian_matrix.xiz;
-    derivatives.h_gammaz[_index] = jacobian_matrix.gammaz;
+    derivatives.h_xix[_index] = jacobian_matrix.xix();
+    derivatives.h_gammax[_index] = jacobian_matrix.gammax();
+    derivatives.h_xiz[_index] = jacobian_matrix.xiz();
+    derivatives.h_gammaz[_index] = jacobian_matrix.gammaz();
     if constexpr (StoreJacobian) {
-      derivatives.h_jacobian[_index] = jacobian_matrix.jacobian;
+      derivatives.h_jacobian[_index] = jacobian_matrix.jacobian();
     }
   }
 }

--- a/core/specfem/assembly/jacobian_matrix/dim2/jacobian_matrix.cpp
+++ b/core/specfem/assembly/jacobian_matrix/dim2/jacobian_matrix.cpp
@@ -66,7 +66,7 @@ specfem::assembly::jacobian_matrix<specfem::element::dimension_tag::dim2>::
       for (int ix = 0; ix < ngllx; ++ix) {
 
         // compute Jacobian matrix
-        std::vector<std::vector<type_real> > sv_dershape2D(
+        std::vector<std::vector<type_real>> sv_dershape2D(
             2, std::vector<type_real>(ngnod));
         for (int in = 0; in < ngnod; ++in) {
           for (int idim = 0; idim < ndim; ++idim) {
@@ -76,11 +76,11 @@ specfem::assembly::jacobian_matrix<specfem::element::dimension_tag::dim2>::
 
         auto jacobian = jacobian::compute_jacobian(coorg, ngnod, sv_dershape2D);
 
-        this->h_xix(ispec, iz, ix) = jacobian.xix;
-        this->h_gammax(ispec, iz, ix) = jacobian.gammax;
-        this->h_xiz(ispec, iz, ix) = jacobian.xiz;
-        this->h_gammaz(ispec, iz, ix) = jacobian.gammaz;
-        this->h_jacobian(ispec, iz, ix) = jacobian.jacobian;
+        this->h_xix(ispec, iz, ix) = jacobian.xix();
+        this->h_gammax(ispec, iz, ix) = jacobian.gammax();
+        this->h_xiz(ispec, iz, ix) = jacobian.xiz();
+        this->h_gammaz(ispec, iz, ix) = jacobian.gammaz();
+        this->h_jacobian(ispec, iz, ix) = jacobian.jacobian();
       }
     }
   };
@@ -103,7 +103,7 @@ void specfem::assembly::jacobian_matrix<
   specfem::datatype::deep_copy(jacobian, h_jacobian);
 }
 
-std::tuple<bool, Kokkos::View<bool *, Kokkos::DefaultHostExecutionSpace> >
+std::tuple<bool, Kokkos::View<bool *, Kokkos::DefaultHostExecutionSpace>>
 specfem::assembly::jacobian_matrix<
     specfem::element::dimension_tag::dim2>::check_small_jacobian() const {
   Kokkos::View<bool *, Kokkos::DefaultHostExecutionSpace> small_jacobian(
@@ -129,7 +129,7 @@ specfem::assembly::jacobian_matrix<
             const auto jacobian = [&]() {
               PointJacobianMatrixType jacobian_matrix;
               specfem::assembly::load_on_host(index, *this, jacobian_matrix);
-              return jacobian_matrix.jacobian;
+              return jacobian_matrix.jacobian();
             }();
             if (jacobian < threshold) {
               small_jacobian(ispec) = true;

--- a/core/specfem/assembly/jacobian_matrix/dim3/impl_load.hpp
+++ b/core/specfem/assembly/jacobian_matrix/dim3/impl_load.hpp
@@ -36,49 +36,49 @@ KOKKOS_FORCEINLINE_FUNCTION void impl_load(const IndexType &index,
   const auto mask = index.template get_mask<simd>();
 
   if constexpr (on_device) {
-    point.xix = Kokkos::Experimental::simd_partial_load(&container.xix[_index],
-                                                        mask, tag_type());
-    point.xiy = Kokkos::Experimental::simd_partial_load(&container.xiy[_index],
-                                                        mask, tag_type());
-    point.xiz = Kokkos::Experimental::simd_partial_load(&container.xiz[_index],
-                                                        mask, tag_type());
-    point.etax = Kokkos::Experimental::simd_partial_load(
+    point.xix() = Kokkos::Experimental::simd_partial_load(
+        &container.xix[_index], mask, tag_type());
+    point.xiy() = Kokkos::Experimental::simd_partial_load(
+        &container.xiy[_index], mask, tag_type());
+    point.xiz() = Kokkos::Experimental::simd_partial_load(
+        &container.xiz[_index], mask, tag_type());
+    point.etax() = Kokkos::Experimental::simd_partial_load(
         &container.etax[_index], mask, tag_type());
-    point.etay = Kokkos::Experimental::simd_partial_load(
+    point.etay() = Kokkos::Experimental::simd_partial_load(
         &container.etay[_index], mask, tag_type());
-    point.etaz = Kokkos::Experimental::simd_partial_load(
+    point.etaz() = Kokkos::Experimental::simd_partial_load(
         &container.etaz[_index], mask, tag_type());
-    point.gammax = Kokkos::Experimental::simd_partial_load(
+    point.gammax() = Kokkos::Experimental::simd_partial_load(
         &container.gammax[_index], mask, tag_type());
-    point.gammay = Kokkos::Experimental::simd_partial_load(
+    point.gammay() = Kokkos::Experimental::simd_partial_load(
         &container.gammay[_index], mask, tag_type());
-    point.gammaz = Kokkos::Experimental::simd_partial_load(
+    point.gammaz() = Kokkos::Experimental::simd_partial_load(
         &container.gammaz[_index], mask, tag_type());
     if constexpr (load_jacobian) {
-      point.jacobian = Kokkos::Experimental::simd_partial_load(
+      point.jacobian() = Kokkos::Experimental::simd_partial_load(
           &container.jacobian[_index], mask, tag_type());
     }
   } else {
-    point.xix = Kokkos::Experimental::simd_partial_load(
+    point.xix() = Kokkos::Experimental::simd_partial_load(
         &container.h_xix[_index], mask, tag_type());
-    point.xiy = Kokkos::Experimental::simd_partial_load(
+    point.xiy() = Kokkos::Experimental::simd_partial_load(
         &container.h_xiy[_index], mask, tag_type());
-    point.xiz = Kokkos::Experimental::simd_partial_load(
+    point.xiz() = Kokkos::Experimental::simd_partial_load(
         &container.h_xiz[_index], mask, tag_type());
-    point.etax = Kokkos::Experimental::simd_partial_load(
+    point.etax() = Kokkos::Experimental::simd_partial_load(
         &container.h_etax[_index], mask, tag_type());
-    point.etay = Kokkos::Experimental::simd_partial_load(
+    point.etay() = Kokkos::Experimental::simd_partial_load(
         &container.h_etay[_index], mask, tag_type());
-    point.etaz = Kokkos::Experimental::simd_partial_load(
+    point.etaz() = Kokkos::Experimental::simd_partial_load(
         &container.h_etaz[_index], mask, tag_type());
-    point.gammax = Kokkos::Experimental::simd_partial_load(
+    point.gammax() = Kokkos::Experimental::simd_partial_load(
         &container.h_gammax[_index], mask, tag_type());
-    point.gammay = Kokkos::Experimental::simd_partial_load(
+    point.gammay() = Kokkos::Experimental::simd_partial_load(
         &container.h_gammay[_index], mask, tag_type());
-    point.gammaz = Kokkos::Experimental::simd_partial_load(
+    point.gammaz() = Kokkos::Experimental::simd_partial_load(
         &container.h_gammaz[_index], mask, tag_type());
     if constexpr (load_jacobian) {
-      point.jacobian = Kokkos::Experimental::simd_partial_load(
+      point.jacobian() = Kokkos::Experimental::simd_partial_load(
           &container.h_jacobian[_index], mask, tag_type());
     }
   }
@@ -109,30 +109,30 @@ KOKKOS_FORCEINLINE_FUNCTION void impl_load(const PointIndexType &index,
   const std::size_t _index = mapping(index.ispec, index.iz, index.iy, index.ix);
 
   if constexpr (on_device) {
-    point.xix = container.xix.get_base_view().data()[_index];
-    point.xiy = container.xiy.get_base_view().data()[_index];
-    point.xiz = container.xiz.get_base_view().data()[_index];
-    point.etax = container.etax.get_base_view().data()[_index];
-    point.etay = container.etay.get_base_view().data()[_index];
-    point.etaz = container.etaz.get_base_view().data()[_index];
-    point.gammax = container.gammax.get_base_view().data()[_index];
-    point.gammay = container.gammay.get_base_view().data()[_index];
-    point.gammaz = container.gammaz.get_base_view().data()[_index];
+    point.xix() = container.xix.get_base_view().data()[_index];
+    point.xiy() = container.xiy.get_base_view().data()[_index];
+    point.xiz() = container.xiz.get_base_view().data()[_index];
+    point.etax() = container.etax.get_base_view().data()[_index];
+    point.etay() = container.etay.get_base_view().data()[_index];
+    point.etaz() = container.etaz.get_base_view().data()[_index];
+    point.gammax() = container.gammax.get_base_view().data()[_index];
+    point.gammay() = container.gammay.get_base_view().data()[_index];
+    point.gammaz() = container.gammaz.get_base_view().data()[_index];
     if constexpr (load_jacobian) {
-      point.jacobian = container.jacobian.get_base_view().data()[_index];
+      point.jacobian() = container.jacobian.get_base_view().data()[_index];
     }
   } else {
-    point.xix = container.h_xix[_index];
-    point.xiy = container.h_xiy[_index];
-    point.xiz = container.h_xiz[_index];
-    point.etax = container.h_etax[_index];
-    point.etay = container.h_etay[_index];
-    point.etaz = container.h_etaz[_index];
-    point.gammax = container.h_gammax[_index];
-    point.gammay = container.h_gammay[_index];
-    point.gammaz = container.h_gammaz[_index];
+    point.xix() = container.h_xix[_index];
+    point.xiy() = container.h_xiy[_index];
+    point.xiz() = container.h_xiz[_index];
+    point.etax() = container.h_etax[_index];
+    point.etay() = container.h_etay[_index];
+    point.etaz() = container.h_etaz[_index];
+    point.gammax() = container.h_gammax[_index];
+    point.gammay() = container.h_gammay[_index];
+    point.gammaz() = container.h_gammaz[_index];
     if constexpr (load_jacobian) {
-      point.jacobian = container.h_jacobian[_index];
+      point.jacobian() = container.h_jacobian[_index];
     }
   }
 }

--- a/core/specfem/assembly/jacobian_matrix/dim3/impl_store.hpp
+++ b/core/specfem/assembly/jacobian_matrix/dim3/impl_store.hpp
@@ -35,50 +35,50 @@ inline void impl_store(const IndexType &index, const ContainerType &container,
   const auto mask = index.template get_mask<simd>();
 
   if constexpr (on_device) {
-    Kokkos::Experimental::simd_partial_store(point.xix, &container.xix[_index],
-                                             mask, tag_type());
-    Kokkos::Experimental::simd_partial_store(point.xiy, &container.xiy[_index],
-                                             mask, tag_type());
-    Kokkos::Experimental::simd_partial_store(point.xiz, &container.xiz[_index],
-                                             mask, tag_type());
     Kokkos::Experimental::simd_partial_store(
-        point.etax, &container.etax[_index], mask, tag_type());
+        point.xix(), &container.xix[_index], mask, tag_type());
     Kokkos::Experimental::simd_partial_store(
-        point.etay, &container.etay[_index], mask, tag_type());
+        point.xiy(), &container.xiy[_index], mask, tag_type());
     Kokkos::Experimental::simd_partial_store(
-        point.etaz, &container.etaz[_index], mask, tag_type());
+        point.xiz(), &container.xiz[_index], mask, tag_type());
     Kokkos::Experimental::simd_partial_store(
-        point.gammax, &container.gammax[_index], mask, tag_type());
+        point.etax(), &container.etax[_index], mask, tag_type());
     Kokkos::Experimental::simd_partial_store(
-        point.gammay, &container.gammay[_index], mask, tag_type());
+        point.etay(), &container.etay[_index], mask, tag_type());
     Kokkos::Experimental::simd_partial_store(
-        point.gammaz, &container.gammaz[_index], mask, tag_type());
+        point.etaz(), &container.etaz[_index], mask, tag_type());
+    Kokkos::Experimental::simd_partial_store(
+        point.gammax(), &container.gammax[_index], mask, tag_type());
+    Kokkos::Experimental::simd_partial_store(
+        point.gammay(), &container.gammay[_index], mask, tag_type());
+    Kokkos::Experimental::simd_partial_store(
+        point.gammaz(), &container.gammaz[_index], mask, tag_type());
     if constexpr (store_jacobian) {
       Kokkos::Experimental::simd_partial_store(
-          point.jacobian, &container.jacobian[_index], mask, tag_type());
+          point.jacobian(), &container.jacobian[_index], mask, tag_type());
     }
   } else {
     Kokkos::Experimental::simd_partial_store(
-        point.xix, &container.h_xix[_index], mask, tag_type());
+        point.xix(), &container.h_xix[_index], mask, tag_type());
     Kokkos::Experimental::simd_partial_store(
-        point.xiy, &container.h_xiy[_index], mask, tag_type());
+        point.xiy(), &container.h_xiy[_index], mask, tag_type());
     Kokkos::Experimental::simd_partial_store(
-        point.xiz, &container.h_xiz[_index], mask, tag_type());
+        point.xiz(), &container.h_xiz[_index], mask, tag_type());
     Kokkos::Experimental::simd_partial_store(
-        point.etax, &container.h_etax[_index], mask, tag_type());
+        point.etax(), &container.h_etax[_index], mask, tag_type());
     Kokkos::Experimental::simd_partial_store(
-        point.etay, &container.h_etay[_index], mask, tag_type());
+        point.etay(), &container.h_etay[_index], mask, tag_type());
     Kokkos::Experimental::simd_partial_store(
-        point.etaz, &container.h_etaz[_index], mask, tag_type());
+        point.etaz(), &container.h_etaz[_index], mask, tag_type());
     Kokkos::Experimental::simd_partial_store(
-        point.gammax, &container.h_gammax[_index], mask, tag_type());
+        point.gammax(), &container.h_gammax[_index], mask, tag_type());
     Kokkos::Experimental::simd_partial_store(
-        point.gammay, &container.h_gammay[_index], mask, tag_type());
+        point.gammay(), &container.h_gammay[_index], mask, tag_type());
     Kokkos::Experimental::simd_partial_store(
-        point.gammaz, &container.h_gammaz[_index], mask, tag_type());
+        point.gammaz(), &container.h_gammaz[_index], mask, tag_type());
     if constexpr (store_jacobian) {
       Kokkos::Experimental::simd_partial_store(
-          point.jacobian, &container.h_jacobian[_index], mask, tag_type());
+          point.jacobian(), &container.h_jacobian[_index], mask, tag_type());
     }
   }
 }
@@ -108,30 +108,30 @@ KOKKOS_FORCEINLINE_FUNCTION void impl_store(const PointIndexType &index,
   const std::size_t _index = mapping(index.ispec, index.iz, index.iy, index.ix);
 
   if constexpr (on_device) {
-    container.xix.get_base_view().data()[_index] = point.xix;
-    container.xiy.get_base_view().data()[_index] = point.xiy;
-    container.xiz.get_base_view().data()[_index] = point.xiz;
-    container.etax.get_base_view().data()[_index] = point.etax;
-    container.etay.get_base_view().data()[_index] = point.etay;
-    container.etaz.get_base_view().data()[_index] = point.etaz;
-    container.gammax.get_base_view().data()[_index] = point.gammax;
-    container.gammay.get_base_view().data()[_index] = point.gammay;
-    container.gammaz.get_base_view().data()[_index] = point.gammaz;
+    container.xix.get_base_view().data()[_index] = point.xix();
+    container.xiy.get_base_view().data()[_index] = point.xiy();
+    container.xiz.get_base_view().data()[_index] = point.xiz();
+    container.etax.get_base_view().data()[_index] = point.etax();
+    container.etay.get_base_view().data()[_index] = point.etay();
+    container.etaz.get_base_view().data()[_index] = point.etaz();
+    container.gammax.get_base_view().data()[_index] = point.gammax();
+    container.gammay.get_base_view().data()[_index] = point.gammay();
+    container.gammaz.get_base_view().data()[_index] = point.gammaz();
     if constexpr (store_jacobian) {
-      container.jacobian.get_base_view().data()[_index] = point.jacobian;
+      container.jacobian.get_base_view().data()[_index] = point.jacobian();
     }
   } else {
-    container.h_xix[_index] = point.xix;
-    container.h_xiy[_index] = point.xiy;
-    container.h_xiz[_index] = point.xiz;
-    container.h_etax[_index] = point.etax;
-    container.h_etay[_index] = point.etay;
-    container.h_etaz[_index] = point.etaz;
-    container.h_gammax[_index] = point.gammax;
-    container.h_gammay[_index] = point.gammay;
-    container.h_gammaz[_index] = point.gammaz;
+    container.h_xix[_index] = point.xix();
+    container.h_xiy[_index] = point.xiy();
+    container.h_xiz[_index] = point.xiz();
+    container.h_etax[_index] = point.etax();
+    container.h_etay[_index] = point.etay();
+    container.h_etaz[_index] = point.etaz();
+    container.h_gammax[_index] = point.gammax();
+    container.h_gammay[_index] = point.gammay();
+    container.h_gammaz[_index] = point.gammaz();
     if constexpr (store_jacobian) {
-      container.h_jacobian[_index] = point.jacobian;
+      container.h_jacobian[_index] = point.jacobian();
     }
   }
 }

--- a/core/specfem/assembly/jacobian_matrix/dim3/jacobian_matrix.cpp
+++ b/core/specfem/assembly/jacobian_matrix/dim3/jacobian_matrix.cpp
@@ -112,7 +112,7 @@ specfem::assembly::jacobian_matrix<
               const auto jacobian = [&]() {
                 PointJacobianMatrixType jacobian_matrix;
                 specfem::assembly::load_on_host(index, *this, jacobian_matrix);
-                return jacobian_matrix.jacobian;
+                return jacobian_matrix.jacobian();
               }();
 
               // Check if below threshold

--- a/core/specfem/assembly/jacobian_matrix/dim3/load_on_host.hpp
+++ b/core/specfem/assembly/jacobian_matrix/dim3/load_on_host.hpp
@@ -27,17 +27,20 @@ void load_on_host(const PointIndexType &index, const ContainerType &container,
                                                PointType>::value,
       "Incompatible Index, Container, and Point Types.");
 
-  point.xix = container.h_xix(index.ispec, index.iz, index.iy, index.ix);
-  point.xiy = container.h_xiy(index.ispec, index.iz, index.iy, index.ix);
-  point.xiz = container.h_xiz(index.ispec, index.iz, index.iy, index.ix);
-  point.etax = container.h_etax(index.ispec, index.iz, index.iy, index.ix);
-  point.etay = container.h_etay(index.ispec, index.iz, index.iy, index.ix);
-  point.etaz = container.h_etaz(index.ispec, index.iz, index.iy, index.ix);
-  point.gammax = container.h_gammax(index.ispec, index.iz, index.iy, index.ix);
-  point.gammay = container.h_gammay(index.ispec, index.iz, index.iy, index.ix);
-  point.gammaz = container.h_gammaz(index.ispec, index.iz, index.iy, index.ix);
+  point.xix() = container.h_xix(index.ispec, index.iz, index.iy, index.ix);
+  point.xiy() = container.h_xiy(index.ispec, index.iz, index.iy, index.ix);
+  point.xiz() = container.h_xiz(index.ispec, index.iz, index.iy, index.ix);
+  point.etax() = container.h_etax(index.ispec, index.iz, index.iy, index.ix);
+  point.etay() = container.h_etay(index.ispec, index.iz, index.iy, index.ix);
+  point.etaz() = container.h_etaz(index.ispec, index.iz, index.iy, index.ix);
+  point.gammax() =
+      container.h_gammax(index.ispec, index.iz, index.iy, index.ix);
+  point.gammay() =
+      container.h_gammay(index.ispec, index.iz, index.iy, index.ix);
+  point.gammaz() =
+      container.h_gammaz(index.ispec, index.iz, index.iy, index.ix);
   if constexpr (load_jacobian) {
-    point.jacobian =
+    point.jacobian() =
         container.h_jacobian(index.ispec, index.iz, index.iy, index.ix);
   }
 }

--- a/core/specfem/assembly/jacobian_matrix/dim3/store_on_host.hpp
+++ b/core/specfem/assembly/jacobian_matrix/dim3/store_on_host.hpp
@@ -26,18 +26,21 @@ void store_on_host(const PointIndexType &index, const PointType &point,
 
   constexpr static bool store_jacobian = PointType::store_jacobian;
 
-  container.h_xix(index.ispec, index.iz, index.iy, index.ix) = point.xix;
-  container.h_xiy(index.ispec, index.iz, index.iy, index.ix) = point.xiy;
-  container.h_xiz(index.ispec, index.iz, index.iy, index.ix) = point.xiz;
-  container.h_etax(index.ispec, index.iz, index.iy, index.ix) = point.etax;
-  container.h_etay(index.ispec, index.iz, index.iy, index.ix) = point.etay;
-  container.h_etaz(index.ispec, index.iz, index.iy, index.ix) = point.etaz;
-  container.h_gammax(index.ispec, index.iz, index.iy, index.ix) = point.gammax;
-  container.h_gammay(index.ispec, index.iz, index.iy, index.ix) = point.gammay;
-  container.h_gammaz(index.ispec, index.iz, index.iy, index.ix) = point.gammaz;
+  container.h_xix(index.ispec, index.iz, index.iy, index.ix) = point.xix();
+  container.h_xiy(index.ispec, index.iz, index.iy, index.ix) = point.xiy();
+  container.h_xiz(index.ispec, index.iz, index.iy, index.ix) = point.xiz();
+  container.h_etax(index.ispec, index.iz, index.iy, index.ix) = point.etax();
+  container.h_etay(index.ispec, index.iz, index.iy, index.ix) = point.etay();
+  container.h_etaz(index.ispec, index.iz, index.iy, index.ix) = point.etaz();
+  container.h_gammax(index.ispec, index.iz, index.iy, index.ix) =
+      point.gammax();
+  container.h_gammay(index.ispec, index.iz, index.iy, index.ix) =
+      point.gammay();
+  container.h_gammaz(index.ispec, index.iz, index.iy, index.ix) =
+      point.gammaz();
   if constexpr (store_jacobian) {
     container.h_jacobian(index.ispec, index.iz, index.iy, index.ix) =
-        point.jacobian;
+        point.jacobian();
   }
 }
 

--- a/core/specfem/assembly/jacobian_matrix/load_on_device.hpp
+++ b/core/specfem/assembly/jacobian_matrix/load_on_device.hpp
@@ -46,8 +46,8 @@ namespace specfem::assembly {
  * point_jac);
  *
  * // Access loaded values
- * type_real xix_val = point_jac.xix;          // ∂ξ/∂x
- * type_real det_jac = point_jac.jacobian;     // |J|
+ * type_real xix_val = point_jac.xix();        // ∂ξ/∂x
+ * type_real det_jac = point_jac.jacobian();   // |J|
  * @endcode
  */
 template <

--- a/core/specfem/assembly/jacobian_matrix/load_on_host.hpp
+++ b/core/specfem/assembly/jacobian_matrix/load_on_host.hpp
@@ -46,8 +46,8 @@ namespace specfem::assembly {
  * point_jac);
  *
  * // Process loaded transformation data
- * type_real volume_element = point_jac.jacobian;
- * type_real dxi_dx = point_jac.xix;
+ * type_real volume_element = point_jac.jacobian();
+ * type_real dxi_dx = point_jac.xix();
  * @endcode
  */
 template <

--- a/core/specfem/assembly/jacobian_matrix/store_on_device.hpp
+++ b/core/specfem/assembly/jacobian_matrix/store_on_device.hpp
@@ -44,8 +44,8 @@ namespace specfem::assembly {
  * computed_jac;
  *
  * // Compute Jacobian values (simplified)
- * computed_jac.xix = compute_xix(mesh_coords);
- * computed_jac.jacobian = compute_jacobian_determinant(mesh_coords);
+ * computed_jac.xix() = compute_xix(mesh_coords);
+ * computed_jac.jacobian() = compute_jacobian_determinant(mesh_coords);
  *
  * // Store back to global container
  * specfem::assembly::store_on_device(idx, jacobian_container, computed_jac);

--- a/core/specfem/compute/impl/compute_mass_matrix.tpp
+++ b/core/specfem/compute/impl/compute_mass_matrix.tpp
@@ -26,8 +26,7 @@ void specfem::compute::impl::compute_mass_matrix(
   constexpr auto attenuation_tag = Tags::attenuation_tag;
 
   const auto elements = assembly.element_types.get_elements_on_device(
-          medium_tag, property_tag, attenuation_tag, boundary_tag,
-          Tags::mpi_tag);
+      medium_tag, property_tag, attenuation_tag, boundary_tag, Tags::mpi_tag);
 
   // Get number of elements matching the tag combinations
   const int nelements = elements.extent(0);
@@ -102,7 +101,8 @@ void specfem::compute::impl::compute_mass_matrix(
             specfem::medium_physics::mass_matrix_component<PointTags>(
                 point_property);
 
-        mass_matrix *= point_weights.product() * point_jacobian_matrix.jacobian;
+        mass_matrix *=
+            point_weights.product() * point_jacobian_matrix.jacobian();
 
         PointBoundaryType point_boundary;
         specfem::assembly::load_on_device(index, boundaries, point_boundary);

--- a/core/specfem/compute/impl/stiffness_kernels.hpp
+++ b/core/specfem/compute/impl/stiffness_kernels.hpp
@@ -198,7 +198,7 @@ public:
                                                   point_jacobian_matrix);
 
                 const auto factor =
-                    point_weights.product() * point_jacobian_matrix.jacobian;
+                    point_weights.product() * point_jacobian_matrix.jacobian();
 
                 specfem::medium_physics::compute_damping_force<decltype(factor),
                                                                PointTags>(
@@ -214,14 +214,14 @@ public:
                   for (int icomp = 0; icomp < ncomp; ++icomp) {
                     T_recovered.T(icomp, 0) =
                         stress_integrand.F(local_index, icomp, 0) *
-                            point_jacobian_matrix.gammaz -
+                            point_jacobian_matrix.gammaz() -
                         stress_integrand.F(local_index, icomp, 1) *
-                            point_jacobian_matrix.xiz;
+                            point_jacobian_matrix.xiz();
                     T_recovered.T(icomp, 1) =
                         -stress_integrand.F(local_index, icomp, 0) *
-                            point_jacobian_matrix.gammax +
+                            point_jacobian_matrix.gammax() +
                         stress_integrand.F(local_index, icomp, 1) *
-                            point_jacobian_matrix.xix;
+                            point_jacobian_matrix.xix();
                   }
                   // acceleration is already negated;
                   // compute_cosserat_couple_stress accumulates positively, so
@@ -420,7 +420,8 @@ public:
 
                   specfem::medium_physics::compute_cosserat_couple_stress(
                       point_property,
-                      point_weights.product() * point_jacobian_matrix.jacobian,
+                      point_weights.product() *
+                          point_jacobian_matrix.jacobian(),
                       point_stress, cosserat_delta);
 
                   for (int icomp = 0; icomp < ncomp; ++icomp)
@@ -461,7 +462,7 @@ public:
                                                   point_jacobian_matrix);
 
                 const auto factor =
-                    point_weights.product() * point_jacobian_matrix.jacobian;
+                    point_weights.product() * point_jacobian_matrix.jacobian();
 
                 specfem::medium_physics::compute_damping_force<decltype(factor),
                                                                PointTags>(

--- a/core/specfem/datatype/point_view.hpp
+++ b/core/specfem/datatype/point_view.hpp
@@ -8,6 +8,7 @@
 #include "simd.hpp"
 #include "specfem/setup.hpp"
 #include <Kokkos_Core.hpp>
+#include <type_traits>
 
 namespace specfem {
 namespace datatype {

--- a/core/specfem/datatype/point_view.hpp
+++ b/core/specfem/datatype/point_view.hpp
@@ -222,5 +222,17 @@ struct TensorPointViewType
   }
 };
 
+// Point views are bit-copied by Kokkos (as `View` elements and as reduction
+// scalars), so they must stay relocatable in both the scalar and the SIMD
+// instantiation -- see issue #2008.
+static_assert(
+    std::is_trivially_copyable_v<VectorPointViewType<type_real, 3, false>> &&
+        std::is_trivially_copyable_v<VectorPointViewType<type_real, 3, true>> &&
+        std::is_trivially_copyable_v<
+            TensorPointViewType<type_real, 3, 3, false>> &&
+        std::is_trivially_copyable_v<
+            TensorPointViewType<type_real, 3, 3, true>>,
+    "Point view types must be trivially copyable");
+
 } // namespace datatype
 } // namespace specfem

--- a/core/specfem/datatype/register_array.hpp
+++ b/core/specfem/datatype/register_array.hpp
@@ -253,16 +253,5 @@ private:
   }
 };
 
-// Kokkos bit-copies register arrays (as `View` elements, and as reduction
-// scalars via `Kokkos::Sum<>`), so they must survive a `memcpy`. Guard the
-// property here rather than discovering it as a segfault under a threaded
-// backend -- see issue #2008.
-static_assert(
-    std::is_trivially_copyable_v<RegisterArray<
-            double, Kokkos::extents<std::size_t, 3, 3>, Kokkos::layout_left>> &&
-        std::is_trivially_copyable_v<RegisterArray<
-            float, Kokkos::extents<std::size_t, 3, 3>, Kokkos::layout_left>>,
-    "RegisterArray must be trivially copyable");
-
 } // namespace datatype
 } // namespace specfem

--- a/core/specfem/datatype/register_array.hpp
+++ b/core/specfem/datatype/register_array.hpp
@@ -93,15 +93,13 @@ public:
 
   /**
    * @brief Copy constructor
-   * @param other Array to copy from
+   *
+   * Defaulted on purpose: a user-provided copy constructor would make the type
+   * non-trivially-copyable, and Kokkos bit-copies this type both as a `View`
+   * element and as a reduction scalar.
    */
   KOKKOS_INLINE_FUNCTION
-  RegisterArray(const RegisterArray &other) {
-
-    for (std::size_t i = 0; i < size; ++i) {
-      m_value[i] = other.m_value[i];
-    }
-  }
+  RegisterArray(const RegisterArray &other) = default;
 
   /**
    * @brief Default constructor (zero-initialized)
@@ -254,6 +252,17 @@ private:
     return 0.0;
   }
 };
+
+// Kokkos bit-copies register arrays (as `View` elements, and as reduction
+// scalars via `Kokkos::Sum<>`), so they must survive a `memcpy`. Guard the
+// property here rather than discovering it as a segfault under a threaded
+// backend -- see issue #2008.
+static_assert(
+    std::is_trivially_copyable_v<RegisterArray<
+            double, Kokkos::extents<std::size_t, 3, 3>, Kokkos::layout_left>> &&
+        std::is_trivially_copyable_v<RegisterArray<
+            float, Kokkos::extents<std::size_t, 3, 3>, Kokkos::layout_left>>,
+    "RegisterArray must be trivially copyable");
 
 } // namespace datatype
 } // namespace specfem

--- a/core/specfem/point/jacobian_matrix.hpp
+++ b/core/specfem/point/jacobian_matrix.hpp
@@ -142,13 +142,7 @@ public:
   ///@}
 
   KOKKOS_FUNCTION
-  void init() {
-    this->xix() = 0.0;
-    this->gammax() = 0.0;
-    this->xiz() = 0.0;
-    this->gammaz() = 0.0;
-    return;
-  }
+  void init() { _data = tensor_type(); }
 
   /**
    * @brief Access the underlying 2x2 transformation tensor
@@ -373,18 +367,7 @@ public:
   ///@}
 
   KOKKOS_FUNCTION
-  void init() {
-    this->xix() = 0.0;
-    this->etax() = 0.0;
-    this->gammax() = 0.0;
-    this->xiy() = 0.0;
-    this->etay() = 0.0;
-    this->gammay() = 0.0;
-    this->xiz() = 0.0;
-    this->etaz() = 0.0;
-    this->gammaz() = 0.0;
-    return;
-  }
+  void init() { _data = tensor_type(); }
 
   /**
    * @brief Access the underlying 3x3 transformation tensor
@@ -583,7 +566,8 @@ public:
   ///@}
 
   KOKKOS_FUNCTION bool operator==(const jacobian_matrix &rhs) const {
-    return (static_cast<base_type>(*this) == static_cast<base_type>(rhs)) &&
+    return (static_cast<const base_type &>(*this) ==
+            static_cast<const base_type &>(rhs)) &&
            (specfem::utilities::is_close(this->jacobian(), rhs.jacobian()));
   }
 
@@ -738,7 +722,8 @@ public:
 
   // operator==
   KOKKOS_FUNCTION bool operator==(const jacobian_matrix &rhs) const {
-    return (static_cast<base_type>(*this) == static_cast<base_type>(rhs)) &&
+    return (static_cast<const base_type &>(*this) ==
+            static_cast<const base_type &>(rhs)) &&
            (specfem::utilities::is_close(this->jacobian(), rhs.jacobian()));
   }
 
@@ -819,22 +804,20 @@ private:
 // It must therefore have no self-pointers -- storing references into its own
 // tensor made it dangle after a `memcpy`, which segfaulted under threaded
 // backends while passing on Serial (issue #2008).
-#define SPECFEM_ASSERT_JACOBIAN_MATRIX_RELOCATABLE(UseSIMD)                    \
-  static_assert(                                                               \
-      std::is_trivially_copyable_v<specfem::point::jacobian_matrix<            \
-              specfem::element::dimension_tag::dim2, false, UseSIMD>> &&       \
-          std::is_trivially_copyable_v<specfem::point::jacobian_matrix<        \
-              specfem::element::dimension_tag::dim2, true, UseSIMD>> &&        \
-          std::is_trivially_copyable_v<specfem::point::jacobian_matrix<        \
-              specfem::element::dimension_tag::dim3, false, UseSIMD>> &&       \
-          std::is_trivially_copyable_v<specfem::point::jacobian_matrix<        \
-              specfem::element::dimension_tag::dim3, true, UseSIMD>>,          \
-      "point::jacobian_matrix must be trivially copyable")
+//
+// The `store_jacobian = true` specializations derive from their
+// `store_jacobian = false` counterparts, and a derived class cannot be
+// trivially copyable unless its bases are, so checking the former covers both.
+template <bool UseSIMD>
+inline constexpr bool jacobian_matrix_is_relocatable_v =
+    std::is_trivially_copyable_v<jacobian_matrix<
+        specfem::element::dimension_tag::dim2, true, UseSIMD>> &&
+    std::is_trivially_copyable_v<
+        jacobian_matrix<specfem::element::dimension_tag::dim3, true, UseSIMD>>;
 
-SPECFEM_ASSERT_JACOBIAN_MATRIX_RELOCATABLE(false);
-SPECFEM_ASSERT_JACOBIAN_MATRIX_RELOCATABLE(true);
-
-#undef SPECFEM_ASSERT_JACOBIAN_MATRIX_RELOCATABLE
+static_assert(jacobian_matrix_is_relocatable_v<false> &&
+                  jacobian_matrix_is_relocatable_v<true>,
+              "point::jacobian_matrix must be trivially copyable");
 
 } // namespace point
 } // namespace specfem

--- a/core/specfem/point/jacobian_matrix.hpp
+++ b/core/specfem/point/jacobian_matrix.hpp
@@ -6,6 +6,7 @@
 #include "specfem/setup.hpp"
 #include "specfem/utilities.hpp"
 #include <Kokkos_Core.hpp>
+#include <type_traits>
 
 namespace specfem {
 namespace point {

--- a/core/specfem/point/jacobian_matrix.hpp
+++ b/core/specfem/point/jacobian_matrix.hpp
@@ -53,16 +53,11 @@ public:
   ///@}
 
 private:
+  // J = [ xix  gammax ]   (row = spatial coord x/z, col = reference coord ξ/γ)
+  //     [ xiz  gammaz ]
   tensor_type _data; ///< Underlying 2x2 tensor storage
 
 public:
-  // J = [ xix  gammax ]   (row = spatial coord x/z, col = reference coord ξ/γ)
-  //     [ xiz  gammaz ]
-  value_type &xix;    ///< @f$ \partial \xi / \partial x @f$
-  value_type &gammax; ///< @f$ \partial \gamma / \partial x @f$
-  value_type &xiz;    ///< @f$ \partial \xi / \partial z @f$
-  value_type &gammaz; ///< @f$ \partial \gamma / \partial z @f$
-
   /**
    * @name Constructors
    *
@@ -73,11 +68,7 @@ public:
    *
    */
   KOKKOS_FUNCTION
-  jacobian_matrix()
-      : _data(), xix(_data(0, 0)), gammax(_data(0, 1)), xiz(_data(1, 0)),
-        gammaz(_data(1, 1)) {
-    return;
-  }
+  jacobian_matrix() : _data() { return; }
 
   /**
    * @brief Constructor with values
@@ -90,12 +81,11 @@ public:
   KOKKOS_FUNCTION
   jacobian_matrix(const value_type &xix, const value_type &gammax,
                   const value_type &xiz, const value_type &gammaz)
-      : _data(), xix(_data(0, 0)), gammax(_data(0, 1)), xiz(_data(1, 0)),
-        gammaz(_data(1, 1)) {
-    this->xix = xix;
-    this->gammax = gammax;
-    this->xiz = xiz;
-    this->gammaz = gammaz;
+      : _data() {
+    this->xix() = xix;
+    this->gammax() = gammax;
+    this->xiz() = xiz;
+    this->gammaz() = gammaz;
   }
 
   /**
@@ -104,9 +94,7 @@ public:
    * @param constant Value to initialize all members to
    */
   KOKKOS_FUNCTION
-  jacobian_matrix(const value_type constant)
-      : _data(constant), xix(_data(0, 0)), gammax(_data(0, 1)),
-        xiz(_data(1, 0)), gammaz(_data(1, 1)) {}
+  jacobian_matrix(const value_type constant) : _data(constant) {}
 
   /**
    * @brief Construct from a 2x2 tensor
@@ -114,35 +102,51 @@ public:
    * @param t Tensor to copy into the matrix
    */
   KOKKOS_FUNCTION
-  jacobian_matrix(const tensor_type &t)
-      : _data(t), xix(_data(0, 0)), gammax(_data(0, 1)), xiz(_data(1, 0)),
-        gammaz(_data(1, 1)) {}
+  jacobian_matrix(const tensor_type &t) : _data(t) {}
+  ///@}
 
   /**
-   * @brief Copy constructor — rebinds references to this object's tensor
+   * @name Component accessors
+   *
+   * The tensor is the sole storage; each component is addressed by its
+   * position in it.
    */
-  KOKKOS_FUNCTION
-  jacobian_matrix(const jacobian_matrix &other)
-      : _data(other._data), xix(_data(0, 0)), gammax(_data(0, 1)),
-        xiz(_data(1, 0)), gammaz(_data(1, 1)) {}
+  ///@{
+  /**
+   * @brief @f$ \partial \xi / \partial x @f$
+   * @return Reference to the (0, 0) component
+   */
+  KOKKOS_FUNCTION value_type &xix() { return _data(0, 0); }
+  KOKKOS_FUNCTION const value_type &xix() const { return _data(0, 0); }
 
   /**
-   * @brief Copy assignment — copies tensor data; references remain bound to
-   * this object's tensor
+   * @brief @f$ \partial \gamma / \partial x @f$
+   * @return Reference to the (0, 1) component
    */
-  KOKKOS_FUNCTION
-  jacobian_matrix &operator=(const jacobian_matrix &other) {
-    _data = other._data;
-    return *this;
-  }
+  KOKKOS_FUNCTION value_type &gammax() { return _data(0, 1); }
+  KOKKOS_FUNCTION const value_type &gammax() const { return _data(0, 1); }
+
+  /**
+   * @brief @f$ \partial \xi / \partial z @f$
+   * @return Reference to the (1, 0) component
+   */
+  KOKKOS_FUNCTION value_type &xiz() { return _data(1, 0); }
+  KOKKOS_FUNCTION const value_type &xiz() const { return _data(1, 0); }
+
+  /**
+   * @brief @f$ \partial \gamma / \partial z @f$
+   * @return Reference to the (1, 1) component
+   */
+  KOKKOS_FUNCTION value_type &gammaz() { return _data(1, 1); }
+  KOKKOS_FUNCTION const value_type &gammaz() const { return _data(1, 1); }
   ///@}
 
   KOKKOS_FUNCTION
   void init() {
-    this->xix = 0.0;
-    this->gammax = 0.0;
-    this->xiz = 0.0;
-    this->gammaz = 0.0;
+    this->xix() = 0.0;
+    this->gammax() = 0.0;
+    this->xiz() = 0.0;
+    this->gammaz() = 0.0;
     return;
   }
 
@@ -152,36 +156,34 @@ public:
   ///@{
   KOKKOS_FUNCTION tensor_type &tensor() { return _data; }
   KOKKOS_FUNCTION const tensor_type &tensor() const { return _data; }
-  KOKKOS_FUNCTION operator tensor_type &() { return _data; }
-  KOKKOS_FUNCTION operator const tensor_type &() const { return _data; }
   ///@}
 
   // operator+
   KOKKOS_FUNCTION jacobian_matrix operator+(const jacobian_matrix &rhs) const {
-    return { xix + rhs.xix, gammax + rhs.gammax, xiz + rhs.xiz,
-             gammaz + rhs.gammaz };
+    return { xix() + rhs.xix(), gammax() + rhs.gammax(), xiz() + rhs.xiz(),
+             gammaz() + rhs.gammaz() };
   }
 
   // operator+=
   KOKKOS_FUNCTION jacobian_matrix &operator+=(const jacobian_matrix &rhs) {
-    this->xix = this->xix + rhs.xix;
-    this->gammax = this->gammax + rhs.gammax;
-    this->xiz = this->xiz + rhs.xiz;
-    this->gammaz = this->gammaz + rhs.gammaz;
+    this->xix() = this->xix() + rhs.xix();
+    this->gammax() = this->gammax() + rhs.gammax();
+    this->xiz() = this->xiz() + rhs.xiz();
+    this->gammaz() = this->gammaz() + rhs.gammaz();
     return *this;
   }
 
   // operator*
-  KOKKOS_FUNCTION jacobian_matrix operator*(const type_real &rhs) {
-    return { xix * rhs, gammax * rhs, xiz * rhs, gammaz * rhs };
+  KOKKOS_FUNCTION jacobian_matrix operator*(const type_real &rhs) const {
+    return { xix() * rhs, gammax() * rhs, xiz() * rhs, gammaz() * rhs };
   }
 
   // operator==
   KOKKOS_FUNCTION bool operator==(const jacobian_matrix &rhs) const {
-    return (specfem::utilities::is_close(this->xix, rhs.xix)) &&
-           (specfem::utilities::is_close(this->gammax, rhs.gammax)) &&
-           (specfem::utilities::is_close(this->xiz, rhs.xiz)) &&
-           (specfem::utilities::is_close(this->gammaz, rhs.gammaz));
+    return (specfem::utilities::is_close(this->xix(), rhs.xix())) &&
+           (specfem::utilities::is_close(this->gammax(), rhs.gammax())) &&
+           (specfem::utilities::is_close(this->xiz(), rhs.xiz())) &&
+           (specfem::utilities::is_close(this->gammaz(), rhs.gammaz()));
   }
 };
 
@@ -196,8 +198,8 @@ KOKKOS_FUNCTION std::enable_if_t<
             PointJacobianMatrixType>::value,
     PointJacobianMatrixType>
 operator*(const type_real &lhs, const PointJacobianMatrixType &rhs) {
-  return PointJacobianMatrixType(rhs.xix * lhs, rhs.gammax * lhs, rhs.xiz * lhs,
-                                 rhs.gammaz * lhs);
+  return PointJacobianMatrixType(rhs.xix() * lhs, rhs.gammax() * lhs,
+                                 rhs.xiz() * lhs, rhs.gammaz() * lhs);
 }
 
 /**
@@ -232,23 +234,13 @@ public:
   ///@}
 
 private:
-  tensor_type _data; ///< Underlying 3x3 tensor storage
-
-public:
   // J = [ xix  etax  gammax ]   (row = spatial coord x/y/z, col = ref coord
   // ξ/η/γ)
   //     [ xiy  etay  gammay ]
   //     [ xiz  etaz  gammaz ]
-  value_type &xix;    ///< @f$ \partial \xi / \partial x @f$
-  value_type &etax;   ///< @f$ \partial \eta / \partial x @f$
-  value_type &gammax; ///< @f$ \partial \gamma / \partial x @f$
-  value_type &xiy;    ///< @f$ \partial \xi / \partial y @f$
-  value_type &etay;   ///< @f$ \partial \eta / \partial y @f$
-  value_type &gammay; ///< @f$ \partial \gamma / \partial y @f$
-  value_type &xiz;    ///< @f$ \partial \xi / \partial z @f$
-  value_type &etaz;   ///< @f$ \partial \eta / \partial z @f$
-  value_type &gammaz; ///< @f$ \partial \gamma / \partial z @f$
+  tensor_type _data; ///< Underlying 3x3 tensor storage
 
+public:
   /**
    * @name Constructors
    *
@@ -259,12 +251,7 @@ public:
    *
    */
   KOKKOS_FUNCTION
-  jacobian_matrix()
-      : _data(), xix(_data(0, 0)), etax(_data(0, 1)), gammax(_data(0, 2)),
-        xiy(_data(1, 0)), etay(_data(1, 1)), gammay(_data(1, 2)),
-        xiz(_data(2, 0)), etaz(_data(2, 1)), gammaz(_data(2, 2)) {
-    return;
-  }
+  jacobian_matrix() : _data() { return; }
 
   /**
    * @brief Constructor with values
@@ -285,18 +272,16 @@ public:
                   const value_type &etay, const value_type &gammay,
                   const value_type &xiz, const value_type &etaz,
                   const value_type &gammaz)
-      : _data(), xix(_data(0, 0)), etax(_data(0, 1)), gammax(_data(0, 2)),
-        xiy(_data(1, 0)), etay(_data(1, 1)), gammay(_data(1, 2)),
-        xiz(_data(2, 0)), etaz(_data(2, 1)), gammaz(_data(2, 2)) {
-    this->xix = xix;
-    this->etax = etax;
-    this->gammax = gammax;
-    this->xiy = xiy;
-    this->etay = etay;
-    this->gammay = gammay;
-    this->xiz = xiz;
-    this->etaz = etaz;
-    this->gammaz = gammaz;
+      : _data() {
+    this->xix() = xix;
+    this->etax() = etax;
+    this->gammax() = gammax;
+    this->xiy() = xiy;
+    this->etay() = etay;
+    this->gammay() = gammay;
+    this->xiz() = xiz;
+    this->etaz() = etaz;
+    this->gammaz() = gammaz;
   }
 
   /**
@@ -305,11 +290,7 @@ public:
    * @param constant Value to initialize all members to
    */
   KOKKOS_FUNCTION
-  jacobian_matrix(const value_type constant)
-      : _data(constant), xix(_data(0, 0)), etax(_data(0, 1)),
-        gammax(_data(0, 2)), xiy(_data(1, 0)), etay(_data(1, 1)),
-        gammay(_data(1, 2)), xiz(_data(2, 0)), etaz(_data(2, 1)),
-        gammaz(_data(2, 2)) {}
+  jacobian_matrix(const value_type constant) : _data(constant) {}
 
   /**
    * @brief Construct from a 3x3 tensor
@@ -317,43 +298,91 @@ public:
    * @param t Tensor to copy into the matrix
    */
   KOKKOS_FUNCTION
-  jacobian_matrix(const tensor_type &t)
-      : _data(t), xix(_data(0, 0)), etax(_data(0, 1)), gammax(_data(0, 2)),
-        xiy(_data(1, 0)), etay(_data(1, 1)), gammay(_data(1, 2)),
-        xiz(_data(2, 0)), etaz(_data(2, 1)), gammaz(_data(2, 2)) {}
+  jacobian_matrix(const tensor_type &t) : _data(t) {}
+  ///@}
 
   /**
-   * @brief Copy constructor — rebinds references to this object's tensor
+   * @name Component accessors
+   *
+   * The tensor is the sole storage; each component is addressed by its
+   * position in it.
    */
-  KOKKOS_FUNCTION
-  jacobian_matrix(const jacobian_matrix &other)
-      : _data(other._data), xix(_data(0, 0)), etax(_data(0, 1)),
-        gammax(_data(0, 2)), xiy(_data(1, 0)), etay(_data(1, 1)),
-        gammay(_data(1, 2)), xiz(_data(2, 0)), etaz(_data(2, 1)),
-        gammaz(_data(2, 2)) {}
+  ///@{
+  /**
+   * @brief @f$ \partial \xi / \partial x @f$
+   * @return Reference to the (0, 0) component
+   */
+  KOKKOS_FUNCTION value_type &xix() { return _data(0, 0); }
+  KOKKOS_FUNCTION const value_type &xix() const { return _data(0, 0); }
 
   /**
-   * @brief Copy assignment — copies tensor data; references remain bound to
-   * this object's tensor
+   * @brief @f$ \partial \eta / \partial x @f$
+   * @return Reference to the (0, 1) component
    */
-  KOKKOS_FUNCTION
-  jacobian_matrix &operator=(const jacobian_matrix &other) {
-    _data = other._data;
-    return *this;
-  }
+  KOKKOS_FUNCTION value_type &etax() { return _data(0, 1); }
+  KOKKOS_FUNCTION const value_type &etax() const { return _data(0, 1); }
+
+  /**
+   * @brief @f$ \partial \gamma / \partial x @f$
+   * @return Reference to the (0, 2) component
+   */
+  KOKKOS_FUNCTION value_type &gammax() { return _data(0, 2); }
+  KOKKOS_FUNCTION const value_type &gammax() const { return _data(0, 2); }
+
+  /**
+   * @brief @f$ \partial \xi / \partial y @f$
+   * @return Reference to the (1, 0) component
+   */
+  KOKKOS_FUNCTION value_type &xiy() { return _data(1, 0); }
+  KOKKOS_FUNCTION const value_type &xiy() const { return _data(1, 0); }
+
+  /**
+   * @brief @f$ \partial \eta / \partial y @f$
+   * @return Reference to the (1, 1) component
+   */
+  KOKKOS_FUNCTION value_type &etay() { return _data(1, 1); }
+  KOKKOS_FUNCTION const value_type &etay() const { return _data(1, 1); }
+
+  /**
+   * @brief @f$ \partial \gamma / \partial y @f$
+   * @return Reference to the (1, 2) component
+   */
+  KOKKOS_FUNCTION value_type &gammay() { return _data(1, 2); }
+  KOKKOS_FUNCTION const value_type &gammay() const { return _data(1, 2); }
+
+  /**
+   * @brief @f$ \partial \xi / \partial z @f$
+   * @return Reference to the (2, 0) component
+   */
+  KOKKOS_FUNCTION value_type &xiz() { return _data(2, 0); }
+  KOKKOS_FUNCTION const value_type &xiz() const { return _data(2, 0); }
+
+  /**
+   * @brief @f$ \partial \eta / \partial z @f$
+   * @return Reference to the (2, 1) component
+   */
+  KOKKOS_FUNCTION value_type &etaz() { return _data(2, 1); }
+  KOKKOS_FUNCTION const value_type &etaz() const { return _data(2, 1); }
+
+  /**
+   * @brief @f$ \partial \gamma / \partial z @f$
+   * @return Reference to the (2, 2) component
+   */
+  KOKKOS_FUNCTION value_type &gammaz() { return _data(2, 2); }
+  KOKKOS_FUNCTION const value_type &gammaz() const { return _data(2, 2); }
   ///@}
 
   KOKKOS_FUNCTION
   void init() {
-    this->xix = 0.0;
-    this->etax = 0.0;
-    this->gammax = 0.0;
-    this->xiy = 0.0;
-    this->etay = 0.0;
-    this->gammay = 0.0;
-    this->xiz = 0.0;
-    this->etaz = 0.0;
-    this->gammaz = 0.0;
+    this->xix() = 0.0;
+    this->etax() = 0.0;
+    this->gammax() = 0.0;
+    this->xiy() = 0.0;
+    this->etay() = 0.0;
+    this->gammay() = 0.0;
+    this->xiz() = 0.0;
+    this->etaz() = 0.0;
+    this->gammaz() = 0.0;
     return;
   }
 
@@ -363,48 +392,47 @@ public:
   ///@{
   KOKKOS_FUNCTION tensor_type &tensor() { return _data; }
   KOKKOS_FUNCTION const tensor_type &tensor() const { return _data; }
-  KOKKOS_FUNCTION operator tensor_type &() { return _data; }
-  KOKKOS_FUNCTION operator const tensor_type &() const { return _data; }
   ///@}
 
   // operator+
   KOKKOS_FUNCTION jacobian_matrix operator+(const jacobian_matrix &rhs) const {
-    return { xix + rhs.xix, etax + rhs.etax, gammax + rhs.gammax,
-             xiy + rhs.xiy, etay + rhs.etay, gammay + rhs.gammay,
-             xiz + rhs.xiz, etaz + rhs.etaz, gammaz + rhs.gammaz };
+    return { xix() + rhs.xix(), etax() + rhs.etax(), gammax() + rhs.gammax(),
+             xiy() + rhs.xiy(), etay() + rhs.etay(), gammay() + rhs.gammay(),
+             xiz() + rhs.xiz(), etaz() + rhs.etaz(), gammaz() + rhs.gammaz() };
   }
 
   // operator+=
   KOKKOS_FUNCTION jacobian_matrix &operator+=(const jacobian_matrix &rhs) {
-    this->xix = this->xix + rhs.xix;
-    this->etax = this->etax + rhs.etax;
-    this->gammax = this->gammax + rhs.gammax;
-    this->xiy = this->xiy + rhs.xiy;
-    this->etay = this->etay + rhs.etay;
-    this->gammay = this->gammay + rhs.gammay;
-    this->xiz = this->xiz + rhs.xiz;
-    this->etaz = this->etaz + rhs.etaz;
-    this->gammaz = this->gammaz + rhs.gammaz;
+    this->xix() = this->xix() + rhs.xix();
+    this->etax() = this->etax() + rhs.etax();
+    this->gammax() = this->gammax() + rhs.gammax();
+    this->xiy() = this->xiy() + rhs.xiy();
+    this->etay() = this->etay() + rhs.etay();
+    this->gammay() = this->gammay() + rhs.gammay();
+    this->xiz() = this->xiz() + rhs.xiz();
+    this->etaz() = this->etaz() + rhs.etaz();
+    this->gammaz() = this->gammaz() + rhs.gammaz();
     return *this;
   }
 
   // operator*
-  KOKKOS_FUNCTION jacobian_matrix operator*(const type_real &rhs) {
-    return { xix * rhs,    etax * rhs, gammax * rhs, xiy * rhs,   etay * rhs,
-             gammay * rhs, xiz * rhs,  etaz * rhs,   gammaz * rhs };
+  KOKKOS_FUNCTION jacobian_matrix operator*(const type_real &rhs) const {
+    return { xix() * rhs, etax() * rhs, gammax() * rhs,
+             xiy() * rhs, etay() * rhs, gammay() * rhs,
+             xiz() * rhs, etaz() * rhs, gammaz() * rhs };
   }
 
   // operator==
   KOKKOS_FUNCTION bool operator==(const jacobian_matrix &rhs) const {
-    return (specfem::utilities::is_close(this->xix, rhs.xix)) &&
-           (specfem::utilities::is_close(this->etax, rhs.etax)) &&
-           (specfem::utilities::is_close(this->gammax, rhs.gammax)) &&
-           (specfem::utilities::is_close(this->xiy, rhs.xiy)) &&
-           (specfem::utilities::is_close(this->etay, rhs.etay)) &&
-           (specfem::utilities::is_close(this->gammay, rhs.gammay)) &&
-           (specfem::utilities::is_close(this->xiz, rhs.xiz)) &&
-           (specfem::utilities::is_close(this->etaz, rhs.etaz)) &&
-           (specfem::utilities::is_close(this->gammaz, rhs.gammaz));
+    return (specfem::utilities::is_close(this->xix(), rhs.xix())) &&
+           (specfem::utilities::is_close(this->etax(), rhs.etax())) &&
+           (specfem::utilities::is_close(this->gammax(), rhs.gammax())) &&
+           (specfem::utilities::is_close(this->xiy(), rhs.xiy())) &&
+           (specfem::utilities::is_close(this->etay(), rhs.etay())) &&
+           (specfem::utilities::is_close(this->gammay(), rhs.gammay())) &&
+           (specfem::utilities::is_close(this->xiz(), rhs.xiz())) &&
+           (specfem::utilities::is_close(this->etaz(), rhs.etaz())) &&
+           (specfem::utilities::is_close(this->gammaz(), rhs.gammaz()));
   }
 };
 
@@ -420,9 +448,9 @@ template <typename PointJacobianMatrixType,
 KOKKOS_FUNCTION PointJacobianMatrixType
 operator*(const type_real &lhs, const PointJacobianMatrixType &rhs) {
   return PointJacobianMatrixType(
-      rhs.xix * lhs, rhs.etax * lhs, rhs.gammax * lhs, rhs.xiy * lhs,
-      rhs.etay * lhs, rhs.gammay * lhs, rhs.xiz * lhs, rhs.etaz * lhs,
-      rhs.gammaz * lhs);
+      rhs.xix() * lhs, rhs.etax() * lhs, rhs.gammax() * lhs, rhs.xiy() * lhs,
+      rhs.etay() * lhs, rhs.gammay() * lhs, rhs.xiz() * lhs, rhs.etaz() * lhs,
+      rhs.gammaz() * lhs);
 }
 
 /**
@@ -452,8 +480,10 @@ public:
   constexpr static bool store_jacobian = true;
   ///@}
 
-  value_type jacobian; ///< Jacobian determinant @f$ J @f$
+private:
+  value_type jacobian_; ///< Jacobian determinant @f$ J @f$
 
+public:
   /**
    * @name Constructors
    *
@@ -465,7 +495,7 @@ public:
    *
    */
   KOKKOS_FUNCTION
-  jacobian_matrix() : base_type(), jacobian(0.0) { return; }
+  jacobian_matrix() : base_type(), jacobian_(0.0) { return; }
 
   /**
    * @brief Constructor with values
@@ -482,7 +512,7 @@ public:
                   const value_type &jacobian)
       : jacobian_matrix<specfem::element::dimension_tag::dim2, false, UseSIMD>(
             xix, gammax, xiz, gammaz),
-        jacobian(jacobian) {}
+        jacobian_(jacobian) {}
 
   /**
    * @brief Constructor with constant value
@@ -493,7 +523,7 @@ public:
   jacobian_matrix(const value_type constant)
       : jacobian_matrix<specfem::element::dimension_tag::dim2, false, UseSIMD>(
             constant),
-        jacobian(constant) {}
+        jacobian_(constant) {}
 
   /**
    * @brief Construct from a 2x2 tensor and Jacobian determinant
@@ -505,16 +535,22 @@ public:
   jacobian_matrix(const tensor_type &t, const value_type &jacobian)
       : jacobian_matrix<specfem::element::dimension_tag::dim2, false, UseSIMD>(
             t),
-        jacobian(jacobian) {}
+        jacobian_(jacobian) {}
+  ///@}
+
+  /**
+   * @brief Jacobian determinant @f$ J @f$
+   * @return Reference to the stored Jacobian determinant
+   */
+  ///@{
+  KOKKOS_FUNCTION value_type &jacobian() { return jacobian_; }
+  KOKKOS_FUNCTION const value_type &jacobian() const { return jacobian_; }
   ///@}
 
   KOKKOS_FUNCTION
   void init() {
-    this->xix = 0.0;
-    this->gammax = 0.0;
-    this->xiz = 0.0;
-    this->gammaz = 0.0;
-    this->jacobian = 0.0;
+    base_type::init();
+    this->jacobian_ = 0.0;
     return;
   }
 
@@ -548,36 +584,36 @@ public:
 
   KOKKOS_FUNCTION bool operator==(const jacobian_matrix &rhs) const {
     return (static_cast<base_type>(*this) == static_cast<base_type>(rhs)) &&
-           (specfem::utilities::is_close(this->jacobian, rhs.jacobian));
+           (specfem::utilities::is_close(this->jacobian(), rhs.jacobian()));
   }
 
 private:
   specfem::datatype::VectorPointViewType<type_real, 2, UseSIMD>
   impl_compute_normal_bottom() const {
     return { static_cast<value_type>(static_cast<type_real>(-1.0) *
-                                     this->gammax * this->jacobian),
+                                     this->gammax() * this->jacobian()),
              static_cast<value_type>(static_cast<type_real>(-1.0) *
-                                     this->gammaz * this->jacobian) };
+                                     this->gammaz() * this->jacobian()) };
   };
 
   specfem::datatype::VectorPointViewType<type_real, 2, UseSIMD>
   impl_compute_normal_top() const {
-    return { static_cast<value_type>(this->gammax * this->jacobian),
-             static_cast<value_type>(this->gammaz * this->jacobian) };
+    return { static_cast<value_type>(this->gammax() * this->jacobian()),
+             static_cast<value_type>(this->gammaz() * this->jacobian()) };
   };
 
   specfem::datatype::VectorPointViewType<type_real, 2, UseSIMD>
   impl_compute_normal_left() const {
-    return { static_cast<value_type>(static_cast<type_real>(-1.0) * this->xix *
-                                     this->jacobian),
-             static_cast<value_type>(static_cast<type_real>(-1.0) * this->xiz *
-                                     this->jacobian) };
+    return { static_cast<value_type>(static_cast<type_real>(-1.0) *
+                                     this->xix() * this->jacobian()),
+             static_cast<value_type>(static_cast<type_real>(-1.0) *
+                                     this->xiz() * this->jacobian()) };
   };
 
   specfem::datatype::VectorPointViewType<type_real, 2, UseSIMD>
   impl_compute_normal_right() const {
-    return { static_cast<value_type>(this->xix * this->jacobian),
-             static_cast<value_type>(this->xiz * this->jacobian) };
+    return { static_cast<value_type>(this->xix() * this->jacobian()),
+             static_cast<value_type>(this->xiz() * this->jacobian()) };
   };
 };
 
@@ -608,8 +644,10 @@ public:
   constexpr static bool store_jacobian = true;
   ///@}
 
-  value_type jacobian; ///< Jacobian determinant @f$ J @f$
+private:
+  value_type jacobian_; ///< Jacobian determinant @f$ J @f$
 
+public:
   /**
    * @name Constructors
    *
@@ -621,7 +659,7 @@ public:
    *
    */
   KOKKOS_FUNCTION
-  jacobian_matrix() : base_type(), jacobian(0.0) { return; }
+  jacobian_matrix() : base_type(), jacobian_(0.0) { return; }
 
   /**
    * @brief Constructor with values
@@ -645,7 +683,7 @@ public:
                   const value_type &gammaz, const value_type &jacobian)
       : jacobian_matrix<specfem::element::dimension_tag::dim3, false, UseSIMD>(
             xix, etax, gammax, xiy, etay, gammay, xiz, etaz, gammaz),
-        jacobian(jacobian) {}
+        jacobian_(jacobian) {}
 
   /**
    * @brief Constructor with constant value
@@ -656,7 +694,7 @@ public:
   jacobian_matrix(const value_type constant)
       : jacobian_matrix<specfem::element::dimension_tag::dim3, false, UseSIMD>(
             constant),
-        jacobian(constant) {}
+        jacobian_(constant) {}
 
   /**
    * @brief Construct from a 3x3 tensor and Jacobian determinant
@@ -668,21 +706,22 @@ public:
   jacobian_matrix(const tensor_type &t, const value_type &jacobian)
       : jacobian_matrix<specfem::element::dimension_tag::dim3, false, UseSIMD>(
             t),
-        jacobian(jacobian) {}
+        jacobian_(jacobian) {}
+  ///@}
+
+  /**
+   * @brief Jacobian determinant @f$ J @f$
+   * @return Reference to the stored Jacobian determinant
+   */
+  ///@{
+  KOKKOS_FUNCTION value_type &jacobian() { return jacobian_; }
+  KOKKOS_FUNCTION const value_type &jacobian() const { return jacobian_; }
   ///@}
 
   KOKKOS_FUNCTION
   void init() {
-    this->xix = 0.0;
-    this->etax = 0.0;
-    this->gammax = 0.0;
-    this->xiy = 0.0;
-    this->etay = 0.0;
-    this->gammay = 0.0;
-    this->xiz = 0.0;
-    this->etaz = 0.0;
-    this->gammaz = 0.0;
-    this->jacobian = 0.0;
+    base_type::init();
+    this->jacobian_ = 0.0;
     return;
   }
 
@@ -700,7 +739,7 @@ public:
   // operator==
   KOKKOS_FUNCTION bool operator==(const jacobian_matrix &rhs) const {
     return (static_cast<base_type>(*this) == static_cast<base_type>(rhs)) &&
-           (specfem::utilities::is_close(this->jacobian, rhs.jacobian));
+           (specfem::utilities::is_close(this->jacobian(), rhs.jacobian()));
   }
 
   /**
@@ -724,56 +763,78 @@ private:
   specfem::datatype::VectorPointViewType<type_real, 3, UseSIMD>
   impl_compute_normal_bottom() const {
     return { static_cast<value_type>(static_cast<type_real>(-1.0) *
-                                     this->gammax * this->jacobian),
+                                     this->gammax() * this->jacobian()),
              static_cast<value_type>(static_cast<type_real>(-1.0) *
-                                     this->gammay * this->jacobian),
+                                     this->gammay() * this->jacobian()),
              static_cast<value_type>(static_cast<type_real>(-1.0) *
-                                     this->gammaz * this->jacobian) };
+                                     this->gammaz() * this->jacobian()) };
   };
 
   specfem::datatype::VectorPointViewType<type_real, 3, UseSIMD>
   impl_compute_normal_top() const {
-    return { static_cast<value_type>(this->gammax * this->jacobian),
-             static_cast<value_type>(this->gammay * this->jacobian),
-             static_cast<value_type>(this->gammaz * this->jacobian) };
+    return { static_cast<value_type>(this->gammax() * this->jacobian()),
+             static_cast<value_type>(this->gammay() * this->jacobian()),
+             static_cast<value_type>(this->gammaz() * this->jacobian()) };
   };
 
   specfem::datatype::VectorPointViewType<type_real, 3, UseSIMD>
   impl_compute_normal_left() const {
-    return { static_cast<value_type>(static_cast<type_real>(-1.0) * this->xix *
-                                     this->jacobian),
-             static_cast<value_type>(static_cast<type_real>(-1.0) * this->xiy *
-                                     this->jacobian),
-             static_cast<value_type>(static_cast<type_real>(-1.0) * this->xiz *
-                                     this->jacobian) };
+    return { static_cast<value_type>(static_cast<type_real>(-1.0) *
+                                     this->xix() * this->jacobian()),
+             static_cast<value_type>(static_cast<type_real>(-1.0) *
+                                     this->xiy() * this->jacobian()),
+             static_cast<value_type>(static_cast<type_real>(-1.0) *
+                                     this->xiz() * this->jacobian()) };
   };
 
   specfem::datatype::VectorPointViewType<type_real, 3, UseSIMD>
   impl_compute_normal_right() const {
-    return { static_cast<value_type>(this->xix * this->jacobian),
-             static_cast<value_type>(this->xiy * this->jacobian),
-             static_cast<value_type>(this->xiz * this->jacobian) };
+    return { static_cast<value_type>(this->xix() * this->jacobian()),
+             static_cast<value_type>(this->xiy() * this->jacobian()),
+             static_cast<value_type>(this->xiz() * this->jacobian()) };
   };
 
   specfem::datatype::VectorPointViewType<type_real, 3, UseSIMD>
   impl_compute_normal_front() const {
     // front = eta=-1 face (iy=0); outward normal = -J*nabla(eta)
-    return { static_cast<value_type>(static_cast<type_real>(-1.0) * this->etax *
-                                     this->jacobian),
-             static_cast<value_type>(static_cast<type_real>(-1.0) * this->etay *
-                                     this->jacobian),
-             static_cast<value_type>(static_cast<type_real>(-1.0) * this->etaz *
-                                     this->jacobian) };
+    return { static_cast<value_type>(static_cast<type_real>(-1.0) *
+                                     this->etax() * this->jacobian()),
+             static_cast<value_type>(static_cast<type_real>(-1.0) *
+                                     this->etay() * this->jacobian()),
+             static_cast<value_type>(static_cast<type_real>(-1.0) *
+                                     this->etaz() * this->jacobian()) };
   };
 
   specfem::datatype::VectorPointViewType<type_real, 3, UseSIMD>
   impl_compute_normal_back() const {
     // back = eta=+1 face (iy=nglly-1); outward normal = +J*nabla(eta)
-    return { static_cast<value_type>(this->etax * this->jacobian),
-             static_cast<value_type>(this->etay * this->jacobian),
-             static_cast<value_type>(this->etaz * this->jacobian) };
+    return { static_cast<value_type>(this->etax() * this->jacobian()),
+             static_cast<value_type>(this->etay() * this->jacobian()),
+             static_cast<value_type>(this->etaz() * this->jacobian()) };
   };
 };
+
+// Kokkos bit-copies this type both as a `View` element and as the reduction
+// scalar of `Kokkos::Sum<>` (see specfem::algorithms::interpolate_function).
+// It must therefore have no self-pointers -- storing references into its own
+// tensor made it dangle after a `memcpy`, which segfaulted under threaded
+// backends while passing on Serial (issue #2008).
+#define SPECFEM_ASSERT_JACOBIAN_MATRIX_RELOCATABLE(UseSIMD)                    \
+  static_assert(                                                               \
+      std::is_trivially_copyable_v<specfem::point::jacobian_matrix<            \
+              specfem::element::dimension_tag::dim2, false, UseSIMD>> &&       \
+          std::is_trivially_copyable_v<specfem::point::jacobian_matrix<        \
+              specfem::element::dimension_tag::dim2, true, UseSIMD>> &&        \
+          std::is_trivially_copyable_v<specfem::point::jacobian_matrix<        \
+              specfem::element::dimension_tag::dim3, false, UseSIMD>> &&       \
+          std::is_trivially_copyable_v<specfem::point::jacobian_matrix<        \
+              specfem::element::dimension_tag::dim3, true, UseSIMD>>,          \
+      "point::jacobian_matrix must be trivially copyable")
+
+SPECFEM_ASSERT_JACOBIAN_MATRIX_RELOCATABLE(false);
+SPECFEM_ASSERT_JACOBIAN_MATRIX_RELOCATABLE(true);
+
+#undef SPECFEM_ASSERT_JACOBIAN_MATRIX_RELOCATABLE
 
 } // namespace point
 } // namespace specfem

--- a/core/specfem/point/stress.hpp
+++ b/core/specfem/point/stress.hpp
@@ -130,11 +130,9 @@ public:
   value_type operator*(const specfem::point::jacobian_matrix<
                        specfem::element::dimension_tag::dim2, true, UseSIMD>
                            &jacobian_matrix) const {
-    const auto &J = static_cast<
-        const typename std::decay_t<decltype(jacobian_matrix)>::tensor_type &>(
-        jacobian_matrix);
+    const auto &J = jacobian_matrix.tensor();
     value_type F = T * J;
-    F *= jacobian_matrix.jacobian;
+    F *= jacobian_matrix.jacobian();
     return F;
   }
 
@@ -153,11 +151,9 @@ public:
   value_type operator*(const specfem::point::jacobian_matrix<
                        specfem::element::dimension_tag::dim3, true, UseSIMD>
                            &jacobian_matrix) const {
-    const auto &J = static_cast<
-        const typename std::decay_t<decltype(jacobian_matrix)>::tensor_type &>(
-        jacobian_matrix);
+    const auto &J = jacobian_matrix.tensor();
     value_type F = T * J;
-    F *= jacobian_matrix.jacobian;
+    F *= jacobian_matrix.jacobian();
     return F;
   }
 

--- a/docs/sections/developer_documentation/tutorials/tutorial1/Chapter8/index.rst
+++ b/docs/sections/developer_documentation/tutorials/tutorial1/Chapter8/index.rst
@@ -128,17 +128,17 @@ Next, lets implement ``compute_stiffness_interaction`` kernel.
                 properties.mu * (du(0, 1) + du(1, 0));
 
             F(0, 0) =
-                sigma_xx * jacobian_matrix.xix +
-                sigma_xz * jacobian_matrix.xiz;
+                sigma_xx * jacobian_matrix.xix() +
+                sigma_xz * jacobian_matrix.xiz();
             F(0, 1) =
-                sigma_xz * jacobian_matrix.xix +
-                sigma_zz * jacobian_matrix.xiz;
+                sigma_xz * jacobian_matrix.xix() +
+                sigma_zz * jacobian_matrix.xiz();
             F(1, 0) =
-                sigma_xx * jacobian_matrix.gammax +
-                sigma_xz * jacobian_matrix.gammaz;
+                sigma_xx * jacobian_matrix.gammax() +
+                sigma_xz * jacobian_matrix.gammaz();
             F(1, 1) =
-                sigma_xz * jacobian_matrix.gammax +
-                sigma_zz * jacobian_matrix.gammaz;
+                sigma_xz * jacobian_matrix.gammax() +
+                sigma_zz * jacobian_matrix.gammaz();
         };
 
     void domain::compute_stiffness_interaction() {

--- a/tests/unit-tests/assembly/nonconforming_interfaces/container_init_test.cpp
+++ b/tests/unit-tests/assembly/nonconforming_interfaces/container_init_test.cpp
@@ -116,20 +116,20 @@ void estimate_verify_normal(
                                   type_real &, type_real &> {
     if (iedge == specfem::mesh_entity::dim2::type::bottom) {
       gamma = -1;
-      return { gamma, jacobian.xix, jacobian.xiz, jacobian.gammax,
-               jacobian.gammaz };
+      return { gamma, jacobian.xix(), jacobian.xiz(), jacobian.gammax(),
+               jacobian.gammaz() };
     } else if (iedge == specfem::mesh_entity::dim2::type::right) {
       xi = 1;
-      return { xi, jacobian.gammax, jacobian.gammaz, jacobian.xix,
-               jacobian.xiz };
+      return { xi, jacobian.gammax(), jacobian.gammaz(), jacobian.xix(),
+               jacobian.xiz() };
     } else if (iedge == specfem::mesh_entity::dim2::type::top) {
       gamma = 1;
-      return { gamma, jacobian.xix, jacobian.xiz, jacobian.gammax,
-               jacobian.gammaz };
+      return { gamma, jacobian.xix(), jacobian.xiz(), jacobian.gammax(),
+               jacobian.gammaz() };
     } else {
       xi = -1;
-      return { xi, jacobian.gammax, jacobian.gammaz, jacobian.xix,
-               jacobian.xiz };
+      return { xi, jacobian.gammax(), jacobian.gammaz(), jacobian.xix(),
+               jacobian.xiz() };
     }
   }();
   jacobian = specfem::jacobian::compute_jacobian(coorg, ngnod, xi, gamma);

--- a/tests/unit-tests/assembly_mesh/jacobian_matrix/compute_jacobian_matrix_tests.cpp
+++ b/tests/unit-tests/assembly_mesh/jacobian_matrix/compute_jacobian_matrix_tests.cpp
@@ -107,13 +107,13 @@ TEST(ASSEMBLY_MESH, compute_jacobian_matrix) {
         }();
         const int ispec_mesh = compute_mesh.h_compute_to_mesh(ispec);
 
-        EXPECT_NEAR(point_jacobian_matrix.xix, xix_ref.data(ispec_mesh, iz, ix),
-                    xix_ref.tol);
-        EXPECT_NEAR(point_jacobian_matrix.gammax,
+        EXPECT_NEAR(point_jacobian_matrix.xix(),
+                    xix_ref.data(ispec_mesh, iz, ix), xix_ref.tol);
+        EXPECT_NEAR(point_jacobian_matrix.gammax(),
                     gammax_ref.data(ispec_mesh, iz, ix), gammax_ref.tol);
-        EXPECT_NEAR(point_jacobian_matrix.gammaz,
+        EXPECT_NEAR(point_jacobian_matrix.gammaz(),
                     gammaz_ref.data(ispec_mesh, iz, ix), gammaz_ref.tol);
-        EXPECT_NEAR(point_jacobian_matrix.jacobian,
+        EXPECT_NEAR(point_jacobian_matrix.jacobian(),
                     jacobian_ref.data(ispec_mesh, iz, ix), jacobian_ref.tol);
       }
     }
@@ -140,13 +140,13 @@ TEST(ASSEMBLY_MESH, compute_jacobian_matrix) {
 
         for (int i = 0; i < num_elements; ++i) {
           const int ispec_mesh = compute_mesh.h_compute_to_mesh(ispec + i);
-          EXPECT_NEAR(point_jacobian_matrix.xix[i],
+          EXPECT_NEAR(point_jacobian_matrix.xix()[i],
                       xix_ref.data(ispec_mesh, iz, ix), xix_ref.tol);
-          EXPECT_NEAR(point_jacobian_matrix.gammax[i],
+          EXPECT_NEAR(point_jacobian_matrix.gammax()[i],
                       gammax_ref.data(ispec_mesh, iz, ix), gammax_ref.tol);
-          EXPECT_NEAR(point_jacobian_matrix.gammaz[i],
+          EXPECT_NEAR(point_jacobian_matrix.gammaz()[i],
                       gammaz_ref.data(ispec_mesh, iz, ix), gammaz_ref.tol);
-          EXPECT_NEAR(point_jacobian_matrix.jacobian[i],
+          EXPECT_NEAR(point_jacobian_matrix.jacobian()[i],
                       jacobian_ref.data(ispec_mesh, iz, ix), jacobian_ref.tol);
         }
       }

--- a/tests/unit-tests/jacobian/dim2/compute_jacobian_tests.cpp
+++ b/tests/unit-tests/jacobian/dim2/compute_jacobian_tests.cpp
@@ -101,24 +101,24 @@ TEST_F(ComputeJacobianDim2Test, UnitSquareIdentityMapping) {
   auto result = compute_jacobian(coorg, ngnod, 0.0, 0.0);
 
   // For unit square, jacobian should be 0.25 (area = 1, reference area = 4)
-  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian,
+  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian(),
                                            static_cast<type_real>(0.25)))
-      << expected_got(0.25, result.jacobian);
+      << expected_got(0.25, result.jacobian());
 
   // For unit square mapping, the inverse jacobian matrix elements should be:
   // xi_x = 2, gamma_x = 0, xi_z = 0, gamma_z = 2
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.xix, static_cast<type_real>(2.0)))
-      << expected_got(2.0, result.xix);
+      specfem::utilities::is_close(result.xix(), static_cast<type_real>(2.0)))
+      << expected_got(2.0, result.xix());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammax(),
+                                           static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.gammax());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammax, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.gammax);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.xiz, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.xiz);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammaz, static_cast<type_real>(2.0)))
-      << expected_got(2.0, result.gammaz);
+      specfem::utilities::is_close(result.xiz(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.xiz());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammaz(),
+                                           static_cast<type_real>(2.0)))
+      << expected_got(2.0, result.gammaz());
 }
 
 TEST_F(ComputeJacobianDim2Test, ScaledSquareMapping) {
@@ -130,24 +130,24 @@ TEST_F(ComputeJacobianDim2Test, ScaledSquareMapping) {
   auto result = compute_jacobian(coorg, ngnod, 0.0, 0.0);
 
   // For 2x2 square, jacobian should be 1.0 (area = 4, reference area = 4)
-  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian,
+  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian(),
                                            static_cast<type_real>(1.0)))
-      << expected_got(1.0, result.jacobian);
+      << expected_got(1.0, result.jacobian());
 
   // For 2x2 square mapping, the inverse jacobian matrix elements should be:
   // xi_x = 1, gamma_x = 0, xi_z = 0, gamma_z = 1
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.xix, static_cast<type_real>(1.0)))
-      << expected_got(1.0, result.xix);
+      specfem::utilities::is_close(result.xix(), static_cast<type_real>(1.0)))
+      << expected_got(1.0, result.xix());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammax(),
+                                           static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.gammax());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammax, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.gammax);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.xiz, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.xiz);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammaz, static_cast<type_real>(1.0)))
-      << expected_got(1.0, result.gammaz);
+      specfem::utilities::is_close(result.xiz(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.xiz());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammaz(),
+                                           static_cast<type_real>(1.0)))
+      << expected_got(1.0, result.gammaz());
 }
 
 TEST_F(ComputeJacobianDim2Test, TranslatedSquareMapping) {
@@ -159,21 +159,21 @@ TEST_F(ComputeJacobianDim2Test, TranslatedSquareMapping) {
   auto result = compute_jacobian(coorg, ngnod, 0.0, 0.0);
 
   // Translation shouldn't change jacobian values
-  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian,
+  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian(),
                                            static_cast<type_real>(0.25)))
-      << expected_got(0.25, result.jacobian);
+      << expected_got(0.25, result.jacobian());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.xix, static_cast<type_real>(2.0)))
-      << expected_got(2.0, result.xix);
+      specfem::utilities::is_close(result.xix(), static_cast<type_real>(2.0)))
+      << expected_got(2.0, result.xix());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammax(),
+                                           static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.gammax());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammax, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.gammax);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.xiz, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.xiz);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammaz, static_cast<type_real>(2.0)))
-      << expected_got(2.0, result.gammaz);
+      specfem::utilities::is_close(result.xiz(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.xiz());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammaz(),
+                                           static_cast<type_real>(2.0)))
+      << expected_got(2.0, result.gammaz());
 }
 
 TEST_F(ComputeJacobianDim2Test, ShearMapping) {
@@ -194,25 +194,25 @@ TEST_F(ComputeJacobianDim2Test, ShearMapping) {
   auto result = compute_jacobian(coorg, ngnod, 0.0, 0.0);
 
   // Jacobian should still be 0.25 (area preserved under shear)
-  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian,
+  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian(),
                                            static_cast<type_real>(0.25)))
-      << expected_got(0.25, result.jacobian);
+      << expected_got(0.25, result.jacobian());
 
   // Check that jacobian matrix elements account for shear
   // For this shear mapping: dx/dxi = 0.5, dx/dgamma = 0.25, dz/dxi = 0,
   // dz/dgamma = 0.5 Inverse jacobian: xix = 2, gammax = 0, xiz = -1, gammaz = 2
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.xix, static_cast<type_real>(2.0)))
-      << expected_got(2.0, result.xix);
+      specfem::utilities::is_close(result.xix(), static_cast<type_real>(2.0)))
+      << expected_got(2.0, result.xix());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammax(),
+                                           static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.gammax());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammax, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.gammax);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.xiz, static_cast<type_real>(-1.0)))
-      << expected_got(-1.0, result.xiz);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammaz, static_cast<type_real>(2.0)))
-      << expected_got(2.0, result.gammaz);
+      specfem::utilities::is_close(result.xiz(), static_cast<type_real>(-1.0)))
+      << expected_got(-1.0, result.xiz());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammaz(),
+                                           static_cast<type_real>(2.0)))
+      << expected_got(2.0, result.gammaz());
 }
 
 TEST_F(ComputeJacobianDim2Test, JacobianConsistencyAcrossElement) {
@@ -237,37 +237,39 @@ TEST_F(ComputeJacobianDim2Test, JacobianConsistencyAcrossElement) {
 
   // Jacobian should be constant across element
   EXPECT_TRUE(specfem::utilities::is_close(
-      result_center.jacobian, static_cast<type_real>(result_corner1.jacobian)))
-      << expected_got(result_corner1.jacobian, result_center.jacobian);
+      result_center.jacobian(),
+      static_cast<type_real>(result_corner1.jacobian())))
+      << expected_got(result_corner1.jacobian(), result_center.jacobian());
   EXPECT_TRUE(specfem::utilities::is_close(
-      result_center.jacobian, static_cast<type_real>(result_corner2.jacobian)))
-      << expected_got(result_corner2.jacobian, result_center.jacobian);
+      result_center.jacobian(),
+      static_cast<type_real>(result_corner2.jacobian())))
+      << expected_got(result_corner2.jacobian(), result_center.jacobian());
 
   // Inverse jacobian matrix elements should also be constant
   EXPECT_TRUE(specfem::utilities::is_close(
-      result_center.xix, static_cast<type_real>(result_corner1.xix)))
-      << expected_got(result_corner1.xix, result_center.xix);
+      result_center.xix(), static_cast<type_real>(result_corner1.xix())))
+      << expected_got(result_corner1.xix(), result_center.xix());
   EXPECT_TRUE(specfem::utilities::is_close(
-      result_center.xix, static_cast<type_real>(result_corner2.xix)))
-      << expected_got(result_corner2.xix, result_center.xix);
+      result_center.xix(), static_cast<type_real>(result_corner2.xix())))
+      << expected_got(result_corner2.xix(), result_center.xix());
   EXPECT_TRUE(specfem::utilities::is_close(
-      result_center.gammax, static_cast<type_real>(result_corner1.gammax)))
-      << expected_got(result_corner1.gammax, result_center.gammax);
+      result_center.gammax(), static_cast<type_real>(result_corner1.gammax())))
+      << expected_got(result_corner1.gammax(), result_center.gammax());
   EXPECT_TRUE(specfem::utilities::is_close(
-      result_center.gammax, static_cast<type_real>(result_corner2.gammax)))
-      << expected_got(result_corner2.gammax, result_center.gammax);
+      result_center.gammax(), static_cast<type_real>(result_corner2.gammax())))
+      << expected_got(result_corner2.gammax(), result_center.gammax());
   EXPECT_TRUE(specfem::utilities::is_close(
-      result_center.xiz, static_cast<type_real>(result_corner1.xiz)))
-      << expected_got(result_corner1.xiz, result_center.xiz);
+      result_center.xiz(), static_cast<type_real>(result_corner1.xiz())))
+      << expected_got(result_corner1.xiz(), result_center.xiz());
   EXPECT_TRUE(specfem::utilities::is_close(
-      result_center.xiz, static_cast<type_real>(result_corner2.xiz)))
-      << expected_got(result_corner2.xiz, result_center.xiz);
+      result_center.xiz(), static_cast<type_real>(result_corner2.xiz())))
+      << expected_got(result_corner2.xiz(), result_center.xiz());
   EXPECT_TRUE(specfem::utilities::is_close(
-      result_center.gammaz, static_cast<type_real>(result_corner1.gammaz)))
-      << expected_got(result_corner1.gammaz, result_center.gammaz);
+      result_center.gammaz(), static_cast<type_real>(result_corner1.gammaz())))
+      << expected_got(result_corner1.gammaz(), result_center.gammaz());
   EXPECT_TRUE(specfem::utilities::is_close(
-      result_center.gammaz, static_cast<type_real>(result_corner2.gammaz)))
-      << expected_got(result_corner2.gammaz, result_center.gammaz);
+      result_center.gammaz(), static_cast<type_real>(result_corner2.gammaz())))
+      << expected_got(result_corner2.gammaz(), result_center.gammaz());
 }
 
 TEST_F(ComputeJacobianDim2Test, RectangleMapping) {
@@ -288,25 +290,25 @@ TEST_F(ComputeJacobianDim2Test, RectangleMapping) {
   auto result = compute_jacobian(coorg, ngnod, 0.0, 0.0);
 
   // For 4x2 rectangle, jacobian should be 2.0 (area = 8, reference area = 4)
-  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian,
+  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian(),
                                            static_cast<type_real>(2.0)))
-      << expected_got(2.0, result.jacobian);
+      << expected_got(2.0, result.jacobian());
 
   // For 4x2 rectangle mapping:
   // dx/dxi = 2, dx/dgamma = 0, dz/dxi = 0, dz/dgamma = 1
   // Inverse jacobian: xi_x = 0.5, gamma_x = 0, xi_z = 0, gamma_z = 1
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.xix, static_cast<type_real>(0.5)))
-      << expected_got(0.5, result.xix);
+      specfem::utilities::is_close(result.xix(), static_cast<type_real>(0.5)))
+      << expected_got(0.5, result.xix());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammax(),
+                                           static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.gammax());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammax, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.gammax);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.xiz, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.xiz);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammaz, static_cast<type_real>(1.0)))
-      << expected_got(1.0, result.gammaz);
+      specfem::utilities::is_close(result.xiz(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.xiz());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammaz(),
+                                           static_cast<type_real>(1.0)))
+      << expected_got(1.0, result.gammaz());
 }
 
 TEST_F(ComputeJacobianDim2Test, PositiveJacobianCheck) {
@@ -318,7 +320,7 @@ TEST_F(ComputeJacobianDim2Test, PositiveJacobianCheck) {
       coorg("coorg", ngnod);
 
   // Various properly oriented quadrilaterals
-  std::vector<std::array<std::array<type_real, 2>, 4> > test_elements = {
+  std::vector<std::array<std::array<type_real, 2>, 4>> test_elements = {
     // Unit square
     { { { 0.0, 0.0 }, { 1.0, 0.0 }, { 1.0, 1.0 }, { 0.0, 1.0 } } },
     // Trapezoid
@@ -333,7 +335,7 @@ TEST_F(ComputeJacobianDim2Test, PositiveJacobianCheck) {
     }
 
     auto result = compute_jacobian(coorg, ngnod, 0.0, 0.0);
-    EXPECT_GT(result.jacobian, 0.0)
+    EXPECT_GT(result.jacobian(), 0.0)
         << "Jacobian should be positive for properly oriented element";
   }
 }
@@ -353,7 +355,7 @@ TEST_F(ComputeJacobianDim2Test, NegativeJacobianCheck) {
   coorg(3) = { 1.0, 0.0 }; // Bottom-right (swapped)
 
   auto result = compute_jacobian(coorg, ngnod, 0.0, 0.0);
-  EXPECT_LT(result.jacobian, 0.0)
+  EXPECT_LT(result.jacobian(), 0.0)
       << "Jacobian should be negative for improperly oriented element";
 }
 
@@ -372,7 +374,7 @@ TEST_F(ComputeJacobianDim2Test, OverloadedFunction) {
   coorg(3) = { 0.0, 1.0 };
 
   // Create dummy derivative matrix for 4-node element at center
-  std::vector<std::vector<type_real> > dershape2D(2, std::vector<type_real>(4));
+  std::vector<std::vector<type_real>> dershape2D(2, std::vector<type_real>(4));
   // At center (0,0), derivatives for bilinear element:
   dershape2D[0][0] = -0.25;
   dershape2D[1][0] = -0.25; // node 0
@@ -388,21 +390,23 @@ TEST_F(ComputeJacobianDim2Test, OverloadedFunction) {
 
   // Results should match
   EXPECT_TRUE(specfem::utilities::is_close(
-      result_overloaded.jacobian,
-      static_cast<type_real>(result_direct.jacobian)))
-      << expected_got(result_direct.jacobian, result_overloaded.jacobian);
+      result_overloaded.jacobian(),
+      static_cast<type_real>(result_direct.jacobian())))
+      << expected_got(result_direct.jacobian(), result_overloaded.jacobian());
   EXPECT_TRUE(specfem::utilities::is_close(
-      result_overloaded.xix, static_cast<type_real>(result_direct.xix)))
-      << expected_got(result_direct.xix, result_overloaded.xix);
+      result_overloaded.xix(), static_cast<type_real>(result_direct.xix())))
+      << expected_got(result_direct.xix(), result_overloaded.xix());
   EXPECT_TRUE(specfem::utilities::is_close(
-      result_overloaded.gammax, static_cast<type_real>(result_direct.gammax)))
-      << expected_got(result_direct.gammax, result_overloaded.gammax);
+      result_overloaded.gammax(),
+      static_cast<type_real>(result_direct.gammax())))
+      << expected_got(result_direct.gammax(), result_overloaded.gammax());
   EXPECT_TRUE(specfem::utilities::is_close(
-      result_overloaded.xiz, static_cast<type_real>(result_direct.xiz)))
-      << expected_got(result_direct.xiz, result_overloaded.xiz);
+      result_overloaded.xiz(), static_cast<type_real>(result_direct.xiz())))
+      << expected_got(result_direct.xiz(), result_overloaded.xiz());
   EXPECT_TRUE(specfem::utilities::is_close(
-      result_overloaded.gammaz, static_cast<type_real>(result_direct.gammaz)))
-      << expected_got(result_direct.gammaz, result_overloaded.gammaz);
+      result_overloaded.gammaz(),
+      static_cast<type_real>(result_direct.gammaz())))
+      << expected_got(result_direct.gammaz(), result_overloaded.gammaz());
 }
 
 TEST_F(ComputeJacobianDim2Test, NineNodeUnitSquareMapping) {
@@ -414,24 +418,24 @@ TEST_F(ComputeJacobianDim2Test, NineNodeUnitSquareMapping) {
   auto result = compute_jacobian(coorg, ngnod, 0.0, 0.0);
 
   // For unit square, jacobian should be 0.25 (area = 1, reference area = 4)
-  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian,
+  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian(),
                                            static_cast<type_real>(0.25)))
-      << expected_got(0.25, result.jacobian);
+      << expected_got(0.25, result.jacobian());
 
   // For unit square mapping, the inverse jacobian matrix elements should be:
   // Each direction scaled by factor of 2
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.xix, static_cast<type_real>(2.0)))
-      << expected_got(2.0, result.xix);
+      specfem::utilities::is_close(result.xix(), static_cast<type_real>(2.0)))
+      << expected_got(2.0, result.xix());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammax(),
+                                           static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.gammax());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammax, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.gammax);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.xiz, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.xiz);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammaz, static_cast<type_real>(2.0)))
-      << expected_got(2.0, result.gammaz);
+      specfem::utilities::is_close(result.xiz(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.xiz());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammaz(),
+                                           static_cast<type_real>(2.0)))
+      << expected_got(2.0, result.gammaz());
 }
 
 TEST_F(ComputeJacobianDim2Test, NineNodeScaledSquareMapping) {
@@ -457,21 +461,21 @@ TEST_F(ComputeJacobianDim2Test, NineNodeScaledSquareMapping) {
   auto result = compute_jacobian(coorg, ngnod, 0.0, 0.0);
 
   // For 2x2 square, jacobian should be 1.0 (area = 4, reference area = 4)
-  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian,
+  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian(),
                                            static_cast<type_real>(1.0)))
-      << expected_got(1.0, result.jacobian);
+      << expected_got(1.0, result.jacobian());
 
   // For 2x2 square mapping, each direction scaled by factor of 1
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.xix, static_cast<type_real>(1.0)))
-      << expected_got(1.0, result.xix);
+      specfem::utilities::is_close(result.xix(), static_cast<type_real>(1.0)))
+      << expected_got(1.0, result.xix());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammax(),
+                                           static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.gammax());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammax, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.gammax);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.xiz, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.xiz);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammaz, static_cast<type_real>(1.0)))
-      << expected_got(1.0, result.gammaz);
+      specfem::utilities::is_close(result.xiz(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.xiz());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammaz(),
+                                           static_cast<type_real>(1.0)))
+      << expected_got(1.0, result.gammaz());
 }

--- a/tests/unit-tests/jacobian/dim3/compute_jacobian_tests.cpp
+++ b/tests/unit-tests/jacobian/dim3/compute_jacobian_tests.cpp
@@ -143,39 +143,39 @@ TEST_F(ComputeJacobianDim3Test, UnitCubeIdentityMapping) {
   auto result = compute_jacobian(coorg, ngnod, 0.0, 0.0, 0.0);
 
   // For unit cube, jacobian should be 0.125 (volume = 1, reference volume = 8)
-  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian,
+  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian(),
                                            static_cast<type_real>(0.125)))
-      << expected_got(0.125, result.jacobian);
+      << expected_got(0.125, result.jacobian());
 
   // For unit cube mapping, the inverse jacobian matrix elements should be:
   // Each direction scaled by factor of 2
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.xix, static_cast<type_real>(2.0)))
-      << expected_got(2.0, result.xix);
+      specfem::utilities::is_close(result.xix(), static_cast<type_real>(2.0)))
+      << expected_got(2.0, result.xix());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.etax, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.etax);
+      specfem::utilities::is_close(result.etax(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.etax());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammax(),
+                                           static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.gammax());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammax, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.gammax);
+      specfem::utilities::is_close(result.xiy(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.xiy());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.xiy, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.xiy);
+      specfem::utilities::is_close(result.etay(), static_cast<type_real>(2.0)))
+      << expected_got(2.0, result.etay());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammay(),
+                                           static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.gammay());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.etay, static_cast<type_real>(2.0)))
-      << expected_got(2.0, result.etay);
+      specfem::utilities::is_close(result.xiz(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.xiz());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammay, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.gammay);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.xiz, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.xiz);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.etaz, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.etaz);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammaz, static_cast<type_real>(2.0)))
-      << expected_got(2.0, result.gammaz);
+      specfem::utilities::is_close(result.etaz(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.etaz());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammaz(),
+                                           static_cast<type_real>(2.0)))
+      << expected_got(2.0, result.gammaz());
 }
 
 TEST_F(ComputeJacobianDim3Test, ScaledCubeMapping) {
@@ -200,38 +200,38 @@ TEST_F(ComputeJacobianDim3Test, ScaledCubeMapping) {
   auto result = compute_jacobian(coorg, ngnod, 0.0, 0.0, 0.0);
 
   // For 2x2x2 cube, jacobian should be 1.0 (volume = 8, reference volume = 8)
-  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian,
+  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian(),
                                            static_cast<type_real>(1.0)))
-      << expected_got(1.0, result.jacobian);
+      << expected_got(1.0, result.jacobian());
 
   // For 2x2x2 cube mapping, each direction scaled by factor of 1
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.xix, static_cast<type_real>(1.0)))
-      << expected_got(1.0, result.xix);
+      specfem::utilities::is_close(result.xix(), static_cast<type_real>(1.0)))
+      << expected_got(1.0, result.xix());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.etax, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.etax);
+      specfem::utilities::is_close(result.etax(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.etax());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammax(),
+                                           static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.gammax());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammax, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.gammax);
+      specfem::utilities::is_close(result.xiy(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.xiy());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.xiy, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.xiy);
+      specfem::utilities::is_close(result.etay(), static_cast<type_real>(1.0)))
+      << expected_got(1.0, result.etay());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammay(),
+                                           static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.gammay());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.etay, static_cast<type_real>(1.0)))
-      << expected_got(1.0, result.etay);
+      specfem::utilities::is_close(result.xiz(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.xiz());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammay, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.gammay);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.xiz, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.xiz);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.etaz, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.etaz);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammaz, static_cast<type_real>(1.0)))
-      << expected_got(1.0, result.gammaz);
+      specfem::utilities::is_close(result.etaz(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.etaz());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammaz(),
+                                           static_cast<type_real>(1.0)))
+      << expected_got(1.0, result.gammaz());
 }
 
 TEST_F(ComputeJacobianDim3Test, TranslatedCubeMapping) {
@@ -256,37 +256,37 @@ TEST_F(ComputeJacobianDim3Test, TranslatedCubeMapping) {
   auto result = compute_jacobian(coorg, ngnod, 0.0, 0.0, 0.0);
 
   // Translation shouldn't change jacobian values
-  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian,
+  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian(),
                                            static_cast<type_real>(0.125)))
-      << expected_got(0.125, result.jacobian);
+      << expected_got(0.125, result.jacobian());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.xix, static_cast<type_real>(2.0)))
-      << expected_got(2.0, result.xix);
+      specfem::utilities::is_close(result.xix(), static_cast<type_real>(2.0)))
+      << expected_got(2.0, result.xix());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.etay, static_cast<type_real>(2.0)))
-      << expected_got(2.0, result.etay);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammaz, static_cast<type_real>(2.0)))
-      << expected_got(2.0, result.gammaz);
+      specfem::utilities::is_close(result.etay(), static_cast<type_real>(2.0)))
+      << expected_got(2.0, result.etay());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammaz(),
+                                           static_cast<type_real>(2.0)))
+      << expected_got(2.0, result.gammaz());
   // Off-diagonal terms should be zero
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.etax, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.etax);
+      specfem::utilities::is_close(result.etax(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.etax());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammax(),
+                                           static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.gammax());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammax, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.gammax);
+      specfem::utilities::is_close(result.xiy(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.xiy());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammay(),
+                                           static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.gammay());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.xiy, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.xiy);
+      specfem::utilities::is_close(result.xiz(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.xiz());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammay, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.gammay);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.xiz, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.xiz);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.etaz, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.etaz);
+      specfem::utilities::is_close(result.etaz(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.etaz());
 }
 
 TEST_F(ComputeJacobianDim3Test, RectangularPrismMapping) {
@@ -311,41 +311,41 @@ TEST_F(ComputeJacobianDim3Test, RectangularPrismMapping) {
   auto result = compute_jacobian(coorg, ngnod, 0.0, 0.0, 0.0);
 
   // For 4x2x3 prism, jacobian should be 3.0 (volume = 24, reference volume = 8)
-  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian,
+  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian(),
                                            static_cast<type_real>(3.0)))
-      << expected_got(3.0, result.jacobian);
+      << expected_got(3.0, result.jacobian());
 
   // For 4x2x3 prism mapping:
   // dx/dxi = 2, dy/deta = 1, dz/dgamma = 1.5
   // Inverse jacobian: xi_x = 0.5, eta_y = 1.0, gamma_z = 2/3
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.xix, static_cast<type_real>(0.5)))
-      << expected_got(0.5, result.xix);
+      specfem::utilities::is_close(result.xix(), static_cast<type_real>(0.5)))
+      << expected_got(0.5, result.xix());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.etay, static_cast<type_real>(1.0)))
-      << expected_got(1.0, result.etay);
-  EXPECT_TRUE(specfem::utilities::is_close(result.gammaz,
+      specfem::utilities::is_close(result.etay(), static_cast<type_real>(1.0)))
+      << expected_got(1.0, result.etay());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammaz(),
                                            static_cast<type_real>(2.0 / 3.0)))
-      << expected_got(2.0 / 3.0, result.gammaz);
+      << expected_got(2.0 / 3.0, result.gammaz());
   // Off-diagonal terms should be zero
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.etax, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.etax);
+      specfem::utilities::is_close(result.etax(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.etax());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammax(),
+                                           static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.gammax());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammax, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.gammax);
+      specfem::utilities::is_close(result.xiy(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.xiy());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammay(),
+                                           static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.gammay());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.xiy, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.xiy);
+      specfem::utilities::is_close(result.xiz(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.xiz());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammay, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.gammay);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.xiz, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.xiz);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.etaz, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.etaz);
+      specfem::utilities::is_close(result.etaz(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.etaz());
 }
 
 TEST_F(ComputeJacobianDim3Test, ShearMapping) {
@@ -370,9 +370,9 @@ TEST_F(ComputeJacobianDim3Test, ShearMapping) {
   auto result = compute_jacobian(coorg, ngnod, 0.0, 0.0, 0.0);
 
   // Volume should be preserved under shear, so jacobian should be 0.125
-  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian,
+  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian(),
                                            static_cast<type_real>(0.125)))
-      << expected_got(0.125, result.jacobian);
+      << expected_got(0.125, result.jacobian());
 
   // Check that jacobian matrix elements account for shear
   // For this shear mapping: dx/dxi = 0.5, dx/deta = 0, dx/dgamma = 0.25
@@ -380,32 +380,32 @@ TEST_F(ComputeJacobianDim3Test, ShearMapping) {
   //                        dz/dxi = 0,   dz/deta = 0,   dz/dgamma = 0.5
   // The shear introduces coupling in the xiz term (∂ξ/∂z)
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.xix, static_cast<type_real>(2.0)))
-      << expected_got(2.0, result.xix);
+      specfem::utilities::is_close(result.xix(), static_cast<type_real>(2.0)))
+      << expected_got(2.0, result.xix());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.etax, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.etax);
+      specfem::utilities::is_close(result.etax(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.etax());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammax(),
+                                           static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.gammax());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammax, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.gammax);
+      specfem::utilities::is_close(result.xiy(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.xiy());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.xiy, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.xiy);
+      specfem::utilities::is_close(result.etay(), static_cast<type_real>(2.0)))
+      << expected_got(2.0, result.etay());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammay(),
+                                           static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.gammay());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.etay, static_cast<type_real>(2.0)))
-      << expected_got(2.0, result.etay);
+      specfem::utilities::is_close(result.xiz(), static_cast<type_real>(-1.0)))
+      << expected_got(-1.0, result.xiz()); // Shear coupling
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammay, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.gammay);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.xiz, static_cast<type_real>(-1.0)))
-      << expected_got(-1.0, result.xiz); // Shear coupling
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.etaz, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.etaz);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammaz, static_cast<type_real>(2.0)))
-      << expected_got(2.0, result.gammaz);
+      specfem::utilities::is_close(result.etaz(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.etaz());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammaz(),
+                                           static_cast<type_real>(2.0)))
+      << expected_got(2.0, result.gammaz());
 }
 
 TEST_F(ComputeJacobianDim3Test, JacobianConsistencyAcrossElement) {
@@ -434,31 +434,33 @@ TEST_F(ComputeJacobianDim3Test, JacobianConsistencyAcrossElement) {
 
   // Jacobian should be constant across element
   EXPECT_TRUE(specfem::utilities::is_close(
-      result_center.jacobian, static_cast<type_real>(result_corner1.jacobian)))
-      << expected_got(result_corner1.jacobian, result_center.jacobian);
+      result_center.jacobian(),
+      static_cast<type_real>(result_corner1.jacobian())))
+      << expected_got(result_corner1.jacobian(), result_center.jacobian());
   EXPECT_TRUE(specfem::utilities::is_close(
-      result_center.jacobian, static_cast<type_real>(result_corner2.jacobian)))
-      << expected_got(result_corner2.jacobian, result_center.jacobian);
+      result_center.jacobian(),
+      static_cast<type_real>(result_corner2.jacobian())))
+      << expected_got(result_corner2.jacobian(), result_center.jacobian());
 
   // Inverse jacobian matrix elements should also be constant
   EXPECT_TRUE(specfem::utilities::is_close(
-      result_center.xix, static_cast<type_real>(result_corner1.xix)))
-      << expected_got(result_corner1.xix, result_center.xix);
+      result_center.xix(), static_cast<type_real>(result_corner1.xix())))
+      << expected_got(result_corner1.xix(), result_center.xix());
   EXPECT_TRUE(specfem::utilities::is_close(
-      result_center.xix, static_cast<type_real>(result_corner2.xix)))
-      << expected_got(result_corner2.xix, result_center.xix);
+      result_center.xix(), static_cast<type_real>(result_corner2.xix())))
+      << expected_got(result_corner2.xix(), result_center.xix());
   EXPECT_TRUE(specfem::utilities::is_close(
-      result_center.etax, static_cast<type_real>(result_corner1.etax)))
-      << expected_got(result_corner1.etax, result_center.etax);
+      result_center.etax(), static_cast<type_real>(result_corner1.etax())))
+      << expected_got(result_corner1.etax(), result_center.etax());
   EXPECT_TRUE(specfem::utilities::is_close(
-      result_center.etax, static_cast<type_real>(result_corner2.etax)))
-      << expected_got(result_corner2.etax, result_center.etax);
+      result_center.etax(), static_cast<type_real>(result_corner2.etax())))
+      << expected_got(result_corner2.etax(), result_center.etax());
   EXPECT_TRUE(specfem::utilities::is_close(
-      result_center.gammax, static_cast<type_real>(result_corner1.gammax)))
-      << expected_got(result_corner1.gammax, result_center.gammax);
+      result_center.gammax(), static_cast<type_real>(result_corner1.gammax())))
+      << expected_got(result_corner1.gammax(), result_center.gammax());
   EXPECT_TRUE(specfem::utilities::is_close(
-      result_center.gammax, static_cast<type_real>(result_corner2.gammax)))
-      << expected_got(result_corner2.gammax, result_center.gammax);
+      result_center.gammax(), static_cast<type_real>(result_corner2.gammax())))
+      << expected_got(result_corner2.gammax(), result_center.gammax());
 }
 
 TEST_F(ComputeJacobianDim3Test, PositiveJacobianCheck) {
@@ -470,7 +472,7 @@ TEST_F(ComputeJacobianDim3Test, PositiveJacobianCheck) {
       coorg("coorg", ngnod);
 
   // Various properly oriented hexahedra
-  std::vector<std::array<std::array<type_real, 3>, 8> > test_elements = {
+  std::vector<std::array<std::array<type_real, 3>, 8>> test_elements = {
     // Unit cube
     { { { 0.0, 0.0, 0.0 },
         { 1.0, 0.0, 0.0 },
@@ -497,7 +499,7 @@ TEST_F(ComputeJacobianDim3Test, PositiveJacobianCheck) {
     }
 
     auto result = compute_jacobian(coorg, ngnod, 0.0, 0.0, 0.0);
-    EXPECT_GT(result.jacobian, 0.0)
+    EXPECT_GT(result.jacobian(), 0.0)
         << "Jacobian should be positive for properly oriented element";
   }
 }
@@ -521,7 +523,7 @@ TEST_F(ComputeJacobianDim3Test, NegativeJacobianCheck) {
   coorg(7) = { 1.0, 0.0, 1.0 }; // Swapped with node 5
 
   auto result = compute_jacobian(coorg, ngnod, 0.0, 0.0, 0.0);
-  EXPECT_LT(result.jacobian, 0.0)
+  EXPECT_LT(result.jacobian(), 0.0)
       << "Jacobian should be negative for improperly oriented element";
 }
 
@@ -546,20 +548,20 @@ TEST_F(ComputeJacobianDim3Test, JacobianDeterminantFormula) {
   auto result = compute_jacobian(coorg, ngnod, 0.0, 0.0, 0.0);
 
   // For this prism: jacobian determinant = 1.5 * 1.0 * 2.0 = 3.0
-  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian,
+  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian(),
                                            static_cast<type_real>(3.0)))
-      << expected_got(3.0, result.jacobian);
+      << expected_got(3.0, result.jacobian());
 
   // Check specific inverse jacobian elements
-  EXPECT_TRUE(specfem::utilities::is_close(result.xix,
+  EXPECT_TRUE(specfem::utilities::is_close(result.xix(),
                                            static_cast<type_real>(1.0 / 1.5)))
-      << expected_got(1.0 / 1.5, result.xix); // 1/(dx/dxi)
-  EXPECT_TRUE(specfem::utilities::is_close(result.etay,
+      << expected_got(1.0 / 1.5, result.xix()); // 1/(dx/dxi)
+  EXPECT_TRUE(specfem::utilities::is_close(result.etay(),
                                            static_cast<type_real>(1.0 / 1.0)))
-      << expected_got(1.0 / 1.0, result.etay); // 1/(dy/deta)
-  EXPECT_TRUE(specfem::utilities::is_close(result.gammaz,
+      << expected_got(1.0 / 1.0, result.etay()); // 1/(dy/deta)
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammaz(),
                                            static_cast<type_real>(1.0 / 2.0)))
-      << expected_got(1.0 / 2.0, result.gammaz); // 1/(dz/dgamma)
+      << expected_got(1.0 / 2.0, result.gammaz()); // 1/(dz/dgamma)
 }
 
 TEST_F(ComputeJacobianDim3Test, SmallElementStability) {
@@ -586,19 +588,19 @@ TEST_F(ComputeJacobianDim3Test, SmallElementStability) {
   // Expected jacobian for small cube
   type_real expected_jacobian = (scale * scale * scale) / 8.0;
   EXPECT_TRUE(specfem::utilities::is_close(
-      result.jacobian, static_cast<type_real>(expected_jacobian)))
-      << expected_got(expected_jacobian, result.jacobian);
+      result.jacobian(), static_cast<type_real>(expected_jacobian)))
+      << expected_got(expected_jacobian, result.jacobian());
 
   // Inverse jacobian elements should scale appropriately
-  EXPECT_TRUE(specfem::utilities::is_close(result.xix,
+  EXPECT_TRUE(specfem::utilities::is_close(result.xix(),
                                            static_cast<type_real>(2.0 / scale)))
-      << expected_got(2.0 / scale, result.xix);
-  EXPECT_TRUE(specfem::utilities::is_close(result.etay,
+      << expected_got(2.0 / scale, result.xix());
+  EXPECT_TRUE(specfem::utilities::is_close(result.etay(),
                                            static_cast<type_real>(2.0 / scale)))
-      << expected_got(2.0 / scale, result.etay);
-  EXPECT_TRUE(specfem::utilities::is_close(result.gammaz,
+      << expected_got(2.0 / scale, result.etay());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammaz(),
                                            static_cast<type_real>(2.0 / scale)))
-      << expected_got(2.0 / scale, result.gammaz);
+      << expected_got(2.0 / scale, result.gammaz());
 }
 
 TEST_F(ComputeJacobianDim3Test, TwentySevenNodeUnitCubeMapping) {
@@ -649,39 +651,39 @@ TEST_F(ComputeJacobianDim3Test, TwentySevenNodeUnitCubeMapping) {
   auto result = compute_jacobian(coorg, ngnod, 0.0, 0.0, 0.0);
 
   // For unit cube, jacobian should be 0.125 (volume = 1, reference volume = 8)
-  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian,
+  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian(),
                                            static_cast<type_real>(0.125)))
-      << expected_got(0.125, result.jacobian);
+      << expected_got(0.125, result.jacobian());
 
   // For unit cube mapping, the inverse jacobian matrix elements should be:
   // Each direction scaled by factor of 2
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.xix, static_cast<type_real>(2.0)))
-      << expected_got(2.0, result.xix);
+      specfem::utilities::is_close(result.xix(), static_cast<type_real>(2.0)))
+      << expected_got(2.0, result.xix());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.etax, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.etax);
+      specfem::utilities::is_close(result.etax(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.etax());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammax(),
+                                           static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.gammax());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammax, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.gammax);
+      specfem::utilities::is_close(result.xiy(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.xiy());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.xiy, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.xiy);
+      specfem::utilities::is_close(result.etay(), static_cast<type_real>(2.0)))
+      << expected_got(2.0, result.etay());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammay(),
+                                           static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.gammay());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.etay, static_cast<type_real>(2.0)))
-      << expected_got(2.0, result.etay);
+      specfem::utilities::is_close(result.xiz(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.xiz());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammay, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.gammay);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.xiz, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.xiz);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.etaz, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.etaz);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammaz, static_cast<type_real>(2.0)))
-      << expected_got(2.0, result.gammaz);
+      specfem::utilities::is_close(result.etaz(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.etaz());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammaz(),
+                                           static_cast<type_real>(2.0)))
+      << expected_got(2.0, result.gammaz());
 }
 
 TEST_F(ComputeJacobianDim3Test, TwentySevenNodeScaledCubeMapping) {
@@ -732,36 +734,36 @@ TEST_F(ComputeJacobianDim3Test, TwentySevenNodeScaledCubeMapping) {
   auto result = compute_jacobian(coorg, ngnod, 0.0, 0.0, 0.0);
 
   // For 2x2x2 cube, jacobian should be 1.0 (volume = 8, reference volume = 8)
-  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian,
+  EXPECT_TRUE(specfem::utilities::is_close(result.jacobian(),
                                            static_cast<type_real>(1.0)))
-      << expected_got(1.0, result.jacobian);
+      << expected_got(1.0, result.jacobian());
 
   // For 2x2x2 cube mapping, each direction scaled by factor of 1
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.xix, static_cast<type_real>(1.0)))
-      << expected_got(1.0, result.xix);
+      specfem::utilities::is_close(result.xix(), static_cast<type_real>(1.0)))
+      << expected_got(1.0, result.xix());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.etax, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.etax);
+      specfem::utilities::is_close(result.etax(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.etax());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammax(),
+                                           static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.gammax());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammax, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.gammax);
+      specfem::utilities::is_close(result.xiy(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.xiy());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.xiy, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.xiy);
+      specfem::utilities::is_close(result.etay(), static_cast<type_real>(1.0)))
+      << expected_got(1.0, result.etay());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammay(),
+                                           static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.gammay());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.etay, static_cast<type_real>(1.0)))
-      << expected_got(1.0, result.etay);
+      specfem::utilities::is_close(result.xiz(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.xiz());
   EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammay, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.gammay);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.xiz, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.xiz);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.etaz, static_cast<type_real>(0.0)))
-      << expected_got(0.0, result.etaz);
-  EXPECT_TRUE(
-      specfem::utilities::is_close(result.gammaz, static_cast<type_real>(1.0)))
-      << expected_got(1.0, result.gammaz);
+      specfem::utilities::is_close(result.etaz(), static_cast<type_real>(0.0)))
+      << expected_got(0.0, result.etaz());
+  EXPECT_TRUE(specfem::utilities::is_close(result.gammaz(),
+                                           static_cast<type_real>(1.0)))
+      << expected_got(1.0, result.gammaz());
 }

--- a/tests/unit-tests/medium/stress/dim3/elastic_isotropic_cosserat.cpp
+++ b/tests/unit-tests/medium/stress/dim3/elastic_isotropic_cosserat.cpp
@@ -399,16 +399,16 @@ TEST(Stress, ElasticIsotropicCosserat3D_CoupleStressAcceleration) {
 
   // Create Jacobian matrix (identity for simplicity)
   JacobianMatrixType jacobian_matrix;
-  jacobian_matrix.xix = 1.0;
-  jacobian_matrix.xiy = 0.0;
-  jacobian_matrix.xiz = 0.0;
-  jacobian_matrix.etax = 0.0;
-  jacobian_matrix.etay = 1.0;
-  jacobian_matrix.etaz = 0.0;
-  jacobian_matrix.gammax = 0.0;
-  jacobian_matrix.gammay = 0.0;
-  jacobian_matrix.gammaz = 1.0;
-  jacobian_matrix.jacobian = 1.0; // det(J) = 1
+  jacobian_matrix.xix() = 1.0;
+  jacobian_matrix.xiy() = 0.0;
+  jacobian_matrix.xiz() = 0.0;
+  jacobian_matrix.etax() = 0.0;
+  jacobian_matrix.etay() = 1.0;
+  jacobian_matrix.etaz() = 0.0;
+  jacobian_matrix.gammax() = 0.0;
+  jacobian_matrix.gammay() = 0.0;
+  jacobian_matrix.gammaz() = 1.0;
+  jacobian_matrix.jacobian() = 1.0; // det(J) = 1
 
   // Initialize acceleration
   AccelerationType acceleration;
@@ -443,7 +443,7 @@ TEST(Stress, ElasticIsotropicCosserat3D_CoupleStressAcceleration) {
   expected_acceleration(1) = 0.0;
   expected_acceleration(2) = 0.0;
   expected_acceleration(3) =
-      (sigma_zy - sigma_yz) * factor / jacobian_matrix.jacobian;
+      (sigma_zy - sigma_yz) * factor / jacobian_matrix.jacobian();
   expected_acceleration(4) = 0.0; // No xz/zx asymmetry
   expected_acceleration(5) = 0.0; // No xy/yx asymmetry
 

--- a/tests/unit-tests/point/jacobian_matrix_tests.cpp
+++ b/tests/unit-tests/point/jacobian_matrix_tests.cpp
@@ -54,14 +54,14 @@ TYPED_TEST(PointJacobianMatrixTest, JacobianMatrix2D_DefaultConstructor) {
   pd.init();
 
   // Use is_close to check values for both SIMD and non-SIMD cases
-  EXPECT_TRUE(specfem::utilities::is_close(pd.xix, zero_val))
-      << ExpectedGot(0.0, pd.xix);
-  EXPECT_TRUE(specfem::utilities::is_close(pd.gammax, zero_val))
-      << ExpectedGot(0.0, pd.gammax);
-  EXPECT_TRUE(specfem::utilities::is_close(pd.xiz, zero_val))
-      << ExpectedGot(0.0, pd.xiz);
-  EXPECT_TRUE(specfem::utilities::is_close(pd.gammaz, zero_val))
-      << ExpectedGot(0.0, pd.gammaz);
+  EXPECT_TRUE(specfem::utilities::is_close(pd.xix(), zero_val))
+      << ExpectedGot(0.0, pd.xix());
+  EXPECT_TRUE(specfem::utilities::is_close(pd.gammax(), zero_val))
+      << ExpectedGot(0.0, pd.gammax());
+  EXPECT_TRUE(specfem::utilities::is_close(pd.xiz(), zero_val))
+      << ExpectedGot(0.0, pd.xiz());
+  EXPECT_TRUE(specfem::utilities::is_close(pd.gammaz(), zero_val))
+      << ExpectedGot(0.0, pd.gammaz());
 }
 
 TYPED_TEST(PointJacobianMatrixTest, JacobianMatrix2D_ValueConstructor) {
@@ -90,14 +90,14 @@ TYPED_TEST(PointJacobianMatrixTest, JacobianMatrix2D_ValueConstructor) {
       pd(xix_val, gammax_val, xiz_val, gammaz_val);
 
   // Check values using is_close
-  EXPECT_TRUE(specfem::utilities::is_close(pd.xix, xix_val))
-      << ExpectedGot(xix_val, pd.xix);
-  EXPECT_TRUE(specfem::utilities::is_close(pd.gammax, gammax_val))
-      << ExpectedGot(gammax_val, pd.gammax);
-  EXPECT_TRUE(specfem::utilities::is_close(pd.xiz, xiz_val))
-      << ExpectedGot(xiz_val, pd.xiz);
-  EXPECT_TRUE(specfem::utilities::is_close(pd.gammaz, gammaz_val))
-      << ExpectedGot(gammaz_val, pd.gammaz);
+  EXPECT_TRUE(specfem::utilities::is_close(pd.xix(), xix_val))
+      << ExpectedGot(xix_val, pd.xix());
+  EXPECT_TRUE(specfem::utilities::is_close(pd.gammax(), gammax_val))
+      << ExpectedGot(gammax_val, pd.gammax());
+  EXPECT_TRUE(specfem::utilities::is_close(pd.xiz(), xiz_val))
+      << ExpectedGot(xiz_val, pd.xiz());
+  EXPECT_TRUE(specfem::utilities::is_close(pd.gammaz(), gammaz_val))
+      << ExpectedGot(gammaz_val, pd.gammaz());
 }
 
 TYPED_TEST(PointJacobianMatrixTest, JacobianMatrix2D_ConstantConstructor) {
@@ -117,14 +117,14 @@ TYPED_TEST(PointJacobianMatrixTest, JacobianMatrix2D_ConstantConstructor) {
       pd(const_val);
 
   // Check values using is_close
-  EXPECT_TRUE(specfem::utilities::is_close(pd.xix, const_val))
-      << ExpectedGot(const_val, pd.xix);
-  EXPECT_TRUE(specfem::utilities::is_close(pd.gammax, const_val))
-      << ExpectedGot(const_val, pd.gammax);
-  EXPECT_TRUE(specfem::utilities::is_close(pd.xiz, const_val))
-      << ExpectedGot(const_val, pd.xiz);
-  EXPECT_TRUE(specfem::utilities::is_close(pd.gammaz, const_val))
-      << ExpectedGot(const_val, pd.gammaz);
+  EXPECT_TRUE(specfem::utilities::is_close(pd.xix(), const_val))
+      << ExpectedGot(const_val, pd.xix());
+  EXPECT_TRUE(specfem::utilities::is_close(pd.gammax(), const_val))
+      << ExpectedGot(const_val, pd.gammax());
+  EXPECT_TRUE(specfem::utilities::is_close(pd.xiz(), const_val))
+      << ExpectedGot(const_val, pd.xiz());
+  EXPECT_TRUE(specfem::utilities::is_close(pd.gammaz(), const_val))
+      << ExpectedGot(const_val, pd.gammaz());
 }
 
 TYPED_TEST(PointJacobianMatrixTest, JacobianMatrix2D_Init) {
@@ -155,14 +155,14 @@ TYPED_TEST(PointJacobianMatrixTest, JacobianMatrix2D_Init) {
   pd.init();
 
   // Check values after init
-  EXPECT_TRUE(specfem::utilities::is_close(pd.xix, zero_val))
-      << ExpectedGot(zero_val, pd.xix);
-  EXPECT_TRUE(specfem::utilities::is_close(pd.gammax, zero_val))
-      << ExpectedGot(zero_val, pd.gammax);
-  EXPECT_TRUE(specfem::utilities::is_close(pd.xiz, zero_val))
-      << ExpectedGot(zero_val, pd.xiz);
-  EXPECT_TRUE(specfem::utilities::is_close(pd.gammaz, zero_val))
-      << ExpectedGot(0.0, pd.gammaz);
+  EXPECT_TRUE(specfem::utilities::is_close(pd.xix(), zero_val))
+      << ExpectedGot(zero_val, pd.xix());
+  EXPECT_TRUE(specfem::utilities::is_close(pd.gammax(), zero_val))
+      << ExpectedGot(zero_val, pd.gammax());
+  EXPECT_TRUE(specfem::utilities::is_close(pd.xiz(), zero_val))
+      << ExpectedGot(zero_val, pd.xiz());
+  EXPECT_TRUE(specfem::utilities::is_close(pd.gammaz(), zero_val))
+      << ExpectedGot(0.0, pd.gammaz());
 }
 
 TYPED_TEST(PointJacobianMatrixTest, JacobianMatrix2D_Arithmetic) {
@@ -201,64 +201,65 @@ TYPED_TEST(PointJacobianMatrixTest, JacobianMatrix2D_Arithmetic) {
   PD b(b_xix_val, b_gammax_val, b_xiz_val, b_gammaz_val);
 
   // Inversion
-  PD a_inv = PD{ specfem::algorithms::inverse(
-      static_cast<const typename PD::tensor_type &>(a)) };
+  PD a_inv = PD{ specfem::algorithms::inverse(a.tensor()) };
   // Inverse of this matrix is
   // [-2    1 ]
   // [3/2 -1/2]
   // with determinant -1/2
   EXPECT_TRUE(specfem::utilities::is_close(
-      a_inv.xix, static_cast<typename PD::value_type>(-2.0)))
-      << ExpectedGot(-2.0, a_inv.xix);
+      a_inv.xix(), static_cast<typename PD::value_type>(-2.0)))
+      << ExpectedGot(-2.0, a_inv.xix());
   EXPECT_TRUE(specfem::utilities::is_close(
-      a_inv.gammax, static_cast<typename PD::value_type>(1.0)))
-      << ExpectedGot(1.0, a_inv.gammax);
+      a_inv.gammax(), static_cast<typename PD::value_type>(1.0)))
+      << ExpectedGot(1.0, a_inv.gammax());
   EXPECT_TRUE(specfem::utilities::is_close(
-      a_inv.xiz, static_cast<typename PD::value_type>(1.5)))
-      << ExpectedGot(1.5, a_inv.xiz);
+      a_inv.xiz(), static_cast<typename PD::value_type>(1.5)))
+      << ExpectedGot(1.5, a_inv.xiz());
   EXPECT_TRUE(specfem::utilities::is_close(
-      a_inv.gammaz, static_cast<typename PD::value_type>(-0.5)))
-      << ExpectedGot(-0.5, a_inv.gammaz);
+      a_inv.gammaz(), static_cast<typename PD::value_type>(-0.5)))
+      << ExpectedGot(-0.5, a_inv.gammaz());
 
   // Addition
   PD c = a + b;
-  EXPECT_TRUE(specfem::utilities::is_close(c.xix, a_xix_val + b_xix_val))
-      << ExpectedGot(a_xix_val + b_xix_val, c.xix);
+  EXPECT_TRUE(specfem::utilities::is_close(c.xix(), a_xix_val + b_xix_val))
+      << ExpectedGot(a_xix_val + b_xix_val, c.xix());
   EXPECT_TRUE(
-      specfem::utilities::is_close(c.gammax, a_gammax_val + b_gammax_val))
-      << ExpectedGot(a_gammax_val + b_gammax_val, c.gammax);
-  EXPECT_TRUE(specfem::utilities::is_close(c.xiz, a_xiz_val + b_xiz_val))
-      << ExpectedGot(a_xiz_val + b_xiz_val, c.xiz);
+      specfem::utilities::is_close(c.gammax(), a_gammax_val + b_gammax_val))
+      << ExpectedGot(a_gammax_val + b_gammax_val, c.gammax());
+  EXPECT_TRUE(specfem::utilities::is_close(c.xiz(), a_xiz_val + b_xiz_val))
+      << ExpectedGot(a_xiz_val + b_xiz_val, c.xiz());
   EXPECT_TRUE(
-      specfem::utilities::is_close(c.gammaz, a_gammaz_val + b_gammaz_val))
-      << ExpectedGot(a_gammaz_val + b_gammaz_val, c.gammaz);
+      specfem::utilities::is_close(c.gammaz(), a_gammaz_val + b_gammaz_val))
+      << ExpectedGot(a_gammaz_val + b_gammaz_val, c.gammaz());
 
   // Addition assignment
   a += b;
-  EXPECT_TRUE(specfem::utilities::is_close(a.xix, a_xix_val + b_xix_val))
-      << ExpectedGot(a_xix_val + b_xix_val, a.xix);
+  EXPECT_TRUE(specfem::utilities::is_close(a.xix(), a_xix_val + b_xix_val))
+      << ExpectedGot(a_xix_val + b_xix_val, a.xix());
   EXPECT_TRUE(
-      specfem::utilities::is_close(a.gammax, a_gammax_val + b_gammax_val))
-      << ExpectedGot(a_gammax_val + b_gammax_val, a.gammax);
-  EXPECT_TRUE(specfem::utilities::is_close(a.xiz, a_xiz_val + b_xiz_val))
-      << ExpectedGot(a_xiz_val + b_xiz_val, a.xiz);
+      specfem::utilities::is_close(a.gammax(), a_gammax_val + b_gammax_val))
+      << ExpectedGot(a_gammax_val + b_gammax_val, a.gammax());
+  EXPECT_TRUE(specfem::utilities::is_close(a.xiz(), a_xiz_val + b_xiz_val))
+      << ExpectedGot(a_xiz_val + b_xiz_val, a.xiz());
   EXPECT_TRUE(
-      specfem::utilities::is_close(a.gammaz, a_gammaz_val + b_gammaz_val))
-      << ExpectedGot(a_gammaz_val + b_gammaz_val, a.gammaz);
+      specfem::utilities::is_close(a.gammaz(), a_gammaz_val + b_gammaz_val))
+      << ExpectedGot(a_gammaz_val + b_gammaz_val, a.gammaz());
 
   // Scalar multiplication (object * scalar)
   if constexpr (!using_simd) {
     type_real scalar_2 = 2.0;
 
     PD d = b * scalar_2;
-    EXPECT_TRUE(specfem::utilities::is_close(d.xix, b_xix_val * scalar_2))
-        << ExpectedGot(b_xix_val * scalar_2, d.xix);
-    EXPECT_TRUE(specfem::utilities::is_close(d.gammax, b_gammax_val * scalar_2))
-        << ExpectedGot(b_gammax_val * scalar_2, d.gammax);
-    EXPECT_TRUE(specfem::utilities::is_close(d.xiz, b_xiz_val * scalar_2))
-        << ExpectedGot(b_xiz_val * scalar_2, d.xiz);
-    EXPECT_TRUE(specfem::utilities::is_close(d.gammaz, b_gammaz_val * scalar_2))
-        << ExpectedGot(b_gammaz_val * scalar_2, d.gammaz);
+    EXPECT_TRUE(specfem::utilities::is_close(d.xix(), b_xix_val * scalar_2))
+        << ExpectedGot(b_xix_val * scalar_2, d.xix());
+    EXPECT_TRUE(
+        specfem::utilities::is_close(d.gammax(), b_gammax_val * scalar_2))
+        << ExpectedGot(b_gammax_val * scalar_2, d.gammax());
+    EXPECT_TRUE(specfem::utilities::is_close(d.xiz(), b_xiz_val * scalar_2))
+        << ExpectedGot(b_xiz_val * scalar_2, d.xiz());
+    EXPECT_TRUE(
+        specfem::utilities::is_close(d.gammaz(), b_gammaz_val * scalar_2))
+        << ExpectedGot(b_gammaz_val * scalar_2, d.gammaz());
 
     // Scalar multiplication (scalar * object)
     typename specfem::datatype::simd<type_real, using_simd>::datatype scalar_3{
@@ -266,14 +267,16 @@ TYPED_TEST(PointJacobianMatrixTest, JacobianMatrix2D_Arithmetic) {
     };
 
     PD e = scalar_3 * b;
-    EXPECT_TRUE(specfem::utilities::is_close(e.xix, scalar_3 * b_xix_val))
-        << ExpectedGot(scalar_3 * b_xix_val, e.xix);
-    EXPECT_TRUE(specfem::utilities::is_close(e.gammax, scalar_3 * b_gammax_val))
-        << ExpectedGot(scalar_3 * b_gammax_val, e.gammax);
-    EXPECT_TRUE(specfem::utilities::is_close(e.xiz, scalar_3 * b_xiz_val))
-        << ExpectedGot(scalar_3 * b_xiz_val, e.xiz);
-    EXPECT_TRUE(specfem::utilities::is_close(e.gammaz, scalar_3 * b_gammaz_val))
-        << ExpectedGot(scalar_3 * b_gammaz_val, e.gammaz);
+    EXPECT_TRUE(specfem::utilities::is_close(e.xix(), scalar_3 * b_xix_val))
+        << ExpectedGot(scalar_3 * b_xix_val, e.xix());
+    EXPECT_TRUE(
+        specfem::utilities::is_close(e.gammax(), scalar_3 * b_gammax_val))
+        << ExpectedGot(scalar_3 * b_gammax_val, e.gammax());
+    EXPECT_TRUE(specfem::utilities::is_close(e.xiz(), scalar_3 * b_xiz_val))
+        << ExpectedGot(scalar_3 * b_xiz_val, e.xiz());
+    EXPECT_TRUE(
+        specfem::utilities::is_close(e.gammaz(), scalar_3 * b_gammaz_val))
+        << ExpectedGot(scalar_3 * b_gammaz_val, e.gammaz());
   }
 }
 
@@ -318,44 +321,44 @@ TYPED_TEST(PointJacobianMatrixTest,
   PD pd1;
   pd1.init();
 
-  EXPECT_TRUE(specfem::utilities::is_close(pd1.xix, zero_val))
-      << ExpectedGot(zero_val, pd1.xix);
-  EXPECT_TRUE(specfem::utilities::is_close(pd1.gammax, zero_val))
-      << ExpectedGot(zero_val, pd1.gammax);
-  EXPECT_TRUE(specfem::utilities::is_close(pd1.xiz, zero_val))
-      << ExpectedGot(zero_val, pd1.xiz);
-  EXPECT_TRUE(specfem::utilities::is_close(pd1.gammaz, zero_val))
-      << ExpectedGot(zero_val, pd1.gammaz);
-  EXPECT_TRUE(specfem::utilities::is_close(pd1.jacobian, zero_val))
-      << ExpectedGot(zero_val, pd1.jacobian);
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.xix(), zero_val))
+      << ExpectedGot(zero_val, pd1.xix());
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.gammax(), zero_val))
+      << ExpectedGot(zero_val, pd1.gammax());
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.xiz(), zero_val))
+      << ExpectedGot(zero_val, pd1.xiz());
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.gammaz(), zero_val))
+      << ExpectedGot(zero_val, pd1.gammaz());
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.jacobian(), zero_val))
+      << ExpectedGot(zero_val, pd1.jacobian());
 
   // Value constructor
   PD pd2(one_val, two_val, three_val, four_val, five_val);
 
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.xix, one_val))
-      << ExpectedGot(one_val, pd2.xix);
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.gammax, two_val))
-      << ExpectedGot(two_val, pd2.gammax);
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.xiz, three_val))
-      << ExpectedGot(three_val, pd2.xiz);
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.gammaz, four_val))
-      << ExpectedGot(four_val, pd2.gammaz);
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.jacobian, five_val))
-      << ExpectedGot(five_val, pd2.jacobian);
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.xix(), one_val))
+      << ExpectedGot(one_val, pd2.xix());
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.gammax(), two_val))
+      << ExpectedGot(two_val, pd2.gammax());
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.xiz(), three_val))
+      << ExpectedGot(three_val, pd2.xiz());
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.gammaz(), four_val))
+      << ExpectedGot(four_val, pd2.gammaz());
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.jacobian(), five_val))
+      << ExpectedGot(five_val, pd2.jacobian());
 
   // Constant constructor
   PD pd3(const_val);
 
-  EXPECT_TRUE(specfem::utilities::is_close(pd3.xix, const_val))
-      << ExpectedGot(const_val, pd3.xix);
-  EXPECT_TRUE(specfem::utilities::is_close(pd3.gammax, const_val))
-      << ExpectedGot(const_val, pd3.gammax);
-  EXPECT_TRUE(specfem::utilities::is_close(pd3.xiz, const_val))
-      << ExpectedGot(const_val, pd3.xiz);
-  EXPECT_TRUE(specfem::utilities::is_close(pd3.gammaz, const_val))
-      << ExpectedGot(const_val, pd3.gammaz);
-  EXPECT_TRUE(specfem::utilities::is_close(pd3.jacobian, const_val))
-      << ExpectedGot(const_val, pd3.jacobian);
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.xix(), const_val))
+      << ExpectedGot(const_val, pd3.xix());
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.gammax(), const_val))
+      << ExpectedGot(const_val, pd3.gammax());
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.xiz(), const_val))
+      << ExpectedGot(const_val, pd3.xiz());
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.gammaz(), const_val))
+      << ExpectedGot(const_val, pd3.gammaz());
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.jacobian(), const_val))
+      << ExpectedGot(const_val, pd3.jacobian());
 }
 
 TYPED_TEST(PointJacobianMatrixTest, JacobianMatrix2D_WithJacobian_Init) {
@@ -390,16 +393,16 @@ TYPED_TEST(PointJacobianMatrixTest, JacobianMatrix2D_WithJacobian_Init) {
   PD pd(one_val, two_val, three_val, four_val, five_val);
   pd.init();
 
-  EXPECT_TRUE(specfem::utilities::is_close(pd.xix, zero_val))
-      << ExpectedGot(zero_val, pd.xix);
-  EXPECT_TRUE(specfem::utilities::is_close(pd.gammax, zero_val))
-      << ExpectedGot(zero_val, pd.gammax);
-  EXPECT_TRUE(specfem::utilities::is_close(pd.xiz, zero_val))
-      << ExpectedGot(zero_val, pd.xiz);
-  EXPECT_TRUE(specfem::utilities::is_close(pd.gammaz, zero_val))
-      << ExpectedGot(zero_val, pd.gammaz);
-  EXPECT_TRUE(specfem::utilities::is_close(pd.jacobian, zero_val))
-      << ExpectedGot(zero_val, pd.jacobian);
+  EXPECT_TRUE(specfem::utilities::is_close(pd.xix(), zero_val))
+      << ExpectedGot(zero_val, pd.xix());
+  EXPECT_TRUE(specfem::utilities::is_close(pd.gammax(), zero_val))
+      << ExpectedGot(zero_val, pd.gammax());
+  EXPECT_TRUE(specfem::utilities::is_close(pd.xiz(), zero_val))
+      << ExpectedGot(zero_val, pd.xiz());
+  EXPECT_TRUE(specfem::utilities::is_close(pd.gammaz(), zero_val))
+      << ExpectedGot(zero_val, pd.gammaz());
+  EXPECT_TRUE(specfem::utilities::is_close(pd.jacobian(), zero_val))
+      << ExpectedGot(zero_val, pd.jacobian());
 }
 
 // ===============================
@@ -458,99 +461,99 @@ TYPED_TEST(PointJacobianMatrixTest,
   PD pd1;
   pd1.init();
 
-  EXPECT_TRUE(specfem::utilities::is_close(pd1.xix, zero_val))
-      << ExpectedGot(zero_val, pd1.xix);
-  EXPECT_TRUE(specfem::utilities::is_close(pd1.etax, zero_val))
-      << ExpectedGot(zero_val, pd1.etax);
-  EXPECT_TRUE(specfem::utilities::is_close(pd1.gammax, zero_val))
-      << ExpectedGot(zero_val, pd1.gammax);
-  EXPECT_TRUE(specfem::utilities::is_close(pd1.xiy, zero_val))
-      << ExpectedGot(zero_val, pd1.xiy);
-  EXPECT_TRUE(specfem::utilities::is_close(pd1.etay, zero_val))
-      << ExpectedGot(zero_val, pd1.etay);
-  EXPECT_TRUE(specfem::utilities::is_close(pd1.gammay, zero_val))
-      << ExpectedGot(zero_val, pd1.gammay);
-  EXPECT_TRUE(specfem::utilities::is_close(pd1.xiz, zero_val))
-      << ExpectedGot(zero_val, pd1.xiz);
-  EXPECT_TRUE(specfem::utilities::is_close(pd1.etaz, zero_val))
-      << ExpectedGot(zero_val, pd1.etaz);
-  EXPECT_TRUE(specfem::utilities::is_close(pd1.gammaz, zero_val))
-      << ExpectedGot(zero_val, pd1.gammaz);
-  EXPECT_TRUE(specfem::utilities::is_close(pd1.jacobian, zero_val))
-      << ExpectedGot(zero_val, pd1.jacobian);
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.xix(), zero_val))
+      << ExpectedGot(zero_val, pd1.xix());
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.etax(), zero_val))
+      << ExpectedGot(zero_val, pd1.etax());
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.gammax(), zero_val))
+      << ExpectedGot(zero_val, pd1.gammax());
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.xiy(), zero_val))
+      << ExpectedGot(zero_val, pd1.xiy());
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.etay(), zero_val))
+      << ExpectedGot(zero_val, pd1.etay());
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.gammay(), zero_val))
+      << ExpectedGot(zero_val, pd1.gammay());
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.xiz(), zero_val))
+      << ExpectedGot(zero_val, pd1.xiz());
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.etaz(), zero_val))
+      << ExpectedGot(zero_val, pd1.etaz());
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.gammaz(), zero_val))
+      << ExpectedGot(zero_val, pd1.gammaz());
+  EXPECT_TRUE(specfem::utilities::is_close(pd1.jacobian(), zero_val))
+      << ExpectedGot(zero_val, pd1.jacobian());
 
   // Value constructor
   PD pd2(one_val, two_val, three_val, four_val, five_val, six_val, seven_val,
          eight_val, nine_val, ten_val);
 
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.xix, one_val))
-      << ExpectedGot(one_val, pd2.xix);
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.etax, two_val))
-      << ExpectedGot(two_val, pd2.etax);
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.gammax, three_val))
-      << ExpectedGot(three_val, pd2.gammax);
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.xiy, four_val))
-      << ExpectedGot(four_val, pd2.xiy);
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.etay, five_val))
-      << ExpectedGot(five_val, pd2.etay);
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.gammay, six_val))
-      << ExpectedGot(six_val, pd2.gammay);
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.xiz, seven_val))
-      << ExpectedGot(seven_val, pd2.xiz);
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.etaz, eight_val))
-      << ExpectedGot(eight_val, pd2.etaz);
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.gammaz, nine_val))
-      << ExpectedGot(nine_val, pd2.gammaz);
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.jacobian, ten_val))
-      << ExpectedGot(ten_val, pd2.jacobian);
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.xix(), one_val))
+      << ExpectedGot(one_val, pd2.xix());
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.etax(), two_val))
+      << ExpectedGot(two_val, pd2.etax());
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.gammax(), three_val))
+      << ExpectedGot(three_val, pd2.gammax());
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.xiy(), four_val))
+      << ExpectedGot(four_val, pd2.xiy());
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.etay(), five_val))
+      << ExpectedGot(five_val, pd2.etay());
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.gammay(), six_val))
+      << ExpectedGot(six_val, pd2.gammay());
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.xiz(), seven_val))
+      << ExpectedGot(seven_val, pd2.xiz());
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.etaz(), eight_val))
+      << ExpectedGot(eight_val, pd2.etaz());
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.gammaz(), nine_val))
+      << ExpectedGot(nine_val, pd2.gammaz());
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.jacobian(), ten_val))
+      << ExpectedGot(ten_val, pd2.jacobian());
 
   // Constant constructor
   PD pd3(const_val);
 
-  EXPECT_TRUE(specfem::utilities::is_close(pd3.xix, const_val))
-      << ExpectedGot(const_val, pd3.xix);
-  EXPECT_TRUE(specfem::utilities::is_close(pd3.etax, const_val))
-      << ExpectedGot(const_val, pd3.etax);
-  EXPECT_TRUE(specfem::utilities::is_close(pd3.gammax, const_val))
-      << ExpectedGot(const_val, pd3.gammax);
-  EXPECT_TRUE(specfem::utilities::is_close(pd3.xiy, const_val))
-      << ExpectedGot(const_val, pd3.xiy);
-  EXPECT_TRUE(specfem::utilities::is_close(pd3.etay, const_val))
-      << ExpectedGot(const_val, pd3.etay);
-  EXPECT_TRUE(specfem::utilities::is_close(pd3.gammay, const_val))
-      << ExpectedGot(const_val, pd3.gammay);
-  EXPECT_TRUE(specfem::utilities::is_close(pd3.xiz, const_val))
-      << ExpectedGot(const_val, pd3.xiz);
-  EXPECT_TRUE(specfem::utilities::is_close(pd3.etaz, const_val))
-      << ExpectedGot(const_val, pd3.etaz);
-  EXPECT_TRUE(specfem::utilities::is_close(pd3.gammaz, const_val))
-      << ExpectedGot(const_val, pd3.gammaz);
-  EXPECT_TRUE(specfem::utilities::is_close(pd3.jacobian, const_val))
-      << ExpectedGot(const_val, pd3.jacobian);
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.xix(), const_val))
+      << ExpectedGot(const_val, pd3.xix());
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.etax(), const_val))
+      << ExpectedGot(const_val, pd3.etax());
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.gammax(), const_val))
+      << ExpectedGot(const_val, pd3.gammax());
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.xiy(), const_val))
+      << ExpectedGot(const_val, pd3.xiy());
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.etay(), const_val))
+      << ExpectedGot(const_val, pd3.etay());
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.gammay(), const_val))
+      << ExpectedGot(const_val, pd3.gammay());
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.xiz(), const_val))
+      << ExpectedGot(const_val, pd3.xiz());
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.etaz(), const_val))
+      << ExpectedGot(const_val, pd3.etaz());
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.gammaz(), const_val))
+      << ExpectedGot(const_val, pd3.gammaz());
+  EXPECT_TRUE(specfem::utilities::is_close(pd3.jacobian(), const_val))
+      << ExpectedGot(const_val, pd3.jacobian());
 
   // re-initialize pd2 to check init functionality
   pd2.init();
 
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.xix, zero_val))
-      << ExpectedGot(zero_val, pd2.xix);
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.etax, zero_val))
-      << ExpectedGot(zero_val, pd2.etax);
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.gammax, zero_val))
-      << ExpectedGot(zero_val, pd2.gammax);
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.xiy, zero_val))
-      << ExpectedGot(zero_val, pd2.xiy);
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.etay, zero_val))
-      << ExpectedGot(zero_val, pd2.etay);
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.gammay, zero_val))
-      << ExpectedGot(zero_val, pd2.gammay);
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.xiz, zero_val))
-      << ExpectedGot(zero_val, pd2.xiz);
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.etaz, zero_val))
-      << ExpectedGot(zero_val, pd2.etaz);
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.gammaz, zero_val))
-      << ExpectedGot(zero_val, pd2.gammaz);
-  EXPECT_TRUE(specfem::utilities::is_close(pd2.jacobian, zero_val))
-      << ExpectedGot(zero_val, pd2.jacobian);
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.xix(), zero_val))
+      << ExpectedGot(zero_val, pd2.xix());
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.etax(), zero_val))
+      << ExpectedGot(zero_val, pd2.etax());
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.gammax(), zero_val))
+      << ExpectedGot(zero_val, pd2.gammax());
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.xiy(), zero_val))
+      << ExpectedGot(zero_val, pd2.xiy());
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.etay(), zero_val))
+      << ExpectedGot(zero_val, pd2.etay());
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.gammay(), zero_val))
+      << ExpectedGot(zero_val, pd2.gammay());
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.xiz(), zero_val))
+      << ExpectedGot(zero_val, pd2.xiz());
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.etaz(), zero_val))
+      << ExpectedGot(zero_val, pd2.etaz());
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.gammaz(), zero_val))
+      << ExpectedGot(zero_val, pd2.gammaz());
+  EXPECT_TRUE(specfem::utilities::is_close(pd2.jacobian(), zero_val))
+      << ExpectedGot(zero_val, pd2.jacobian());
 }
 
 // ===============================
@@ -565,7 +568,7 @@ TYPED_TEST(PointJacobianMatrixTest, VerifySIMDTypes) {
   using simd_type2D = typename PD2D::simd;
   bool is_expected_simd2D =
       std::is_same<simd_type2D,
-                   specfem::datatype::simd<type_real, using_simd> >::value;
+                   specfem::datatype::simd<type_real, using_simd>>::value;
   EXPECT_TRUE(is_expected_simd2D);
 
   // Verify 3D types
@@ -574,7 +577,7 @@ TYPED_TEST(PointJacobianMatrixTest, VerifySIMDTypes) {
   using simd_type3D = typename PD3D::simd;
   bool is_expected_simd3D =
       std::is_same<simd_type3D,
-                   specfem::datatype::simd<type_real, using_simd> >::value;
+                   specfem::datatype::simd<type_real, using_simd>>::value;
   EXPECT_TRUE(is_expected_simd3D);
 
   // Verify 2D with Jacobian
@@ -583,7 +586,7 @@ TYPED_TEST(PointJacobianMatrixTest, VerifySIMDTypes) {
   using simd_type2DJac = typename PD2DJac::simd;
   bool is_expected_simd2DJac =
       std::is_same<simd_type2DJac,
-                   specfem::datatype::simd<type_real, using_simd> >::value;
+                   specfem::datatype::simd<type_real, using_simd>>::value;
   EXPECT_TRUE(is_expected_simd2DJac);
 
   // Verify 3D with Jacobian
@@ -592,6 +595,6 @@ TYPED_TEST(PointJacobianMatrixTest, VerifySIMDTypes) {
   using simd_type3DJac = typename PD3DJac::simd;
   bool is_expected_simd3DJac =
       std::is_same<simd_type3DJac,
-                   specfem::datatype::simd<type_real, using_simd> >::value;
+                   specfem::datatype::simd<type_real, using_simd>>::value;
   EXPECT_TRUE(is_expected_simd3DJac);
 }

--- a/tests/unit-tests/point/stress_tests.cpp
+++ b/tests/unit-tests/point/stress_tests.cpp
@@ -47,7 +47,7 @@ TYPED_TEST(PointStressTest, Stress2DAcoustic) {
   // Define the stress type for 2D acoustic medium
   using stress_type = point::stress<
       specfem::tags::Tags<specfem::element::dimension_tag::dim2,
-                          element::medium_tag::acoustic, using_simd> >;
+                          element::medium_tag::acoustic, using_simd>>;
 
   // Verify static properties
   constexpr int expected_dimension =
@@ -89,7 +89,7 @@ TYPED_TEST(PointStressTest, Stress2DElastic) {
   // Define the stress type for 2D elastic medium
   using stress_type = point::stress<
       specfem::tags::Tags<specfem::element::dimension_tag::dim2,
-                          element::medium_tag::elastic_psv, using_simd> >;
+                          element::medium_tag::elastic_psv, using_simd>>;
 
   // Verify static properties
   constexpr int expected_dimension =
@@ -145,7 +145,7 @@ TYPED_TEST(PointStressTest, Stress2DPoroelastic) {
   // Define the stress type for 2D poroelastic medium
   using stress_type = point::stress<
       specfem::tags::Tags<specfem::element::dimension_tag::dim2,
-                          element::medium_tag::poroelastic, using_simd> >;
+                          element::medium_tag::poroelastic, using_simd>>;
 
   // Verify static properties
   constexpr int expected_dimension =
@@ -200,7 +200,7 @@ TYPED_TEST(PointStressTest, Stress3DAcoustic) {
   // Define the stress type for 3D acoustic medium
   using stress_type = point::stress<
       specfem::tags::Tags<specfem::element::dimension_tag::dim3,
-                          element::medium_tag::acoustic, using_simd> >;
+                          element::medium_tag::acoustic, using_simd>>;
 
   // Verify static properties
   constexpr int expected_dimension =
@@ -245,7 +245,7 @@ TYPED_TEST(PointStressTest, Stress3DElastic) {
   // Define the stress type for 3D elastic medium
   using stress_type = point::stress<
       specfem::tags::Tags<specfem::element::dimension_tag::dim3,
-                          element::medium_tag::elastic, using_simd> >;
+                          element::medium_tag::elastic, using_simd>>;
 
   // Verify static properties
   constexpr int expected_dimension =
@@ -299,7 +299,7 @@ TYPED_TEST(PointStressTest, DefaultConstructor) {
   // Define the stress type for 2D acoustic medium
   using stress_type = point::stress<
       specfem::tags::Tags<specfem::element::dimension_tag::dim2,
-                          element::medium_tag::acoustic, using_simd> >;
+                          element::medium_tag::acoustic, using_simd>>;
 
   // Create a zero value for comparison
   typename specfem::datatype::simd<type_real, using_simd>::datatype zero_val{
@@ -323,7 +323,7 @@ TEST_F(PointStressTestSerial, StressOperatorMultiply2D) {
   // Define the stress type for 2D elastic medium
   using stress_type = point::stress<
       specfem::tags::Tags<specfem::element::dimension_tag::dim2,
-                          element::medium_tag::elastic_psv, using_simd> >;
+                          element::medium_tag::elastic_psv, using_simd>>;
 
   // Create test values
   typename specfem::datatype::simd<type_real, using_simd>::datatype val11;
@@ -344,11 +344,11 @@ TEST_F(PointStressTestSerial, StressOperatorMultiply2D) {
   using pd_type = point::jacobian_matrix<specfem::element::dimension_tag::dim2,
                                          true, using_simd>;
   pd_type pd;
-  pd.xix = 0.5;      // dx/dxi
-  pd.xiz = 0.6;      // dz/dxi
-  pd.gammax = 0.7;   // dx/dgamma
-  pd.gammaz = 0.8;   // dz/dgamma
-  pd.jacobian = 0.5; // Jacobian factor
+  pd.xix() = 0.5;      // dx/dxi
+  pd.xiz() = 0.6;      // dz/dxi
+  pd.gammax() = 0.7;   // dx/dgamma
+  pd.gammaz() = 0.8;   // dz/dgamma
+  pd.jacobian() = 0.5; // Jacobian factor
 
   // Construct stress object
   stress_type stress(T);
@@ -380,7 +380,7 @@ TEST_F(PointStressTestSerial, StressOperatorMultiply2DAcoustic) {
   // Define the stress type for 2D acoustic medium
   using stress_type = point::stress<
       specfem::tags::Tags<specfem::element::dimension_tag::dim2,
-                          element::medium_tag::acoustic, using_simd> >;
+                          element::medium_tag::acoustic, using_simd>>;
 
   // Create a stress tensor with transposed indexing
   typename stress_type::value_type T(5.0, 6.0); // T(0,0)=5.0, T(0,1)=6.0
@@ -389,11 +389,11 @@ TEST_F(PointStressTestSerial, StressOperatorMultiply2DAcoustic) {
   using pd_type = point::jacobian_matrix<specfem::element::dimension_tag::dim2,
                                          true, using_simd>;
   pd_type pd;
-  pd.xix = 0.5;      // dx/dxi
-  pd.xiz = 0.6;      // dz/dxi
-  pd.gammax = 0.7;   // dx/dgamma
-  pd.gammaz = 0.8;   // dz/dgamma
-  pd.jacobian = 0.5; // Jacobian factor
+  pd.xix() = 0.5;      // dx/dxi
+  pd.xiz() = 0.6;      // dz/dxi
+  pd.gammax() = 0.7;   // dx/dgamma
+  pd.gammaz() = 0.8;   // dz/dgamma
+  pd.jacobian() = 0.5; // Jacobian factor
 
   // Construct stress object
   stress_type stress(T);
@@ -418,7 +418,7 @@ TYPED_TEST(PointStressTest, AccessorBaseType) {
 
   using stress_type = point::stress<
       specfem::tags::Tags<specfem::element::dimension_tag::dim2,
-                          element::medium_tag::acoustic, using_simd> >;
+                          element::medium_tag::acoustic, using_simd>>;
 
   // Check if stress_type is derived from the correct base class
   bool is_accessor =
@@ -437,7 +437,7 @@ TYPED_TEST(PointStressTest, SIMDTypePropagation) {
 
   using stress_type = point::stress<
       specfem::tags::Tags<specfem::element::dimension_tag::dim2,
-                          element::medium_tag::acoustic, using_simd> >;
+                          element::medium_tag::acoustic, using_simd>>;
 
   using expected_simd_type = specfem::datatype::simd<type_real, using_simd>;
   using actual_simd_type = typename stress_type::simd;
@@ -462,19 +462,19 @@ TYPED_TEST(PointStressTest, TensorShape) {
   // Test various element types and dimensions
   using acoustic_2d = point::stress<
       specfem::tags::Tags<specfem::element::dimension_tag::dim2,
-                          element::medium_tag::acoustic, using_simd> >;
+                          element::medium_tag::acoustic, using_simd>>;
   using elastic_2d = point::stress<
       specfem::tags::Tags<specfem::element::dimension_tag::dim2,
-                          element::medium_tag::elastic_psv, using_simd> >;
+                          element::medium_tag::elastic_psv, using_simd>>;
   using acoustic_3d = point::stress<
       specfem::tags::Tags<specfem::element::dimension_tag::dim3,
-                          element::medium_tag::acoustic, using_simd> >;
+                          element::medium_tag::acoustic, using_simd>>;
   using elastic_3d = point::stress<
       specfem::tags::Tags<specfem::element::dimension_tag::dim3,
-                          element::medium_tag::elastic, using_simd> >;
+                          element::medium_tag::elastic, using_simd>>;
   using poro_2d = point::stress<
       specfem::tags::Tags<specfem::element::dimension_tag::dim2,
-                          element::medium_tag::poroelastic, using_simd> >;
+                          element::medium_tag::poroelastic, using_simd>>;
 
   // Verify tensor shapes
   EXPECT_EQ(acoustic_2d::dimension, 2);


### PR DESCRIPTION
Fixes #2008.

## The bug

`point::jacobian_matrix` stored a `tensor_type _data` plus public reference members (`value_type &xix`, ...) aliasing it. Reference members are pointers into the object's own storage, so the type was **not relocatable**: after a byte-wise copy the references still pointed at the source object.

Kokkos bit-copies this type both as a `View` element and as the reduction scalar of `Kokkos::Sum<>` in `algorithms::interpolate_function`. Under a threaded backend, OpenMP accumulates into per-thread reduction scratch and copies out; once that scratch was freed, reading `.xix` dereferenced freed memory and segfaulted. Serial accumulates in place, which is why every Serial build passed and only the OpenMP cells failed.

## The fix

Option B from the issue: the tensor stays the sole storage and the components become accessor methods.

- Drop the reference members; add paired `xix()` / `xix() const` accessors (and the rest) that index into the tensor. The hand-written copy constructor and copy assignment, which existed only to rebind the references, are gone.
- Make the `jacobian` determinant a private `jacobian_` with a `jacobian()` accessor, so the whole component API is uniform.
- Remove the implicit `operator tensor_type&()` conversions; `tensor()` is now the single tensor accessor. Its three users all went through an explicit `static_cast` already.
- Default `RegisterArray`'s copy constructor. The hand-written loop was plain memberwise copy of its `T m_value[size]`, and being user-provided was the only thing keeping `RegisterArray` (and so the point views) from being trivially copyable. Its default constructor is left alone: it zero-initializes, which `reduction_identity<T>::sum()` relies on.
- Add `static_assert(std::is_trivially_copyable_v<...>)` guards, turning this bug class into a compile error on every backend rather than a segfault on threaded ones only.

Call sites (~820) are mechanical `.xix` -> `.xix()`. The similarly named members of the `assembly::jacobian_matrix` container views are untouched.

Adds a `release-openmp` preset and a matching CI job, since GitHub CI was Serial-only. `Kokkos_ENABLE_ATOMICS_BYPASS` is OFF there: it is a single-thread-only optimization that is ON in every other preset. The job runs the whole `tests` tree, because the Newmark moment-tensor cases that crashed are integration tests.

## Second commit: cleanup pass

A follow-up commit simplifies the guards and a few call sites, with no behavior change:

- **The relocatability assert moved to the choke point.** It now sits next to both `Kokkos::Sum<T>` reductions in `algorithms/interpolate.hpp` — the actual crash site — so any scalar reduced through that path is checked, not just the one type that happened to break.
- Replaced the `#define`/invoke-twice/`#undef` macro in `point/jacobian_matrix.hpp` with a `jacobian_matrix_is_relocatable_v` variable template, dropping two of four conjuncts (the `store_jacobian = true` specializations derive from the `false` ones, and a derived class cannot be trivially copyable unless its bases are).
- Dropped the third copy of the guard in `register_array.hpp` — it hardcoded extents no production code instantiates directly, and was already implied by the `point_view.hpp` assert.
- `init()` re-listed all 4 / all 9 components; both bodies are now `_data = tensor_type()`.
- `operator==` cast to `base_type` by value, slicing two temporaries per comparison; now `const base_type &`.
- `release-openmp` now `inherits` `release-nosimd` plus its four genuine deltas, instead of restating 11 cache variables.
- Collapsed the 6-branch face dispatch in `locate_point/dim3` to 3 — bottom/top returned byte-identical tuples, as did left/right and front/back; only the constrained coordinate's sign differed.

## Verification

1334/1334 tests pass under both `release` (Serial, SIMD) and `release-openmp` (`OMP_NUM_THREADS=4`), including the `ASSEMBLY_NO_LOAD.compute_source_array_from_tensor` repro from the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)