### PR TITLE
Issue 1984 - Phase 1: Mass/damping assembly and Belos gate for the implicit solver

### DIFF
--- a/core/specfem/linear_system/CMakeLists.txt
+++ b/core/specfem/linear_system/CMakeLists.txt
@@ -8,14 +8,17 @@ target_link_libraries(
         PUBLIC
         Kokkos::kokkos
         specfem::assembly
-        # Only Tpetra is linked for now: trilinos_smoke_test() is the sole
-        # consumer today. Trilinos::all_selected_libs (Belos/Ifpack2/MueLu/
-        # Amesos2) fails to link against the float-only (Tpetra_INST_DOUBLE=OFF)
-        # TROMP Trilinos install -- MueLu references Xpetra::Matrix<double, ...>
-        # symbols unconditionally, which that install doesn't instantiate. Link
-        # the other packages once real assembly/solver code needs them and the
-        # install is revisited.
+        # Tpetra (matrices/vectors), Belos (GMRES), and Ifpack2 (RILUK /
+        # relaxation preconditioners) are linked individually; all three are
+        # templated on the Tpetra scalar and instantiate for float builds.
+        # Trilinos::all_selected_libs stays unusable against the float-only
+        # (Tpetra_INST_DOUBLE=OFF) TROMP Trilinos install -- MueLu references
+        # Xpetra::Matrix<double, ...> symbols unconditionally, which that
+        # install doesn't instantiate. MueLu/Amesos2 remain unlinked until the
+        # install is revisited (issue #1984).
         $<$<BOOL:${SPECFEM_ENABLE_TRILINOS}>:Tpetra::all_libs>
+        $<$<BOOL:${SPECFEM_ENABLE_TRILINOS}>:Belos::all_libs>
+        $<$<BOOL:${SPECFEM_ENABLE_TRILINOS}>:Ifpack2::all_libs>
 )
 
 target_compile_definitions(

--- a/core/specfem/linear_system/damping_assembler.cpp
+++ b/core/specfem/linear_system/damping_assembler.cpp
@@ -1,0 +1,179 @@
+#include "specfem/linear_system/damping_assembler.hpp"
+
+#ifdef SPECFEM_ENABLE_TRILINOS
+
+#include "specfem/assembly/assembly.hpp"
+#include "specfem/compute/impl/compute_stiffness_interaction.hpp"
+#include "specfem/linear_system/element_stiffness.hpp"
+#include "specfem/tags.hpp"
+#include <Kokkos_Core.hpp>
+#include <Teuchos_ArrayView.hpp>
+#include <array>
+#include <cstddef>
+#include <sstream>
+#include <stdexcept>
+#include <vector>
+
+template <typename Tags>
+specfem::linear_system::DampingAssembler<Tags>::DampingAssembler(
+    AssemblyType &assembly, const DofMap &dof_map)
+    : assembly_(assembly), dof_map_(dof_map) {
+
+  // The probe shares the stiffness probe's scope (NGLL = 5, matching
+  // property tag, no attenuation) but tolerates Stacey boundaries -- they
+  // are exactly what it measures.
+  specfem::linear_system::validate_stiffness_scope<Tags>(
+      assembly_, specfem::linear_system::StiffnessScope::with_stacey);
+
+  const auto &field = assembly_.fields.template get_simulation_field<
+      specfem::simulation::field_type::forward>();
+  const auto &field_impl = field.template get_field<medium_tag>();
+  if (field_impl.nglob != dof_map_.nglob()) {
+    throw std::runtime_error(
+        "specfem::linear_system::DampingAssembler: the dof map does not "
+        "match the assembly's forward field.");
+  }
+}
+
+template <typename Tags>
+Teuchos::RCP<specfem::linear_system::crs_matrix_type>
+specfem::linear_system::DampingAssembler<Tags>::assemble() const {
+  constexpr auto forward = specfem::simulation::field_type::forward;
+  constexpr auto outer = specfem::element::mpi_tag::outer;
+  constexpr auto inner = specfem::element::mpi_tag::inner;
+  using BaseTags = specfem::tags::Tags<dimension_tag, forward, medium_tag>;
+
+  auto &field = assembly_.fields.template get_simulation_field<forward>();
+  const auto &field_impl = field.template get_field<medium_tag>();
+  const auto h_u = field_impl.get_host_field();
+  const auto h_v = field_impl.get_host_field_dot();
+  const auto h_a = field_impl.get_host_field_dot_dot();
+  const int nglob = dof_map_.nglob();
+
+  // Probed blocks: block(p, r, c) = C_p(r, c). Interior points stay exactly
+  // zero -- the u = 0 stiffness path adds exact zeros everywhere and the
+  // Stacey traction touches boundary points only -- so a nonzero test is an
+  // exact damping-point mask, not a tolerance.
+  Kokkos::View<type_real ***, Kokkos::HostSpace> block(
+      "specfem::linear_system::damping_blocks", nglob, ncomp, ncomp);
+
+  for (int c = 0; c < ncomp; ++c) {
+    Kokkos::deep_copy(h_u, 0);
+    Kokkos::deep_copy(h_v, 0);
+    Kokkos::deep_copy(h_a, 0);
+    for (int iglob = 0; iglob < nglob; ++iglob) {
+      h_v(iglob, c) = 1;
+    }
+    assembly_.fields.copy_to_device();
+
+    // istep 0 is a placeholder: the probe runs in the setup phase, before
+    // any time loop touches the boundary-value recording.
+    specfem::compute::impl::compute_stiffness_interaction<
+        5, specfem::tags::expand<BaseTags, outer>>(assembly_, 0);
+    specfem::compute::impl::compute_stiffness_interaction<
+        5, specfem::tags::expand<BaseTags, inner>>(assembly_, 0);
+    assembly_.fields.copy_to_host();
+
+    for (int iglob = 0; iglob < nglob; ++iglob) {
+      for (int r = 0; r < ncomp; ++r) {
+        block(iglob, r, c) = -h_a(iglob, r);
+      }
+    }
+  }
+
+  // Leave the probe scratch as found (all fields zero, host and device).
+  Kokkos::deep_copy(h_u, 0);
+  Kokkos::deep_copy(h_v, 0);
+  Kokkos::deep_copy(h_a, 0);
+  assembly_.fields.copy_to_device();
+
+  std::vector<bool> is_damping_point(nglob, false);
+  for (int iglob = 0; iglob < nglob; ++iglob) {
+    for (int r = 0; r < ncomp && !is_damping_point[iglob]; ++r) {
+      for (int c = 0; c < ncomp; ++c) {
+        if (block(iglob, r, c) != 0) {
+          is_damping_point[iglob] = true;
+          break;
+        }
+      }
+    }
+  }
+
+  // Compact graph: ncomp entries per row at damping points, empty rows
+  // elsewhere -- a K-sized graph would waste a full matrix of memory on a
+  // block-diagonal operator.
+  std::vector<std::size_t> entries_per_row(
+      static_cast<std::size_t>(dof_map_.num_global_dofs()), 0);
+  for (int iglob = 0; iglob < nglob; ++iglob) {
+    if (!is_damping_point[iglob]) {
+      continue;
+    }
+    for (int r = 0; r < ncomp; ++r) {
+      entries_per_row[static_cast<std::size_t>(dof_map_.gid(iglob, r))] = ncomp;
+    }
+  }
+
+  auto graph = Teuchos::rcp(
+      new crs_graph_type(dof_map_.overlap_map(),
+                         Teuchos::ArrayView<const std::size_t>(
+                             entries_per_row.data(), entries_per_row.size())));
+
+  std::vector<global_ordinal_type> cols(ncomp);
+  for (int iglob = 0; iglob < nglob; ++iglob) {
+    if (!is_damping_point[iglob]) {
+      continue;
+    }
+    for (int c = 0; c < ncomp; ++c) {
+      cols[c] = dof_map_.gid(iglob, c);
+    }
+    for (int r = 0; r < ncomp; ++r) {
+      graph->insertGlobalIndices(dof_map_.gid(iglob, r), ncomp, cols.data());
+    }
+  }
+  graph->fillComplete(dof_map_.owned_map(), dof_map_.owned_map());
+
+  auto matrix = Teuchos::rcp(new crs_matrix_type(graph));
+  std::vector<scalar_type> values(ncomp);
+  for (int iglob = 0; iglob < nglob; ++iglob) {
+    if (!is_damping_point[iglob]) {
+      continue;
+    }
+    for (int c = 0; c < ncomp; ++c) {
+      cols[c] = dof_map_.gid(iglob, c);
+    }
+    for (int r = 0; r < ncomp; ++r) {
+      for (int c = 0; c < ncomp; ++c) {
+        values[c] = block(iglob, r, c);
+      }
+      const int updated = matrix->sumIntoGlobalValues(
+          dof_map_.gid(iglob, r), ncomp, values.data(), cols.data());
+      if (updated != ncomp) {
+        std::ostringstream message;
+        message << "specfem::linear_system::DampingAssembler: block scatter "
+                   "at point "
+                << iglob << " updated " << updated << " of " << ncomp
+                << " entries; the graph does not match the damping mask.";
+        throw std::runtime_error(message.str());
+      }
+    }
+  }
+  matrix->fillComplete(dof_map_.owned_map(), dof_map_.owned_map());
+
+  return matrix;
+}
+
+namespace specfem::linear_system_impl {
+/// Tag bundle for the only combination explicitly instantiated for the
+/// linear system (issue #1982).
+using elastic_isotropic_tags =
+    specfem::tags::Tags<specfem::element::dimension_tag::dim3,
+                        specfem::element::medium_tag::elastic,
+                        specfem::element::property_tag::isotropic,
+                        specfem::element::attenuation_tag::none>;
+} // namespace specfem::linear_system_impl
+
+// Explicit instantiation: 3D elastic isotropic
+template class specfem::linear_system::DampingAssembler<
+    specfem::linear_system_impl::elastic_isotropic_tags>;
+
+#endif // SPECFEM_ENABLE_TRILINOS

--- a/core/specfem/linear_system/damping_assembler.hpp
+++ b/core/specfem/linear_system/damping_assembler.hpp
@@ -1,0 +1,103 @@
+#pragma once
+
+#ifdef SPECFEM_ENABLE_TRILINOS
+
+#include "specfem/enums.hpp"
+#include "specfem/linear_system/dof_map.hpp"
+#include <Teuchos_RCP.hpp>
+
+namespace specfem {
+namespace linear_system {
+
+/**
+ * @brief Assembles the Stacey damping matrix \f$ C \f$ of one medium as a
+ * `Tpetra::CrsMatrix` by probing the velocity path of the production
+ * stiffness kernel.
+ *
+ * The Stacey traction is pointwise in velocity, so \f$ C \f$ is
+ * block-diagonal: one symmetric positive-semidefinite `ncomp x ncomp` block
+ * per boundary GLL point,
+ * \f$ C_p = \sum_{\mathrm{faces}} w J \left( \rho (v_p - v_s) \,
+ * n \otimes n + \rho v_s \, I \right) \f$, accumulated over all faces
+ * containing the point; interior points contribute exactly nothing.
+ *
+ * Probing runs the matrix-free `compute_stiffness_interaction` kernel --
+ * which computes `accel += -K u - C v` -- with displacement \f$ \equiv 0 \f$
+ * (the stiffness path contributes exact zeros) and unit velocity
+ * \f$ v = e_c \f$ at every mesh point simultaneously; block-diagonality
+ * means columns never mix, so `ncomp` kernel launches recover all blocks:
+ * \f$ C(\cdot, c) = -\mathrm{accel} \f$. Probing the production kernel (not
+ * a re-derivation of the traction) keeps the assembled \f$ C \f$ consistent
+ * with the explicit solver by construction.
+ *
+ * The assembled operator satisfies \f$ C v = \f$ damping force
+ * \f$ = -\mathrm{accel} \f$ of the matrix-free kernel at zero displacement
+ * (before mass division), matching the equation of motion
+ * \f$ M \ddot{u} + C \dot{u} + K u = f \f$.
+ *
+ * On meshes without Stacey boundaries the result is an empty (zero-entry)
+ * matrix whose `apply()` is a no-op, so callers can use one code path.
+ *
+ * @tparam Tags Compile-time tags (dimension, medium, property, attenuation);
+ *              only `dim3, elastic, isotropic, none` is instantiated
+ */
+template <typename Tags> class DampingAssembler {
+public:
+  constexpr static auto dimension_tag = Tags::dimension_tag;
+  constexpr static auto medium_tag = Tags::medium_tag;
+
+  static_assert(dimension_tag == specfem::element::dimension_tag::dim3,
+                "DampingAssembler takes a dim3 assembly; Tags must be a "
+                "dim3 bundle.");
+
+  /// Field components per mesh point of the medium
+  constexpr static int ncomp =
+      specfem::element::attributes<dimension_tag, medium_tag>::components;
+
+  using AssemblyType = specfem::assembly::assembly<dimension_tag>;
+
+  /**
+   * @brief Validate scope and store the probe target.
+   *
+   * Throws `std::runtime_error` if any element of the medium is outside the
+   * Stacey-tolerant stiffness scope (see @ref validate_stiffness_scope with
+   * `StiffnessScope::with_stacey`) or if `dof_map` does not match the
+   * assembly's forward field.
+   *
+   * @param assembly Assembled mesh, material properties, and fields; the
+   *        forward field's displacement/velocity/acceleration storage is
+   *        used as probe scratch and zeroed afterwards. Must outlive the
+   *        assembler.
+   * @param dof_map Dof numbering shared with the stiffness matrix (same
+   *        instance the `StiffnessAssembler` exposes)
+   */
+  DampingAssembler(AssemblyType &assembly, const DofMap &dof_map);
+
+  /**
+   * @brief Probe the velocity path and assemble the damping matrix.
+   *
+   * The matrix lives on a compact graph: at most `ncomp` entries per row at
+   * damping (boundary) points, empty rows at interior points. Every entry's
+   * `(row, column)` pair also exists in the stiffness matrix's graph
+   * (same-point pairs are same-element pairs), so the implicit Newmark
+   * operator can `sumInto` \f$ C \f$ on the stiffness graph.
+   *
+   * All probe fields (displacement, velocity, acceleration) are zeroed on
+   * host and device before returning.
+   *
+   * @return Fill-complete damping matrix on the owned map
+   */
+  Teuchos::RCP<crs_matrix_type> assemble() const;
+
+  /// Dof map shared by the matrix and any right-hand-side/solution vectors
+  const DofMap &dof_map() const { return dof_map_; }
+
+private:
+  AssemblyType &assembly_; ///< Borrowed assembly (probe scratch, not owned)
+  DofMap dof_map_;         ///< Per-medium dof numbering and maps
+};
+
+} // namespace linear_system
+} // namespace specfem
+
+#endif // SPECFEM_ENABLE_TRILINOS

--- a/core/specfem/linear_system/dof_map.hpp
+++ b/core/specfem/linear_system/dof_map.hpp
@@ -9,7 +9,10 @@
 #include <Teuchos_Comm.hpp>
 #include <Teuchos_RCP.hpp>
 #include <Tpetra_Core.hpp>
+#include <Tpetra_CrsGraph.hpp>
+#include <Tpetra_CrsMatrix.hpp>
 #include <Tpetra_Map.hpp>
+#include <Tpetra_Vector.hpp>
 #include <stdexcept>
 #include <string>
 
@@ -31,6 +34,15 @@ using map_type = Tpetra::Map<>;
 
 /// Global ordinal used for degree-of-freedom ids
 using global_ordinal_type = map_type::global_ordinal_type;
+
+/// Tpetra vector shared by mass, state, and right-hand-side vectors
+using vector_type = Tpetra::Vector<scalar_type>;
+
+/// Tpetra sparsity graph with the default ordinals and node type
+using crs_graph_type = Tpetra::CrsGraph<>;
+
+/// Assembled sparse matrix type (see @ref scalar_type for the precision)
+using crs_matrix_type = Tpetra::CrsMatrix<scalar_type>;
 
 /**
  * @brief Maps SPECFEM++ (iglob, icomp) degrees of freedom of one medium to

--- a/core/specfem/linear_system/element_stiffness.cpp
+++ b/core/specfem/linear_system/element_stiffness.cpp
@@ -18,7 +18,8 @@ using elastic_isotropic_tags =
 template <typename Tags>
 void specfem::linear_system::validate_stiffness_scope(
     const specfem::assembly::assembly<specfem::element::dimension_tag::dim3>
-        &assembly) {
+        &assembly,
+    const specfem::linear_system::StiffnessScope scope) {
 
   static_assert(Tags::dimension_tag == specfem::element::dimension_tag::dim3,
                 "validate_stiffness_scope takes a dim3 assembly; Tags must be "
@@ -60,16 +61,27 @@ void specfem::linear_system::validate_stiffness_scope(
     }
 
     const auto boundary_tag = element_types.get_boundary_tag(ispec);
-    if (boundary_tag != specfem::element::boundary_tag::none &&
-        boundary_tag != specfem::element::boundary_tag::acoustic_free_surface) {
+    const bool boundary_admitted =
+        boundary_tag == specfem::element::boundary_tag::none ||
+        boundary_tag == specfem::element::boundary_tag::acoustic_free_surface ||
+        (scope == specfem::linear_system::StiffnessScope::with_stacey &&
+         boundary_tag == specfem::element::boundary_tag::stacey);
+    if (!boundary_admitted) {
       std::ostringstream message;
       message << "specfem::linear_system::validate_stiffness_scope: element "
               << ispec << " has boundary tag '"
-              << specfem::element::to_string(boundary_tag)
-              << "'; only natural boundary conditions ('none', "
-                 "'acoustic_free_surface') are supported. Stacey boundaries "
-                 "add a velocity-dependent term the stiffness probe does not "
-                 "capture.";
+              << specfem::element::to_string(boundary_tag) << "'; ";
+      if (scope == specfem::linear_system::StiffnessScope::with_stacey) {
+        message << "only 'none', 'acoustic_free_surface', and 'stacey' are "
+                   "supported in the with_stacey scope. Dirichlet masks "
+                   "('composite_stacey_dirichlet') are not representable yet.";
+      } else {
+        message << "only natural boundary conditions ('none', "
+                   "'acoustic_free_surface') are supported. Stacey boundaries "
+                   "add a velocity-dependent term the stiffness probe does "
+                   "not capture; opt in with StiffnessScope::with_stacey and "
+                   "assemble the damping matrix separately.";
+      }
       throw std::runtime_error(message.str());
     }
   }
@@ -98,7 +110,8 @@ void specfem::linear_system::compute_element_stiffness(
 // Explicit instantiations: 3D elastic isotropic, NGLL = 5
 template void specfem::linear_system::validate_stiffness_scope<
     specfem::linear_system_impl::elastic_isotropic_tags>(
-    const specfem::assembly::assembly<specfem::element::dimension_tag::dim3> &);
+    const specfem::assembly::assembly<specfem::element::dimension_tag::dim3> &,
+    const specfem::linear_system::StiffnessScope);
 
 template void specfem::linear_system::compute_element_stiffness<
     5, specfem::linear_system_impl::elastic_isotropic_tags>(

--- a/core/specfem/linear_system/element_stiffness.hpp
+++ b/core/specfem/linear_system/element_stiffness.hpp
@@ -37,15 +37,28 @@ local_dof_index(const int icomp, const int iz, const int iy, const int ix) {
 }
 
 /**
+ * @brief Boundary conditions the caller's probe/assembly can represent.
+ *
+ * `natural_boundaries` keeps the historical strict check: only `none` and
+ * `acoustic_free_surface` boundary tags (natural boundary conditions) are
+ * admitted. `with_stacey` additionally admits `boundary_tag::stacey` -- valid
+ * because the displacement probe runs with velocity \f$ \equiv 0 \f$, where
+ * the Stacey dashpot contributes exactly nothing to \f$ K \f$; the caller
+ * must assemble the damping matrix \f$ C \f$ separately (see
+ * @ref DampingAssembler). `composite_stacey_dirichlet` stays rejected in
+ * both scopes (a Dirichlet mask is not representable yet).
+ */
+enum class StiffnessScope { natural_boundaries, with_stacey };
+
+/**
  * @brief Verify that every element of `Tags::medium_tag` is within the scope
  * supported by the stiffness probe.
  *
  * Throws `std::runtime_error` naming the offending element and tag unless all
  * elements of the medium match `Tags::property_tag`, have
- * `attenuation_tag::none`, a boundary tag of `none` or
- * `acoustic_free_surface` (natural boundary conditions only -- Stacey terms
- * would add a velocity-dependent contribution the probe does not capture),
- * and the mesh uses NGLL = 5 (the only 3D instantiation).
+ * `attenuation_tag::none`, a boundary tag admitted by `scope` (see
+ * @ref StiffnessScope), and the mesh uses NGLL = 5 (the only 3D
+ * instantiation).
  *
  * The check is per-medium: a mixed mesh passes as long as the elements of
  * `Tags::medium_tag` conform. Restrictions on the mesh as a whole (e.g.
@@ -53,11 +66,14 @@ local_dof_index(const int icomp, const int iz, const int iy, const int ix) {
  *
  * @tparam Tags Compile-time tags (dimension, medium, property, attenuation)
  * @param assembly Assembled mesh, element types, and material properties
+ * @param scope Boundary conditions the caller can represent; defaults to the
+ *              strict natural-boundaries check
  */
 template <typename Tags>
 void validate_stiffness_scope(
     const specfem::assembly::assembly<specfem::element::dimension_tag::dim3>
-        &assembly);
+        &assembly,
+    const StiffnessScope scope = StiffnessScope::natural_boundaries);
 
 /**
  * @brief Compute dense element stiffness blocks \f$ K_e \f$ for a contiguous

--- a/core/specfem/linear_system/mass_vector.cpp
+++ b/core/specfem/linear_system/mass_vector.cpp
@@ -1,0 +1,96 @@
+#include "specfem/linear_system/mass_vector.hpp"
+
+#ifdef SPECFEM_ENABLE_TRILINOS
+
+#include "specfem/assembly/assembly.hpp"
+#include "specfem/compute/initialize_mass_matrix.hpp"
+#include "specfem/tags.hpp"
+#include <Kokkos_Core.hpp>
+#include <Tpetra_Vector.hpp>
+#include <cstddef>
+#include <stdexcept>
+
+template <typename Tags>
+Teuchos::RCP<specfem::linear_system::vector_type>
+specfem::linear_system::assemble_mass_vector(
+    specfem::assembly::assembly<Tags::dimension_tag> &assembly,
+    const DofMap &dof_map) {
+
+  static_assert(Tags::dimension_tag == specfem::element::dimension_tag::dim3,
+                "assemble_mass_vector takes a dim3 assembly; Tags must be a "
+                "dim3 bundle.");
+
+  if (assembly.mesh.element_grid != 5) {
+    throw std::runtime_error(
+        "specfem::linear_system::assemble_mass_vector: only NGLL == 5 "
+        "meshes are supported (the only 3D instantiation).");
+  }
+
+  constexpr auto forward = specfem::simulation::field_type::forward;
+  constexpr auto outer = specfem::element::mpi_tag::outer;
+  constexpr auto inner = specfem::element::mpi_tag::inner;
+
+  auto &field = assembly.fields.template get_simulation_field<forward>();
+  const auto &field_impl = field.template get_field<Tags::medium_tag>();
+  const auto mass = field_impl.get_mass_inverse();
+  const auto h_mass = field_impl.get_host_mass_inverse();
+
+  if (field_impl.nglob != dof_map.nglob()) {
+    throw std::runtime_error(
+        "specfem::linear_system::assemble_mass_vector: the dof map does not "
+        "match the assembly's forward field.");
+  }
+
+  // The forward field's (not-yet-inverted) mass storage is the accumulation
+  // target of the production path; treat it strictly as scratch.
+  Kokkos::deep_copy(mass, 0);
+
+  // dt = 0: the Stacey lumped term (dt/2) C 1 vanishes exactly, leaving the
+  // pure mass on any mesh.
+  using BaseTags =
+      specfem::tags::Tags<Tags::dimension_tag, forward, Tags::medium_tag>;
+  specfem::compute::compute_mass_matrix<5,
+                                        specfem::tags::expand<BaseTags, outer>>(
+      assembly, static_cast<type_real>(0));
+  specfem::compute::compute_mass_matrix<5,
+                                        specfem::tags::expand<BaseTags, inner>>(
+      assembly, static_cast<type_real>(0));
+
+  Kokkos::deep_copy(h_mass, mass);
+
+  auto mass_vector = Teuchos::rcp(new vector_type(dof_map.owned_map()));
+  {
+    auto view = mass_vector->getLocalViewHost(Tpetra::Access::OverwriteAll);
+    for (int iglob = 0; iglob < dof_map.nglob(); ++iglob) {
+      for (int icomp = 0; icomp < dof_map.ncomp(); ++icomp) {
+        view(static_cast<std::size_t>(dof_map.gid(iglob, icomp)), 0) =
+            h_mass(iglob, icomp);
+      }
+    }
+  }
+
+  // Leave the assembly as found for the explicit solver's own mass init.
+  Kokkos::deep_copy(mass, 0);
+  Kokkos::deep_copy(h_mass, 0);
+
+  return mass_vector;
+}
+
+namespace specfem::linear_system_impl {
+/// Tag bundle for the only combination explicitly instantiated for the
+/// linear system (issue #1982).
+using elastic_isotropic_tags =
+    specfem::tags::Tags<specfem::element::dimension_tag::dim3,
+                        specfem::element::medium_tag::elastic,
+                        specfem::element::property_tag::isotropic,
+                        specfem::element::attenuation_tag::none>;
+} // namespace specfem::linear_system_impl
+
+// Explicit instantiation: 3D elastic isotropic
+template Teuchos::RCP<specfem::linear_system::vector_type>
+specfem::linear_system::assemble_mass_vector<
+    specfem::linear_system_impl::elastic_isotropic_tags>(
+    specfem::assembly::assembly<specfem::element::dimension_tag::dim3> &,
+    const specfem::linear_system::DofMap &);
+
+#endif // SPECFEM_ENABLE_TRILINOS

--- a/core/specfem/linear_system/mass_vector.hpp
+++ b/core/specfem/linear_system/mass_vector.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#ifdef SPECFEM_ENABLE_TRILINOS
+
+#include "specfem/enums.hpp"
+#include "specfem/linear_system/dof_map.hpp"
+#include <Teuchos_RCP.hpp>
+
+namespace specfem {
+namespace linear_system {
+
+/**
+ * @brief Assemble the lumped diagonal mass matrix \f$ M \f$ of one medium as
+ * a `Tpetra::Vector`.
+ *
+ * Drives the production `initialize_mass_matrix` accumulation path with
+ * `dt = 0`: the Stacey boundary contribution to the lumped mass is exactly
+ * \f$ (\Delta t / 2) \, C \, \mathbf{1} \f$ (linear in `dt`), so it vanishes
+ * identically and the result is the pure mass \f$ M \f$ on any mesh,
+ * including meshes with Stacey boundaries. The damping matrix \f$ C \f$ is
+ * assembled separately (see @ref DampingAssembler).
+ *
+ * The forward simulation field's mass storage is used as accumulation
+ * scratch: it is zeroed before the accumulation, read back through the host
+ * mirror, and zeroed again on exit, so the assembly is left as found. The
+ * inversion step of the explicit solver (`invert_mass`) is never called.
+ *
+ * Entry `DofMap::gid(iglob, icomp)` of the returned vector holds the lumped
+ * mass of component `icomp` at mesh point `iglob`.
+ *
+ * @tparam Tags Compile-time tags (dimension, medium, property, attenuation);
+ *              only `dim3, elastic, isotropic, none` is instantiated
+ * @param assembly Assembled mesh, material properties, and fields; the
+ *        forward field's mass storage is used as scratch
+ * @param dof_map Dof numbering shared with the stiffness/damping matrices
+ * @return Lumped mass vector on the owned map
+ */
+template <typename Tags>
+Teuchos::RCP<vector_type>
+assemble_mass_vector(specfem::assembly::assembly<Tags::dimension_tag> &assembly,
+                     const DofMap &dof_map);
+
+} // namespace linear_system
+} // namespace specfem
+
+#endif // SPECFEM_ENABLE_TRILINOS

