### PR TITLE
Issue 1984 - Phase 2: Implicit Newmark solver

### DIFF
--- a/core/specfem/solver/CMakeLists.txt
+++ b/core/specfem/solver/CMakeLists.txt
@@ -18,4 +18,7 @@ target_link_libraries(
         specfem::io
         specfem::assembly
         specfem::compute
+        # Assembled operators (K, C, M) for the implicit solver; carries the
+        # Tpetra/Belos/Ifpack2 links when SPECFEM_ENABLE_TRILINOS is ON.
+        specfem::linear_system
 )

--- a/core/specfem/solver/implicit_solver.cpp
+++ b/core/specfem/solver/implicit_solver.cpp
@@ -1,0 +1,417 @@
+#include "specfem/solver/implicit_solver.hpp"
+
+#ifdef SPECFEM_ENABLE_TRILINOS
+
+#include "specfem/assembly/assembly.hpp"
+#include "specfem/compute.tpp"
+#include "specfem/compute/impl/compute_source_interaction.hpp"
+#include "specfem/linear_system/damping_assembler.hpp"
+#include "specfem/linear_system/mass_vector.hpp"
+#include "specfem/linear_system/tpetra_assembler.hpp"
+#include "specfem/logger.hpp"
+#include "specfem/tags.hpp"
+#include <BelosPseudoBlockGmresSolMgr.hpp>
+#include <BelosTpetraAdapter.hpp>
+#include <Ifpack2_Factory.hpp>
+#include <Kokkos_Core.hpp>
+#include <algorithm>
+#include <cstddef>
+#include <sstream>
+#include <stdexcept>
+#include <utility>
+
+template <typename Tags>
+specfem::solver::ImplicitNewmarkSolver<Tags>::ImplicitNewmarkSolver(
+    const std::shared_ptr<specfem::time_scheme::time_scheme> time_scheme,
+    const std::vector<
+        std::shared_ptr<specfem::periodic_tasks::periodic_task<dimension_tag>>>
+        &tasks,
+    AssemblyType assembly, const ImplicitSolverConfig &config)
+    : time_scheme_(time_scheme), tasks_(tasks), assembly_(assembly),
+      config_(config) {
+
+  if (!(config_.newmark.beta > 0)) {
+    throw std::runtime_error(
+        "specfem::solver::ImplicitNewmarkSolver: Newmark beta must be > 0 "
+        "(the explicit beta = 0 limit has no displacement-form operator); "
+        "use the explicit time_marching solver instead.");
+  }
+
+  specfem::linear_system::StiffnessAssembler<Tags> stiffness_assembler(
+      assembly_,
+      specfem::linear_system::StiffnessAssembler<Tags>::default_batch_size,
+      specfem::linear_system::StiffnessScope::with_stacey);
+  stiffness_ = stiffness_assembler.assemble();
+  dof_map_ = std::make_unique<specfem::linear_system::DofMap>(
+      stiffness_assembler.dof_map());
+
+  specfem::linear_system::DampingAssembler<Tags> damping_assembler(assembly_,
+                                                                   *dof_map_);
+  damping_ = damping_assembler.assemble();
+
+  mass_ =
+      specfem::linear_system::assemble_mass_vector<Tags>(assembly_, *dof_map_);
+
+  const auto map = dof_map_->owned_map();
+  u_ = Teuchos::rcp(new specfem::linear_system::vector_type(map));
+  v_ = Teuchos::rcp(new specfem::linear_system::vector_type(map));
+  a_ = Teuchos::rcp(new specfem::linear_system::vector_type(map));
+  u_new_ = Teuchos::rcp(new specfem::linear_system::vector_type(map));
+  v_new_ = Teuchos::rcp(new specfem::linear_system::vector_type(map));
+  a_new_ = Teuchos::rcp(new specfem::linear_system::vector_type(map));
+  rhs_ = Teuchos::rcp(new specfem::linear_system::vector_type(map));
+  tmp_ = Teuchos::rcp(new specfem::linear_system::vector_type(map));
+  tmp2_ = Teuchos::rcp(new specfem::linear_system::vector_type(map));
+
+  form_operator(time_scheme_->get_timestep());
+}
+
+template <typename Tags>
+void specfem::solver::ImplicitNewmarkSolver<Tags>::form_operator(
+    const type_real dt) {
+  using scalar_type = specfem::linear_system::scalar_type;
+  using crs_matrix_type = specfem::linear_system::crs_matrix_type;
+  using global_ordinal_type = specfem::linear_system::global_ordinal_type;
+
+  const type_real beta = config_.newmark.beta;
+  const type_real gamma = config_.newmark.gamma;
+  const scalar_type mass_coefficient =
+      static_cast<scalar_type>(1) / (beta * dt * dt);
+  const scalar_type damping_coefficient =
+      static_cast<scalar_type>(gamma / (beta * dt));
+
+  // A on K's static graph: every C block entry is a same-element pair and
+  // the M diagonal is a self-pair, so both sumInto below always hit.
+  auto system = Teuchos::rcp(new crs_matrix_type(stiffness_->getCrsGraph()));
+
+  const global_ordinal_type num_rows = dof_map_->num_global_dofs();
+  typename crs_matrix_type::nonconst_global_inds_host_view_type columns(
+      "specfem::solver::implicit_operator_columns",
+      stiffness_->getGlobalMaxNumRowEntries());
+  typename crs_matrix_type::nonconst_values_host_view_type values(
+      "specfem::solver::implicit_operator_values",
+      stiffness_->getGlobalMaxNumRowEntries());
+
+  for (global_ordinal_type row = 0; row < num_rows; ++row) {
+    std::size_t row_entries = 0;
+    stiffness_->getGlobalRowCopy(row, columns, values, row_entries);
+    const int replaced = system->replaceGlobalValues(
+        row, static_cast<int>(row_entries), values.data(), columns.data());
+    if (replaced != static_cast<int>(row_entries)) {
+      throw std::runtime_error(
+          "specfem::solver::ImplicitNewmarkSolver: copying K into the "
+          "system operator failed; the graphs disagree.");
+    }
+  }
+
+  if (damping_->getGlobalNumEntries() > 0) {
+    typename crs_matrix_type::nonconst_global_inds_host_view_type
+        damping_columns("specfem::solver::implicit_damping_columns",
+                        damping_->getGlobalMaxNumRowEntries());
+    typename crs_matrix_type::nonconst_values_host_view_type damping_values(
+        "specfem::solver::implicit_damping_values",
+        damping_->getGlobalMaxNumRowEntries());
+    for (global_ordinal_type row = 0; row < num_rows; ++row) {
+      std::size_t row_entries = 0;
+      damping_->getGlobalRowCopy(row, damping_columns, damping_values,
+                                 row_entries);
+      if (row_entries == 0) {
+        continue;
+      }
+      for (std::size_t k = 0; k < row_entries; ++k) {
+        damping_values(k) *= damping_coefficient;
+      }
+      const int updated = system->sumIntoGlobalValues(
+          row, static_cast<int>(row_entries), damping_values.data(),
+          damping_columns.data());
+      if (updated != static_cast<int>(row_entries)) {
+        throw std::runtime_error(
+            "specfem::solver::ImplicitNewmarkSolver: summing C into the "
+            "system operator failed; a damping entry is outside K's graph.");
+      }
+    }
+  }
+
+  {
+    const auto mass_view = mass_->getLocalViewHost(Tpetra::Access::ReadOnly);
+    for (global_ordinal_type row = 0; row < num_rows; ++row) {
+      const scalar_type diagonal_term =
+          mass_view(static_cast<std::size_t>(row), 0) * mass_coefficient;
+      const int updated =
+          system->sumIntoGlobalValues(row, 1, &diagonal_term, &row);
+      if (updated != 1) {
+        throw std::runtime_error(
+            "specfem::solver::ImplicitNewmarkSolver: the system operator's "
+            "graph is missing a diagonal entry.");
+      }
+    }
+  }
+
+  system->fillComplete(dof_map_->owned_map(), dof_map_->owned_map());
+  system_operator_ = system;
+
+  // MueLu (AMG) deferred: the float-only TROMP Trilinos installs do not
+  // link it (MueLu references Xpetra::Matrix<double> unconditionally);
+  // revisit with the follow-up of issue #1984.
+  using row_matrix_type =
+      Tpetra::RowMatrix<scalar_type, crs_matrix_type::local_ordinal_type,
+                        crs_matrix_type::global_ordinal_type,
+                        crs_matrix_type::node_type>;
+  auto preconditioner = Ifpack2::Factory::create<row_matrix_type>(
+      config_.preconditioner, system_operator_);
+  Teuchos::ParameterList preconditioner_params = config_.preconditioner_params;
+  if (config_.preconditioner == "RILUK" &&
+      !preconditioner_params.isParameter("fact: iluk level-of-fill")) {
+    // ILU(0): the fill pattern is A's own graph. Spectral-element rows carry
+    // ~2000 nonzeros (all dofs of all adjacent elements), so level-1 fill
+    // (~the pattern of A^2) explodes combinatorially -- RILUK's symbolic
+    // setup runs for minutes and gigabytes. Override via
+    // preconditioner_params for small problems.
+    preconditioner_params.set("fact: iluk level-of-fill", 0);
+  }
+  preconditioner->setParameters(preconditioner_params);
+  preconditioner->initialize();
+  preconditioner->compute();
+  preconditioner_ = preconditioner;
+
+  problem_ = Teuchos::rcp(
+      new Belos::LinearProblem<scalar_type, multivector_type, operator_type>(
+          system_operator_, u_new_, rhs_));
+  // Right preconditioning keeps the convergence test on the true residual.
+  problem_->setRightPrec(preconditioner_);
+
+  auto belos_params = Teuchos::rcp(new Teuchos::ParameterList());
+  belos_params->set("Convergence Tolerance", config_.gmres_tolerance);
+  belos_params->set("Maximum Iterations", config_.gmres_max_iterations);
+  belos_params->set("Num Blocks", config_.gmres_restart_length);
+  belos_params->set("Verbosity", Belos::Errors + Belos::Warnings);
+  gmres_ = Teuchos::rcp(
+      new Belos::PseudoBlockGmresSolMgr<scalar_type, multivector_type,
+                                        operator_type>(problem_, belos_params));
+}
+
+template <typename Tags>
+void specfem::solver::ImplicitNewmarkSolver<Tags>::extract_source_vector(
+    const int istep, specfem::linear_system::vector_type &f) {
+  constexpr auto forward = specfem::simulation::field_type::forward;
+
+  auto &field = assembly_.fields.template get_simulation_field<forward>();
+  const auto &field_impl = field.template get_field<medium_tag>();
+  const auto device_acceleration = field_impl.get_field_dot_dot();
+  const auto host_acceleration = field_impl.get_host_field_dot_dot();
+
+  // The source kernel only adds into the acceleration field, and the state
+  // is rewritten by write_state_to_fields() at the end of the step, so
+  // zeroing here is the only bookkeeping the probe needs.
+  Kokkos::deep_copy(device_acceleration, 0);
+  specfem::compute::impl::compute_source_interaction<
+      5, specfem::tags::Tags<dimension_tag, forward, medium_tag>>(assembly_,
+                                                                  istep);
+  Kokkos::deep_copy(host_acceleration, device_acceleration);
+
+  auto view = f.getLocalViewHost(Tpetra::Access::OverwriteAll);
+  for (int iglob = 0; iglob < dof_map_->nglob(); ++iglob) {
+    for (int icomp = 0; icomp < dof_map_->ncomp(); ++icomp) {
+      view(static_cast<std::size_t>(dof_map_->gid(iglob, icomp)), 0) =
+          host_acceleration(iglob, icomp);
+    }
+  }
+}
+
+template <typename Tags>
+void specfem::solver::ImplicitNewmarkSolver<Tags>::write_state_to_fields() {
+  constexpr auto forward = specfem::simulation::field_type::forward;
+
+  auto &field = assembly_.fields.template get_simulation_field<forward>();
+  const auto &field_impl = field.template get_field<medium_tag>();
+  const auto h_u = field_impl.get_host_field();
+  const auto h_v = field_impl.get_host_field_dot();
+  const auto h_a = field_impl.get_host_field_dot_dot();
+
+  {
+    const auto u_view = u_->getLocalViewHost(Tpetra::Access::ReadOnly);
+    const auto v_view = v_->getLocalViewHost(Tpetra::Access::ReadOnly);
+    const auto a_view = a_->getLocalViewHost(Tpetra::Access::ReadOnly);
+    for (int iglob = 0; iglob < dof_map_->nglob(); ++iglob) {
+      for (int icomp = 0; icomp < dof_map_->ncomp(); ++icomp) {
+        const auto dof = static_cast<std::size_t>(dof_map_->gid(iglob, icomp));
+        h_u(iglob, icomp) = u_view(dof, 0);
+        h_v(iglob, icomp) = v_view(dof, 0);
+        h_a(iglob, icomp) = a_view(dof, 0);
+      }
+    }
+  }
+
+  // Copy only the three state views (not fields.copy_to_device(), which
+  // would also touch the mass storage the assemblers treat as scratch).
+  Kokkos::deep_copy(field_impl.get_field(), h_u);
+  Kokkos::deep_copy(field_impl.get_field_dot(), h_v);
+  Kokkos::deep_copy(field_impl.get_field_dot_dot(), h_a);
+}
+
+template <typename Tags>
+void specfem::solver::ImplicitNewmarkSolver<Tags>::run() {
+  constexpr auto forward = specfem::simulation::field_type::forward;
+  using scalar_type = specfem::linear_system::scalar_type;
+
+  const type_real dt = time_scheme_->get_timestep();
+  const type_real beta = config_.newmark.beta;
+  const type_real gamma = config_.newmark.gamma;
+  const int nstep = time_scheme_->get_max_timestep();
+
+  // Displacement-form Newmark coefficients (see the class docs).
+  const scalar_type c_a0 = static_cast<scalar_type>(1 / (beta * dt * dt));
+  const scalar_type c_a1 = static_cast<scalar_type>(1 / (beta * dt));
+  const scalar_type c_a2 = static_cast<scalar_type>(1 / (2 * beta) - 1);
+  const scalar_type c_c0 = static_cast<scalar_type>(gamma / (beta * dt));
+  const scalar_type c_c1 = static_cast<scalar_type>(gamma / beta - 1);
+  const scalar_type c_c2 =
+      static_cast<scalar_type>(dt * (gamma / (2 * beta) - 1));
+  const scalar_type c_v0 = static_cast<scalar_type>(dt * (1 - gamma));
+  const scalar_type c_v1 = static_cast<scalar_type>(dt * gamma);
+
+  u_->putScalar(0);
+  v_->putScalar(0);
+  a_->putScalar(0);
+  last_step_ = 0;
+
+  const bool has_damping = damping_->getGlobalNumEntries() > 0;
+  const bool check_steady_state = config_.steady_state_tolerance > 0;
+  type_real velocity_scale = 0;
+  type_real acceleration_scale = 0;
+
+  for (const auto &task : tasks_) {
+    task->initialize(assembly_);
+  }
+
+  for (const auto [istep, dt_step] : time_scheme_->iterate_forward()) {
+    (void)dt_step;
+
+    // b = f_{n+1}: the explicit loop pairs STF(istep = n) with the state at
+    // t_{n+1}; the implicit loop must match.
+    extract_source_vector(istep, *rhs_);
+
+    if (has_damping) {
+      tmp_->update(c_c0, *u_, c_c1, *v_, 0);
+      tmp_->update(c_c2, *a_, static_cast<scalar_type>(1));
+      damping_->apply(*tmp_, *tmp2_);
+      rhs_->update(static_cast<scalar_type>(1), *tmp2_,
+                   static_cast<scalar_type>(1));
+    }
+
+    tmp_->update(c_a0, *u_, c_a1, *v_, 0);
+    tmp_->update(c_a2, *a_, static_cast<scalar_type>(1));
+    rhs_->elementWiseMultiply(static_cast<scalar_type>(1), *mass_, *tmp_,
+                              static_cast<scalar_type>(1));
+
+    // Warm start from u_n: near steady state GMRES converges in a few
+    // iterations.
+    u_new_->update(static_cast<scalar_type>(1), *u_, 0);
+    problem_->setProblem(u_new_, rhs_);
+    if (gmres_->solve() != Belos::Converged) {
+      std::ostringstream message;
+      message << "specfem::solver::ImplicitNewmarkSolver: GMRES did not "
+                 "converge at step "
+              << istep << " (" << gmres_->getNumIters()
+              << " iterations, achieved tolerance " << gmres_->achievedTol()
+              << ", requested " << config_.gmres_tolerance << ").";
+      throw std::runtime_error(message.str());
+    }
+
+    // a_{n+1} = c_a0 (u_{n+1} - u_n - dt v_n) - c_a2 a_n
+    a_new_->update(c_a0, *u_new_, -c_a0, *u_, 0);
+    a_new_->update(static_cast<scalar_type>(-c_a0 * dt), *v_,
+                   static_cast<scalar_type>(1));
+    a_new_->update(-c_a2, *a_, static_cast<scalar_type>(1));
+    // v_{n+1} = v_n + dt (1 - gamma) a_n + dt gamma a_{n+1}
+    v_new_->update(static_cast<scalar_type>(1), *v_, c_v0, *a_, 0);
+    v_new_->update(c_v1, *a_new_, static_cast<scalar_type>(1));
+
+    bool steady = false;
+    if (check_steady_state) {
+      tmp_->update(static_cast<scalar_type>(1), *v_new_,
+                   static_cast<scalar_type>(-1), *v_, 0);
+      const type_real velocity_increment = tmp_->norm2();
+      tmp_->update(static_cast<scalar_type>(1), *a_new_,
+                   static_cast<scalar_type>(-1), *a_, 0);
+      const type_real acceleration_increment = tmp_->norm2();
+      // Increments relative to the running maxima -- the natural problem
+      // scales; a displacement criterion would never fire on the
+      // constant-velocity drift asymptote (see ImplicitSolverConfig).
+      velocity_scale =
+          std::max(velocity_scale, static_cast<type_real>(v_new_->norm2()));
+      acceleration_scale =
+          std::max(acceleration_scale, static_cast<type_real>(a_new_->norm2()));
+      steady = velocity_scale > 0 && acceleration_scale > 0 &&
+               velocity_increment <=
+                   config_.steady_state_tolerance * velocity_scale &&
+               acceleration_increment <=
+                   config_.steady_state_tolerance * acceleration_scale;
+    }
+
+    std::swap(u_, u_new_);
+    std::swap(v_, v_new_);
+    std::swap(a_, a_new_);
+
+    write_state_to_fields();
+
+    if (time_scheme_->compute_seismogram(istep)) {
+      specfem::compute::compute_seismograms<
+          5, specfem::tags::Tags<dimension_tag, forward>>(
+          assembly_, time_scheme_->get_seismogram_step());
+      time_scheme_->increment_seismogram_step();
+    }
+    for (const auto &task : tasks_) {
+      if (task && task->should_run(istep + 1)) {
+        task->run(assembly_, istep + 1);
+      }
+    }
+
+    last_step_ = istep + 1;
+
+    if (istep % 10 == 0) {
+      std::ostringstream message;
+      message << "Progress : executed " << istep << " steps of " << nstep
+              << " steps (GMRES: " << gmres_->getNumIters() << " iterations)"
+              << std::endl;
+      specfem::Logger::info(message.str());
+    }
+
+    if (steady) {
+      std::ostringstream message;
+      message << "Steady state reached at step " << last_step_ << " of "
+              << nstep << " (velocity and acceleration increments below "
+              << config_.steady_state_tolerance << ").";
+      specfem::Logger::info(message.str());
+      break;
+    }
+  }
+
+  for (const auto &task : tasks_) {
+    if (task && !task->should_run(last_step_) && task->should_run(-1)) {
+      task->run(assembly_, last_step_);
+    }
+  }
+
+  for (const auto &task : tasks_) {
+    task->finalize(assembly_);
+  }
+
+  specfem::Logger::info(" -- Implicit simulation complete. -- \n");
+}
+
+namespace specfem::solver_impl {
+/// Tag bundle for the only combination explicitly instantiated for the
+/// implicit solver (issue #1984), matching the linear_system scope.
+using elastic_isotropic_tags =
+    specfem::tags::Tags<specfem::element::dimension_tag::dim3,
+                        specfem::element::medium_tag::elastic,
+                        specfem::element::property_tag::isotropic,
+                        specfem::element::attenuation_tag::none>;
+} // namespace specfem::solver_impl
+
+// Explicit instantiation: 3D elastic isotropic
+template class specfem::solver::ImplicitNewmarkSolver<
+    specfem::solver_impl::elastic_isotropic_tags>;
+
+#endif // SPECFEM_ENABLE_TRILINOS