--- a/core/specfem/linear_system/tpetra_assembler.cpp
+++ b/core/specfem/linear_system/tpetra_assembler.cpp
@@ -17,7 +17,8 @@
 
 template <typename Tags>
 specfem::linear_system::StiffnessAssembler<Tags>::StiffnessAssembler(
-    const AssemblyType &assembly, const int batch_size)
+    const AssemblyType &assembly, const int batch_size,
+    const specfem::linear_system::StiffnessScope scope)
     : assembly_(assembly),
       dof_map_(DofMap::from_assembly<Tags::medium_tag>(assembly)),
       batch_size_(batch_size) {
@@ -28,7 +29,7 @@ specfem::linear_system::StiffnessAssembler<Tags>::StiffnessAssembler(
         "least 1.");
   }
 
-  specfem::linear_system::validate_stiffness_scope<Tags>(assembly_);
+  specfem::linear_system::validate_stiffness_scope<Tags>(assembly_, scope);
 
   // Single-medium milestone: matrix blocks coupling different media
   // (fluid-solid) are deferred, so reject mixed meshes outright rather than

--- a/core/specfem/linear_system/tpetra_assembler.hpp
+++ b/core/specfem/linear_system/tpetra_assembler.hpp
@@ -4,6 +4,7 @@
 
 #include "specfem/enums.hpp"
 #include "specfem/linear_system/dof_map.hpp"
+#include "specfem/linear_system/element_stiffness.hpp"
 #include <Teuchos_RCP.hpp>
 #include <Tpetra_CrsGraph.hpp>
 #include <Tpetra_CrsMatrix.hpp>
@@ -11,12 +12,6 @@
 
 namespace specfem {
 namespace linear_system {
-
-/// Tpetra sparsity graph with the default ordinals and node type
-using crs_graph_type = Tpetra::CrsGraph<>;
-
-/// Assembled sparse matrix type (see @ref scalar_type for the precision)
-using crs_matrix_type = Tpetra::CrsMatrix<scalar_type>;
 
 /**
  * @brief Assembles the global stiffness matrix \f$ K \f$ of one medium as a
@@ -73,9 +68,13 @@ public:
    * @param assembly Assembled mesh, jacobian matrix, material properties,
    *        and fields; must outlive the assembler
    * @param batch_size Elements per probe-kernel launch (>= 1)
+   * @param scope Boundary conditions the caller can represent (see
+   *        @ref StiffnessScope); pass `with_stacey` only when the Stacey
+   *        damping matrix is assembled separately
    */
-  StiffnessAssembler(const AssemblyType &assembly,
-                     const int batch_size = default_batch_size);
+  StiffnessAssembler(
+      const AssemblyType &assembly, const int batch_size = default_batch_size,
+      const StiffnessScope scope = StiffnessScope::natural_boundaries);
 
   /**
    * @brief Assemble the stiffness matrix.

--- a/core/specfem/linear_system/trilinos_smoke.cpp
+++ b/core/specfem/linear_system/trilinos_smoke.cpp
@@ -2,11 +2,22 @@
 
 #ifdef SPECFEM_ENABLE_TRILINOS
 
+#include "specfem/setup.hpp"
+#include <BelosLinearProblem.hpp>
+#include <BelosPseudoBlockGmresSolMgr.hpp>
+#include <BelosTpetraAdapter.hpp>
+#include <Ifpack2_Factory.hpp>
+#include <Teuchos_ParameterList.hpp>
 #include <Teuchos_RCP.hpp>
 #include <Teuchos_Tuple.hpp>
 #include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 #include <Tpetra_Map.hpp>
+#include <Tpetra_MultiVector.hpp>
+#include <Tpetra_Vector.hpp>
+#include <cmath>
+#include <stdexcept>
+#include <string>
 
 int specfem::linear_system::trilinos_smoke_test() {
   using map_type = Tpetra::Map<>;
@@ -32,8 +43,91 @@ int specfem::linear_system::trilinos_smoke_test() {
   return static_cast<int>(matrix.getGlobalNumRows());
 }
 
+int specfem::linear_system::linear_solver_smoke_test() {
+  using scalar_type = type_real;
+  using map_type = Tpetra::Map<>;
+  using crs_matrix_type = Tpetra::CrsMatrix<scalar_type>;
+  using multivector_type = Tpetra::MultiVector<scalar_type>;
+  using vector_type = Tpetra::Vector<scalar_type>;
+  using operator_type = Tpetra::Operator<scalar_type>;
+  using row_matrix_type =
+      Tpetra::RowMatrix<scalar_type, crs_matrix_type::local_ordinal_type,
+                        crs_matrix_type::global_ordinal_type,
+                        crs_matrix_type::node_type>;
+  using global_ordinal_type = map_type::global_ordinal_type;
+
+  const auto comm = Tpetra::getDefaultComm();
+
+  // SPD tridiagonal [-1, 2, -1] system, small enough to converge in a
+  // handful of iterations yet exercising a genuine RILUK factorization.
+  const Tpetra::global_size_t n = 16;
+  const Teuchos::RCP<const map_type> map(
+      new map_type(n, /*index_base=*/0, comm));
+
+  auto matrix = Teuchos::rcp(new crs_matrix_type(map, /*maxEntriesPerRow=*/3));
+  for (global_ordinal_type row = 0; row < static_cast<global_ordinal_type>(n);
+       ++row) {
+    if (row > 0) {
+      matrix->insertGlobalValues(row, Teuchos::tuple(row - 1),
+                                 Teuchos::tuple(scalar_type(-1)));
+    }
+    matrix->insertGlobalValues(row, Teuchos::tuple(row),
+                               Teuchos::tuple(scalar_type(2)));
+    if (row < static_cast<global_ordinal_type>(n) - 1) {
+      matrix->insertGlobalValues(row, Teuchos::tuple(row + 1),
+                                 Teuchos::tuple(scalar_type(-1)));
+    }
+  }
+  matrix->fillComplete();
+
+  // b = A * 1 so the exact solution is the vector of ones.
+  auto x_exact = Teuchos::rcp(new vector_type(map));
+  x_exact->putScalar(scalar_type(1));
+  auto b = Teuchos::rcp(new vector_type(map));
+  matrix->apply(*x_exact, *b);
+
+  auto prec = Ifpack2::Factory::create<row_matrix_type>("RILUK", matrix);
+  Teuchos::ParameterList prec_params;
+  prec_params.set("fact: iluk level-of-fill", 1);
+  prec->setParameters(prec_params);
+  prec->initialize();
+  prec->compute();
+
+  auto x = Teuchos::rcp(new vector_type(map));
+  auto problem = Teuchos::rcp(
+      new Belos::LinearProblem<scalar_type, multivector_type, operator_type>(
+          matrix, x, b));
+  problem->setRightPrec(prec);
+  problem->setProblem();
+
+  auto belos_params = Teuchos::rcp(new Teuchos::ParameterList());
+  belos_params->set("Convergence Tolerance", scalar_type(1e-5));
+  belos_params->set("Maximum Iterations", 100);
+  Belos::PseudoBlockGmresSolMgr<scalar_type, multivector_type, operator_type>
+      solver(problem, belos_params);
+
+  if (solver.solve() != Belos::Converged) {
+    throw std::runtime_error(
+        "specfem::linear_system::linear_solver_smoke_test: GMRES did not "
+        "converge on the 16x16 tridiagonal system.");
+  }
+
+  x->update(scalar_type(-1), *x_exact, scalar_type(1));
+  const auto error = x->norm2();
+  if (!(error < scalar_type(1e-3))) {
+    throw std::runtime_error(
+        "specfem::linear_system::linear_solver_smoke_test: converged "
+        "solution is wrong (||x - 1||_2 = " +
+        std::to_string(error) + ").");
+  }
+
+  return solver.getNumIters();
+}
+
 #else
 
 int specfem::linear_system::trilinos_smoke_test() { return 0; }