--- a/core/specfem/solver/implicit_solver.hpp
+++ b/core/specfem/solver/implicit_solver.hpp
@@ -1,0 +1,262 @@
+#pragma once
+
+#ifdef SPECFEM_ENABLE_TRILINOS
+
+#include "solver.hpp"
+#include "specfem/enums.hpp"
+#include "specfem/linear_system/dof_map.hpp"
+#include "specfem/periodic_tasks.hpp"
+#include "specfem/timescheme.hpp"
+#include <BelosLinearProblem.hpp>
+#include <BelosSolverManager.hpp>
+#include <Teuchos_ParameterList.hpp>
+#include <Teuchos_RCP.hpp>
+#include <Tpetra_MultiVector.hpp>
+#include <Tpetra_Operator.hpp>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace specfem {
+namespace solver {
+
+/**
+ * @brief Newmark-beta parameters of the implicit update.
+ *
+ * The defaults (\f$ \beta = 1/4, \gamma = 1/2 \f$, average acceleration) are
+ * unconditionally stable and non-dissipative. For steady-state driving use
+ * @ref dissipative: \f$ \gamma > 1/2 \f$ introduces algorithmic damping of
+ * the modes a large time step cannot resolve, and
+ * \f$ \beta = (\gamma + 1/2)^2 / 4 \f$ keeps the scheme unconditionally
+ * stable and second-order in the resolved modes.
+ */
+struct NewmarkBetaParameters {
+  type_real beta = static_cast<type_real>(0.25); ///< Newmark \f$ \beta > 0 \f$
+  type_real gamma = static_cast<type_real>(0.5); ///< Newmark \f$ \gamma \f$
+
+  /**
+   * @brief Dissipative preset for driving a run to steady state.
+   *
+   * @param gamma Newmark \f$ \gamma > 1/2 \f$; larger means stronger
+   *        high-frequency dissipation
+   * @return Parameters with \f$ \beta = (\gamma + 1/2)^2 / 4 \f$
+   */
+  static NewmarkBetaParameters dissipative(const type_real gamma) {
+    NewmarkBetaParameters parameters;
+    parameters.gamma = gamma;
+    parameters.beta = (gamma + static_cast<type_real>(0.5)) *
+                      (gamma + static_cast<type_real>(0.5)) /
+                      static_cast<type_real>(4);
+    return parameters;
+  }
+};
+
+/**
+ * @brief Linear-solver and stopping configuration of the implicit solver.
+ */
+struct ImplicitSolverConfig {
+  NewmarkBetaParameters newmark{}; ///< Newmark update parameters
+
+  /// GMRES relative residual tolerance. Floor ~1e-6 in single precision.
+  specfem::linear_system::scalar_type gmres_tolerance =
+      static_cast<specfem::linear_system::scalar_type>(1e-5);
+  int gmres_max_iterations = 1000; ///< GMRES iteration cap per solve
+  int gmres_restart_length = 100;  ///< GMRES restart (Belos "Num Blocks")
+
+  /// Ifpack2 factory name: "RILUK" (default) or "RELAXATION" (symmetric
+  /// Gauss-Seidel fallback if RILUK misbehaves on a platform).
+  std::string preconditioner = "RILUK";
+  Teuchos::ParameterList preconditioner_params{}; ///< Ifpack2 parameters
+
+  /**
+   * @brief Early-stop tolerance for steady-state driving; 0 disables (run
+   * all steps).
+   *
+   * The run stops once the velocity and acceleration increments both drop
+   * below the tolerance relative to their running maxima:
+   * \f$ \| v_{n+1} - v_n \| \le \mathrm{tol} \cdot \max_k \| v_k \| \f$ and
+   * the same for \f$ a \f$. Velocity-based on purpose: a nonzero-net-force
+   * source on a Stacey-truncated box converges to a constant-velocity drift
+   * superposed on the converged deformation, so a displacement increment
+   * never vanishes.
+   */
+  type_real steady_state_tolerance = 0;
+};
+
+/**
+ * @brief Implicit Newmark solver: one Belos GMRES solve per time step on the
+ * assembled operator \f$ A = M / (\beta \Delta t^2) + \gamma / (\beta \Delta
+ * t) \, C + K \f$.
+ *
+ * Solves the semi-discrete equation of motion
+ * \f$ M \ddot{u} + C \dot{u} + K u = f \f$ with the Newmark-beta update
+ * \f[ u_{n+1} = u_n + \Delta t \, v_n + \Delta t^2 \left[ (1/2 - \beta) a_n
+ * + \beta \, a_{n+1} \right], \quad
+ * v_{n+1} = v_n + \Delta t \left[ (1 - \gamma) a_n + \gamma \, a_{n+1}
+ * \right] \f]
+ * in displacement form: \f$ A u_{n+1} = b \f$ with
+ * \f[ b = f_{n+1}
+ * + M \circ \left[ \frac{u_n}{\beta \Delta t^2} + \frac{v_n}{\beta \Delta t}
+ *   + \left( \frac{1}{2\beta} - 1 \right) a_n \right]
+ * + C \left[ \frac{\gamma}{\beta \Delta t} u_n
+ *   + \left( \frac{\gamma}{\beta} - 1 \right) v_n
+ *   + \Delta t \left( \frac{\gamma}{2\beta} - 1 \right) a_n \right]. \f]
+ * Acceleration and velocity then follow as
+ * \f$ a_{n+1} = (u_{n+1} - u_n - \Delta t \, v_n) / (\beta \Delta t^2) -
+ * (1/(2\beta) - 1) a_n \f$ and the update above.
+ *
+ * The operators come from `specfem::linear_system`: \f$ K \f$ from the
+ * `StiffnessAssembler` (Stacey-tolerant scope), \f$ C \f$ from the
+ * `DampingAssembler` (empty on Stacey-free meshes), \f$ M \f$ from
+ * `assemble_mass_vector`. \f$ A \f$ is constant for a fixed \f$ \Delta t \f$
+ * and is assembled, fill-completed, and preconditioned once; each step is
+ * one GMRES solve warm-started from \f$ u_n \f$ with an Ifpack2 right
+ * preconditioner (true-residual convergence test). Without fluid-solid
+ * coupling \f$ A \f$ is symmetric positive definite; GMRES is used so the
+ * solver survives the non-symmetric coupling blocks planned next.
+ * MueLu (AMG) is deferred: the float-only cluster Trilinos installs do not
+ * link it (issue #1984).
+ *
+ * State \f$ (u, v, a) \f$ lives in Tpetra vectors; the assembly fields serve
+ * as source-probe scratch and as the mirror that seismogram computation and
+ * periodic tasks read. Run with a large dissipative step (see
+ * @ref NewmarkBetaParameters::dissipative and
+ * @ref ImplicitSolverConfig::steady_state_tolerance) the solver acts as a
+ * static solver, recreating an explicit run driven to steady state in a few
+ * solves.
+ *
+ * Scope (this milestone): serial, dim3, single-medium elastic isotropic,
+ * NGLL = 5, no attenuation; boundaries `none`, `acoustic_free_surface`, or
+ * `stacey`.
+ *
+ * @tparam Tags Compile-time tags (dimension, medium, property, attenuation);
+ *              only `dim3, elastic, isotropic, none` is instantiated
+ */
+template <typename Tags> class ImplicitNewmarkSolver : public solver {
+public:
+  constexpr static auto dimension_tag = Tags::dimension_tag;
+  constexpr static auto medium_tag = Tags::medium_tag;
+
+  static_assert(dimension_tag == specfem::element::dimension_tag::dim3,
+                "ImplicitNewmarkSolver takes a dim3 assembly; Tags must be a "
+                "dim3 bundle.");
+
+  using AssemblyType = specfem::assembly::assembly<dimension_tag>;
+  using multivector_type =
+      Tpetra::MultiVector<specfem::linear_system::scalar_type>;
+  using operator_type = Tpetra::Operator<specfem::linear_system::scalar_type>;
+
+  /**
+   * @brief Assemble the operators and set up the linear solver.
+   *
+   * Assembles \f$ K \f$, \f$ C \f$, and \f$ M \f$, forms \f$ A \f$ for
+   * `time_scheme->get_timestep()`, computes the Ifpack2 preconditioner, and
+   * builds the Belos GMRES problem. Throws `std::runtime_error` outside the
+   * supported scope (see the class docs) or for `beta <= 0` (the explicit
+   * limit has no displacement-form operator).
+   *
+   * @param time_scheme Supplies the time step, step count, and seismogram
+   *        cadence. Its predictor/corrector phases are NOT used -- the
+   *        implicit update replaces them; \f$ \beta, \gamma \f$ come from
+   *        `config`.
+   * @param tasks Periodic tasks executed during the run (plotting, output)
+   * @param assembly Spectral element assembly (shallow view-handle copy,
+   *        like the explicit solver); fields are used as probe scratch and
+   *        output mirror
+   * @param config Newmark parameters, GMRES/preconditioner settings, and the
+   *        optional steady-state stopping tolerance
+   */
+  ImplicitNewmarkSolver(
+      const std::shared_ptr<specfem::time_scheme::time_scheme> time_scheme,
+      const std::vector<std::shared_ptr<
+          specfem::periodic_tasks::periodic_task<dimension_tag>>> &tasks,
+      AssemblyType assembly, const ImplicitSolverConfig &config = {});
+
+  /**
+   * @brief Execute the implicit time loop.
+   *
+   * Per step: extract the source vector, form the right-hand side from the
+   * previous state, solve \f$ A u_{n+1} = b \f$ (throws on GMRES
+   * non-convergence), recover \f$ a_{n+1}, v_{n+1} \f$, write the state back
+   * to the assembly fields, and run seismogram computation and periodic
+   * tasks on the explicit solver's cadence. Stops early when the
+   * steady-state criterion fires (if enabled).
+   */
+  void run() override;
+
+  /// Dof numbering shared by all assembled operators
+  const specfem::linear_system::DofMap &dof_map() const { return *dof_map_; }
+  /// Assembled stiffness matrix \f$ K \f$
+  Teuchos::RCP<const specfem::linear_system::crs_matrix_type>
+  stiffness() const {
+    return stiffness_;
+  }
+  /// Assembled Stacey damping matrix \f$ C \f$ (empty without Stacey)
+  Teuchos::RCP<const specfem::linear_system::crs_matrix_type> damping() const {
+    return damping_;
+  }
+  /// Lumped mass vector \f$ M \f$
+  Teuchos::RCP<const specfem::linear_system::vector_type> mass() const {
+    return mass_;
+  }
+  /// Implicit Newmark operator \f$ A \f$ for the configured time step
+  Teuchos::RCP<const specfem::linear_system::crs_matrix_type>
+  system_operator() const {
+    return system_operator_;
+  }
+  /// Steps actually executed by the last run() (equals the step count unless
+  /// the steady-state criterion stopped the run early)
+  int last_step() const { return last_step_; }
+
+private:
+  /// (Re)build A from K, C, M for time step `dt`, then preconditioner and
+  /// Belos problem. Idempotent; exact for any dt since K, C, M are kept.
+  void form_operator(const type_real dt);
+
+  /// Zero the acceleration field, run the production source kernel at
+  /// `istep`, and gather the result: f = source vector at t_{n+1}
+  void extract_source_vector(const int istep,
+                             specfem::linear_system::vector_type &f);
+
+  /// Scatter (u, v, a) into the assembly's forward field (host views, then
+  /// device) so seismograms and periodic tasks see the current state
+  void write_state_to_fields();
+
+  std::shared_ptr<specfem::time_scheme::time_scheme> time_scheme_;
+  std::vector<
+      std::shared_ptr<specfem::periodic_tasks::periodic_task<dimension_tag>>>
+      tasks_;                   ///< Periodic tasks
+  AssemblyType assembly_;       ///< Assembly (probe scratch + output mirror)
+  ImplicitSolverConfig config_; ///< Solver configuration
+
+  std::unique_ptr<specfem::linear_system::DofMap> dof_map_; ///< Dof numbering
+  Teuchos::RCP<specfem::linear_system::crs_matrix_type> stiffness_;       ///< K
+  Teuchos::RCP<specfem::linear_system::crs_matrix_type> damping_;         ///< C
+  Teuchos::RCP<specfem::linear_system::vector_type> mass_;                ///< M
+  Teuchos::RCP<specfem::linear_system::crs_matrix_type> system_operator_; ///< A
+
+  Teuchos::RCP<operator_type> preconditioner_; ///< Ifpack2 right prec
+  Teuchos::RCP<Belos::LinearProblem<specfem::linear_system::scalar_type,
+                                    multivector_type, operator_type>>
+      problem_; ///< Belos linear problem A u_new = b
+  Teuchos::RCP<Belos::SolverManager<specfem::linear_system::scalar_type,
+                                    multivector_type, operator_type>>
+      gmres_; ///< Belos GMRES solver manager
+
+  Teuchos::RCP<specfem::linear_system::vector_type> u_;     ///< u_n
+  Teuchos::RCP<specfem::linear_system::vector_type> v_;     ///< v_n
+  Teuchos::RCP<specfem::linear_system::vector_type> a_;     ///< a_n
+  Teuchos::RCP<specfem::linear_system::vector_type> u_new_; ///< u_{n+1}
+  Teuchos::RCP<specfem::linear_system::vector_type> a_new_; ///< a_{n+1}
+  Teuchos::RCP<specfem::linear_system::vector_type> v_new_; ///< v_{n+1}
+  Teuchos::RCP<specfem::linear_system::vector_type> rhs_;   ///< b
+  Teuchos::RCP<specfem::linear_system::vector_type> tmp_;   ///< scratch
+  Teuchos::RCP<specfem::linear_system::vector_type> tmp2_;  ///< scratch
+
+  int last_step_ = 0; ///< Steps executed by the last run()
+};
+
+} // namespace solver
+} // namespace specfem
+
+#endif // SPECFEM_ENABLE_TRILINOS

--- a/docs/sections/api/specfem/solver/implicit_solver.rst
+++ b/docs/sections/api/specfem/solver/implicit_solver.rst
@@ -1,0 +1,36 @@
+``specfem::solver::ImplicitNewmarkSolver``
+==========================================
+
+Implicit Newmark solver (issue #1984): one Belos GMRES solve per time step
+on the assembled operator
+:math:`A = M / (\beta \Delta t^2) + \gamma / (\beta \Delta t)\, C + K`,
+with the operators assembled by :ref:`specfem::linear_system
+<linear_system_api>` (stiffness probe, Stacey velocity-path probe, and the
+:math:`\Delta t = 0` lumped-mass path). :math:`A` is constant for a fixed
+time step, so it is assembled and preconditioned once (Ifpack2 RILUK with
+zero fill by default, applied as a right preconditioner); each step is a
+single warm-started GMRES solve. MueLu (algebraic multigrid) stays deferred
+until the float-only cluster Trilinos installs are revisited.
+
+Run with a large dissipative step
+(:cpp:func:`specfem::solver::NewmarkBetaParameters::dissipative` and a
+nonzero ``steady_state_tolerance``) the solver acts as a **static solver**:
+it recreates an explicit run driven to steady state in a few large solves.
+The steady-state criterion is velocity/acceleration-based on purpose -- a
+nonzero-net-force source on a Stacey-truncated box converges to a
+constant-velocity drift superposed on the converged deformation, so a
+displacement increment never vanishes.
+
+Only available when SPECFEM++ is built with Trilinos
+(``SPECFEM_ENABLE_TRILINOS=ON``). Scope of this milestone: serial, dim3,
+single-medium elastic isotropic, NGLL = 5, boundaries ``none``,
+``acoustic_free_surface``, or ``stacey``.
+
+.. doxygenstruct:: specfem::solver::NewmarkBetaParameters
+    :members:
+
+.. doxygenstruct:: specfem::solver::ImplicitSolverConfig
+    :members:
+
+.. doxygenclass:: specfem::solver::ImplicitNewmarkSolver
+    :members:

--- a/docs/sections/api/specfem/solver/index.rst
+++ b/docs/sections/api/specfem/solver/index.rst
@@ -10,3 +10,4 @@
 
     solver
     time_marching
+    implicit_solver

--- a/tests/integration-tests/displacement_tests/ImplicitNewmark/dim3/implicit_newmark_tests.cpp
+++ b/tests/integration-tests/displacement_tests/ImplicitNewmark/dim3/implicit_newmark_tests.cpp
@@ -1,0 +1,219 @@
+#include "SPECFEM_Environment.hpp"
+#include <gtest/gtest.h>
+
+#ifdef SPECFEM_ENABLE_TRILINOS
+
+#include "specfem/assembly/assembly.hpp"
+#include "specfem/io.hpp"
+#include "specfem/logger.hpp"
+#include "specfem/mesh.hpp"
+#include "specfem/quadrature.hpp"
+#include "specfem/runtime_configuration.hpp"
+#include "specfem/solver.hpp"
+#include "specfem/solver/implicit_solver.hpp"
+#include "specfem/tags.hpp"
+#include "specfem/timescheme.hpp"
+#include <array>
+#include <cmath>
+#include <map>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace implicit_newmark_test {
+
+constexpr auto dim3_tag = specfem::element::dimension_tag::dim3;
+constexpr int ncomp = 3;
+
+using AssemblyType = specfem::assembly::assembly<dim3_tag>;
+using SolverTags =
+    specfem::tags::Tags<dim3_tag, specfem::element::medium_tag::elastic,
+                        specfem::element::property_tag::isotropic,
+                        specfem::element::attenuation_tag::none>;
+using ImplicitSolverType = specfem::solver::ImplicitNewmarkSolver<SolverTags>;
+
+// One time sample of one station/seismogram-type trace.
+using Sample = std::array<type_real, ncomp>;
+// Keyed by (station, network, seismogram type index).
+using TraceMap = std::map<std::tuple<std::string, std::string, int>,
+                          std::vector<std::pair<type_real, Sample>>>;
+
+struct TestCase {
+  std::unique_ptr<AssemblyType> assembly;
+  std::shared_ptr<specfem::time_scheme::time_scheme> time_scheme;
+  specfem::runtime_configuration::setup setup;
+};
+
+TestCase build_case_3d(const std::string &test_name) {
+  const std::string test_path =
+      "displacement_tests/Newmark/serial/dim3/" + test_name;
+
+  specfem::runtime_configuration::setup setup(test_path +
+                                              "/specfem_config.yaml");
+
+  const auto database_filename = setup.get_databases();
+  const auto &source_entries = setup.get_source_entries();
+  const auto stations_node = setup.get_stations();
+  const auto quadratures = setup.instantiate_quadrature();
+
+  auto mesh = specfem::io::read_3d_mesh(database_filename,
+                                        setup.get_attenuation_setup());
+
+  const type_real dt = setup.get_dt();
+  const int nsteps = setup.get_nsteps();
+
+  auto [sources, t0, starttime] = specfem::io::read_sources<dim3_tag>(
+      source_entries, nsteps, setup.get_t0(), dt, setup.get_simulation_type());
+  (void)starttime;
+  setup.update_t0(t0);
+
+  auto receivers = specfem::io::read_3d_receivers(stations_node);
+
+  auto assembly = std::make_unique<AssemblyType>(
+      mesh, quadratures, sources, receivers, setup.get_seismogram_types(),
+      setup.get_t0(), dt, nsteps, setup.get_max_seismogram_step(),
+      setup.get_nstep_between_samples(), setup.get_simulation_type(),
+      setup.allocate_boundary_values(), setup.instantiate_property_reader());
+  auto time_scheme = setup.instantiate_timescheme(assembly->fields);
+  return TestCase{ std::move(assembly), time_scheme, std::move(setup) };
+}
+
+// Collect all recorded seismograms of an assembly into a plain map.
+TraceMap collect_traces(AssemblyType &assembly) {
+  TraceMap traces;
+  auto seismograms = assembly.receivers;
+  seismograms.sync_seismograms();
+
+  for (auto station_info : seismograms.stations()) {
+    const std::string network_name = station_info.network_name;
+    const std::string station_name = station_info.station_name;
+    for (auto seismogram_type : station_info.get_seismogram_types()) {
+      auto &trace = traces[{ station_name, network_name,
+                             static_cast<int>(seismogram_type) }];
+      for (auto [time, value] : seismograms.get_seismogram(
+               station_name, network_name, seismogram_type)) {
+        Sample sample{};
+        for (int icomp = 0; icomp < ncomp; ++icomp) {
+          sample[icomp] = value[icomp];
+        }
+        trace.emplace_back(time, sample);
+      }
+    }
+  }
+  return traces;
+}
+
+// Implicit Newmark (beta = 1/4, gamma = 1/2) against the explicit solver on
+// the same mesh, sources, and time grid. Both schemes are second-order but
+// have different numerical dispersion, so agreement is O(dt^2)-bound, not
+// roundoff-bound: the tolerance is calibrated, not derived. The fixture has
+// no Stacey boundaries, so this exercises the M + K path (C empty).
+TEST(ImplicitNewmark3D, MatchesExplicitRunOnNaturalBoundaryMesh) {
+  const std::string fixture = "HomogeneousHalfspaceSmallNoABCForceSource";
+
+  // Reference: the production explicit solver.
+  TraceMap explicit_traces;
+  {
+    auto test_case = build_case_3d(fixture);
+    auto solver = test_case.setup.instantiate_solver<5>(
+        test_case.setup.get_dt(), *test_case.assembly, test_case.time_scheme,
+        {});
+    solver->run();
+    explicit_traces = collect_traces(*test_case.assembly);
+  }
+  ASSERT_FALSE(explicit_traces.empty());
+
+  // Implicit run on a fresh assembly (zeroed fields, fresh seismogram step).
+  TraceMap implicit_traces;
+  {
+    auto test_case = build_case_3d(fixture);
+    ImplicitSolverType solver(test_case.time_scheme, {}, *test_case.assembly);
+    solver.run();
+    implicit_traces = collect_traces(*test_case.assembly);
+  }
+
+  ASSERT_EQ(implicit_traces.size(), explicit_traces.size());
+
+  // The two schemes carry opposite-sign period errors -- average
+  // acceleration elongates by (w dt)^2 / 12, central difference shortens by
+  // (w dt)^2 / 24 -- so at this fixture's coarse dt (0.035 s against a
+  // 1.25 Hz Ricker with content to ~3 Hz) the phase gap accumulates to
+  // ~1.6 rad at the top of the band over 75 steps: the implicit trace lags
+  // the explicit one by up to a few samples late in the record. Measured
+  // full-trace relative L2 gaps: ~0.10 (displacement), ~0.27 (velocity),
+  // ~0.48 (acceleration) -- growing with derivative order because
+  // differentiation weights the dispersive high frequencies. The tolerances
+  // bound those calibrated values.
+  const auto tolerance_for = [](const int type) -> double {
+    switch (static_cast<specfem::enums::wavefield>(type)) {
+    case specfem::enums::wavefield::displacement:
+      return 0.15;
+    case specfem::enums::wavefield::velocity:
+      return 0.35;
+    default:
+      return 0.55;
+    }
+  };
+
+  // No shift-alignment assertion on purpose: a +-1-sample comparison
+  // between these two schemes is confounded in BOTH directions. Early in
+  // the record the implicit trace leads by up to one sample (with beta > 0
+  // the force at t_{n+1} moves u_{n+1} within the same step; with beta = 0
+  // displacement cannot respond until the following step), while late in
+  // the record the dispersion lag dominates in the other direction. Both
+  // effects were measured on this fixture. Exact time-grid agreement is
+  // asserted below via the recorded sample times; operator correctness is
+  // pinned exactly by the ImplicitSolver3D.OperatorMatchesConstituents
+  // unit test and the linear_system cross-path checks.
+  for (const auto &[key, explicit_trace] : explicit_traces) {
+    const auto it = implicit_traces.find(key);
+    ASSERT_NE(it, implicit_traces.end())
+        << "station " << std::get<0>(key) << "." << std::get<1>(key)
+        << " missing from the implicit run";
+    const auto &implicit_trace = it->second;
+    ASSERT_EQ(implicit_trace.size(), explicit_trace.size());
+    double error = 0;
+    double reference_norm = 0;
+    for (std::size_t sample = 0; sample < explicit_trace.size(); ++sample) {
+      ASSERT_NEAR(implicit_trace[sample].first, explicit_trace[sample].first,
+                  1e-3)
+          << "seismogram time grids disagree";
+      for (int icomp = 0; icomp < ncomp; ++icomp) {
+        const double difference =
+            static_cast<double>(implicit_trace[sample].second[icomp]) -
+            static_cast<double>(explicit_trace[sample].second[icomp]);
+        const double reference =
+            static_cast<double>(explicit_trace[sample].second[icomp]);
+        error += difference * difference;
+        reference_norm += reference * reference;
+      }
+    }
+    ASSERT_GT(reference_norm, 0.0);
+
+    const double relative_error = std::sqrt(error / reference_norm);
+    EXPECT_LE(relative_error, tolerance_for(std::get<2>(key)))
+        << "implicit vs explicit relative L2 mismatch at station "
+        << std::get<0>(key) << "." << std::get<1>(key) << " (type "
+        << std::get<2>(key) << ")";
+  }
+}
+
+} // namespace implicit_newmark_test
+
+#else // !SPECFEM_ENABLE_TRILINOS
+
+TEST(ImplicitNewmark3D, SkippedWithoutTrilinos) {
+  GTEST_SKIP() << "SPECFEM++ was built without Trilinos "
+                  "(SPECFEM_ENABLE_TRILINOS=OFF); the implicit solver is "
+                  "unavailable.";
+}
+
+#endif // SPECFEM_ENABLE_TRILINOS
+
+int main(int argc, char *argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new SPECFEMEnvironment);
+  return RUN_ALL_TESTS();
+}