+
+int specfem::linear_system::linear_solver_smoke_test() { return -1; }
 
 #endif

--- a/core/specfem/linear_system/trilinos_smoke.hpp
+++ b/core/specfem/linear_system/trilinos_smoke.hpp
@@ -23,5 +23,29 @@ namespace linear_system {
  */
 int trilinos_smoke_test();
 
+/**
+ * @brief Minimal Belos + Ifpack2 toolchain check (gate for the implicit
+ * Newmark solver, issue #1984).
+ *
+ * Solves a small SPD tridiagonal system \f$ A x = b \f$ (with \f$ b = A
+ * \mathbf{1} \f$) through the exact stack the implicit solver uses: an
+ * `Ifpack2::Factory`-created RILUK preconditioner applied as a right
+ * preconditioner inside `Belos::PseudoBlockGmresSolMgr`, on
+ * `scalar_type = type_real`. Its purpose is to prove -- before any solver
+ * code lands -- that the Trilinos install provides Belos and Ifpack2
+ * instantiations for the build's scalar (the cluster installs are
+ * float-only).
+ *
+ * When SPECFEM++ is built without Trilinos (`SPECFEM_ENABLE_TRILINOS=OFF`),
+ * this is a no-op that returns -1.
+ *
+ * @return Number of GMRES iterations to convergence (>= 0); throws
+ * `std::runtime_error` if the solve does not converge or the solution is
+ * wrong. Returns -1 without Trilinos.
+ *
+ * @note Assumes Kokkos has already been initialized by the calling program.
+ */
+int linear_solver_smoke_test();
+
 } // namespace linear_system
 } // namespace specfem