--- a/tests/integration-tests/serial.cmake
+++ b/tests/integration-tests/serial.cmake
@@ -24,3 +24,9 @@ specfem_add_test(displacement_newmark_3d_tests
   SOURCES   displacement_tests/Newmark/dim3/newmark_tests.cpp
   LIBRARIES ${DISPLACEMENT_TEST_LIBS}
 )
+
+specfem_add_test(implicit_newmark_3d_tests
+  SOURCES   displacement_tests/ImplicitNewmark/dim3/implicit_newmark_tests.cpp
+  LIBRARIES ${DISPLACEMENT_TEST_LIBS} specfem::linear_system
+  TIMEOUT   1800
+)

--- a/tests/unit-tests/serial.cmake
+++ b/tests/unit-tests/serial.cmake
@@ -694,6 +694,24 @@ specfem_add_test(mass_vector_tests
             -lpthread -lm
 )
 
+specfem_add_test(implicit_solver_tests
+  SOURCES solver/implicit_solver_tests.cpp
+  LIBRARIES specfem::linear_system
+            specfem::quadrature
+            specfem::mesh
+            yaml-cpp
+            specfem_environment
+            specfem::assembly
+            specfem::runtime_configuration
+            timescheme
+            point
+            specfem::algorithms
+            specfem::solver
+            specfem::periodic_tasks
+            ${BOOST_LIBS}
+            -lpthread -lm
+)
+
 specfem_add_test(damping_assembler_tests
   SOURCES linear_system/damping_assembler_tests.cpp
   LIBRARIES specfem::linear_system

--- a/tests/unit-tests/solver/implicit_solver_tests.cpp
+++ b/tests/unit-tests/solver/implicit_solver_tests.cpp
@@ -1,0 +1,203 @@
+#include "../SPECFEM_Environment.hpp"
+#include <gtest/gtest.h>
+
+#ifdef SPECFEM_ENABLE_TRILINOS
+
+#include "specfem/assembly/assembly.hpp"
+#include "specfem/io.hpp"
+#include "specfem/mesh.hpp"
+#include "specfem/quadrature.hpp"
+#include "specfem/runtime_configuration.hpp"
+#include "specfem/solver/implicit_solver.hpp"
+#include "specfem/tags.hpp"
+#include <Kokkos_Core.hpp>
+#include <cmath>
+#include <cstddef>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+namespace implicit_solver_test {
+
+constexpr auto dim3_tag = specfem::element::dimension_tag::dim3;
+
+constexpr bool single_precision = sizeof(type_real) == sizeof(float);
+const type_real rel_tol = single_precision ? static_cast<type_real>(2e-3)
+                                           : static_cast<type_real>(1e-10);
+
+using AssemblyType = specfem::assembly::assembly<dim3_tag>;
+using SolverTags =
+    specfem::tags::Tags<dim3_tag, specfem::element::medium_tag::elastic,
+                        specfem::element::property_tag::isotropic,
+                        specfem::element::attenuation_tag::none>;
+using SolverType = specfem::solver::ImplicitNewmarkSolver<SolverTags>;
+using VectorType = specfem::linear_system::vector_type;
+
+// Assembly plus the time scheme built from the same fixture configuration.
+struct TestCase {
+  std::unique_ptr<AssemblyType> assembly;
+  std::shared_ptr<specfem::time_scheme::time_scheme> time_scheme;
+};
+
+// Build a full assembly + time scheme from a Newmark displacement-test
+// dataset. Paths are relative to TEST_OUTPUT_DIR, where the
+// displacement_tests data tree is linked (see SERIAL_LINK_DIRS in
+// serial.cmake).
+TestCase build_case_3d(const std::string &test_name) {
+  const std::string test_path =
+      "displacement_tests/Newmark/serial/dim3/" + test_name;
+
+  specfem::runtime_configuration::setup setup(test_path +
+                                              "/specfem_config.yaml");
+
+  const auto database_filename = setup.get_databases();
+  const auto &source_entries = setup.get_source_entries();
+  const auto stations_node = setup.get_stations();
+  const auto quadratures = setup.instantiate_quadrature();
+
+  auto mesh = specfem::io::read_3d_mesh(database_filename,
+                                        setup.get_attenuation_setup());
+
+  const type_real dt = setup.get_dt();
+  const int nsteps = setup.get_nsteps();
+
+  auto [sources, t0, starttime] = specfem::io::read_sources<dim3_tag>(
+      source_entries, nsteps, setup.get_t0(), dt, setup.get_simulation_type());
+  (void)starttime;
+  setup.update_t0(t0);
+
+  auto receivers = specfem::io::read_3d_receivers(stations_node);
+
+  TestCase test_case;
+  test_case.assembly = std::make_unique<AssemblyType>(
+      mesh, quadratures, sources, receivers, setup.get_seismogram_types(),
+      setup.get_t0(), dt, nsteps, setup.get_max_seismogram_step(),
+      setup.get_nstep_between_samples(), setup.get_simulation_type(),
+      setup.allocate_boundary_values(), setup.instantiate_property_reader());
+  test_case.time_scheme =
+      setup.instantiate_timescheme(test_case.assembly->fields);
+  return test_case;
+}
+
+TEST(ImplicitSolverScope3D, RejectsExplicitBeta) {
+  auto test_case = build_case_3d("HomogeneousHalfspaceSmallNoABCForceSource");
+  specfem::solver::ImplicitSolverConfig config;
+  config.newmark.beta = 0;
+  EXPECT_THROW(
+      SolverType solver(test_case.time_scheme, {}, *test_case.assembly, config),
+      std::runtime_error);
+}
+
+TEST(ImplicitSolverScope3D, RejectsMixedMediumMesh) {
+  auto test_case = build_case_3d("AcousticElasticForce");
+  EXPECT_THROW(
+      SolverType solver(test_case.time_scheme, {}, *test_case.assembly),
+      std::runtime_error);
+}
+
+// Shared fixture: the solver on the Stacey halfspace (K, C, M, and A all
+// nontrivial), built once on first access.
+class ImplicitSolver3D : public ::testing::Test {
+protected:
+  static void TearDownTestSuite() {
+    solver_.reset();
+    delete test_case_;
+    test_case_ = nullptr;
+  }
+
+  static TestCase &test_case() {
+    if (test_case_ == nullptr) {
+      test_case_ = new TestCase(build_case_3d("HomogeneousHalfSpaceStacey"));
+    }
+    return *test_case_;
+  }
+
+  static SolverType &solver() {
+    if (!solver_) {
+      solver_ = std::make_unique<SolverType>(
+          test_case().time_scheme,
+          std::vector<std::shared_ptr<
+              specfem::periodic_tasks::periodic_task<dim3_tag>>>{},
+          *test_case().assembly);
+    }
+    return *solver_;
+  }
+
+  static TestCase *test_case_;
+  static std::unique_ptr<SolverType> solver_;
+};
+
+TestCase *ImplicitSolver3D::test_case_ = nullptr;
+std::unique_ptr<SolverType> ImplicitSolver3D::solver_;
+
+TEST_F(ImplicitSolver3D, ConstructsOnStaceyMesh) {
+  const auto &solver = this->solver();
+  EXPECT_GT(solver.stiffness()->getGlobalNumEntries(), 0u);
+  EXPECT_GT(solver.damping()->getGlobalNumEntries(), 0u)
+      << "the Stacey fixture must produce a nonempty damping matrix";
+  EXPECT_EQ(solver.system_operator()->getGlobalNumEntries(),
+            solver.stiffness()->getGlobalNumEntries())
+      << "A must live on K's graph";
+}
+
+// A x must equal M/(beta dt^2) x + gamma/(beta dt) C x + K x entry by entry
+// -- validates the value plumbing of form_operator (K copy, scaled C sum,
+// mass diagonal) through independent applies of the constituent operators.
+TEST_F(ImplicitSolver3D, OperatorMatchesConstituents) {
+  const auto &solver = this->solver();
+  const auto &dof_map = solver.dof_map();
+
+  const type_real dt = test_case().time_scheme->get_timestep();
+  const specfem::solver::ImplicitSolverConfig config; // defaults the solver
+                                                      // used
+  const type_real beta = config.newmark.beta;
+  const type_real gamma = config.newmark.gamma;
+  const type_real mass_coefficient = 1 / (beta * dt * dt);
+  const type_real damping_coefficient = gamma / (beta * dt);
+
+  VectorType x(dof_map.owned_map());
+  x.randomize();
+
+  VectorType a_x(dof_map.owned_map()), reference(dof_map.owned_map()),
+      scratch(dof_map.owned_map());
+  solver.system_operator()->apply(x, a_x);
+
+  solver.stiffness()->apply(x, reference);
+  solver.damping()->apply(x, scratch);
+  reference.update(damping_coefficient, scratch, 1);
+  reference.elementWiseMultiply(mass_coefficient, *solver.mass(), x, 1);
+
+  type_real scale = 0;
+  type_real max_diff = 0;
+  {
+    const auto a_view = a_x.getLocalViewHost(Tpetra::Access::ReadOnly);
+    const auto ref_view = reference.getLocalViewHost(Tpetra::Access::ReadOnly);
+    for (std::size_t dof = 0;
+         dof < static_cast<std::size_t>(dof_map.num_global_dofs()); ++dof) {
+      scale = std::max(scale, std::abs(ref_view(dof, 0)));
+      max_diff =
+          std::max(max_diff, std::abs(a_view(dof, 0) - ref_view(dof, 0)));
+    }
+  }
+  ASSERT_GT(scale, static_cast<type_real>(0));
+  EXPECT_LE(max_diff, rel_tol * scale)
+      << "A x disagrees with M/(beta dt^2) x + gamma/(beta dt) C x + K x";
+}
+
+} // namespace implicit_solver_test
+
+#else // !SPECFEM_ENABLE_TRILINOS
+
+TEST(ImplicitSolver3D, SkippedWithoutTrilinos) {
+  GTEST_SKIP() << "SPECFEM++ was built without Trilinos "
+                  "(SPECFEM_ENABLE_TRILINOS=OFF); the implicit solver is "
+                  "unavailable.";
+}
+
+#endif // SPECFEM_ENABLE_TRILINOS
+
+int main(int argc, char *argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new SPECFEMEnvironment);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
> [!NOTE]
> **Stacked PR (2/3)** for the implicit Newmark solver (issue #1984), based on #2023 (`issue-1984-phase-1`). Only the last commit is new here. Merge order: #2002 → #2023 → this → phase 3.

## Description

Adds `specfem::solver::ImplicitNewmarkSolver`, adjacent to `time_marching`: one Belos GMRES solve per time step on the assembled displacement-form operator A = M/(β dt²) + γ/(β dt) C + K, built from the `linear_system` assemblers (Stacey-tolerant stiffness scope, velocity-path damping probe, dt = 0 lumped mass). A lives on K's static graph, is assembled and preconditioned once per time step size, and each step is a warm-started solve with an Ifpack2 RILUK right preconditioner.

RILUK defaults to zero fill: spectral-element rows carry ~2000 nonzeros, so level-1 fill (~the pattern of A²) explodes combinatorially in Ifpack2's symbolic setup. MueLu stays deferred (float-only cluster installs).

Run with the dissipative Newmark preset (γ > 1/2, β = (γ + 1/2)²/4) and the velocity-based steady-state stopping criterion, the solver acts as a static solver: it recreates an explicit run driven to steady state in a few large steps. The criterion is velocity/acceleration-based because a nonzero-net-force source on a Stacey box converges to a constant-velocity drift, not a displacement fixed point.

**Tests:** constructor scope rejections, exact operator identity against independently applied K/C/M, and a dynamic-equivalence integration test against the explicit solver on the natural-boundary fixture. The equivalence tolerances (0.15/0.35/0.55 relative L2 for u/v/a) are scheme-difference-bound: average acceleration elongates periods while central difference shortens them, and the measured gaps (0.10/0.27/0.48 at the fixture's coarse dt against a 1.25 Hz Ricker) are dominated by that dispersion, growing with derivative order.

## Issue Number

Part of #1984

## Checklist

Please make sure to check developer documentation on specfem docs.

- [ ] I ran the code through pre-commit to check style
- [ ] **THE DOCUMENTATION BUILDS WITHOUT WARNINGS/ERRORS**
- [ ] I have added labels to the PR (see right hand side of the PR page)
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [ ] I have added/updated documentation for the changes I am proposing
- [ ] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)