--- a/docs/sections/api/specfem/linear_system/index.rst
+++ b/docs/sections/api/specfem/linear_system/index.rst
@@ -4,10 +4,15 @@
 ==========================
 
 Utilities for assembling the spectral-element operator into an explicit
-linear system (issue #1982). Provides dense element stiffness extraction --
-probing the matrix-free element operator with local unit vectors -- for the
-3D elastic isotropic medium, plus a scope validator that rejects meshes
-outside the supported tag combination (attenuation, Stacey boundaries).
+linear system (issues #1982, #1984). Provides dense element stiffness
+extraction -- probing the matrix-free element operator with local unit
+vectors -- for the 3D elastic isotropic medium, plus a scope validator that
+rejects meshes outside the supported tag combination. The validator has two
+scopes (``StiffnessScope``): the strict default admits natural boundary
+conditions only, while ``with_stacey`` additionally admits Stacey boundaries
+-- valid because the displacement probe runs at zero velocity, where the
+Stacey dashpot contributes nothing to :math:`K`; callers opting in must
+assemble the damping matrix separately.
 
 When SPECFEM++ is built with Trilinos (``SPECFEM_ENABLE_TRILINOS=ON``), the
 module additionally provides ``DofMap`` -- the per-medium mapping from
@@ -21,6 +26,31 @@ connectivity. The assembled operator satisfies :math:`K u =` internal force
 ``compute_stiffness_interaction`` kernel (before mass division). Assembly is
 serial-only in this milestone; the owned/overlap map split in ``DofMap``
 keeps the API ready for distributed Export(ADD) assembly.
+
+Toward the implicit Newmark solver (issue #1984), the module also assembles
+the remaining operators of the equation of motion
+:math:`M \ddot{u} + C \dot{u} + K u = f`:
+
+- ``assemble_mass_vector`` returns the lumped diagonal mass :math:`M` as a
+  ``Tpetra::Vector`` by driving the production ``initialize_mass_matrix``
+  accumulation with :math:`\Delta t = 0`. The Stacey contribution to the
+  lumped mass is exactly :math:`(\Delta t / 2)\, C \, \mathbf{1}` (linear in
+  :math:`\Delta t`), so it vanishes identically and the result is the pure
+  mass on any mesh, including meshes with Stacey boundaries.
+- ``DampingAssembler`` assembles the Stacey damping matrix :math:`C` by
+  probing the velocity path of the production stiffness kernel: with
+  displacement :math:`\equiv 0` and unit velocity :math:`e_c` at every mesh
+  point, the kernel returns :math:`-C e_c` per point. Because the Stacey
+  traction is pointwise in velocity, :math:`C` is block-diagonal (one
+  symmetric positive-semidefinite ``ncomp x ncomp`` block per boundary GLL
+  point) and ``ncomp`` kernel launches recover all blocks. The matrix lives
+  on a compact graph whose entries all exist in the stiffness graph, so an
+  implicit Newmark operator :math:`M/(\beta \Delta t^2) + \gamma/(\beta
+  \Delta t)\, C + K` can be summed on :math:`K`'s graph.
+
+``linear_solver_smoke_test`` gates the Belos + Ifpack2 toolchain (GMRES with
+a RILUK right preconditioner on ``type_real``) ahead of the implicit solver;
+MueLu remains unlinked until the float-only cluster installs are revisited.
 
 .. doxygennamespace:: specfem::linear_system
     :members:

--- a/tests/unit-tests/linear_system/damping_assembler_tests.cpp
+++ b/tests/unit-tests/linear_system/damping_assembler_tests.cpp
@@ -1,0 +1,371 @@
+#include "../SPECFEM_Environment.hpp"
+#include <gtest/gtest.h>
+
+#ifdef SPECFEM_ENABLE_TRILINOS
+
+#include "specfem/assembly/assembly.hpp"
+#include "specfem/compute/impl/compute_stiffness_interaction.hpp"
+#include "specfem/compute/initialize_mass_matrix.hpp"
+#include "specfem/io.hpp"
+#include "specfem/linear_system/damping_assembler.hpp"
+#include "specfem/linear_system/mass_vector.hpp"
+#include "specfem/linear_system/tpetra_assembler.hpp"
+#include "specfem/mesh.hpp"
+#include "specfem/quadrature.hpp"
+#include "specfem/runtime_configuration.hpp"
+#include "specfem/tags.hpp"
+#include <Kokkos_Core.hpp>
+#include <Tpetra_Vector.hpp>
+#include <cmath>
+#include <cstddef>
+#include <memory>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace damping_assembler_test {
+
+constexpr auto dim3_tag = specfem::element::dimension_tag::dim3;
+constexpr auto elastic_tag = specfem::element::medium_tag::elastic;
+constexpr auto forward_tag = specfem::simulation::field_type::forward;
+constexpr int NGLL = 5;
+constexpr int ncomp = 3;
+
+constexpr bool single_precision = sizeof(type_real) == sizeof(float);
+const type_real rel_tol = single_precision ? static_cast<type_real>(2e-3)
+                                           : static_cast<type_real>(1e-10);
+
+using AssemblyType = specfem::assembly::assembly<dim3_tag>;
+using DampingTags =
+    specfem::tags::Tags<dim3_tag, elastic_tag,
+                        specfem::element::property_tag::isotropic,
+                        specfem::element::attenuation_tag::none>;
+using DampingAssemblerType =
+    specfem::linear_system::DampingAssembler<DampingTags>;
+using StiffnessAssemblerType =
+    specfem::linear_system::StiffnessAssembler<DampingTags>;
+using VectorType = specfem::linear_system::vector_type;
+
+// Build a full assembly from a Newmark displacement-test dataset. Paths are
+// relative to TEST_OUTPUT_DIR, where the displacement_tests data tree is
+// linked (see SERIAL_LINK_DIRS in serial.cmake).
+std::unique_ptr<AssemblyType> build_assembly_3d(const std::string &test_name) {
+  const std::string test_path =
+      "displacement_tests/Newmark/serial/dim3/" + test_name;
+
+  specfem::runtime_configuration::setup setup(test_path +
+                                              "/specfem_config.yaml");
+
+  const auto database_filename = setup.get_databases();
+  const auto &source_entries = setup.get_source_entries();
+  const auto stations_node = setup.get_stations();
+  const auto quadratures = setup.instantiate_quadrature();
+
+  auto mesh = specfem::io::read_3d_mesh(database_filename,
+                                        setup.get_attenuation_setup());
+
+  const type_real dt = setup.get_dt();
+  const int nsteps = setup.get_nsteps();
+
+  auto [sources, t0, starttime] = specfem::io::read_sources<dim3_tag>(
+      source_entries, nsteps, setup.get_t0(), dt, setup.get_simulation_type());
+  (void)starttime;
+  setup.update_t0(t0);
+
+  auto receivers = specfem::io::read_3d_receivers(stations_node);
+
+  return std::make_unique<AssemblyType>(
+      mesh, quadratures, sources, receivers, setup.get_seismogram_types(),
+      setup.get_t0(), dt, nsteps, setup.get_max_seismogram_step(),
+      setup.get_nstep_between_samples(), setup.get_simulation_type(),
+      setup.allocate_boundary_values(), setup.instantiate_property_reader());
+}
+
+// Shared fixture: the Stacey halfspace assembly and its damping matrix,
+// built once on first access so a throwing constructor fails inside a test
+// body, not in SetUpTestSuite.
+class DampingAssembler3D : public ::testing::Test {
+protected:
+  static void TearDownTestSuite() {
+    matrix_ = Teuchos::null;
+    dof_map_.reset();
+    delete assembly_;
+    assembly_ = nullptr;
+  }
+
+  static AssemblyType &assembly() {
+    if (assembly_ == nullptr) {
+      assembly_ = build_assembly_3d("HomogeneousHalfSpaceStacey").release();
+    }
+    return *assembly_;
+  }
+
+  static const specfem::linear_system::DofMap &dof_map() {
+    if (!dof_map_) {
+      dof_map_ = std::make_unique<specfem::linear_system::DofMap>(
+          specfem::linear_system::DofMap::from_assembly<elastic_tag>(
+              assembly()));
+    }
+    return *dof_map_;
+  }
+
+  static Teuchos::RCP<specfem::linear_system::crs_matrix_type> matrix() {
+    if (matrix_.is_null()) {
+      DampingAssemblerType assembler(assembly(), dof_map());
+      matrix_ = assembler.assemble();
+    }
+    return matrix_;
+  }
+
+  static AssemblyType *assembly_;
+  static std::unique_ptr<specfem::linear_system::DofMap> dof_map_;
+  static Teuchos::RCP<specfem::linear_system::crs_matrix_type> matrix_;
+};
+
+AssemblyType *DampingAssembler3D::assembly_ = nullptr;
+std::unique_ptr<specfem::linear_system::DofMap> DampingAssembler3D::dof_map_;
+Teuchos::RCP<specfem::linear_system::crs_matrix_type>
+    DampingAssembler3D::matrix_;
+
+// Largest absolute matrix entry -- the natural scale for tolerances.
+type_real max_abs_entry(
+    const Teuchos::RCP<specfem::linear_system::crs_matrix_type> &matrix) {
+  const auto values = matrix->getLocalMatrixHost().values;
+  type_real scale = 0;
+  for (std::size_t k = 0; k < values.extent(0); ++k) {
+    scale = std::max(scale, std::abs(values(k)));
+  }
+  return scale;
+}
+
+TEST(DampingAssemblerScope3D, EmptyOnNaturalBoundaryMesh) {
+  const auto assembly =
+      build_assembly_3d("HomogeneousHalfspaceSmallNoABCForceSource");
+  const auto dof_map =
+      specfem::linear_system::DofMap::from_assembly<elastic_tag>(*assembly);
+  DampingAssemblerType assembler(*assembly, dof_map);
+  const auto matrix = assembler.assemble();
+  EXPECT_EQ(matrix->getGlobalNumEntries(), 0u)
+      << "a mesh without Stacey boundaries must yield an empty damping "
+         "matrix";
+}
+
+TEST(DampingAssemblerScope3D, WithStaceyScopeAcceptsStaceyMesh) {
+  const auto assembly = build_assembly_3d("HomogeneousHalfSpaceStacey");
+  // The default (natural-boundaries) scope rejects this mesh -- covered by
+  // StiffnessAssemblerScope3D.RejectsStaceyBoundaries -- while the opt-in
+  // admits it because the displacement probe runs at zero velocity.
+  EXPECT_NO_THROW(StiffnessAssemblerType assembler(
+      *assembly, StiffnessAssemblerType::default_batch_size,
+      specfem::linear_system::StiffnessScope::with_stacey));
+}
+
+TEST_F(DampingAssembler3D, BlockDiagonalWithEmptyInteriorRows) {
+  const auto matrix = this->matrix();
+  const auto &dof_map = this->dof_map();
+
+  const auto graph = matrix->getCrsGraph();
+  std::size_t nonempty_rows = 0;
+  for (std::size_t row = 0;
+       row < static_cast<std::size_t>(dof_map.num_global_dofs()); ++row) {
+    const auto row_entries = graph->getNumEntriesInGlobalRow(
+        static_cast<specfem::linear_system::global_ordinal_type>(row));
+    if (row_entries == 0) {
+      continue;
+    }
+    ++nonempty_rows;
+    EXPECT_EQ(row_entries, static_cast<std::size_t>(ncomp))
+        << "damping row " << row << " is not a single ncomp block";
+  }
+
+  // The Stacey fixture has boundary points (nonempty rows) and interior
+  // points (empty rows); all components of a damping point carry a block.
+  EXPECT_GT(nonempty_rows, 0u);
+  EXPECT_LT(nonempty_rows, static_cast<std::size_t>(dof_map.num_global_dofs()));
+  EXPECT_EQ(nonempty_rows % ncomp, 0u);
+}
+
+TEST_F(DampingAssembler3D, SymmetricPositiveSemidefinite) {
+  const auto matrix = this->matrix();
+  const auto &dof_map = this->dof_map();
+
+  VectorType x(dof_map.owned_map()), z(dof_map.owned_map());
+  x.randomize();
+  z.randomize();
+
+  VectorType c_x(dof_map.owned_map()), c_z(dof_map.owned_map());
+  matrix->apply(x, c_x);
+  matrix->apply(z, c_z);
+
+  // Symmetry through the bilinear form: z' C x == x' C z.
+  const type_real z_c_x = z.dot(c_x);
+  const type_real x_c_z = x.dot(c_z);
+  const type_real scale =
+      max_abs_entry(matrix) * static_cast<type_real>(x.norm2() * z.norm2());
+  ASSERT_GT(scale, static_cast<type_real>(0));
+  EXPECT_LE(std::abs(x_c_z - z_c_x), rel_tol * scale)
+      << "damping matrix is not symmetric";
+
+  // Positive semidefinite: the dashpot only ever removes energy.
+  const type_real x_c_x = x.dot(c_x);
+  EXPECT_GE(x_c_x, -rel_tol * scale)
+      << "damping quadratic form is not positive semidefinite";
+}
+
+TEST_F(DampingAssembler3D, MatchesProductionKernelForRandomVelocity) {
+  const auto matrix = this->matrix();
+  const auto &dof_map = this->dof_map();
+
+  auto &field = assembly().fields.template get_simulation_field<forward_tag>();
+  const auto &field_impl = field.template get_field<elastic_tag>();
+  const auto h_u = field_impl.get_host_field();
+  const auto h_v = field_impl.get_host_field_dot();
+  const auto h_a = field_impl.get_host_field_dot_dot();
+  const int nglob = dof_map.nglob();
+
+  // Random velocity over the whole mesh; displacement and acceleration zero,
+  // so the production kernel computes accel = -C v exactly.
+  std::mt19937 generator(98765);
+  std::uniform_real_distribution<type_real> distribution(-1, 1);
+  Kokkos::deep_copy(h_u, 0);
+  Kokkos::deep_copy(h_a, 0);
+  for (int iglob = 0; iglob < nglob; ++iglob) {
+    for (int icomp = 0; icomp < ncomp; ++icomp) {
+      h_v(iglob, icomp) = distribution(generator);
+    }
+  }
+  assembly().fields.copy_to_device();
+
+  using BaseTags = specfem::tags::Tags<dim3_tag, forward_tag, elastic_tag>;
+  specfem::compute::impl::compute_stiffness_interaction<
+      NGLL, specfem::tags::expand<BaseTags, specfem::element::mpi_tag::outer>>(
+      assembly(), 0);
+  specfem::compute::impl::compute_stiffness_interaction<
+      NGLL, specfem::tags::expand<BaseTags, specfem::element::mpi_tag::inner>>(
+      assembly(), 0);
+  assembly().fields.copy_to_host();
+
+  VectorType v(dof_map.owned_map()), c_v(dof_map.owned_map());
+  {
+    auto view = v.getLocalViewHost(Tpetra::Access::OverwriteAll);
+    for (int iglob = 0; iglob < nglob; ++iglob) {
+      for (int icomp = 0; icomp < ncomp; ++icomp) {
+        view(static_cast<std::size_t>(dof_map.gid(iglob, icomp)), 0) =
+            h_v(iglob, icomp);
+      }
+    }
+  }
+  matrix->apply(v, c_v);
+
+  type_real scale = 0;
+  type_real max_diff = 0;
+  {
+    auto view = c_v.getLocalViewHost(Tpetra::Access::ReadOnly);
+    for (int iglob = 0; iglob < nglob; ++iglob) {
+      for (int icomp = 0; icomp < ncomp; ++icomp) {
+        const type_real expected = -h_a(iglob, icomp);
+        const type_real actual =
+            view(static_cast<std::size_t>(dof_map.gid(iglob, icomp)), 0);
+        scale = std::max(scale, std::abs(expected));
+        max_diff = std::max(max_diff, std::abs(expected - actual));
+      }
+    }
+  }
+  ASSERT_GT(scale, static_cast<type_real>(0));
+  EXPECT_LE(max_diff, rel_tol * scale)
+      << "assembled C v disagrees with the production kernel's velocity "
+         "path";
+
+  // Leave the probe scratch as found for the other tests.
+  Kokkos::deep_copy(h_u, 0);
+  Kokkos::deep_copy(h_v, 0);
+  Kokkos::deep_copy(h_a, 0);
+  assembly().fields.copy_to_device();
+}
+
+// Independent cross-path check: the explicit solver folds the Stacey term
+// into the lumped mass as M(dt) = M(0) + (dt/2) C 1 (the mass path evaluates
+// the traction at velocity -dt/2, a different code path than the velocity
+// probe). The assembled C must reproduce that difference exactly.
+TEST_F(DampingAssembler3D, MassPathCrossCheck) {
+  const auto matrix = this->matrix();
+  const auto &dof_map = this->dof_map();
+  const int nglob = dof_map.nglob();
+
+  // dt large enough that the Stacey term is well separated from float
+  // cancellation in M(dt) - M(0).
+  const type_real dt = static_cast<type_real>(0.5);
+
+  const auto mass_zero =
+      specfem::linear_system::assemble_mass_vector<DampingTags>(assembly(),
+                                                                dof_map);
+
+  // Manual M(dt) accumulation through the production path, using the same
+  // scratch discipline as assemble_mass_vector.
+  auto &field = assembly().fields.template get_simulation_field<forward_tag>();
+  const auto &field_impl = field.template get_field<elastic_tag>();
+  const auto mass = field_impl.get_mass_inverse();
+  const auto h_mass = field_impl.get_host_mass_inverse();
+
+  Kokkos::deep_copy(mass, 0);
+  using BaseTags = specfem::tags::Tags<dim3_tag, forward_tag, elastic_tag>;
+  specfem::compute::compute_mass_matrix<
+      NGLL, specfem::tags::expand<BaseTags, specfem::element::mpi_tag::outer>>(
+      assembly(), dt);
+  specfem::compute::compute_mass_matrix<
+      NGLL, specfem::tags::expand<BaseTags, specfem::element::mpi_tag::inner>>(
+      assembly(), dt);
+  Kokkos::deep_copy(h_mass, mass);
+
+  std::vector<type_real> mass_dt(
+      static_cast<std::size_t>(dof_map.num_global_dofs()));
+  for (int iglob = 0; iglob < nglob; ++iglob) {
+    for (int icomp = 0; icomp < ncomp; ++icomp) {
+      mass_dt[static_cast<std::size_t>(dof_map.gid(iglob, icomp))] =
+          h_mass(iglob, icomp);
+    }
+  }
+  Kokkos::deep_copy(mass, 0);
+  Kokkos::deep_copy(h_mass, 0);
+
+  // (dt/2) C 1: row sums of the damping matrix.
+  VectorType ones(dof_map.owned_map()), row_sums(dof_map.owned_map());
+  ones.putScalar(static_cast<type_real>(1));
+  matrix->apply(ones, row_sums);
+
+  type_real scale = 0;
+  type_real max_diff = 0;
+  {
+    const auto m0 = mass_zero->getLocalViewHost(Tpetra::Access::ReadOnly);
+    const auto sums = row_sums.getLocalViewHost(Tpetra::Access::ReadOnly);
+    for (std::size_t dof = 0;
+         dof < static_cast<std::size_t>(dof_map.num_global_dofs()); ++dof) {
+      const type_real expected = dt / 2 * sums(dof, 0);
+      const type_real actual = mass_dt[dof] - m0(dof, 0);
+      scale = std::max(scale, std::abs(expected));
+      max_diff = std::max(max_diff, std::abs(expected - actual));
+    }
+  }
+  ASSERT_GT(scale, static_cast<type_real>(0));
+  EXPECT_LE(max_diff, rel_tol * scale)
+      << "M(dt) - M(0) disagrees with (dt/2) C 1";
+}
+
+} // namespace damping_assembler_test
+
+#else // !SPECFEM_ENABLE_TRILINOS
+
+TEST(DampingAssembler3D, SkippedWithoutTrilinos) {
+  GTEST_SKIP() << "SPECFEM++ was built without Trilinos "
+                  "(SPECFEM_ENABLE_TRILINOS=OFF); the damping assembler is "
+                  "unavailable.";
+}
+
+#endif // SPECFEM_ENABLE_TRILINOS
+
+int main(int argc, char *argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new SPECFEMEnvironment);
+  return RUN_ALL_TESTS();
+}

--- a/tests/unit-tests/linear_system/mass_vector_tests.cpp
+++ b/tests/unit-tests/linear_system/mass_vector_tests.cpp
@@ -1,0 +1,139 @@
+#include "../SPECFEM_Environment.hpp"
+#include <gtest/gtest.h>
+
+#ifdef SPECFEM_ENABLE_TRILINOS
+
+#include "specfem/assembly/assembly.hpp"
+#include "specfem/io.hpp"
+#include "specfem/linear_system/dof_map.hpp"
+#include "specfem/linear_system/mass_vector.hpp"
+#include "specfem/mesh.hpp"
+#include "specfem/quadrature.hpp"
+#include "specfem/runtime_configuration.hpp"
+#include "specfem/tags.hpp"
+#include <Kokkos_Core.hpp>
+#include <cmath>
+#include <cstddef>
+#include <memory>
+#include <string>
+
+namespace mass_vector_test {
+
+constexpr auto dim3_tag = specfem::element::dimension_tag::dim3;
+constexpr auto elastic_tag = specfem::element::medium_tag::elastic;
+constexpr int ncomp = 3;
+
+using AssemblyType = specfem::assembly::assembly<dim3_tag>;
+using MassTags = specfem::tags::Tags<dim3_tag, elastic_tag,
+                                     specfem::element::property_tag::isotropic,
+                                     specfem::element::attenuation_tag::none>;
+
+// Homogeneous density of both fixtures (see the meshfem3D Mesh_Par_file
+// under each fixture's provenance/ directory).
+constexpr type_real fixture_density = 2700;
+
+// Build a full assembly from a Newmark displacement-test dataset. Paths are
+// relative to TEST_OUTPUT_DIR, where the displacement_tests data tree is
+// linked (see SERIAL_LINK_DIRS in serial.cmake).
+std::unique_ptr<AssemblyType> build_assembly_3d(const std::string &test_name) {
+  const std::string test_path =
+      "displacement_tests/Newmark/serial/dim3/" + test_name;
+
+  specfem::runtime_configuration::setup setup(test_path +
+                                              "/specfem_config.yaml");
+
+  const auto database_filename = setup.get_databases();
+  const auto &source_entries = setup.get_source_entries();
+  const auto stations_node = setup.get_stations();
+  const auto quadratures = setup.instantiate_quadrature();
+
+  auto mesh = specfem::io::read_3d_mesh(database_filename,
+                                        setup.get_attenuation_setup());
+
+  const type_real dt = setup.get_dt();
+  const int nsteps = setup.get_nsteps();
+
+  auto [sources, t0, starttime] = specfem::io::read_sources<dim3_tag>(
+      source_entries, nsteps, setup.get_t0(), dt, setup.get_simulation_type());
+  (void)starttime;
+  setup.update_t0(t0);
+
+  auto receivers = specfem::io::read_3d_receivers(stations_node);
+
+  return std::make_unique<AssemblyType>(
+      mesh, quadratures, sources, receivers, setup.get_seismogram_types(),
+      setup.get_t0(), dt, nsteps, setup.get_max_seismogram_step(),
+      setup.get_nstep_between_samples(), setup.get_simulation_type(),
+      setup.allocate_boundary_values(), setup.instantiate_property_reader());
+}
+
+void check_mass_vector(const std::string &fixture) {
+  const auto assembly = build_assembly_3d(fixture);
+  const auto dof_map =
+      specfem::linear_system::DofMap::from_assembly<elastic_tag>(*assembly);
+  const auto mass = specfem::linear_system::assemble_mass_vector<MassTags>(
+      *assembly, dof_map);
+
+  ASSERT_EQ(static_cast<std::size_t>(mass->getGlobalLength()),
+            static_cast<std::size_t>(dof_map.num_global_dofs()));
+
+  const auto view = mass->getLocalViewHost(Tpetra::Access::ReadOnly);
+  const int nglob = dof_map.nglob();
+
+  // Lumped mass is strictly positive everywhere and, for an isotropic
+  // medium, identical across components (same rho * w * J accumulation; the
+  // tolerance only covers accumulation-order rounding on threaded backends).
+  double total_mass = 0;
+  for (int iglob = 0; iglob < nglob; ++iglob) {
+    const type_real reference =
+        view(static_cast<std::size_t>(dof_map.gid(iglob, 0)), 0);
+    ASSERT_GT(reference, 0) << "non-positive lumped mass at point " << iglob;
+    total_mass += static_cast<double>(reference);
+    for (int icomp = 1; icomp < ncomp; ++icomp) {
+      const type_real other =
+          view(static_cast<std::size_t>(dof_map.gid(iglob, icomp)), 0);
+      EXPECT_NEAR(other, reference, 1e-5 * reference)
+          << "component " << icomp << " mass differs at point " << iglob;
+    }
+  }
+
+  // Per component, the lumped masses sum to the domain mass rho * V. The
+  // fixtures are homogeneous boxes, so V comes exactly from the coordinate
+  // extents; GLL quadrature integrates the constant density exactly.
+  const auto &mesh = assembly->mesh;
+  const double volume = static_cast<double>(mesh.xmax - mesh.xmin) *
+                        static_cast<double>(mesh.ymax - mesh.ymin) *
+                        static_cast<double>(mesh.zmax - mesh.zmin);
+  const double expected_mass = static_cast<double>(fixture_density) * volume;
+  EXPECT_NEAR(total_mass, expected_mass, 1e-3 * expected_mass)
+      << "total lumped mass disagrees with rho * V on " << fixture;
+}
+
+TEST(MassVector3D, PositiveAndMatchesDomainMassOnNaturalBoundaryMesh) {
+  check_mass_vector("HomogeneousHalfspaceSmallNoABCForceSource");
+}
+
+// dt = 0 kills the Stacey (dt/2) C 1 lumped term exactly, so the mass on a
+// Stacey mesh is the same pure rho-integral as on a natural-boundary mesh;
+// the cross-check against (dt/2) C 1 lives in the damping assembler tests.
+TEST(MassVector3D, PositiveAndMatchesDomainMassOnStaceyMesh) {
+  check_mass_vector("HomogeneousHalfSpaceStacey");
+}
+
+} // namespace mass_vector_test
+
+#else // !SPECFEM_ENABLE_TRILINOS
+
+TEST(MassVector3D, SkippedWithoutTrilinos) {
+  GTEST_SKIP() << "SPECFEM++ was built without Trilinos "
+                  "(SPECFEM_ENABLE_TRILINOS=OFF); the mass vector assembly "
+                  "is unavailable.";
+}
+
+#endif // SPECFEM_ENABLE_TRILINOS
+
+int main(int argc, char *argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new SPECFEMEnvironment);
+  return RUN_ALL_TESTS();
+}

--- a/tests/unit-tests/linear_system/trilinos_smoke_tests.cpp
+++ b/tests/unit-tests/linear_system/trilinos_smoke_tests.cpp
@@ -12,6 +12,22 @@ TEST(LinearSystemTrilinosSmoke, BuildsAndFillsOneByOneMatrix) {
 #endif
 }
 
+TEST(LinearSystemTrilinosSmoke, SolvesWithBelosGmresAndIfpack2) {
+#ifdef SPECFEM_ENABLE_TRILINOS
+  // Gate for the implicit solver (issue #1984): proves the install provides
+  // Belos + Ifpack2 instantiations for type_real (cluster installs are
+  // float-only). Throws on non-convergence or a wrong solution.
+  int iterations = -1;
+  EXPECT_NO_THROW(iterations =
+                      specfem::linear_system::linear_solver_smoke_test());
+  EXPECT_GE(iterations, 0)
+      << "Expected a non-negative GMRES iteration count from the smoke solve";
+#else
+  EXPECT_EQ(specfem::linear_system::linear_solver_smoke_test(), -1)
+      << "Expected the no-op stub to return -1 when Trilinos is disabled";
+#endif
+}
+
 int main(int argc, char *argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new SPECFEMEnvironment);

--- a/tests/unit-tests/serial.cmake
+++ b/tests/unit-tests/serial.cmake
@@ -675,3 +675,39 @@ specfem_add_test(stiffness_assembler_tests
             ${BOOST_LIBS}
             -lpthread -lm
 )
+
+specfem_add_test(mass_vector_tests
+  SOURCES linear_system/mass_vector_tests.cpp
+  LIBRARIES specfem::linear_system
+            specfem::quadrature
+            specfem::mesh
+            yaml-cpp
+            specfem_environment
+            specfem::assembly
+            specfem::runtime_configuration
+            timescheme
+            point
+            specfem::algorithms
+            specfem::solver
+            specfem::periodic_tasks
+            ${BOOST_LIBS}
+            -lpthread -lm
+)
+
+specfem_add_test(damping_assembler_tests
+  SOURCES linear_system/damping_assembler_tests.cpp
+  LIBRARIES specfem::linear_system
+            specfem::quadrature
+            specfem::mesh
+            yaml-cpp
+            specfem_environment
+            specfem::assembly
+            specfem::runtime_configuration
+            timescheme
+            point
+            specfem::algorithms
+            specfem::solver
+            specfem::periodic_tasks
+            ${BOOST_LIBS}
+            -lpthread -lm
+)


### PR DESCRIPTION
> [!NOTE]
> **Stacked PR (1/3)** for the implicit Newmark solver (issue #1984), based on #2002 (`issue-1982-phase-2`). Only the last three commits are new here; the rest belong to the base PR. Merge order: #2002 → this → phase 2 → phase 3.

## Description

Foundations for the implicit Newmark solver:

- **Belos + Ifpack2 linked into `specfem_linear_system`** (MueLu stays deferred: the float-only TROMP install does not instantiate `Xpetra::Matrix<double>`). `linear_solver_smoke_test()` gates the toolchain: a tridiagonal solve through Ifpack2-RILUK + Belos PseudoBlockGmres on `type_real`.
- **`StiffnessScope`**: the strict scope validator gains a `with_stacey` opt-in — the displacement probe runs at zero velocity, where the Stacey dashpot contributes nothing to K; callers must assemble C separately.
- **`assemble_mass_vector()`**: lumped diagonal mass M as a `Tpetra::Vector` via the production `initialize_mass_matrix` path with dt = 0 (the Stacey (dt/2) C 1 lumped term is linear in dt and vanishes exactly).
- **`DampingAssembler`**: Stacey damping C by probing the velocity path of the production stiffness kernel (u = 0, v = e_c at all points; C is block-diagonal so ncomp launches recover all blocks), assembled on a compact graph whose entries all exist in K's graph.

Unit tests cover positivity and rho·V total mass of M, block structure / symmetry / PSD of C, agreement of C·v with the production kernel for a random velocity, and the cross-path identity M(dt) − M(0) = (dt/2) C·1 through the explicit solver's mass path.

## Issue Number

Part of #1984

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)